### PR TITLE
add support for automatically unloading a model (#10)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 test:
+	go test -short -v ./proxy
+
+test-all:
 	go test -v ./proxy
 
 # Build OSX binary

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ models:
     # until the server is ready
     checkEndpoint: /custom-endpoint
 
+    # automatically unload the model after 10 seconds
+    # ttl values must be a value greater than 0
+    # default: 0 = never unload model
+    ttl: 5
+
   "qwen":
     # environment variables to pass to the command
     env:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -17,6 +17,9 @@ models:
     # check this path for a HTTP 200 response for the server to be ready
     checkEndpoint: /health
 
+    # unload model after 5 seconds
+    ttl: 5
+
   "qwen":
     cmd: models/llama-server-osx --port 8999 -m models/qwen2.5-0.5b-instruct-q8_0.gguf
     proxy: http://127.0.0.1:8999

--- a/misc/simple-responder/simple-responder.go
+++ b/misc/simple-responder/simple-responder.go
@@ -20,7 +20,11 @@ func main() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		// Set the header to text/plain
 		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintln(w, *responseMessage)
+	})
 
+	http.HandleFunc("/env", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintln(w, *responseMessage)
 
 		// Get environment variables

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -14,6 +14,7 @@ type ModelConfig struct {
 	Aliases       []string `yaml:"aliases"`
 	Env           []string `yaml:"env"`
 	CheckEndpoint string   `yaml:"checkEndpoint"`
+	UnloadAfter   int      `yaml:"ttl"`
 }
 
 func (m *ModelConfig) SanitizedCommand() ([]string, error) {

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -99,8 +99,8 @@ func (pm *ProxyManager) swapModel(requestedModel string) error {
 		}
 	}
 
-	pm.currentProcess = NewProcess(modelID, modelConfig, pm.logMonitor)
-	return pm.currentProcess.Start(pm.config.HealthCheckTimeout)
+	pm.currentProcess = NewProcess(modelID, pm.config.HealthCheckTimeout, modelConfig, pm.logMonitor)
+	return nil
 }
 
 func (pm *ProxyManager) proxyChatRequestHandler(c *gin.Context) {


### PR DESCRIPTION
This adds the enhancement to for #10. 

When the loaded model has not served a request in `ttl` seconds it will be unloaded from memory. The default behavior of never unloading a model is preserved. 