### PR TITLE
Implement Multi-Process Handling (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,22 @@
 
 ![llama-swap header image](header.jpeg)
 
-[llama.cpp's server](https://github.com/ggerganov/llama.cpp/tree/master/examples/server) can't swap models on demand. So let's swap the server on demand instead!
+llama-swap is a golang server that automatically swaps the llama.cpp server on demand. Since [llama.cpp's server](https://github.com/ggerganov/llama.cpp/tree/master/examples/server) can't swap models, let's swap the server instead!
 
-llama-swap is a proxy server that sits in front of llama-server. When a request for `/v1/chat/completions` comes in it will extract the `model` requested and change the underlying llama-server automatically.
+Features:
 
-- ✅ easy to deploy: single binary with no dependencies
-- ✅ full control over llama-server's startup settings
-- ✅ ❤️ for users who are rely on llama.cpp for LLM inference
+- ✅ Easy to deploy: single binary with no dependencies
+- ✅ Single yaml configuration file
+- ✅ Automatically switching between models
+- ✅ Full control over llama.cpp server settings per model
+- ✅ OpenAI API support (`v1/completions` and `v1/chat/completions`)
+- ✅ Multiple GPU support
+- ✅ Run multiple models at once with `profiles`
+- ✅ Remote log monitoring at `/log`
 
 ## config.yaml
 
-llama-swap's configuration purposefully simple.
+llama-swap's configuration is purposefully simple.
 
 ```yaml
 # Seconds to wait for llama.cpp to load and be ready to serve requests
@@ -24,25 +29,24 @@ models:
   "llama":
     cmd: llama-server --port 8999 -m Llama-3.2-1B-Instruct-Q4_K_M.gguf
 
-    # where to reach the server started by cmd
+    # where to reach the server started by cmd, make sure the ports match
     proxy: http://127.0.0.1:8999
 
-    # aliases model names to use this configuration for
+    # aliases names to use this model for
     aliases:
     - "gpt-4o-mini"
     - "gpt-3.5-turbo"
 
-    # wait for this path to return an HTTP 200 before serving requests
-    # defaults to /health to match llama.cpp
-    #
-    # use "none" to skip endpoint checking. This may cause requests to fail
-    # until the server is ready
+    # check this path for an HTTP 200 OK before serving requests
+    # default: /health to match llama.cpp
+    # use "none" to skip endpoint checking, but may cause HTTP errors
+    # until the model is ready
     checkEndpoint: /custom-endpoint
 
-    # automatically unload the model after 10 seconds
+    # automatically unload the model after this many seconds
     # ttl values must be a value greater than 0
     # default: 0 = never unload model
-    ttl: 5
+    ttl: 60
 
   "qwen":
     # environment variables to pass to the command
@@ -53,8 +57,18 @@ models:
     cmd: >
       llama-server --port 8999
       --model path/to/Qwen2.5-1.5B-Instruct-Q4_K_M.gguf
-
     proxy: http://127.0.0.1:8999
+
+# profiles make it easy to managing multi model (and gpu) configurations.
+#
+# Tips:
+#  - each model must be listening on a unique address and port
+#  - the model name is in this format: "profile_name/model", like "coding/qwen"
+#  - the profile will load and unload all models in the profile at the same time
+profiles:
+  coding:
+    - "qwen"
+    - "llama"
 ```
 
 ## Installation

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -46,15 +46,8 @@ models:
     cmd: models/llama-server-osx --port 8999 -m models/qwen2.5-0.5b-instruct-q8_0.gguf
     proxy: http://127.0.0.1:9000
 
-# groups allows more control over the usage of VRAM. In case where there is more
-# VRAM available than required it is desirable to have multiple models loaded
-# to reduce thet time to first token.
-#
-# important:
-#  - each model *must* be listening on a unique address and port
-#  - the model name is now in this format: "group/model", like "code/qwen"
-#  - loading one model will load all the models in the group
-groups:
-  code:
+# creating a coding profile with models for code generation and general questions
+profiles:
+  coding:
     - "qwen"
     - "llama"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -56,6 +56,5 @@ models:
 #  - loading one model will load all the models in the group
 groups:
   code:
-    models:
-      - "qwen"
-      - "llama"
+    - "qwen"
+    - "llama"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,9 +6,9 @@ models:
   "llama":
     cmd: >
       models/llama-server-osx
-      --port 8999
+      --port 9001
       -m models/Llama-3.2-1B-Instruct-Q4_0.gguf
-    proxy: http://127.0.0.1:8999
+    proxy: http://127.0.0.1:9001
 
     # list of model name aliases this llama.cpp instance can serve
     aliases:
@@ -21,8 +21,8 @@ models:
     ttl: 5
 
   "qwen":
-    cmd: models/llama-server-osx --port 8999 -m models/qwen2.5-0.5b-instruct-q8_0.gguf
-    proxy: http://127.0.0.1:8999
+    cmd: models/llama-server-osx --port 9002 -m models/qwen2.5-0.5b-instruct-q8_0.gguf
+    proxy: http://127.0.0.1:9002
     aliases:
     - gpt-3.5-turbo
 
@@ -45,3 +45,17 @@ models:
   "broken_timeout":
     cmd: models/llama-server-osx --port 8999 -m models/qwen2.5-0.5b-instruct-q8_0.gguf
     proxy: http://127.0.0.1:9000
+
+# groups allows more control over the usage of VRAM. In case where there is more
+# VRAM available than required it is desirable to have multiple models loaded
+# to reduce thet time to first token.
+#
+# important:
+#  - each model *must* be listening on a unique address and port
+#  - the model name is now in this format: "group/model", like "code/qwen"
+#  - loading one model will load all the models in the group
+groups:
+  code:
+    models:
+      - "qwen"
+      - "llama"

--- a/misc/simple-responder/simple-responder.go
+++ b/misc/simple-responder/simple-responder.go
@@ -16,12 +16,16 @@ func main() {
 
 	flag.Parse() // Parse the command-line flags
 
-	// Set up the handler function using the provided response message
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	responseMessageHandler := func(w http.ResponseWriter, r *http.Request) {
 		// Set the header to text/plain
 		w.Header().Set("Content-Type", "text/plain")
 		fmt.Fprintln(w, *responseMessage)
-	})
+	}
+
+	// Set up the handler function using the provided response message
+	http.HandleFunc("/v1/chat/completions", responseMessageHandler)
+	http.HandleFunc("/v1/completions", responseMessageHandler)
+	http.HandleFunc("/test", responseMessageHandler)
 
 	http.HandleFunc("/env", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
@@ -41,6 +45,11 @@ func main() {
 		w.Header().Set("Content-Type", "application/json")
 		response := `{"status": "ok"}`
 		w.Write([]byte(response))
+	})
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprintf(w, "%s %s", r.Method, r.URL.Path)
 	})
 
 	address := "127.0.0.1:" + *port // Address with the specified port

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -24,7 +24,7 @@ func (m *ModelConfig) SanitizedCommand() ([]string, error) {
 type Config struct {
 	HealthCheckTimeout int                    `yaml:"healthCheckTimeout"`
 	Models             map[string]ModelConfig `yaml:"models"`
-	Groups             map[string][]string    `yaml:"groups"`
+	Profiles           map[string][]string    `yaml:"profiles"`
 
 	// map aliases to actual model IDs
 	aliases map[string]string

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -17,13 +17,18 @@ type ModelConfig struct {
 	UnloadAfter   int      `yaml:"ttl"`
 }
 
+type ModelGroup struct {
+	Models []ModelConfig `yaml:"models"`
+}
+
 func (m *ModelConfig) SanitizedCommand() ([]string, error) {
 	return SanitizeCommand(m.Cmd)
 }
 
 type Config struct {
-	Models             map[string]ModelConfig `yaml:"models"`
 	HealthCheckTimeout int                    `yaml:"healthCheckTimeout"`
+	Models             map[string]ModelConfig `yaml:"models"`
+	Groups             map[string]ModelGroup  `yaml:"groups"`
 }
 
 func (c *Config) FindConfig(modelName string) (ModelConfig, string, bool) {

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -25,24 +25,27 @@ type Config struct {
 	HealthCheckTimeout int                    `yaml:"healthCheckTimeout"`
 	Models             map[string]ModelConfig `yaml:"models"`
 	Groups             map[string][]string    `yaml:"groups"`
+
+	// map aliases to actual model IDs
+	aliases map[string]string
+}
+
+func (c *Config) RealModelName(search string) (string, bool) {
+	if _, found := c.Models[search]; found {
+		return search, true
+	} else if name, found := c.aliases[search]; found {
+		return name, found
+	} else {
+		return "", false
+	}
 }
 
 func (c *Config) FindConfig(modelName string) (ModelConfig, string, bool) {
-	modelConfig, found := c.Models[modelName]
-	if found {
-		return modelConfig, modelName, true
+	if realName, found := c.RealModelName(modelName); !found {
+		return ModelConfig{}, "", false
+	} else {
+		return c.Models[realName], realName, true
 	}
-
-	// Search through aliases to find the right config
-	for actual, config := range c.Models {
-		for _, alias := range config.Aliases {
-			if alias == modelName {
-				return config, actual, true
-			}
-		}
-	}
-
-	return ModelConfig{}, "", false
 }
 
 func LoadConfig(path string) (*Config, error) {
@@ -59,6 +62,14 @@ func LoadConfig(path string) (*Config, error) {
 
 	if config.HealthCheckTimeout < 15 {
 		config.HealthCheckTimeout = 15
+	}
+
+	// Populate the aliases map
+	config.aliases = make(map[string]string)
+	for modelName, modelConfig := range config.Models {
+		for _, alias := range modelConfig.Aliases {
+			config.aliases[alias] = modelName
+		}
 	}
 
 	return &config, nil

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -17,10 +17,6 @@ type ModelConfig struct {
 	UnloadAfter   int      `yaml:"ttl"`
 }
 
-type ModelGroup struct {
-	Models []ModelConfig `yaml:"models"`
-}
-
 func (m *ModelConfig) SanitizedCommand() ([]string, error) {
 	return SanitizeCommand(m.Cmd)
 }
@@ -28,7 +24,7 @@ func (m *ModelConfig) SanitizedCommand() ([]string, error) {
 type Config struct {
 	HealthCheckTimeout int                    `yaml:"healthCheckTimeout"`
 	Models             map[string]ModelConfig `yaml:"models"`
-	Groups             map[string]ModelGroup  `yaml:"groups"`
+	Groups             map[string][]string    `yaml:"groups"`
 }
 
 func (c *Config) FindConfig(modelName string) (ModelConfig, string, bool) {

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -36,7 +36,7 @@ models:
       - "m2"
     checkEndpoint: "/"
 healthCheckTimeout: 15
-groups:
+profiles:
   test:
     - model1
     - model2
@@ -70,7 +70,7 @@ groups:
 			},
 		},
 		HealthCheckTimeout: 15,
-		Groups: map[string][]string{
+		Profiles: map[string][]string{
 			"test": {"model1", "model2"},
 		},
 		aliases: map[string]string{

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -73,9 +73,18 @@ groups:
 		Groups: map[string][]string{
 			"test": {"model1", "model2"},
 		},
+		aliases: map[string]string{
+			"m1":        "model1",
+			"model-one": "model1",
+			"m2":        "model2",
+		},
 	}
 
 	assert.Equal(t, expected, config)
+
+	realname, found := config.RealModelName("m1")
+	assert.True(t, found)
+	assert.Equal(t, "model1", realname)
 }
 
 func TestConfig_ModelConfigSanitizedCommand(t *testing.T) {
@@ -91,6 +100,9 @@ func TestConfig_ModelConfigSanitizedCommand(t *testing.T) {
 }
 
 func TestConfig_FindConfig(t *testing.T) {
+
+	// TODO?
+	// make make this shared between the different tests
 	config := &Config{
 		Models: map[string]ModelConfig{
 			"model1": {
@@ -109,6 +121,11 @@ func TestConfig_FindConfig(t *testing.T) {
 			},
 		},
 		HealthCheckTimeout: 10,
+		aliases: map[string]string{
+			"m1":        "model1",
+			"model-one": "model1",
+			"m2":        "model2",
+		},
 	}
 
 	// Test finding a model by its name

--- a/proxy/helpers_test.go
+++ b/proxy/helpers_test.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+
+	"github.com/gin-gonic/gin"
 )
 
 var (
@@ -21,6 +23,9 @@ func TestMain(m *testing.M) {
 		fmt.Printf("simple-responder not found at %s, did you `make simple-responder`?\n", binaryPath)
 		os.Exit(1)
 	}
+
+	gin.SetMode(gin.TestMode)
+
 	m.Run()
 }
 

--- a/proxy/helpers_test.go
+++ b/proxy/helpers_test.go
@@ -1,0 +1,53 @@
+package proxy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+var (
+	nextTestPort int = 12000
+	portMutex    sync.Mutex
+)
+
+// Check if the binary exists
+func TestMain(m *testing.M) {
+	binaryPath := getSimpleResponderPath()
+	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
+		fmt.Printf("simple-responder not found at %s, did you `make simple-responder`?\n", binaryPath)
+		os.Exit(1)
+	}
+	m.Run()
+}
+
+// Helper function to get the binary path
+func getSimpleResponderPath() string {
+	goos := runtime.GOOS
+	goarch := runtime.GOARCH
+	return filepath.Join("..", "build", fmt.Sprintf("simple-responder_%s_%s", goos, goarch))
+}
+
+func getTestSimpleResponderConfig(expectedMessage string) ModelConfig {
+	portMutex.Lock()
+	defer portMutex.Unlock()
+
+	port := nextTestPort
+	nextTestPort++
+
+	return getTestSimpleResponderConfigPort(expectedMessage, port)
+}
+
+func getTestSimpleResponderConfigPort(expectedMessage string, port int) ModelConfig {
+	binaryPath := getSimpleResponderPath()
+
+	// Create a process configuration
+	return ModelConfig{
+		Cmd:           fmt.Sprintf("%s --port %d --respond '%s'", binaryPath, port, expectedMessage),
+		Proxy:         fmt.Sprintf("http://127.0.0.1:%d", port),
+		CheckEndpoint: "/health",
+	}
+}

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -113,7 +113,7 @@ func (p *Process) Stop() {
 	p.Lock()
 	defer p.Unlock()
 
-	if !p.isRunning {
+	if !p.isRunning || p.cmd == nil || p.cmd.Process == nil {
 		return
 	}
 

--- a/proxy/process_test.go
+++ b/proxy/process_test.go
@@ -1,53 +1,14 @@
 package proxy
 
 import (
-	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
-
-// Check if the binary exists
-func TestMain(m *testing.M) {
-	binaryPath := getBinaryPath()
-	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
-		fmt.Printf("simple-responder not found at %s, did you `make simple-responder`?\n", binaryPath)
-		os.Exit(1)
-	}
-	m.Run()
-}
-
-// Helper function to get the binary path
-func getBinaryPath() string {
-	goos := runtime.GOOS
-	goarch := runtime.GOARCH
-	return filepath.Join("..", "build", fmt.Sprintf("simple-responder_%s_%s", goos, goarch))
-}
-
-func getTestSimpleResponderConfig(expectedMessage string) ModelConfig {
-	// Define the range
-	min := 12000
-	max := 13000
-
-	// Generate a random number between 12000 and 13000
-	randomPort := rand.Intn(max-min+1) + min
-	binaryPath := getBinaryPath()
-
-	// Create a process configuration
-	return ModelConfig{
-		Cmd:           fmt.Sprintf("%s --port %d --respond '%s'", binaryPath, randomPort, expectedMessage),
-		Proxy:         fmt.Sprintf("http://127.0.0.1:%d", randomPort),
-		CheckEndpoint: "/health",
-	}
-}
 
 func TestProcess_AutomaticallyStartsUpstream(t *testing.T) {
 	logMonitor := NewLogMonitorWriter(io.Discard)
@@ -56,6 +17,8 @@ func TestProcess_AutomaticallyStartsUpstream(t *testing.T) {
 
 	// Create a process
 	process := NewProcess("test-process", 5, config, logMonitor)
+	defer process.Stop()
+
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 
@@ -92,6 +55,8 @@ func TestProcess_BrokenModelConfig(t *testing.T) {
 	}
 
 	process := NewProcess("broken", 1, config, NewLogMonitor())
+	defer process.Stop()
+
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 	process.ProxyRequest(w, req)
@@ -111,6 +76,8 @@ func TestProcess_UnloadAfterTTL(t *testing.T) {
 	assert.Equal(t, 3, config.UnloadAfter)
 
 	process := NewProcess("ttl", 2, config, NewLogMonitorWriter(io.Discard))
+	defer process.Stop()
+
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 

--- a/proxy/process_test.go
+++ b/proxy/process_test.go
@@ -19,7 +19,7 @@ func TestProcess_AutomaticallyStartsUpstream(t *testing.T) {
 	process := NewProcess("test-process", 5, config, logMonitor)
 	defer process.Stop()
 
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/test", nil)
 	w := httptest.NewRecorder()
 
 	// process is automatically started
@@ -78,7 +78,7 @@ func TestProcess_UnloadAfterTTL(t *testing.T) {
 	process := NewProcess("ttl", 2, config, NewLogMonitorWriter(io.Discard))
 	defer process.Stop()
 
-	req := httptest.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/test", nil)
 	w := httptest.NewRecorder()
 
 	// Proxy the request (auto start)

--- a/proxy/process_test.go
+++ b/proxy/process_test.go
@@ -64,6 +64,7 @@ func TestProcess_BrokenModelConfig(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "unable to start process")
 }
 
+// test that the process unloads after the TTL
 func TestProcess_UnloadAfterTTL(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long auto unload TTL test")

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -108,7 +108,7 @@ func (pm *ProxyManager) swapModel(requestedModel string) (*Process, error) {
 	}
 
 	if groupName != "" {
-		if _, found := pm.config.Groups[groupName]; !found {
+		if _, found := pm.config.Profiles[groupName]; !found {
 			return nil, fmt.Errorf("model group not found %s", groupName)
 		}
 	}
@@ -138,7 +138,7 @@ func (pm *ProxyManager) swapModel(requestedModel string) (*Process, error) {
 		processKey := groupName + "/" + modelID
 		pm.currentProcesses[processKey] = process
 	} else {
-		for _, modelName := range pm.config.Groups[groupName] {
+		for _, modelName := range pm.config.Profiles[groupName] {
 			if realModelName, found := pm.config.RealModelName(modelName); found {
 				modelConfig, modelID, found := pm.config.FindConfig(realModelName)
 				if !found {

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -119,11 +119,9 @@ func (pm *ProxyManager) swapModel(requestedModel string) (*Process, error) {
 		return nil, fmt.Errorf("could not find modelID for %s", requestedModel)
 	}
 
-	realRequestedModelKey := groupName + "/" + realModelName
-
 	// exit early when already running, otherwise stop everything and swap
-	processKey := groupName + "/" + realModelName
-	if process, found := pm.currentProcesses[processKey]; found {
+	requestedProcessKey := groupName + "/" + realModelName
+	if process, found := pm.currentProcesses[requestedProcessKey]; found {
 		return process, nil
 	}
 
@@ -137,7 +135,7 @@ func (pm *ProxyManager) swapModel(requestedModel string) (*Process, error) {
 		}
 
 		process := NewProcess(modelID, pm.config.HealthCheckTimeout, modelConfig, pm.logMonitor)
-		processKey = groupName + "/" + modelID
+		processKey := groupName + "/" + modelID
 		pm.currentProcesses[processKey] = process
 	} else {
 		for _, modelName := range pm.config.Groups[groupName] {
@@ -148,13 +146,14 @@ func (pm *ProxyManager) swapModel(requestedModel string) (*Process, error) {
 				}
 
 				process := NewProcess(modelID, pm.config.HealthCheckTimeout, modelConfig, pm.logMonitor)
-				processKey = groupName + "/" + modelID
+				processKey := groupName + "/" + modelID
 				pm.currentProcesses[processKey] = process
 			}
 		}
 	}
 
-	return pm.currentProcesses[realRequestedModelKey], nil
+	// requestedProcessKey should exist due to swap
+	return pm.currentProcesses[requestedProcessKey], nil
 }
 
 func (pm *ProxyManager) proxyChatRequestHandler(c *gin.Context) {

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -59,6 +59,12 @@ func (pm *ProxyManager) HandlerFunc(w http.ResponseWriter, r *http.Request) {
 	pm.ginEngine.ServeHTTP(w, r)
 }
 
+func (pm *ProxyManager) StopProcesses() {
+	if pm.currentProcess != nil {
+		pm.currentProcess.Stop()
+	}
+}
+
 func (pm *ProxyManager) listModelsHandler(c *gin.Context) {
 	data := []interface{}{}
 	for id := range pm.config.Models {

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -1,0 +1,35 @@
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProxyManager_SwapProcessCorrectly(t *testing.T) {
+
+	config := &Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]ModelConfig{
+			"model1": getTestSimpleResponderConfig("model1"),
+			"model2": getTestSimpleResponderConfig("model2"),
+		},
+	}
+
+	proxy := New(config)
+	defer proxy.StopProcesses()
+
+	for _, modelName := range []string{"model1", "model2"} {
+		reqBody := fmt.Sprintf(`{"model":"%s"}`, modelName)
+		req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+		w := httptest.NewRecorder()
+
+		proxy.HandlerFunc(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), modelName)
+	}
+}

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestProxyManager_SwapProcessCorrectly(t *testing.T) {
-
 	config := &Config{
 		HealthCheckTimeout: 15,
 		Models: map[string]ModelConfig{
@@ -31,5 +30,47 @@ func TestProxyManager_SwapProcessCorrectly(t *testing.T) {
 		proxy.HandlerFunc(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Body.String(), modelName)
+
+		_, exists := proxy.currentProcesses["/"+modelName]
+		assert.True(t, exists, "expected %s key in currentProcesses", modelName)
+
 	}
+
+	// make sure there's only one loaded model
+	assert.Len(t, proxy.currentProcesses, 1)
+}
+
+func TestProxyManager_SwapMultiProcess(t *testing.T) {
+	config := &Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]ModelConfig{
+			"model1": getTestSimpleResponderConfig("model1"),
+			"model2": getTestSimpleResponderConfig("model2"),
+		},
+		Groups: map[string][]string{
+			"test": {"model1", "model2"},
+		},
+	}
+
+	proxy := New(config)
+	defer proxy.StopProcesses()
+
+	for modelID, requestedModel := range map[string]string{"model1": "test/model1", "model2": "test/model2"} {
+		reqBody := fmt.Sprintf(`{"model":"%s"}`, requestedModel)
+		req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+		w := httptest.NewRecorder()
+
+		proxy.HandlerFunc(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), modelID)
+	}
+
+	// make sure there's two loaded models
+	assert.Len(t, proxy.currentProcesses, 2)
+	_, exists := proxy.currentProcesses["test/model1"]
+	assert.True(t, exists, "expected test/model1 key in currentProcesses")
+
+	_, exists = proxy.currentProcesses["test/model2"]
+	assert.True(t, exists, "expected test/model2 key in currentProcesses")
+
 }

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -47,7 +47,7 @@ func TestProxyManager_SwapMultiProcess(t *testing.T) {
 			"model1": getTestSimpleResponderConfig("model1"),
 			"model2": getTestSimpleResponderConfig("model2"),
 		},
-		Groups: map[string][]string{
+		Profiles: map[string][]string{
 			"test": {"model1", "model2"},
 		},
 	}


### PR DESCRIPTION
This change adds functionality for llama-swap to manage multiple llama-server backends. This is an advanced use case that requires enough GPU resources to load multiple models. An example is when programming and a larger model like qwen-coder-32B is used for code generation and qwen-coder-1.5B is used for auto-completion. 

This implements the design from issue #7.  A new `groups` configuration is introduced: 

```yaml
models:
  "qwen-coder-1.5b":
    cmd: llama-server --port 9001 -m models/qwen-coder-1.5b.gguf
    proxy: http://127.0.0.1:9001

  "qwen-coder-32b":
    cmd: llama-server --port 9002 -m models/qwen-coder-32B.gguf
    proxy: http://127.0.0.1:9002

groups:
  coding:
    - "qwen-coder-1.5b"
    - "qwen-coder-32b"
```

When a request to `/v1/chat/completions` with a `{"model":"coding/qwen-coder-1.5b"}` is sent llama-swap will load both models into the GPU(s).  When a request for "coding/qwen-coder-32b" is requested the request will be served immediately. This can greatly reduces the time to first token for a request for both models in the configuration. 

It is up to the operator to ensure the group configuration is viable. Generally watch out for these things: 

1. there is sufficient GPU resources to load all models 
1. there are no `port` conflicts in the configurations 

