### PR TITLE
Improve Concurrency (#19)

### DIFF
--- a/proxy/helpers_test.go
+++ b/proxy/helpers_test.go
@@ -51,7 +51,7 @@ func getTestSimpleResponderConfigPort(expectedMessage string, port int) ModelCon
 
 	// Create a process configuration
 	return ModelConfig{
-		Cmd:           fmt.Sprintf("%s --port %d --respond '%s'", binaryPath, port, expectedMessage),
+		Cmd:           fmt.Sprintf("%s --port %d --silent --respond %s", binaryPath, port, expectedMessage),
 		Proxy:         fmt.Sprintf("http://127.0.0.1:%d", port),
 		CheckEndpoint: "/health",
 	}

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -14,6 +14,15 @@ import (
 	"time"
 )
 
+type ProcessState string
+
+const (
+	StateStopped  ProcessState = ProcessState("stopped")
+	StateReady    ProcessState = ProcessState("ready")
+	StateFailed   ProcessState = ProcessState("failed")
+	StateStopping ProcessState = ProcessState("stopping")
+)
+
 type Process struct {
 	sync.Mutex
 
@@ -23,8 +32,12 @@ type Process struct {
 	logMonitor         *LogMonitor
 	healthCheckTimeout int
 
-	isRunning          bool
 	lastRequestHandled time.Time
+
+	stateMutex sync.RWMutex
+	state      ProcessState
+
+	inFlightRequests sync.WaitGroup
 }
 
 func NewProcess(ID string, healthCheckTimeout int, config ModelConfig, logMonitor *LogMonitor) *Process {
@@ -34,16 +47,22 @@ func NewProcess(ID string, healthCheckTimeout int, config ModelConfig, logMonito
 		cmd:                nil,
 		logMonitor:         logMonitor,
 		healthCheckTimeout: healthCheckTimeout,
+		state:              StateStopped,
 	}
 }
 
-// start the process and check it for errors
+// start the process and returns when it is ready
 func (p *Process) start() error {
-	p.Lock()
-	defer p.Unlock()
 
-	if p.isRunning {
-		return fmt.Errorf("process already running")
+	p.stateMutex.Lock()
+	defer p.stateMutex.Unlock()
+
+	if p.state == StateReady {
+		return nil
+	}
+
+	if p.state == StateFailed {
+		return fmt.Errorf("process is in a failed state and can not be restarted")
 	}
 
 	args, err := p.config.SanitizedCommand()
@@ -57,34 +76,47 @@ func (p *Process) start() error {
 	p.cmd.Env = p.config.Env
 
 	err = p.cmd.Start()
-	p.isRunning = true
 
 	if err != nil {
 		return err
 	}
 
-	// watch for the command to exit
-	cmdCtx, cancel := context.WithCancelCause(context.Background())
+	// One of three things can happen at this stage:
+	// 1. The command exits unexpectedly
+	// 2. The health check fails
+	// 3. The health check passes
+	//
+	// only in the third case will the process be considered Ready to accept
+	healthCheckContext, cancelHealthCheck := context.WithCancelCause(context.Background())
+	defer cancelHealthCheck(nil) // clean up
+	cmdWaitChan := make(chan error, 1)
+	healthCheckChan := make(chan error, 1)
 
-	// monitor the command's exit status. Usually this happens if
-	// the process exited unexpectedly
 	go func() {
-		err := p.cmd.Wait()
-		if err != nil {
-			cancel(fmt.Errorf("command [%s] %s", strings.Join(p.cmd.Args, " "), err.Error()))
-		} else {
-			cancel(nil)
-		}
-
-		p.isRunning = false
+		// possible cmd exits early
+		cmdWaitChan <- p.cmd.Wait()
 	}()
 
-	// wait a bit for process to start before checking the health endpoint
-	time.Sleep(250 * time.Millisecond)
+	go func() {
+		<-time.After(250 * time.Millisecond) // give process a bit of time to start
+		healthCheckChan <- p.checkHealthEndpoint(healthCheckContext)
+	}()
 
-	// wait for checkHealthEndpoint
-	if err := p.checkHealthEndpoint(cmdCtx); err != nil {
+	select {
+	case err := <-cmdWaitChan:
+		p.state = StateFailed
+		if err != nil {
+			err = fmt.Errorf("command [%s] %s", strings.Join(p.cmd.Args, " "), err.Error())
+		} else {
+			err = fmt.Errorf("command [%s] exited unexpected", strings.Join(p.cmd.Args, " "))
+		}
+		cancelHealthCheck(err)
 		return err
+	case err := <-healthCheckChan:
+		if err != nil {
+			p.state = StateFailed
+			return err
+		}
 	}
 
 	if p.config.UnloadAfter > 0 {
@@ -106,27 +138,41 @@ func (p *Process) start() error {
 		}()
 	}
 
+	p.state = StateReady
 	return nil
 }
 
 func (p *Process) Stop() {
-	p.Lock()
-	defer p.Unlock()
 
-	if !p.isRunning || p.cmd == nil || p.cmd.Process == nil {
+	// wait for any inflight requests before proceeding
+	p.inFlightRequests.Wait()
+
+	p.stateMutex.Lock()
+	defer p.stateMutex.Unlock()
+
+	if p.state != StateReady {
+		return
+	}
+
+	if p.cmd == nil || p.cmd.Process == nil {
+		// this situation should never happen... but if it does just update the state
+		fmt.Fprintf(p.logMonitor, "!!! State is Ready but Command is nil.")
+		p.state = StateStopped
 		return
 	}
 
 	p.cmd.Process.Signal(syscall.SIGTERM)
 	p.cmd.Process.Wait()
-	p.isRunning = false
+	p.state = StateStopped
 }
 
-func (p *Process) IsRunning() bool {
-	return p.isRunning
+func (p *Process) CurrentState() ProcessState {
+	p.stateMutex.RLock()
+	defer p.stateMutex.RUnlock()
+	return p.state
 }
 
-func (p *Process) checkHealthEndpoint(cmdCtx context.Context) error {
+func (p *Process) checkHealthEndpoint(ctxFromStart context.Context) error {
 	if p.config.Proxy == "" {
 		return fmt.Errorf("no upstream available to check /health")
 	}
@@ -158,7 +204,7 @@ func (p *Process) checkHealthEndpoint(cmdCtx context.Context) error {
 			return err
 		}
 
-		ctx, cancel := context.WithTimeout(cmdCtx, time.Second)
+		ctx, cancel := context.WithTimeout(ctxFromStart, time.Second)
 		defer cancel()
 		req = req.WithContext(ctx)
 		resp, err := client.Do(req)
@@ -205,13 +251,16 @@ func (p *Process) checkHealthEndpoint(cmdCtx context.Context) error {
 }
 
 func (p *Process) ProxyRequest(w http.ResponseWriter, r *http.Request) {
-	if !p.isRunning {
+	if p.CurrentState() != StateReady {
 		if err := p.start(); err != nil {
 			errstr := fmt.Sprintf("unable to start process: %s", err)
 			http.Error(w, errstr, http.StatusInternalServerError)
 			return
 		}
 	}
+
+	p.inFlightRequests.Add(1)
+	defer p.inFlightRequests.Done()
 
 	p.lastRequestHandled = time.Now()
 

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -17,10 +17,9 @@ import (
 type ProcessState string
 
 const (
-	StateStopped  ProcessState = ProcessState("stopped")
-	StateReady    ProcessState = ProcessState("ready")
-	StateFailed   ProcessState = ProcessState("failed")
-	StateStopping ProcessState = ProcessState("stopping")
+	StateStopped ProcessState = ProcessState("stopped")
+	StateReady   ProcessState = ProcessState("ready")
+	StateFailed  ProcessState = ProcessState("failed")
 )
 
 type Process struct {

--- a/proxy/process_test.go
+++ b/proxy/process_test.go
@@ -26,9 +26,9 @@ func TestProcess_AutomaticallyStartsUpstream(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	// process is automatically started
-	assert.False(t, process.IsRunning())
+	assert.Equal(t, StateStopped, process.CurrentState())
 	process.ProxyRequest(w, req)
-	assert.True(t, process.IsRunning())
+	assert.Equal(t, StateReady, process.CurrentState())
 
 	assert.Equal(t, http.StatusOK, w.Code, "Expected status code %d, got %d", http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), expectedMessage)
@@ -91,14 +91,14 @@ func TestProcess_UnloadAfterTTL(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code, "Expected status code %d, got %d", http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), expectedMessage)
 
-	assert.True(t, process.IsRunning())
+	assert.Equal(t, StateReady, process.CurrentState())
 
 	// wait 5 seconds
 	time.Sleep(5 * time.Second)
-
-	assert.False(t, process.IsRunning())
+	assert.Equal(t, StateStopped, process.CurrentState())
 }
 
+// issue #19
 func TestProcess_HTTPRequestsHaveTimeToFinish(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping long auto unload TTL test")
@@ -118,19 +118,12 @@ func TestProcess_HTTPRequestsHaveTimeToFinish(t *testing.T) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 
-	// after 20ms tell the process to Stop() this should
-	// wait until all queued http requests have completed
-	go func() {
-		<-time.After(20 * time.Millisecond)
-		//process.Stop()
-	}()
-
 	for key := range results {
 		wg.Add(1)
 		go func(key string) {
 			defer wg.Done()
-			// Send a request that takes 100ms to complete (10 characters, 10ms / character)
-			req := httptest.NewRequest("GET", fmt.Sprintf("/slow-respond?echo=%s&delay=100ms", key), nil)
+			// send a request that should take 5 * 200ms (1 second) to complete
+			req := httptest.NewRequest("GET", fmt.Sprintf("/slow-respond?echo=%s&delay=200ms", key), nil)
 			w := httptest.NewRecorder()
 
 			process.ProxyRequest(w, req)
@@ -145,6 +138,12 @@ func TestProcess_HTTPRequestsHaveTimeToFinish(t *testing.T) {
 
 		}(key)
 	}
+
+	// stop the requests in the middle
+	go func() {
+		<-time.After(500 * time.Millisecond)
+		process.Stop()
+	}()
 
 	wg.Wait()
 

--- a/proxy/process_test.go
+++ b/proxy/process_test.go
@@ -101,7 +101,7 @@ func TestProcess_UnloadAfterTTL(t *testing.T) {
 // issue #19
 func TestProcess_HTTPRequestsHaveTimeToFinish(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping long auto unload TTL test")
+		t.Skip("skipping long test")
 	}
 
 	expectedMessage := "12345"

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -69,9 +69,14 @@ func (pm *ProxyManager) StopProcesses() {
 
 // for internal usage
 func (pm *ProxyManager) stopProcesses() {
+	if len(pm.currentProcesses) == 0 {
+		return
+	}
+
 	for _, process := range pm.currentProcesses {
 		process.Stop()
 	}
+
 	pm.currentProcesses = make(map[string]*Process)
 }
 
@@ -185,7 +190,6 @@ func (pm *ProxyManager) proxyChatRequestHandler(c *gin.Context) {
 
 		process.ProxyRequest(c.Writer, c.Request)
 	}
-
 }
 
 func (pm *ProxyManager) proxyNoRouteHandler(c *gin.Context) {

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -72,5 +74,61 @@ func TestProxyManager_SwapMultiProcess(t *testing.T) {
 
 	_, exists = proxy.currentProcesses["test/model2"]
 	assert.True(t, exists, "expected test/model2 key in currentProcesses")
+}
 
+// When a request for a different model comes in ProxyManager should wait until
+// the first request is complete before swapping. Both requests should complete
+func TestProxyManager_SwapMultiProcessParallelRequests(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow test")
+	}
+
+	config := &Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]ModelConfig{
+			"model1": getTestSimpleResponderConfig("model1"),
+			"model2": getTestSimpleResponderConfig("model2"),
+			"model3": getTestSimpleResponderConfig("model3"),
+		},
+	}
+
+	proxy := New(config)
+
+	results := map[string]string{}
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	for key := range config.Models {
+		wg.Add(1)
+		go func(key string) {
+			defer wg.Done()
+
+			reqBody := fmt.Sprintf(`{"model":"%s"}`, key)
+			req := httptest.NewRequest("POST", "/v1/chat/completions?wait=1500ms", bytes.NewBufferString(reqBody))
+			w := httptest.NewRecorder()
+
+			proxy.HandlerFunc(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("Expected status OK, got %d for key %s", w.Code, key)
+			}
+
+			mu.Lock()
+
+			results[key] = w.Body.String()
+			mu.Unlock()
+		}(key)
+
+		<-time.After(time.Millisecond)
+	}
+
+	wg.Wait()
+	assert.Len(t, results, len(config.Models))
+
+	for key, result := range results {
+		assert.Equal(t, key, result)
+	}
+
+	proxy.StopProcesses()
 }

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -93,6 +93,7 @@ func TestProxyManager_SwapMultiProcessParallelRequests(t *testing.T) {
 	}
 
 	proxy := New(config)
+	defer proxy.StopProcesses()
 
 	results := map[string]string{}
 
@@ -105,7 +106,7 @@ func TestProxyManager_SwapMultiProcessParallelRequests(t *testing.T) {
 			defer wg.Done()
 
 			reqBody := fmt.Sprintf(`{"model":"%s"}`, key)
-			req := httptest.NewRequest("POST", "/v1/chat/completions?wait=1500ms", bytes.NewBufferString(reqBody))
+			req := httptest.NewRequest("POST", "/v1/chat/completions?wait=1000ms", bytes.NewBufferString(reqBody))
 			w := httptest.NewRecorder()
 
 			proxy.HandlerFunc(w, req)
@@ -129,6 +130,4 @@ func TestProxyManager_SwapMultiProcessParallelRequests(t *testing.T) {
 	for key, result := range results {
 		assert.Equal(t, key, result)
 	}
-
-	proxy.StopProcesses()
 }


### PR DESCRIPTION
Refactor synchronization logic so: 

- Processes wait until all in progress requests are completed before stopping
- improve stopping logic (likely not compatible with Windows now)
- add test for concurrency 
- rewrite `simple-responder` to simulate slow responses 

Demonstration: 

- ✅ requests are queued until they are completed before swapping
- ✅ no dropped or broken requests 
- ✅ requests routed to correct llama.cpp when using Profiles. No swapping

Set up: MBP M1 Pro - 32GB RAM. Models: llama-3.2-1B and qwen-2.5-0.5B

https://github.com/user-attachments/assets/9138956a-10e9-43af-bbef-6a524ddbd2b3

