### PR TITLE
Add cmd_stop configuration to better support docker (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Introduction
 llama-swap is a light weight, transparent proxy server that provides automatic model swapping to llama.cpp's server.
 
-Written in golang, it is very easy to install (single binary with no dependancies) and configure (single yaml file). 
+Written in golang, it is very easy to install (single binary with no dependancies) and configure (single yaml file).
 
 Download a pre-built [release](https://github.com/mostlygeek/llama-swap/releases) or build it yourself from source with `make clean all`.
 
@@ -30,11 +30,13 @@ Any OpenAI compatible server would work. llama-swap was originally designed for 
   - `v1/rerank`
   - `v1/audio/speech` ([#36](https://github.com/mostlygeek/llama-swap/issues/36))
 - ✅ Multiple GPU support
+- ✅ Docker Support ([#40](https://github.com/mostlygeek/llama-swap/pull/40))
 - ✅ Run multiple models at once with `profiles`
 - ✅ Remote log monitoring at `/log`
 - ✅ Automatic unloading of models from GPUs after timeout
 - ✅ Use any local OpenAI compatible server (llama.cpp, vllm, tabbyAPI, etc)
 - ✅ Direct access to upstream HTTP server via `/upstream/:model_id` ([demo](https://github.com/mostlygeek/llama-swap/pull/31))
+-
 
 ## config.yaml
 
@@ -88,6 +90,20 @@ models:
   "qwen-unlisted":
     cmd: llama-server --port 9999 -m Llama-3.2-1B-Instruct-Q4_K_M.gguf -ngl 0
     unlisted: true
+
+  # Docker Support (Experimental)
+  # see: https://github.com/mostlygeek/llama-swap/pull/40
+  "dockertest":
+    proxy: "http://127.0.0.1:9790"
+
+    # introduced to reliably stop containers
+    cmd_stop: docker stop -t 2 dockertest
+
+    cmd: >
+      docker run --name dockertest
+      --init --rm -p 9790:8080 -v /mnt/nvme/models:/models
+      ghcr.io/ggerganov/llama.cpp:server
+      --model '/models/Qwen2.5-Coder-0.5B-Instruct-Q4_K_M.gguf'
 
 # profiles make it easy to managing multi model (and gpu) configurations.
 #

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -53,6 +53,21 @@ models:
       --ctx-size 8192
       --reranking
 
+  # EXPERIMENTAL! Docker Support
+  # see:
+  #  - https://github.com/mostlygeek/llama-swap/pull/40
+  #  - https://github.com/mostlygeek/llama-swap/issues/35
+  "dockertest":
+    proxy: "http://127.0.0.1:9790"
+
+    # use this to reliably stop named containers
+    cmd_stop: docker stop -t 2 dockertest
+
+    cmd: >
+      docker run --name dockertest
+      --init --rm -p 9790:8080 -v /mnt/nvme/models:/models
+      ghcr.io/ggerganov/llama.cpp:server
+      --model '/models/Qwen2.5-Coder-0.5B-Instruct-Q4_K_M.gguf'
 
   "simple":
     # example of setting environment variables

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -11,6 +11,7 @@ import (
 
 type ModelConfig struct {
 	Cmd           string   `yaml:"cmd"`
+	CmdStop       string   `yaml:"cmd_stop"`
 	Proxy         string   `yaml:"proxy"`
 	Aliases       []string `yaml:"aliases"`
 	Env           []string `yaml:"env"`
@@ -21,6 +22,9 @@ type ModelConfig struct {
 
 func (m *ModelConfig) SanitizedCommand() ([]string, error) {
 	return SanitizeCommand(m.Cmd)
+}
+func (m *ModelConfig) SanitizeCommandStop() ([]string, error) {
+	return SanitizeCommand(m.CmdStop)
 }
 
 type Config struct {

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -188,6 +188,11 @@ func (p *Process) Stop() {
 			// leave the state as it is?
 			return
 		}
+
+		err = cmd.Wait()
+		if err != nil {
+			fmt.Fprintf(p.logMonitor, "!!! WARNING error waiting for stop command to complete: %v", err)
+		}
 	} else {
 		sigtermTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -153,13 +153,13 @@ func (p *Process) Stop() {
 	defer p.stateMutex.Unlock()
 
 	if p.state != StateReady {
-		fmt.Fprintf(p.logMonitor, "!!! Stop() called but Process State is not READY")
+		fmt.Fprintf(p.logMonitor, "!!! Stop() called but Process State is not READY\n")
 		return
 	}
 
 	if p.cmd == nil || p.cmd.Process == nil {
 		// this situation should never happen... but if it does just update the state
-		fmt.Fprintf(p.logMonitor, "!!! State is Ready but Command is nil.")
+		fmt.Fprintf(p.logMonitor, "!!! State is Ready but Command is nil.\n")
 		p.state = StateStopped
 		return
 	}

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -171,19 +171,19 @@ func (p *Process) Stop() {
 		// for issue #35 to do things like `docker stop`
 		args, err := p.config.SanitizeCommandStop()
 		if err != nil {
-			fmt.Fprintf(p.logMonitor, "!!! Error sanitizing stop command: %v", err)
+			fmt.Fprintf(p.logMonitor, "!!! Error sanitizing stop command: %v\n", err)
 
 			// leave the state as it is?
 			return
 		}
 
-		fmt.Fprintf(p.logMonitor, "!!! Running stop command: %s", strings.Join(args, " "))
+		fmt.Fprintf(p.logMonitor, "!!! Running stop command: %s\n", strings.Join(args, " "))
 		cmd := exec.Command(args[0], args[1:]...)
 		cmd.Stdout = p.logMonitor
 		cmd.Stderr = p.logMonitor
 		err = cmd.Start()
 		if err != nil {
-			fmt.Fprintf(p.logMonitor, "!!! Error running stop command: %v", err)
+			fmt.Fprintf(p.logMonitor, "!!! Error running stop command: %v\n", err)
 
 			// leave the state as it is?
 			return
@@ -191,7 +191,7 @@ func (p *Process) Stop() {
 
 		err = cmd.Wait()
 		if err != nil {
-			fmt.Fprintf(p.logMonitor, "!!! WARNING error waiting for stop command to complete: %v", err)
+			fmt.Fprintf(p.logMonitor, "!!! WARNING error waiting for stop command to complete: %v\n", err)
 		}
 	} else {
 		sigtermTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -177,6 +177,7 @@ func (p *Process) Stop() {
 			return
 		}
 
+		fmt.Fprintf(p.logMonitor, "!!! Running stop command: %s", strings.Join(args, " "))
 		cmd := exec.Command(args[0], args[1:]...)
 		cmd.Stdout = p.logMonitor
 		cmd.Stderr = p.logMonitor


### PR DESCRIPTION
Add a new `cmd_stop` configuration directive for models. Instead of the default behaviour of sending a `SIGTERM` this will instead run this command. In my testing it works in starting and stopping docker containers correctly. 

Example configuration: 

```yaml
models:

  # vllm via docker
  "qwen2-vl-7B-gptq-int8":
    aliases:
      - gpt-4-vision
    proxy: "http://127.0.0.1:9797"
    cmd_stop: docker stop qwen2vl
    cmd: >
      docker run --init --rm --runtime=nvidia --name qwen2vl
      --gpus '"device=3"'
      -v /mnt/nvme/models:/models
      -p 9797:8000 vllm/vllm-openai:v0.6.4
      --model "/models/Qwen/Qwen2-VL-7B-Instruct-GPTQ-Int8"
      --served-model-name gpt-4-vision qwen2-vl-7B-gptq-int8
      --disable-log-stats --enforce-eager

  # these are for testing the swapping functionality. The non-cuda llama.cpp container is used
  # with a tiny model for testing due to major delay on startup, see:
  #   - https://github.com/ggerganov/llama.cpp/issues/9492
  #   - https://github.com/ggerganov/llama.cpp/discussions/11005
  "docker1":
    proxy: "http://127.0.0.1:9790"
    cmd_stop: docker stop -t 2 dockertest1
    cmd: >
      docker run --init --rm
      -p 9790:8080 -v /mnt/nvme/models:/models --name dockertest1
      ghcr.io/ggerganov/llama.cpp:server --model '/models/Qwen2.5-Coder-0.5B-Instruct-Q4_K_M.gguf'      

  "docker2":
    proxy: "http://127.0.0.1:9791"
    cmd_stop: docker stop -t 2 dockertest2
    cmd: >
      docker run --init --rm
      -p 9791:8080 -v /mnt/nvme/models:/models --name dockertest2
      ghcr.io/ggerganov/llama.cpp:server --model '/models/Qwen2.5-Coder-0.5B-Instruct-Q4_K_M.gguf'
```

Usage notes: 
 - `cmd_stop` and docker works best when using named containers like, `docker1`, `docker2`, etc. 
 - use unique port numbers for each container! Since there are a lot of messaging between processes there is a high chance of race conditions. Using a unique port per model config avoids this with less complexity.
