### PR TITLE
remove cmd_stop configuration and functionality from PR #40

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,12 @@ Any OpenAI compatible server would work. llama-swap was originally designed for 
   - `v1/rerank`
   - `v1/audio/speech` ([#36](https://github.com/mostlygeek/llama-swap/issues/36))
 - ✅ Multiple GPU support
-- ✅ Docker Support ([#40](https://github.com/mostlygeek/llama-swap/pull/40))
+- ✅ Docker and Podman support
 - ✅ Run multiple models at once with `profiles`
 - ✅ Remote log monitoring at `/log`
 - ✅ Automatic unloading of models from GPUs after timeout
 - ✅ Use any local OpenAI compatible server (llama.cpp, vllm, tabbyAPI, etc)
 - ✅ Direct access to upstream HTTP server via `/upstream/:model_id` ([demo](https://github.com/mostlygeek/llama-swap/pull/31))
--
 
 ## config.yaml
 
@@ -91,14 +90,9 @@ models:
     cmd: llama-server --port 9999 -m Llama-3.2-1B-Instruct-Q4_K_M.gguf -ngl 0
     unlisted: true
 
-  # Docker Support (Experimental)
-  # see: https://github.com/mostlygeek/llama-swap/pull/40
-  "dockertest":
+  # Docker Support (v26.1.4+ required!)
+  "docker-llama":
     proxy: "http://127.0.0.1:9790"
-
-    # introduced to reliably stop containers
-    cmd_stop: docker stop -t 2 dockertest
-
     cmd: >
       docker run --name dockertest
       --init --rm -p 9790:8080 -v /mnt/nvme/models:/models

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -53,16 +53,12 @@ models:
       --ctx-size 8192
       --reranking
 
-  # EXPERIMENTAL! Docker Support
+  # Docker Support (v26.1.4+ required!)
   # see:
   #  - https://github.com/mostlygeek/llama-swap/pull/40
   #  - https://github.com/mostlygeek/llama-swap/issues/35
   "dockertest":
     proxy: "http://127.0.0.1:9790"
-
-    # use this to reliably stop named containers
-    cmd_stop: docker stop -t 2 dockertest
-
     cmd: >
       docker run --name dockertest
       --init --rm -p 9790:8080 -v /mnt/nvme/models:/models

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -54,9 +54,6 @@ models:
       --reranking
 
   # Docker Support (v26.1.4+ required!)
-  # see:
-  #  - https://github.com/mostlygeek/llama-swap/pull/40
-  #  - https://github.com/mostlygeek/llama-swap/issues/35
   "dockertest":
     proxy: "http://127.0.0.1:9790"
     cmd: >

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -11,7 +11,6 @@ import (
 
 type ModelConfig struct {
 	Cmd           string   `yaml:"cmd"`
-	CmdStop       string   `yaml:"cmd_stop"`
 	Proxy         string   `yaml:"proxy"`
 	Aliases       []string `yaml:"aliases"`
 	Env           []string `yaml:"env"`
@@ -22,9 +21,6 @@ type ModelConfig struct {
 
 func (m *ModelConfig) SanitizedCommand() ([]string, error) {
 	return SanitizeCommand(m.Cmd)
-}
-func (m *ModelConfig) SanitizeCommandStop() ([]string, error) {
-	return SanitizeCommand(m.CmdStop)
 }
 
 type Config struct {

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -35,11 +35,6 @@ models:
     aliases:
       - "m2"
     checkEndpoint: "/"
-  docker:
-    cmd: docker run -p 9999:8080 --name "my_container"
-    cmd_stop: docker stop my_container
-    proxy: "http://localhost:9999"
-    checkEndpoint: "/health"
 healthCheckTimeout: 15
 profiles:
   test:
@@ -61,7 +56,6 @@ profiles:
 		Models: map[string]ModelConfig{
 			"model1": {
 				Cmd:           "path/to/cmd --arg1 one",
-				CmdStop:       "",
 				Proxy:         "http://localhost:8080",
 				Aliases:       []string{"m1", "model-one"},
 				Env:           []string{"VAR1=value1", "VAR2=value2"},
@@ -69,18 +63,10 @@ profiles:
 			},
 			"model2": {
 				Cmd:           "path/to/cmd --arg1 one",
-				CmdStop:       "",
 				Proxy:         "http://localhost:8081",
 				Aliases:       []string{"m2"},
 				Env:           nil,
 				CheckEndpoint: "/",
-			},
-			"docker": {
-				Cmd:           `docker run -p 9999:8080 --name "my_container"`,
-				CmdStop:       "docker stop my_container",
-				Proxy:         "http://localhost:9999",
-				Env:           nil,
-				CheckEndpoint: "/health",
 			},
 		},
 		HealthCheckTimeout: 15,
@@ -111,18 +97,6 @@ func TestConfig_ModelConfigSanitizedCommand(t *testing.T) {
 	args, err := config.SanitizedCommand()
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"python", "model1.py", "--arg1", "value1", "--arg2", "value2"}, args)
-}
-
-func TestConfig_ModelConfigSanitizedCommandStop(t *testing.T) {
-	config := &ModelConfig{
-		CmdStop: `docker stop my_container \
-		--arg1 1
-		--arg2 2`,
-	}
-
-	args, err := config.SanitizeCommandStop()
-	assert.NoError(t, err)
-	assert.Equal(t, []string{"docker", "stop", "my_container", "--arg1", "1", "--arg2", "2"}, args)
 }
 
 func TestConfig_FindConfig(t *testing.T) {


### PR DESCRIPTION
After determining that docker v26.1.4+ is required for SIGTERM to `docker run ...` to work I'm reverting the `cmd_stop` functionality how it was before #40. Now llama-swap will only support SIGTERM, the unix way 😆 
