### PR TITLE
Improve shutdown behaviour (#47)

### DIFF
--- a/llama-swap.go
+++ b/llama-swap.go
@@ -47,7 +47,7 @@ func main() {
 	go func() {
 		<-sigChan
 		fmt.Println("Shutting down llama-swap")
-		proxyManager.StopProcesses()
+		proxyManager.Shutdown()
 		os.Exit(0)
 	}()
 

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -22,8 +22,6 @@ const (
 )
 
 type Process struct {
-	sync.Mutex
-
 	ID                 string
 	config             ModelConfig
 	cmd                *exec.Cmd

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -371,7 +371,7 @@ func (p *Process) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 	if p.CurrentState() != StateReady {
 		if err := p.start(); err != nil {
 			errstr := fmt.Sprintf("unable to start process: %s", err)
-			http.Error(w, errstr, http.StatusInternalServerError)
+			http.Error(w, errstr, http.StatusBadGateway)
 			return
 		}
 	}

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -187,11 +187,11 @@ loop:
 		case <-p.shutdownCtx.Done():
 			return errors.New("health check interrupted due to shutdown")
 		default:
-			if err := p.checkHealthEndpoint(endpoint); err != nil {
-				fmt.Printf("!!! Health check failed: %v\n", err)
-			} else {
+			if err := p.checkHealthEndpoint(endpoint); err == nil {
 				cancelHealthCheck()
 				break loop
+			} else {
+				//fmt.Printf("!!! Health check failed: %v\n", err)
 			}
 		}
 

--- a/proxy/process_test.go
+++ b/proxy/process_test.go
@@ -292,7 +292,6 @@ func TestProcess_ShutdownInterruptsHealthCheck(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		<-time.After(time.Second * 2)
-		fmt.Println("Shutting down")
 		process.Shutdown()
 	}()
 	wg.Add(1)

--- a/proxy/process_test.go
+++ b/proxy/process_test.go
@@ -89,7 +89,7 @@ func TestProcess_BrokenModelConfig(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 	process.ProxyRequest(w, req)
-	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Equal(t, http.StatusBadGateway, w.Code)
 	assert.Contains(t, w.Body.String(), "unable to start process")
 
 	w = httptest.NewRecorder()

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -157,7 +157,7 @@ func (pm *ProxyManager) stopProcesses() {
 	}
 
 	for _, process := range pm.currentProcesses {
-		process.Stop()
+		process.Shutdown()
 	}
 
 	pm.currentProcesses = make(map[string]*Process)


### PR DESCRIPTION
Introduce `Process.Shutdown()` and `ProxyManager.Shutdown()`. These two function required a lot of internal process state management refactoring. A key benefit is that `Process.start()` is now interruptable. When `Shutdown()` is called it will break the long health check loop. 

State management within Process is also improved. Added `starting`, `stopping` and `shutdown` states. Additionally, introduced a simple finite state machine to manage transitions.  