### PR TITLE
add Windows build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ linux:
 	@echo "Building Linux binary..."
 	GOOS=linux GOARCH=amd64 go build -ldflags="-X main.commit=${GIT_HASH} -X main.version=local_${GIT_HASH} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-linux-amd64
 
+# Build Windows binary
+windows:
+	@echo "Building Windows binary..."
+	GOOS=windows GOARCH=amd64 go build -ldflags="-X main.commit=${GIT_HASH} -X main.version=local_${GIT_HASH} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-windows-amd64.exe
+
 # for testing proxy.Process
 simple-responder:
 	@echo "Building simple responder"
@@ -60,4 +65,4 @@ release:
 	git tag "$$new_tag";
 
 # Phony targets
-.PHONY: all clean mac linux
+.PHONY: all clean mac linux windows

--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ Pre-built binaries are available for Linux, FreeBSD and Darwin (OSX). These are 
 
 1. Create a configuration file, see [config.example.yaml](config.example.yaml)
 1. Download a [release](https://github.com/mostlygeek/llama-swap/releases) appropriate for your OS and architecture.
-   - _Note: Windows currently untested._
 1. Run the binary with `llama-swap --config path/to/config.yaml`
 
 ### Building from source


### PR DESCRIPTION
Tested and working.

I did not add it to the default target or to the CI, since I am not sure if you want to release Windows binaries.