### PR TITLE
Adds an endpoint '/running' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Written in golang, it is very easy to install (single binary with no dependancie
 - ✅ Remote log monitoring at `/log`
 - ✅ Direct access to upstream HTTP server via `/upstream/:model_id` ([demo](https://github.com/mostlygeek/llama-swap/pull/31))
 - ✅ Manually unload models via `/unload` endpoint ([#58](https://github.com/mostlygeek/llama-swap/issues/58))
+- ✅ Check current monitoring state via `/running` endpoint ([#61](https://github.com/mostlygeek/llama-swap/issues/61))
 - ✅ Automatic unloading of models after timeout by setting a `ttl`
 - ✅ Use any local OpenAI compatible server (llama.cpp, vllm, tabbyAPI, etc)
 - ✅ Docker and Podman support

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -108,6 +108,8 @@ func New(config *Config) *ProxyManager {
 
 	pm.ginEngine.GET("/unload", pm.unloadAllModelsHandler)
 
+	pm.ginEngine.GET("/running", pm.running)
+
 	pm.ginEngine.GET("/", func(c *gin.Context) {
 		// Set the Content-Type header to text/html
 		c.Header("Content-Type", "text/html")
@@ -385,6 +387,27 @@ func (pm *ProxyManager) sendErrorResponse(c *gin.Context, statusCode int, messag
 func (pm *ProxyManager) unloadAllModelsHandler(c *gin.Context) {
 	pm.StopProcesses()
 	c.String(http.StatusOK, "OK")
+}
+
+func (pm *ProxyManager) running(context *gin.Context) {
+	context.Header("Content-Type", "application/json")
+	response := gin.H{} // Default to an empty JSON object
+
+	for _, process := range pm.currentProcesses {
+		if process.config.Unlisted {
+			break // Stop checking if an unlisted process is found
+		}
+
+		// Assign response with model details
+		response = gin.H{
+			"model": process.ID,
+			"state": process.state,
+		}
+		break // Exit loop after finding a valid model
+
+	}
+
+	context.JSON(http.StatusOK, response) // Always return 200 OK
 }
 
 func ProcessKeyName(groupName, modelName string) string {

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -350,6 +350,7 @@ func TestProxyManager_StripProfileSlug(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "ok")
 }
 
+// Test issue #61 `Listing the current list of models and the loaded model.`
 func TestProxyManager_RunningEndpoint(t *testing.T) {
 	// Define a helper struct to parse the JSON response
 	type RunningResponse struct {
@@ -372,7 +373,11 @@ func TestProxyManager_RunningEndpoint(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 
 		var response RunningResponse
+
+		// Check if this is a valid JSON object
 		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+
+		// We should have an empty running array here.
 		assert.Empty(t, response.Running, "expected no running models")
 	})
 
@@ -387,14 +392,14 @@ func TestProxyManager_RunningEndpoint(t *testing.T) {
 		proxy := New(config)
 		defer proxy.StopProcesses()
 
-		// Load model1
+		// Load just a model.
 		reqBody := `{"model":"model1"}`
 		req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
 		w := httptest.NewRecorder()
 		proxy.HandlerFunc(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		// Check /running
+		// Simulate browser call fro /running.
 		req = httptest.NewRequest("GET", "/running", nil)
 		w = httptest.NewRecorder()
 		proxy.HandlerFunc(w, req)
@@ -402,8 +407,13 @@ func TestProxyManager_RunningEndpoint(t *testing.T) {
 		var response RunningResponse
 		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 
+		// Check if we have a single array element.
 		assert.Len(t, response.Running, 1)
+
+		// Is this the right model?
 		assert.Equal(t, "model1", response.Running[0].Model)
+
+		// Is the model loaded?
 		assert.Equal(t, "ready", response.Running[0].State)
 	})
 
@@ -426,7 +436,7 @@ func TestProxyManager_RunningEndpoint(t *testing.T) {
 		proxy := New(config)
 		defer proxy.StopProcesses()
 
-		// Load both models through profile
+		// Load more than one model
 		for _, model := range []string{model1, model2} {
 			profileModel := ProcessKeyName(profileName, model)
 			reqBody := fmt.Sprintf(`{"model":"%s"}`, profileModel)
@@ -436,26 +446,33 @@ func TestProxyManager_RunningEndpoint(t *testing.T) {
 			assert.Equal(t, http.StatusOK, w.Code)
 		}
 
-		// Verify /running
+		// Simulate  the browser call
 		req := httptest.NewRequest("GET", "/running", nil)
 		w := httptest.NewRecorder()
 		proxy.HandlerFunc(w, req)
 
 		var response RunningResponse
+
+		// The JSON response must be valid.
 		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
 
+		// The response should contain 2 models.
 		assert.Len(t, response.Running, 2)
 
 		expectedModels := map[string]struct{}{
 			model1: {},
 			model2: {},
 		}
+
+		// Iterate through the models and check their states as well.
 		for _, entry := range response.Running {
 			_, exists := expectedModels[entry.Model]
 			assert.True(t, exists, "unexpected model %s", entry.Model)
 			assert.Equal(t, "ready", entry.State)
 			delete(expectedModels, entry.Model)
 		}
-		assert.Empty(t, expectedModels, "missing models in response")
+
+		// Since we deleted each model while testing for its validity we should have no more models in the response.
+		assert.Empty(t, expectedModels, "unexpected additional models in response")
 	})
 }


### PR DESCRIPTION
The endpoint returns either an empty JSON object if no model has been loaded so far, or the last model loaded (model key) and it's current state (state key). Possible state values are: stopped, starting, ready and stopping.

Example output if the endpoint is called right after llama-swap has been started:
        **{
          "running": []
        }** 

Example output if the endpoint is called and a model is still being loaded:
        **{
          "running": [
            {
              "model": "DeepSeek-V3-Q4_K_M",
              "state": "starting"
            }
          ]
        }**

Example output if the endpoint is called and a model has been loaded:
        **{
          "running": [
            {
              "model": "DeepSeek-V3-Q4_K_M",
              "state": "ready"
            }
          ]
        }**

Example output if the endpoint is called and a model is being unloaded due to TTL:
        **{
          "running": [
            {
              "model": "DeepSeek-V3-Q4_K_M",
              "state": "stopping"
            }
          ]
        }**

Example output if the endpoint is called and a model has been unloaded due to TTL:
        **{
          "running": [
            {
              "model": "DeepSeek-V3-Q4_K_M",
              "state": "stopped"
            }
          ]
        }**

Example output if the endpoint is called and multiple models have been loaded:
        **{
          "running": [
            {
              "model": "MetaLlama-70B-Q4_K_M",
              "state": "ready"
            },
            {
              "model": "MetaLlama-3B-Q8",
              "state": "ready"
            }
          ]
        }**
