### PR TITLE
Add graceful process termination on Windows

### DIFF
--- a/proxy/process.go
+++ b/proxy/process.go
@@ -304,7 +304,9 @@ func (p *Process) stopCommand(sigtermTTL time.Duration) {
 		return
 	}
 
-	p.cmd.Process.Signal(syscall.SIGTERM)
+	if err := p.terminateProcess(); err != nil {
+		fmt.Fprintf(p.logMonitor, "!!! failed to gracefully terminate process [%s]: %v\n", p.ID, err)
+	}
 
 	select {
 	case <-sigtermTimeout.Done():

--- a/proxy/process_stop.go
+++ b/proxy/process_stop.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package proxy
+
+import "syscall"
+
+func (p *Process) terminateProcess() error {
+	return p.cmd.Process.Signal(syscall.SIGTERM)
+}

--- a/proxy/process_stop_windows.go
+++ b/proxy/process_stop_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package proxy
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func (p *Process) terminateProcess() error {
+	pid := fmt.Sprintf("%d", p.cmd.Process.Pid)
+	cmd := exec.Command("taskkill", "/f", "/t", "/pid", pid)
+	return cmd.Run()
+}


### PR DESCRIPTION
On Windows, the `SIGTERM` signal is ignored, and `p.Signal()` always returns `EWINDOWS` (see [Go source code](https://cs.opensource.google/go/go/+/refs/tags/go1.24.1:src/os/exec_windows.go;l=51)). Previously, this behavior was not handled, causing the code to always fall through to the forceful termination path. As a result, when KoboldCPP is used as a runner, it leaves dangling processes running due to its internal use of a process tree.


This pull request introduces a special case behavior for Windows. It utilizes the [`taskkill`](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/taskkill) command to terminate the entire child process tree. This ensures that all processes are properly terminated, preventing dangling processes from remaining active. Currently, it runs `taskkill /f`, which is forceful, but I haven't observed any adverse effects from this yet.