### PR TITLE
Logging Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/mostlygeek/llama-swap/go-ci.yml)
 ![GitHub Repo stars](https://img.shields.io/github/stars/mostlygeek/llama-swap)
 
-
-
 # llama-swap
 
 llama-swap is a light weight, transparent proxy server that provides automatic model swapping to llama.cpp's server.
@@ -69,8 +67,8 @@ models:
 # Default (and minimum) is 15 seconds
 healthCheckTimeout: 60
 
-# Write HTTP logs (useful for troubleshooting), defaults to false
-logRequests: true
+# Valid log levels: debug, info (default), warn, error
+logLevel: info
 
 # define valid model values and the upstream server start
 models:
@@ -221,8 +219,14 @@ Of course, CLI access is also supported:
 # sends up to the last 10KB of logs
 curl http://host/logs'
 
-# streams logs
+# streams combined logs
 curl -Ns 'http://host/logs/stream'
+
+# just llama-swap's logs
+curl -Ns 'http://host/logs/stream/proxy'
+
+# just upstream's logs
+curl -Ns 'http://host/logs/stream/upstream'
 
 # stream and filter logs with linux pipes
 curl -Ns http://host/logs/stream | grep 'eval time'

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,8 +2,8 @@
 # Default (and minimum): 15 seconds
 healthCheckTimeout: 90
 
-# Log HTTP requests helpful for troubleshoot, defaults to False
-logRequests: true
+# valid log levels: debug, info (default), warn, error
+logLevel: info
 
 models:
   "llama":

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,6 @@
 # Seconds to wait for llama.cpp to be available to serve requests
 # Default (and minimum): 15 seconds
-healthCheckTimeout: 15
+healthCheckTimeout: 90
 
 # Log HTTP requests helpful for troubleshoot, defaults to False
 logRequests: true

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -27,6 +27,7 @@ func (m *ModelConfig) SanitizedCommand() ([]string, error) {
 type Config struct {
 	HealthCheckTimeout int                    `yaml:"healthCheckTimeout"`
 	LogRequests        bool                   `yaml:"logRequests"`
+	LogLevel           string                 `yaml:"logLevel"`
 	Models             map[string]ModelConfig `yaml:"models"`
 	Profiles           map[string][]string    `yaml:"profiles"`
 

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -93,10 +93,12 @@ func (p *Process) swapState(expectedState, newState ProcessState) (ProcessState,
 	}
 
 	if !isValidTransition(p.state, newState) {
+		p.proxyLogger.Warnf("Invalid state transition from %s to %s", p.state, newState)
 		return p.state, ErrInvalidStateTransition
 	}
 
 	p.state = newState
+	p.proxyLogger.Debugf("State transition from %s to %s", expectedState, newState)
 	return p.state, nil
 }
 

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -68,6 +68,11 @@ func NewProcess(ID string, healthCheckTimeout int, config ModelConfig, logMonito
 	}
 }
 
+// LogMonitor returns the log monitor associated with the process.
+func (p *Process) LogMonitor() *LogMonitor {
+	return p.logMonitor
+}
+
 // custom error types for swapping state
 var (
 	ErrExpectedStateMismatch  = errors.New("expected state mismatch")

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -97,8 +97,8 @@ func (p *Process) swapState(expectedState, newState ProcessState) (ProcessState,
 		return p.state, ErrInvalidStateTransition
 	}
 
-	p.state = newState
 	p.proxyLogger.Debugf("State transition from %s to %s", expectedState, newState)
+	p.state = newState
 	return p.state, nil
 }
 

--- a/proxy/process_test.go
+++ b/proxy/process_test.go
@@ -257,9 +257,8 @@ func TestProcess_SwapState(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			p := &Process{
-				state: test.currentState,
-			}
+			p := NewProcess("test", 10, getTestSimpleResponderConfig("test"), discardLogger, discardLogger)
+			p.state = test.currentState
 
 			resultState, err := p.swapState(test.expectedState, test.newState)
 			if err != nil && test.expectedError == nil {

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -289,15 +289,14 @@ func (pm *ProxyManager) swapModel(requestedModel string) (*Process, error) {
 
 	// stop all running models
 	pm.stopProcesses()
-
+	processLogMonitor := NewLogMonitorWriter(pm.muxLogger)
 	if profileName == "" {
 		modelConfig, modelID, found := pm.config.FindConfig(realModelName)
 		if !found {
 			return nil, fmt.Errorf("could not find configuration for %s", realModelName)
 		}
 
-		processLogMonitor := NewLogMonitorWriter(pm.muxLogger)
-		process := NewProcess(modelID, pm.config.HealthCheckTimeout, modelConfig, processLogMonitor)
+		process := NewProcess(modelID, pm.config.HealthCheckTimeout, modelConfig, processLogMonitor, pm.proxyLogger)
 		processKey := ProcessKeyName(profileName, modelID)
 		pm.currentProcesses[processKey] = process
 	} else {
@@ -308,7 +307,7 @@ func (pm *ProxyManager) swapModel(requestedModel string) (*Process, error) {
 					return nil, fmt.Errorf("could not find configuration for %s in group %s", realModelName, profileName)
 				}
 
-				process := NewProcess(modelID, pm.config.HealthCheckTimeout, modelConfig, pm.proxyLogger)
+				process := NewProcess(modelID, pm.config.HealthCheckTimeout, modelConfig, processLogMonitor, pm.proxyLogger)
 				processKey := ProcessKeyName(profileName, modelID)
 				pm.currentProcesses[processKey] = process
 			}

--- a/proxy/proxymanager_loghandlers.go
+++ b/proxy/proxymanager_loghandlers.go
@@ -138,7 +138,7 @@ func (pm *ProxyManager) getLogger(logMonitorId string) (*LogMonitor, error) {
 	if logMonitorId == "" {
 		// maintain the default
 		logger = pm.muxLogger
-	} else if logMonitorId == "_llama-swap" {
+	} else if logMonitorId == ".llama-swap" {
 		logger = pm.proxyLogger
 	} else if processLogKey != "" {
 		if process, found := pm.currentProcesses[processLogKey]; found {

--- a/proxy/proxymanager_loghandlers.go
+++ b/proxy/proxymanager_loghandlers.go
@@ -127,27 +127,15 @@ func (pm *ProxyManager) streamLogsHandlerSSE(c *gin.Context) {
 func (pm *ProxyManager) getLogger(logMonitorId string) (*LogMonitor, error) {
 	var logger *LogMonitor
 
-	// search for a specific model name if it is loaded
-	var processLogKey string
-	profileName, modelName := splitRequestedModel(logMonitorId)
-	realModelName, modelFound := pm.config.RealModelName(modelName)
-	if modelFound {
-		processLogKey = ProcessKeyName(profileName, realModelName)
-	}
-
 	if logMonitorId == "" {
 		// maintain the default
 		logger = pm.muxLogger
-	} else if logMonitorId == ".llama-swap" {
+	} else if logMonitorId == "proxy" {
 		logger = pm.proxyLogger
-	} else if processLogKey != "" {
-		if process, found := pm.currentProcesses[processLogKey]; found {
-			logger = process.LogMonitor()
-		} else {
-			return nil, fmt.Errorf("can not find logger for model because it is not currently loaded: %s", logMonitorId)
-		}
+	} else if logMonitorId == "upstream" {
+		logger = pm.upstreamLogger
 	} else {
-		return nil, fmt.Errorf("invalid configuration ID: %s", logMonitorId)
+		return nil, fmt.Errorf("invalid logger. Use 'proxy' or 'upstream'")
 	}
 
 	return logger, nil


### PR DESCRIPTION
This change revamps the internal logging architecture to be more flexible and descriptive. Previously all logs from both llama-swap and upstream services were mixed together. This makes it harder to troubleshoot and identify problems. This PR adds these new endpoints: 

- `/logs/stream/proxy` - just llama-swap's logs
- `/logs/stream/upstream` - stdout output from the upstream server 
