### PR TITLE
Send stop (and kill) signal to process group.

### DIFF
--- a/proxy/process_stop.go
+++ b/proxy/process_stop.go
@@ -2,8 +2,21 @@
 
 package proxy
 
-import "syscall"
+import (
+	"fmt"
+	"syscall"
+)
 
 func (p *Process) terminateProcess() error {
-	return p.cmd.Process.Signal(syscall.SIGTERM)
+	if p.cmd == nil || p.cmd.Process == nil {
+		return fmt.Errorf("no process to terminate")
+	}
+
+	pgid, err := syscall.Getpgid(p.cmd.Process.Pid)
+	if err != nil {
+		return fmt.Errorf("failed to get pgid: %v", err)
+	}
+
+	p.proxyLogger.Infof("Sending SIGTERM to process group -%d", pgid)
+	return syscall.Kill(-pgid, syscall.SIGTERM)
 }


### PR DESCRIPTION
When I use vLLM with tensor parallel, it will spawn multiple processes (if `-tp 2`, it will spawn 2 processes, one on each GPU). I found llama-swap unable to stop or kill the processes, so I asked ChatGPT to help me. Tested on my machine and it works.