### PR TITLE
feat: Return aliases in /v1/models too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 dist/
 .vscode
 .DS_Store
+config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .vscode
 .DS_Store
 config.yaml
+llama-swap


### PR DESCRIPTION
This includes aliases in the list of models returned by the v1/models endpoint. It's needed if you want to use some tools that expect proprietary models like o1 to exist, but a good thing to have for flexibility, regardless.