### PR TITLE
fix issue where proxy is still proxying with chunked transfer-encoding

### DIFF
--- a/proxy/process.go
+++ b/proxy/process.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -439,6 +440,12 @@ func (p *Process) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req.Header = r.Header.Clone()
+
+	contentLength, err := strconv.ParseInt(req.Header.Get("content-length"), 10, 64)
+	if err == nil {
+		req.ContentLength = contentLength
+	}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -368,6 +368,7 @@ func (pm *ProxyManager) proxyOAIHandler(c *gin.Context) {
 
 	// dechunk it as we already have all the body bytes see issue #11
 	c.Request.Header.Del("transfer-encoding")
+	c.Request.Header.Del("content-length")
 	c.Request.Header.Add("content-length", strconv.Itoa(len(bodyBytes)))
 
 	if err := processGroup.ProxyRequest(realModelName, c.Writer, c.Request); err != nil {


### PR DESCRIPTION
adding the content-length header does not seem to work for me, but setting `.ContentLength` does

see also: https://github.com/golang/go/issues/34295#issuecomment-531451326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the "content-length" header to ensure accurate request body size is set when proxying requests, preventing potential inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->