### PR TITLE
Automatic Port Numbers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ healthCheckTimeout: 60
 # Valid log levels: debug, info (default), warn, error
 logLevel: info
 
+# Automatic Port Values
+# use ${PORT} in model.cmd and model.proxy to use an automatic port number
+# when you use ${PORT} you can omit a custom model.proxy value, as it will
+# default to http://localhost:${PORT}
+
+# override the default port (5800) for automatic port values
+startPort: 10001
+
 # define valid model values and the upstream server start
 models:
   "llama":
@@ -83,6 +91,7 @@ models:
       - "CUDA_VISIBLE_DEVICES=0"
 
     # where to reach the server started by cmd, make sure the ports match
+    # can be omitted if you use an automatic ${PORT} in cmd
     proxy: http://127.0.0.1:8999
 
     # aliases names to use this model for
@@ -109,14 +118,14 @@ models:
   # but they can still be requested as normal
   "qwen-unlisted":
     unlisted: true
-    cmd: llama-server --port 9999 -m Llama-3.2-1B-Instruct-Q4_K_M.gguf -ngl 0
+    cmd: llama-server --port ${PORT} -m Llama-3.2-1B-Instruct-Q4_K_M.gguf -ngl 0
 
   # Docker Support (v26.1.4+ required!)
   "docker-llama":
-    proxy: "http://127.0.0.1:9790"
+    proxy: "http://127.0.0.1:${PORT}"
     cmd: >
       docker run --name dockertest
-      --init --rm -p 9790:8080 -v /mnt/nvme/models:/models
+      --init --rm -p ${PORT}:8080 -v /mnt/nvme/models:/models
       ghcr.io/ggerganov/llama.cpp:server
       --model '/models/Qwen2.5-Coder-0.5B-Instruct-Q4_K_M.gguf'
 

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -66,7 +66,7 @@ type Config struct {
 	aliases map[string]string
 
 	// automatic port assignments
-	StartPort int `yaml:"start_port"`
+	StartPort int `yaml:"startPort"`
 }
 
 func (c *Config) RealModelName(search string) (string, bool) {

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -63,6 +63,10 @@ type Config struct {
 
 	// map aliases to actual model IDs
 	aliases map[string]string
+
+	// automatic port assignments
+	StartPort int `yaml:"start_port"`
+	nextPort  int
 }
 
 func (c *Config) RealModelName(search string) (string, bool) {
@@ -107,6 +111,16 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 	if config.HealthCheckTimeout < 15 {
 		config.HealthCheckTimeout = 15
 	}
+
+	// set default port ranges
+	if config.StartPort == 0 {
+		// default to 5800
+		config.StartPort = 5800
+	} else if config.StartPort < 1 {
+		return Config{}, fmt.Errorf("start_port must be greater than 1")
+	}
+
+	config.nextPort = config.StartPort
 
 	// Populate the aliases map
 	config.aliases = make(map[string]string)

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -152,6 +152,8 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 			}
 			nextPort++
 			config.Models[modelId] = modelConfig
+		} else if modelConfig.Proxy == "" {
+			return Config{}, fmt.Errorf("model %s requires a proxy value when not using automatic ${PORT}", modelId)
 		}
 	}
 	config = AddDefaultGroupToConfig(config)

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -117,7 +117,7 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		// default to 5800
 		config.StartPort = 5800
 	} else if config.StartPort < 1 {
-		return Config{}, fmt.Errorf("start_port must be greater than 1")
+		return Config{}, fmt.Errorf("startPort must be greater than 1")
 	}
 
 	// Populate the aliases map

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -74,6 +74,7 @@ groups:
 	}
 
 	expected := Config{
+		StartPort: 5800,
 		Models: map[string]ModelConfig{
 			"model1": {
 				Cmd:           "path/to/cmd --arg1 one",
@@ -292,7 +293,7 @@ func TestConfig_AutomaticPortAssignments(t *testing.T) {
 		assert.Equal(t, 5800, config.StartPort)
 	})
 	t.Run("User specific port ranges", func(t *testing.T) {
-		content := `start_port: 1000`
+		content := `startPort: 1000`
 		config, err := LoadConfigFromReader(strings.NewReader(content))
 		if !assert.NoError(t, err) {
 			t.Fatalf("Failed to load config: %v", err)
@@ -302,20 +303,20 @@ func TestConfig_AutomaticPortAssignments(t *testing.T) {
 	})
 
 	t.Run("Invalid start port", func(t *testing.T) {
-		content := `start_port: abcd`
+		content := `startPort: abcd`
 		_, err := LoadConfigFromReader(strings.NewReader(content))
 		assert.NotNil(t, err)
 	})
 
 	t.Run("start port must be greater than 1", func(t *testing.T) {
-		content := `start_port: -99`
+		content := `startPort: -99`
 		_, err := LoadConfigFromReader(strings.NewReader(content))
 		assert.NotNil(t, err)
 	})
 
 	t.Run("Automatic port assignments", func(t *testing.T) {
 		content := `
-start_port: 5800
+startPort: 5800
 models:
   model1:
     cmd: svr --port ${PORT}

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -279,3 +279,47 @@ func TestConfig_SanitizeCommand(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, args)
 }
+
+func TestConfig_PortRanges(t *testing.T) {
+
+	t.Run("Default Port Ranges", func(t *testing.T) {
+		content := ``
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		if !assert.NoError(t, err) {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+
+		assert.Equal(t, 5800, config.StartPort)
+	})
+	t.Run("User specific port ranges", func(t *testing.T) {
+		content := `start_port: 1000`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		if !assert.NoError(t, err) {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+
+		assert.Equal(t, 1000, config.StartPort)
+	})
+
+	t.Run("nextPort is equal to StartPort", func(t *testing.T) {
+		content := `start_port: 1000`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		if !assert.NoError(t, err) {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+
+		assert.Equal(t, config.StartPort, config.nextPort)
+	})
+
+	t.Run("Invalid start port", func(t *testing.T) {
+		content := `start_port: abcd`
+		_, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NotNil(t, err)
+	})
+
+	t.Run("start port must be greater than 1", func(t *testing.T) {
+		content := `start_port: -99`
+		_, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NotNil(t, err)
+	})
+}


### PR DESCRIPTION
Fixes #105 

- using `${PORT}` in `model.cmd` will automatically be replaced with a internally managed port numbers
- port numbers start at `config.startPort`, which defaults to 5800
- `model.proxy`, if omitted will automatically be assigned `http://localhost:${PORT}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated instructions to describe automatic port assignment using a ${PORT} placeholder in model commands and proxies.
  - Added details about the new startPort configuration key and clarified default behaviors.
  - Revised model examples to demonstrate dynamic port assignment.

- **New Features**
  - Introduced support for automatic port assignment for models using a configurable start port.

- **Tests**
  - Added tests to verify automatic port assignment and validation of start port values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->