### PR TITLE
ci: re-enabled intel build pipeline

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -15,8 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        #platform: [intel, cuda, vulkan, cpu, musa]
-        platform: [cuda, vulkan, cpu, musa]
+        platform: [intel, cuda, vulkan, cpu, musa]
       fail-fast: false
     steps:
       - name: Checkout code


### PR DESCRIPTION
Intel build pipeline has been unclogged, container images now published without `out of space` error

ref:
- ggml-org/llama.cpp#13426
- [llama.cpp github actions](https://github.com/ggml-org/llama.cpp/actions/runs/14952206255)
- [latest intel container image](https://github.com/ggml-org/llama.cpp/pkgs/container/llama.cpp/412696777?tag=full-intel)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CI workflow to include the "intel" platform in build and push processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->