### PR TITLE
Add a concurrency limit to Process.ProxyRequest

### DIFF
--- a/proxy/config.go
+++ b/proxy/config.go
@@ -23,6 +23,9 @@ type ModelConfig struct {
 	UnloadAfter   int      `yaml:"ttl"`
 	Unlisted      bool     `yaml:"unlisted"`
 	UseModelName  string   `yaml:"useModelName"`
+
+	// Limit concurrency of HTTP requests to process
+	ConcurrencyLimit int `yaml:"concurrencyLimit"`
 }
 
 func (m *ModelConfig) SanitizedCommand() ([]string, error) {


### PR DESCRIPTION
Part of the stability and reliability improvements work. 

llama-swap does not have a concurrent connection limit, or a connection timeout to the upstream. When the upstream does not respond those connections will be kept open, waiting for a response. This PR adds a default connection limit of 10. After 10 concurrent  requests the response will respond with a 429 Too Many Requests. 

This can be overridden in the configuration like so: 

```yaml
models: 
   my_model: 
      cmd: ...
      concurrencyLimit: 100
```

Note: This PR comes out when working with llama.cpp vscode extension for FIM. After restarting llama-swap, hundreds of connections, some waiting for hours, wound up being dropped. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configurable concurrency limit for handling HTTP requests, allowing users to control the maximum number of simultaneous requests processed.
  - Requests exceeding the concurrency limit are now rejected with an HTTP 429 (Too Many Requests) response.

- **Tests**
  - Added tests to verify correct enforcement of the concurrency limit and appropriate response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->