### PR TITLE
Improve testing around using SIGKILL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 test:
-	go test -short -v ./proxy
+	go test -short -v -count=1 ./proxy
 
 test-all:
-	go test -v ./proxy
+	go test -v -count=1 ./proxy
 
 # Build OSX binary
 mac:

--- a/proxy/helpers_test.go
+++ b/proxy/helpers_test.go
@@ -48,14 +48,18 @@ func getSimpleResponderPath() string {
 	return filepath.Join("..", "build", fmt.Sprintf("simple-responder_%s_%s", goos, goarch))
 }
 
-func getTestSimpleResponderConfig(expectedMessage string) ModelConfig {
+func getTestPort() int {
 	portMutex.Lock()
 	defer portMutex.Unlock()
 
 	port := nextTestPort
 	nextTestPort++
 
-	return getTestSimpleResponderConfigPort(expectedMessage, port)
+	return port
+}
+
+func getTestSimpleResponderConfig(expectedMessage string) ModelConfig {
+	return getTestSimpleResponderConfigPort(expectedMessage, getTestPort())
 }
 
 func getTestSimpleResponderConfigPort(expectedMessage string, port int) ModelConfig {

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -339,7 +339,7 @@ func TestProxyManager_RunningEndpoint(t *testing.T) {
 			"model1": getTestSimpleResponderConfig("model1"),
 			"model2": getTestSimpleResponderConfig("model2"),
 		},
-		LogLevel: "debug",
+		LogLevel: "warn",
 	})
 
 	// Define a helper struct to parse the JSON response.


### PR DESCRIPTION
No functionality changes. Improving testing for stop timeout and the usage of SIGKILL (#125)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option for the simple responder to ignore SIGTERM signals and enhanced signal handling for more robust shutdown control.
  - The simple responder now prints its process ID unless running in silent mode.

- **Improvements**
  - Centralized and made configurable the graceful shutdown timeout for process management.
  - Enhanced test reliability by ensuring fresh test runs without caching.
  - Improved test helper modularity for port allocation.

- **Bug Fixes**
  - Added a test to verify forced process termination when graceful shutdown is ignored.

- **Other**
  - Updated logging level in a proxy manager test for clearer output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->