### PR TITLE
Prevent StateFailed after SIGKILL

### DIFF
--- a/proxy/process.go
+++ b/proxy/process.go
@@ -214,6 +214,12 @@ func (p *Process) start() error {
 	go func() {
 		exitErr := p.cmd.Wait()
 		p.proxyLogger.Debugf("<%s> cmd.Wait() returned error: %v", p.ID, exitErr)
+
+		// there is a race condition when SIGKILL is used, p.cmd.Wait() returns, and then
+		// the code below fires, putting an error into cmdWaitChan. This code is to prevent this
+		if exitErr != nil && exitErr.Error() == "signal: killed" {
+			return
+		}
 		p.cmdWaitChan <- exitErr
 	}()
 


### PR DESCRIPTION
Improves #125 so after force termination, the process can be restarted. Supersedes #128 with a much simpler fix. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved a race condition related to process termination, ensuring more reliable handling when a process is killed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->