### PR TITLE
Fix content length being incorrect when useModelName is used

### DIFF
--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -374,7 +374,7 @@ func (pm *ProxyManager) proxyOAIHandler(c *gin.Context) {
 
 	// dechunk it as we already have all the body bytes see issue #11
 	c.Request.Header.Del("transfer-encoding")
-	c.Request.Header.Add("content-length", strconv.Itoa(len(bodyBytes)))
+	c.Request.Header.Set("content-length", strconv.Itoa(len(bodyBytes)))
 
 	if err := processGroup.ProxyRequest(realModelName, c.Writer, c.Request); err != nil {
 		pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error proxying request: %s", err.Error()))

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -375,6 +375,7 @@ func (pm *ProxyManager) proxyOAIHandler(c *gin.Context) {
 	// dechunk it as we already have all the body bytes see issue #11
 	c.Request.Header.Del("transfer-encoding")
 	c.Request.Header.Set("content-length", strconv.Itoa(len(bodyBytes)))
+	c.Request.ContentLength = int64(len(bodyBytes))
 
 	if err := processGroup.ProxyRequest(realModelName, c.Writer, c.Request); err != nil {
 		pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error proxying request: %s", err.Error()))


### PR DESCRIPTION
This PR fixes an issue I discovered where using `useModelName` causes all requests to llama-swap to fail with an error message similar to this:
```
http: ContentLength=84 with Body length 107
```
This bug happens when a model's name and the name in `useModelName` differ in length. When the `model` field in the request body is modified, the length of the request body changes. The current code tries to change the `Content-Length` header to match the new content length, but it uses `Add` instead of `Set`. This causes a second `Content-Length` header to be appended to the request instead of replacing the old one. The mismatch between the new request body size and the first, unmodified `Content-Length` header then causes an error when llama-swap tries to send the request on to the upstream server.

Hopefully I didn't miss anything else that might cause this bug to occur. Let me know if I need to change anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the "content-length" header in proxied requests to ensure more accurate and reliable HTTP header management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->