### PR TITLE
Fix #133 SanitizeCommand removes comments

### DIFF
--- a/proxy/config.go
+++ b/proxy/config.go
@@ -229,9 +229,23 @@ func AddDefaultGroupToConfig(config Config) Config {
 }
 
 func SanitizeCommand(cmdStr string) ([]string, error) {
-	// Remove trailing backslashes
-	cmdStr = strings.ReplaceAll(cmdStr, "\\ \n", " ")
-	cmdStr = strings.ReplaceAll(cmdStr, "\\\n", " ")
+	var cleanedLines []string
+	for _, line := range strings.Split(cmdStr, "\n") {
+		trimmed := strings.TrimSpace(line)
+		// Skip comment lines
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		// Handle trailing backslashes by replacing with space
+		if strings.HasSuffix(trimmed, "\\") {
+			cleanedLines = append(cleanedLines, strings.TrimSuffix(trimmed, "\\")+" ")
+		} else {
+			cleanedLines = append(cleanedLines, line)
+		}
+	}
+
+	// put it back together
+	cmdStr = strings.Join(cleanedLines, "\n")
 
 	// Split the command into arguments
 	var args []string

--- a/proxy/config_posix_test.go
+++ b/proxy/config_posix_test.go
@@ -14,8 +14,14 @@ func TestConfig_SanitizeCommand(t *testing.T) {
 		-a "double quotes" \
 		--arg2 'single quotes'
 		-s
+		# comment 1
 		--arg3 123 \
+
+		  # comment 2
 		--arg4 '"string in string"'
+
+
+		# this will get stripped out as well as the white space above
 		-c "'single quoted'"
 		`)
 	assert.NoError(t, err)

--- a/proxy/config_windows_test.go
+++ b/proxy/config_windows_test.go
@@ -11,10 +11,17 @@ import (
 func TestConfig_SanitizeCommand(t *testing.T) {
 	// does not support single quoted strings like in config_posix_test.go
 	args, err := SanitizeCommand(`python model1.py \
-    -a "double quotes" \
+
+	-a "double quotes" \
 	-s
 	--arg3 123 \
+
+	   # comment 2
 	--arg4 '"string in string"'
+
+
+
+	# this will get stripped out as well as the white space above
 	-c "'single quoted'"
 	`)
 	assert.NoError(t, err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of command input to ignore comment lines and extra whitespace when processing commands.

- **Tests**
  - Updated tests to verify that comment lines and blank lines are correctly ignored during command processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->