### PR TITLE
Allow Failed -> Stopping Process state change

### DIFF
--- a/proxy/process.go
+++ b/proxy/process.go
@@ -149,7 +149,9 @@ func isValidTransition(from, to ProcessState) bool {
 		return to == StateStopping
 	case StateStopping:
 		return to == StateStopped || to == StateShutdown
-	case StateFailed, StateShutdown:
+	case StateFailed:
+		return to == StateStopping
+	case StateShutdown:
 		return false // No transitions allowed from these states
 	}
 	return false
@@ -359,12 +361,21 @@ func (p *Process) StopImmediately() {
 		return
 	}
 
-	p.proxyLogger.Debugf("<%s> Stopping process", p.ID)
+	p.proxyLogger.Debugf("<%s> Stopping process, current state: %s", p.ID, p.CurrentState())
+	currentState := p.CurrentState()
 
-	// calling Stop() when state is invalid is a no-op
-	if curState, err := p.swapState(StateReady, StateStopping); err != nil {
-		p.proxyLogger.Infof("<%s> Stop() Ready -> StateStopping err: %v, current state: %v", p.ID, err, curState)
-		return
+	if currentState == StateFailed {
+		// calling Stop() when state is invalid is a no-op
+		if curState, err := p.swapState(StateFailed, StateStopping); err != nil {
+			p.proxyLogger.Infof("<%s> Stop() Failed -> StateStopping err: %v, current state: %v", p.ID, err, curState)
+			return
+		}
+	} else {
+		// calling Stop() when state is invalid is a no-op
+		if curState, err := p.swapState(StateReady, StateStopping); err != nil {
+			p.proxyLogger.Infof("<%s> Stop() Ready -> StateStopping err: %v, current state: %v", p.ID, err, curState)
+			return
+		}
 	}
 
 	// stop the process with a graceful exit timeout

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -365,13 +365,11 @@ func (p *Process) StopImmediately() {
 	currentState := p.CurrentState()
 
 	if currentState == StateFailed {
-		// calling Stop() when state is invalid is a no-op
 		if curState, err := p.swapState(StateFailed, StateStopping); err != nil {
 			p.proxyLogger.Infof("<%s> Stop() Failed -> StateStopping err: %v, current state: %v", p.ID, err, curState)
 			return
 		}
 	} else {
-		// calling Stop() when state is invalid is a no-op
 		if curState, err := p.swapState(StateReady, StateStopping); err != nil {
 			p.proxyLogger.Infof("<%s> Stop() Ready -> StateStopping err: %v, current state: %v", p.ID, err, curState)
 			return

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -352,6 +352,8 @@ func (pm *ProxyManager) upstreamIndex(c *gin.Context) {
 					stateStr = "Failed"
 				case StateShutdown:
 					stateStr = "Shutdown"
+				case StateStopped:
+					stateStr = "Stopped"
 				default:
 					stateStr = "Unknown"
 				}


### PR DESCRIPTION
This allows a state change from Failed to Stopping. Failed states are no longer unrecoverable and can be transitioned out to Stopped by using `/unload` or swapping to another working model.  Ref: #120 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved process state handling to allow transitions from a failed state to stopping, ensuring more accurate process management.
  - Enhanced immediate stopping behavior to correctly address processes in a failed state.

- **New Features**
  - Added support for displaying a "Stopped" state for processes, providing clearer status information to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->