### PR TITLE
Improve install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,16 +11,16 @@ status() { echo ">>> $*" >&2; }
 error() { echo "${red}ERROR:${plain} $*"; exit 1; }
 warning() { echo "${red}WARNING:${plain} $*"; }
 
-available() { command -v $1 >/dev/null; }
+available() { command -v "$1" >/dev/null; }
 require() {
     local MISSING=''
-    for TOOL in $*; do
-        if ! available $TOOL; then
+    for TOOL in "$@"; do
+        if ! available "$TOOL"; then
             MISSING="$MISSING $TOOL"
         fi
     done
 
-    echo $MISSING
+    echo "$MISSING"
 }
 
 SUDO=
@@ -118,7 +118,7 @@ configure_systemd() {
     fi
 
     status "Adding current user to llama-swap group..."
-    $SUDO usermod -a -G llama-swap $(whoami)
+    $SUDO usermod -a -G llama-swap "$(whoami)"
 
     if [ ! -f "/usr/share/llama-swap/config.yaml" ]; then
         status "Creating default config.yaml..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,14 +13,14 @@ warning() { echo "${red}WARNING:${plain} $*"; }
 
 available() { command -v "$1" >/dev/null; }
 require() {
-    local MISSING=''
+    _MISSING=''
     for TOOL in "$@"; do
         if ! available "$TOOL"; then
-            MISSING="$MISSING $TOOL"
+            _MISSING="$_MISSING $TOOL"
         fi
     done
 
-    echo "$MISSING"
+    echo "$_MISSING"
 }
 
 SUDO=

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,6 +4,8 @@
 
 set -eu
 
+LLAMA_SWAP_DEFAULT_ADDRESS=${LLAMA_SWAP_DEFAULT_ADDRESS:-"127.0.0.1:8080"}
+
 red="$( (/usr/bin/tput bold || :; /usr/bin/tput setaf 1 || :) 2>&-)"
 plain="$( (/usr/bin/tput sgr0 || :) 2>&-)"
 
@@ -160,7 +162,7 @@ User=llama-swap
 Group=llama-swap
 
 # set this to match your environment
-ExecStart=/usr/local/bin/llama-swap --config /usr/share/llama-swap/config.yaml --watch-config
+ExecStart=/usr/local/bin/llama-swap --config /usr/share/llama-swap/config.yaml --watch-config -listen ${LLAMA_SWAP_DEFAULT_ADDRESS}
 
 Restart=on-failure
 RestartSec=3
@@ -194,7 +196,7 @@ if available systemctl; then
 fi
 
 install_success() {
-    status 'The llama-swap API is now available at 127.0.0.1:8080.'
+    status "The llama-swap API is now available at http://${LLAMA_SWAP_DEFAULT_ADDRESS}"
     status 'Customize the config file at /usr/share/llama-swap/config.yaml.'
     status 'Install complete.'
 }


### PR DESCRIPTION
- Use `python3`, which is more likely to be installed (32ae9e4c3083e407fc63b50ae94a6ee3d1d51a4c)
- Server address designation as follows (129b4810a39a9759c5e542cf7105935ada3bfb3c)

```sh
sudo LLAMA_SWAP_DEFAULT_ADDRESS=0.0.0.0:9090 sh ./scripts/install.sh 
```


- Minor shell script updates (497191d1206dd93741fc9ecfea822161672e94cb, e4599a6c037fe17a28176fee69029bc3d0fec502)