### PR TITLE
Add missing object type to /v1/models endpoint

### DIFF
--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -291,7 +291,7 @@ func (pm *ProxyManager) listModelsHandler(c *gin.Context) {
 	}
 
 	// Encode the data as JSON and write it to the response writer
-	if err := json.NewEncoder(c.Writer).Encode(map[string]interface{}{"data": data}); err != nil {
+	if err := json.NewEncoder(c.Writer).Encode(map[string]interface{}{"object": "list", "data": data}); err != nil {
 		pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error encoding JSON %s", err.Error()))
 		return
 	}


### PR DESCRIPTION
This adds the missing `"object": "list"` like specified in https://platform.openai.com/docs/api-reference/models to the models endpoint. 
Should help some more picky clients like BoltAI to actually query the models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The JSON response for model listings now includes an "object" field with the value "list" for improved clarity in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->