### PR TITLE
CORS: Allow all origins in regular non-preflight requests

### DIFF
--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -127,7 +127,6 @@ func (pm *ProxyManager) setupGinEngine() {
 		}
 
 		if c.Request.Method == "OPTIONS" {
-			c.Header("Access-Control-Allow-Origin", "*")
 			c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 
 			// allow whatever the client requested by default

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -120,6 +120,11 @@ func (pm *ProxyManager) setupGinEngine() {
 	// see: issue: #81, #77 and #42 for CORS issues
 	// respond with permissive OPTIONS for any endpoint
 	pm.ginEngine.Use(func(c *gin.Context) {
+		origin := c.Request.Header.Get("Origin")
+		if origin != "" {
+			c.Header("Access-Control-Allow-Origin", origin)
+		}
+
 		if c.Request.Method == "OPTIONS" {
 			c.Header("Access-Control-Allow-Origin", "*")
 			c.Header("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -123,6 +123,7 @@ func (pm *ProxyManager) setupGinEngine() {
 		origin := c.Request.Header.Get("Origin")
 		if origin != "" {
 			c.Header("Access-Control-Allow-Origin", origin)
+			c.Header("Vary", "Origin")
 		}
 
 		if c.Request.Method == "OPTIONS" {


### PR DESCRIPTION
Currently `Access-Control-Allow-Origin` is only added for preflight (OPTIONS) requests. 

There are clients that perform requests with the Origin header set without preflight requests. I encountered this issue wihen trying to use an Obsidian plugin setting `Origin: app://obsidian.md`.

This PR sets this header for all requests, and instead of setting `*` (which is not supported in requests with credentials) sets as allowed origin the one requested by the client. As suggested by [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin)

> If the server supports clients from multiple origins, it must return the origin for the specific client making the request.

This is also what llama-server does with this C code:

```c
res.set_header("Access-Control-Allow-Origin", req.get_header_value("Origin"));
```

I checked the history of the previous issues (42, 77, 81) and MRs/commits and should not introduce any issues.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced CORS middleware to dynamically set the "Access-Control-Allow-Origin" header based on the incoming request's origin, improving cross-origin request handling and browser compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->