### PR TITLE
fix: intel build restored

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -15,8 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        #platform: [intel, cuda, vulkan, cpu, musa]
-        platform: [cuda, vulkan, cpu, musa]
+        platform: [intel, cuda, vulkan, cpu, musa]
       fail-fast: false
     steps:
       - name: Checkout code


### PR DESCRIPTION
Intel build of llama.cpp has been fixed, and has been running well for the past few days.

ref: https://github.com/ggml-org/llama.cpp/actions/runs/15671747643