### PR TITLE
fix: hot-reload config file on macos

### DIFF
--- a/llama-swap.go
+++ b/llama-swap.go
@@ -144,8 +144,8 @@ func watchConfigFileWithReload(configPath string, reloadChan chan<- *proxy.Proxy
 			if !ok {
 				return
 			}
-			// We only care about writes to the specific config file
-			if event.Name == configPath && event.Has(fsnotify.Write) {
+			// We only care about writes/creates to the specific config file
+			if event.Name == configPath && (event.Has(fsnotify.Write) || event.Has(fsnotify.Create)) {
 				// Reset or start the debounce timer
 				if debounceTimer != nil {
 					debounceTimer.Stop()


### PR DESCRIPTION
This PR fixes an issue where changes to the configuration file were not triggering a reload on macOS.

On macOS, the file system behaves slightly differently compared to Linux when handling file modifications. Many applications and editors (like vim, nano, or IDEs) do not modify the file in place. Instead, they write changes to a new temporary file and then atomically replace the original file using a move or rename operation. As a result, the fsnotify watcher may not emit a Write event on the original file, but instead emit a Create event for the new file with the same path.