### PR TITLE
Add name and description to v1/models list

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -49,7 +49,19 @@ models:
     cmd: |
       # ${latest-llama} is a macro that is defined above
       ${latest-llama}
-      --model path/to/Qwen2.5-1.5B-Instruct-Q4_K_M.gguf
+      --model path/to/llama-8B-Q4_K_M.gguf
+
+    # name: a display name for the model
+    # - optional, default: empty string
+    # - if set, it will be used in the v1/models API response
+    # - if not set, it will be omitted in the JSON model record
+    name: "llama 3.1 8B"
+
+    # description: a description for the model
+    # - optional, default: empty string
+    # - if set, it will be used in the v1/models API response
+    # - if not set, it will be omitted in the JSON model record
+    description: "A small but capable model used for quick testing"
 
     # env: define an array of environment variables to inject into cmd's environment
     # - optional, default: empty array

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -28,6 +28,10 @@ type ModelConfig struct {
 	Unlisted      bool     `yaml:"unlisted"`
 	UseModelName  string   `yaml:"useModelName"`
 
+	// #179 for /v1/models
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+
 	// Limit concurrency of HTTP requests to process
 	ConcurrencyLimit int `yaml:"concurrencyLimit"`
 
@@ -48,6 +52,8 @@ func (m *ModelConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		Unlisted:         false,
 		UseModelName:     "",
 		ConcurrencyLimit: 0,
+		Name:             "",
+		Description:      "",
 	}
 
 	// the default cmdStop to taskkill /f /t /pid ${PID}

--- a/proxy/config_posix_test.go
+++ b/proxy/config_posix_test.go
@@ -104,6 +104,8 @@ models:
   model1:
     cmd: path/to/cmd --arg1 one
     proxy: "http://localhost:8080"
+    name: "Model 1"
+    description: "This is model 1"
     aliases:
       - "m1"
       - "model-one"
@@ -168,6 +170,8 @@ groups:
 				Aliases:       []string{"m1", "model-one"},
 				Env:           []string{"VAR1=value1", "VAR2=value2"},
 				CheckEndpoint: "/health",
+				Name:          "Model 1",
+				Description:   "This is model 1",
 			},
 			"model2": {
 				Cmd:           "path/to/server --arg1 one",


### PR DESCRIPTION
## Before: 

![image](https://github.com/user-attachments/assets/ed128bd3-0f52-4a20-92b0-6268aa583140)

## After (for clients with support) 

![image](https://github.com/user-attachments/assets/4b6a223d-7090-4fbf-b784-9cf406a776c2)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional "name" and "description" fields to model configurations, allowing models to display additional metadata in API responses when set.

* **Bug Fixes**
  * Improved handling to ensure that empty or whitespace-only "name" and "description" fields are omitted from model listings.

* **Tests**
  * Enhanced tests to verify correct inclusion and omission of the new metadata fields in model responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->