### PR TITLE
Fix: Strip comments before macro expansion to prevent command parsing errors

### DIFF
--- a/proxy/config.go
+++ b/proxy/config.go
@@ -255,6 +255,10 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 	for _, modelId := range modelIds {
 		modelConfig := config.Models[modelId]
 
+		// Strip comments from command fields before macro expansion
+		modelConfig.Cmd = StripComments(modelConfig.Cmd)
+		modelConfig.CmdStop = StripComments(modelConfig.CmdStop)
+
 		// go through model config fields: cmd, cmdStop, proxy, checkEndPoint and replace macros with macro values
 		for macroName, macroValue := range config.Macros {
 			macroSlug := fmt.Sprintf("${%s}", macroName)
@@ -405,4 +409,17 @@ func SanitizeCommand(cmdStr string) ([]string, error) {
 	}
 
 	return args, nil
+}
+
+func StripComments(cmdStr string) string {
+	var cleanedLines []string
+	for _, line := range strings.Split(cmdStr, "\n") {
+		trimmed := strings.TrimSpace(line)
+		// Skip comment lines
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		cleanedLines = append(cleanedLines, line)
+	}
+	return strings.Join(cleanedLines, "\n")
 }

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -212,11 +212,11 @@ func (p *Process) start() error {
 		if curState, swapErr := p.swapState(StateStarting, StateStopped); swapErr != nil {
 			p.state = StateStopped // force it into a stopped state
 			return fmt.Errorf(
-				"failed to start command and state swap failed. command error: %v, current state: %v, state swap error: %v",
-				err, curState, swapErr,
+				"failed to start command '%s' and state swap failed. command error: %v, current state: %v, state swap error: %v",
+				strings.Join(args, " "), err, curState, swapErr,
 			)
 		}
-		return fmt.Errorf("start() failed: %v", err)
+		return fmt.Errorf("start() failed for command '%s': %v", strings.Join(args, " "), err)
 	}
 
 	// Capture the exit error for later signalling

--- a/proxy/process_test.go
+++ b/proxy/process_test.go
@@ -107,7 +107,7 @@ func TestProcess_BrokenModelConfig(t *testing.T) {
 	w = httptest.NewRecorder()
 	process.ProxyRequest(w, req)
 	assert.Equal(t, http.StatusBadGateway, w.Code)
-	assert.Contains(t, w.Body.String(), "start() failed: ")
+	assert.Contains(t, w.Body.String(), "start() failed for command 'nonexistent-command':")
 }
 
 func TestProcess_UnloadAfterTTL(t *testing.T) {


### PR DESCRIPTION
### Problem

Comments containing macros in YAML configuration caused process startup failures with errors like:

```text
unable to start process: start() failed: exec: "is": executable file not found in $PATH
```

## Example Configuration That Failed

```yaml
macros:
  "latest-llama": >
    /user/llama.cpp/build/bin/llama-server
    --port ${PORT}

models:
  "qwen3-30b-a3b":
    cmd: |
      # ${latest-llama} is a macro that is defined above
      ${latest-llama}
      --model /path/to/model.gguf
      -ngl 99
```

## Root Cause

The issue was caused by **order of operations**:

1. **Macro expansion happened first**: `${latest-llama}` in the comment was expanded, which could make the comment broken into multiple lines after expansion. The comment start character was present only on the first line. The effective command would look as below
```yaml
models:
  "qwen3-30b-a3b":
    cmd: |
      #  /user/llama.cpp/build/bin/llama-server
       --port ${PORT}
       is a macro that is defined above
      /user/llama.cpp/build/bin/llama-server
       --port ${PORT}
      --model /path/to/model.gguf
      -ngl 99
```
3. **Comment removal happened second**: `SanitizeCommand()` only removes lines that start with `#`, so the expanded comment text remained
4. **Command execution failed**: Comment words like "is", "a", "macro" became command arguments, causing the shell to try executing `"is"` as a command

## Solution

**Reversed the order**: Strip comments before macro expansion.
- Strip comments from `cmd` and `cmdStop` fields before macro processing

## Result

Same configuration now produces clean command:
```
/user/llama.cpp/build/bin/llama-server --port 5800 --model /path/to/model.gguf -ngl 99
```

## Testing

- Added test `TestConfig_MacroInCommentStrippedBeforeExpansion` that reproduces the original bug scenario
- Verifies comment text doesn't appear as command arguments
- All existing tests pass

## Impact

- **Fixes critical bug**: Users can safely use comments that reference macros
- **Backward compatible**: All existing configurations continue to work
- **No breaking changes**: Pure bug fix

---
fixes #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages to include the full command string when a process fails to start, providing clearer context in error outputs.

* **Tests**
  * Added tests to verify that comment lines are correctly stripped from command configurations and that macros in comments are not expanded.
  * Refined existing tests to check for more specific error messages, ensuring better validation of failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->