### PR TITLE
Decouple MetricsMiddleware from downstream handlers

### DIFF
--- a/proxy/metrics_middleware.go
+++ b/proxy/metrics_middleware.go
@@ -32,7 +32,6 @@ func MetricsMiddleware(pm *ProxyManager) gin.HandlerFunc {
 			pm.sendErrorResponse(c, http.StatusBadRequest, fmt.Sprintf("could not find real modelID for %s", requestedModel))
 			return
 		}
-		c.Set("ls-real-model-name", realModelName)
 
 		writer := &MetricsResponseWriter{
 			ResponseWriter: c.Writer,


### PR DESCRIPTION
Remove ls-real-model-name optimization. Within proxyOAIHandler the request body's bytes are required for various rewriting features anyways. This negated any benefits from trying not to parse it twice.