### PR TITLE
feat: add homebrew trigger workflow

### DIFF
--- a/.github/workflows/trigger-homebrew-update.yml
+++ b/.github/workflows/trigger-homebrew-update.yml
@@ -1,0 +1,21 @@
+name: Trigger Homebrew Tap Update
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger-tap-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Trigger tap repository update"
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.TAP_REPO_PAT }}
+          repository: mostlygeek/homebrew-llama-swap
+          event-type: new-release
+          client-payload: |-
+            {
+              "release": {
+                  "tag_name": "${{ github.event.release.tag_name }}"
+              }
+            }

--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ $ docker run -it --rm --runtime nvidia -p 9292:8080 \
 
 </details>
 
+## Homebrew Install (macOS/Linux)
+
+For macOS & Linux users, `llama-swap` can be installed via [Homebrew](https://brew.sh):
+
+```shell
+# Set up tap and install formula 
+brew tap mostlygeek/llama-swap
+brew install llama-swap
+# Run llama-swap
+llama-swap --config path/to/config.yaml --listen localhost:8080
+```
+
+This will install the `llama-swap` binary and make it available in your path. See the [configuration documentation](https://github.com/mostlygeek/llama-swap/wiki/Configuration)
+
 ## Bare metal Install ([download](https://github.com/mostlygeek/llama-swap/releases))
 
 Pre-built binaries are available for Linux, Mac, Windows and FreeBSD. These are automatically published and are likely a few hours ahead of the docker releases. The baremetal install works with any OpenAI compatible server, not just llama-server.


### PR DESCRIPTION
### Description:

This PR resolves Issue #26. It allows users to install the latest releases of  `llama-swap` via homebrew on Linux and MacOS machines. 

### Prerequisites

To fully implement this feature, the following steps are required by the owner:
- Create a Personal Access Token (PAT) with a `public_repo` scope. (This is less permissive than the general `repo` scope. Must have access to both `llama-swap` and `homebrew-llama-swap`. The `secrets.GITHUB_TOKEN` cannot be used as discussed [here](https://github.com/peter-evans/repository-dispatch/issues/376#issuecomment-2666244920).
- Add the PAT to secrets (named TAP_REPO_PAT)
- Merge PR. 
- Test on next release. 🤞

### Details
- This PR uses the `peter-evans/repository-dispatch` action to send a `repository_dispatch` event to `mostlygeek/homebrew-llama-swap` repository.
- It also updates the README to instruct users on how to install `llama-swap` via `homebrew` on Linux and macOS machines. 

I tested the workflow on the `homebrew-llama-swap` repo and it works perfectly. I am unable to test this workflow since I can't fork the releases themselves, but I don't foresee any issues. Glad to have helped make `llama-swap` more accessible. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Homebrew installation instructions for macOS and Linux users in the documentation.

* **Chores**
  * Introduced an automated workflow to notify the Homebrew tap repository of new releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->