### PR TITLE
add /health endpoint

### DIFF
--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -191,6 +191,9 @@ func (pm *ProxyManager) setupGinEngine() {
 
 	pm.ginEngine.GET("/unload", pm.unloadAllModelsHandler)
 	pm.ginEngine.GET("/running", pm.listRunningProcessesHandler)
+	pm.ginEngine.GET("/health", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
 
 	pm.ginEngine.GET("/favicon.ico", func(c *gin.Context) {
 		if data, err := reactStaticFS.ReadFile("ui_dist/favicon.ico"); err == nil {


### PR DESCRIPTION
Fix #207 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `/health` endpoint that returns a simple "OK" response to indicate service health.

* **Tests**
  * Introduced tests to verify the correct behavior of the `/health` endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->