### PR TITLE
Add request, response data to recorded metrics

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -17,7 +17,7 @@ logLevel: info
 
 # logHTTPRequests: enable logging of all HTTP requests
 # - optional, default: false
-# - when true, logs all incoming HTTP requests with method, path, and headers
+# - when true, logs all incoming HTTP request and response bodies
 logHTTPRequests: false
 
 # metricsMaxInMemory: maximum number of metrics to keep in memory

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,6 +15,11 @@ healthCheckTimeout: 500
 # - Valid log levels: debug, info, warn, error
 logLevel: info
 
+# logHTTPRequests: enable logging of all HTTP requests
+# - optional, default: false
+# - when true, logs all incoming HTTP requests with method, path, and headers
+logHTTPRequests: false
+
 # metricsMaxInMemory: maximum number of metrics to keep in memory
 # - optional, default: 1000
 # - controls how many metrics are stored in memory before older ones are discarded

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -141,6 +141,7 @@ func (c *GroupConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type Config struct {
 	HealthCheckTimeout int                    `yaml:"healthCheckTimeout"`
 	LogRequests        bool                   `yaml:"logRequests"`
+	LogHTTPRequests    bool                   `yaml:"logHTTPRequests"`
 	LogLevel           string                 `yaml:"logLevel"`
 	MetricsMaxInMemory int                    `yaml:"metricsMaxInMemory"`
 	Models             map[string]ModelConfig `yaml:"models"` /* key is model ID */
@@ -193,6 +194,7 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 	// default configuration values
 	config := Config{
 		HealthCheckTimeout: 120,
+		LogHTTPRequests:    false,
 		StartPort:          5800,
 		LogLevel:           "info",
 		MetricsMaxInMemory: 1000,

--- a/proxy/metrics_middleware.go
+++ b/proxy/metrics_middleware.go
@@ -102,8 +102,8 @@ func (rec *MetricsRecorder) parseAndRecordMetrics(responseBody []byte) bool {
 		DurationMs:      durationMs,
 	}
 	if rec.metricsMonitor.logHTTPRequests {
-		metrics.RequestBody = rec.requestBody
-		metrics.ResponseBody = responseBody
+		metrics.RequestBody = string(rec.requestBody)
+		metrics.ResponseBody = string(responseBody)
 	}
 	rec.metricsMonitor.addMetrics(metrics)
 

--- a/proxy/metrics_monitor.go
+++ b/proxy/metrics_monitor.go
@@ -17,8 +17,8 @@ type TokenMetrics struct {
 	OutputTokens    int       `json:"output_tokens"`
 	TokensPerSecond float64   `json:"tokens_per_second"`
 	DurationMs      int       `json:"duration_ms"`
-	RequestBody     []byte    `json:"request_body,omitempty"`
-	ResponseBody    []byte    `json:"response_body,omitempty"`
+	RequestBody     string    `json:"request_body,omitempty"`
+	ResponseBody    string    `json:"response_body,omitempty"`
 }
 
 // TokenMetricsEvent represents a token metrics event

--- a/ui/src/contexts/APIProvider.tsx
+++ b/ui/src/contexts/APIProvider.tsx
@@ -30,6 +30,8 @@ interface Metrics {
   output_tokens: number;
   tokens_per_second: number;
   duration_ms: number;
+  request_body?: string;
+  response_body?: string;
 }
 
 interface LogData {

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, Fragment } from "react";
 import { useAPI } from "../contexts/APIProvider";
 
 const formatTimestamp = (timestamp: string): string => {
@@ -34,6 +34,50 @@ const ActivityPage = () => {
     );
   }
 
+  const renderMetricRow = (metric: typeof metrics[0], index: number) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const hasRequestData = metric.request_body && metric.response_body;
+
+    return (
+      <Fragment key={`${metric.id}-${index}`}>
+        <tr>
+          <td className="px-6 py-4 whitespace-nowrap text-sm">{formatTimestamp(metric.timestamp)}</td>
+          <td className="px-6 py-4 whitespace-nowrap text-sm">{metric.model}</td>
+          <td className="px-6 py-4 whitespace-nowrap text-sm">{metric.input_tokens.toLocaleString()}</td>
+          <td className="px-6 py-4 whitespace-nowrap text-sm">{metric.output_tokens.toLocaleString()}</td>
+          <td className="px-6 py-4 whitespace-nowrap text-sm">{formatSpeed(metric.tokens_per_second)}</td>
+          <td className="px-6 py-4 whitespace-nowrap text-sm">{formatDuration(metric.duration_ms)}</td>
+          {hasRequestData && (
+            <td className="px-6 py-4 whitespace-nowrap text-sm">
+              <button
+                onClick={() => setIsExpanded(!isExpanded)}
+                className="text-blue-600 hover:text-blue-800 text-sm font-medium"
+              >
+                {isExpanded ? 'Hide' : 'Show'}
+              </button>
+            </td>
+          )}
+        </tr>
+        {isExpanded && hasRequestData && (
+          <tr>
+            <td colSpan={7} className="px-6 py-4 bg-gray-50 border-t">
+              <div className="mt-2">
+                <h4 className="font-medium text-sm mb-2">Request</h4>
+                <pre className="bg-white p-3 rounded border text-sm overflow-auto max-h-40">
+                  <code>{metric.request_body}</code>
+                </pre>
+                <h4 className="font-medium text-sm mt-4 mb-2">Response</h4>
+                <pre className="bg-white p-3 rounded border text-sm overflow-auto max-h-40">
+                  <code>{metric.response_body}</code>
+                </pre>
+              </div>
+            </td>
+          </tr>
+        )}
+      </Fragment>
+    );
+  };
+
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-4">Activity</h1>
@@ -53,19 +97,11 @@ const ActivityPage = () => {
                 <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Output Tokens</th>
                 <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Generation Speed</th>
                 <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Duration</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider">Request data</th>
               </tr>
             </thead>
             <tbody className="divide-y">
-              {metrics.map((metric, index) => (
-                <tr key={`${metric.id}-${index}`}>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm">{formatTimestamp(metric.timestamp)}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm">{metric.model}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm">{metric.input_tokens.toLocaleString()}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm">{metric.output_tokens.toLocaleString()}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm">{formatSpeed(metric.tokens_per_second)}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm">{formatDuration(metric.duration_ms)}</td>
-                </tr>
-              ))}
+              {metrics.map(renderMetricRow)}
             </tbody>
           </table>
         </div>

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -16,6 +16,7 @@ const formatDuration = (ms: number): string => {
 const ActivityPage = () => {
   const { metrics } = useAPI();
   const [error, setError] = useState<string | null>(null);
+  const [expandedMetrics, setExpandedMetrics] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     if (metrics.length > 0) {
@@ -34,12 +35,25 @@ const ActivityPage = () => {
     );
   }
 
+  const toggleExpanded = (id: string) => {
+    setExpandedMetrics(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(id)) {
+        newSet.delete(id);
+      } else {
+        newSet.add(id);
+      }
+      return newSet;
+    });
+  };
+
   const renderMetricRow = (metric: typeof metrics[0], index: number) => {
-    const [isExpanded, setIsExpanded] = useState(false);
+    const key = `${metric.id}-${index}`;
+    const isExpanded = expandedMetrics.has(key);
     const hasRequestData = metric.request_body && metric.response_body;
 
     return (
-      <Fragment key={`${metric.id}-${index}`}>
+      <Fragment key={key}>
         <tr>
           <td className="px-6 py-4 whitespace-nowrap text-sm">{formatTimestamp(metric.timestamp)}</td>
           <td className="px-6 py-4 whitespace-nowrap text-sm">{metric.model}</td>
@@ -50,7 +64,7 @@ const ActivityPage = () => {
           {hasRequestData && (
             <td className="px-6 py-4 whitespace-nowrap text-sm">
               <button
-                onClick={() => setIsExpanded(!isExpanded)}
+                onClick={() => toggleExpanded(key)}
                 className="text-blue-600 hover:text-blue-800 text-sm font-medium"
               >
                 {isExpanded ? 'Hide' : 'Show'}

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -17,12 +17,24 @@ const ActivityPage = () => {
   const { metrics } = useAPI();
   const [error, setError] = useState<string | null>(null);
   const [expandedMetrics, setExpandedMetrics] = useState<Set<string>>(new Set());
+  const [parseJson, setParseJson] = useState<boolean>(false);
 
   useEffect(() => {
     if (metrics.length > 0) {
       setError(null);
     }
   }, [metrics]);
+
+  const beautifyJson = (jsonString?: string): string => {
+    if (typeof jsonString !== "string")
+      return "";
+    try {
+      const parsed = JSON.parse(jsonString);
+      return JSON.stringify(parsed, null, 2);
+    } catch (e) {
+      return jsonString;
+    }
+  };
 
   if (error) {
     return (
@@ -78,11 +90,11 @@ const ActivityPage = () => {
               <div className="mt-2">
                 <h4 className="font-bold text-sm mb-2">Request</h4>
                 <pre className="bg-white p-3 rounded border text-sm whitespace-pre-wrap break-all max-h-40 overflow-y-auto">
-                  <code>{metric.request_body}</code>
+                  <code>{parseJson ? beautifyJson(metric.request_body) : metric.request_body}</code>
                 </pre>
                 <h4 className="font-bold text-sm mt-4 mb-2">Response</h4>
                 <pre className="bg-white p-3 rounded border text-sm whitespace-pre-wrap break-all max-h-40 overflow-y-auto">
-                  <code>{metric.response_body}</code>
+                  <code>{parseJson ? beautifyJson(metric.response_body) : metric.response_body}</code>
                 </pre>
               </div>
             </td>
@@ -95,6 +107,18 @@ const ActivityPage = () => {
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-4">Activity</h1>
+
+      <div>
+        <input
+          type="checkbox"
+          id="parse-json"
+          checked={parseJson}
+          onChange={(e) => setParseJson(e.target.checked)}
+        />
+        <label htmlFor="parse-json">
+          Parse request data as JSON and beautify
+        </label>
+      </div>
 
       {metrics.length === 0 ? (
         <div className="text-center py-8">

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -62,12 +62,12 @@ const ActivityPage = () => {
           <tr>
             <td colSpan={7} className="px-6 py-4 bg-gray-50 border-t">
               <div className="mt-2">
-                <h4 className="font-medium text-sm mb-2">Request</h4>
-                <pre className="bg-white p-3 rounded border text-sm overflow-auto max-h-40">
+                <h4 className="font-bold text-sm mb-2">Request</h4>
+                <pre className="bg-white p-3 rounded border text-sm whitespace-pre-wrap break-all max-h-40 overflow-y-auto">
                   <code>{metric.request_body}</code>
                 </pre>
-                <h4 className="font-medium text-sm mt-4 mb-2">Response</h4>
-                <pre className="bg-white p-3 rounded border text-sm overflow-auto max-h-40">
+                <h4 className="font-bold text-sm mt-4 mb-2">Response</h4>
+                <pre className="bg-white p-3 rounded border text-sm whitespace-pre-wrap break-all max-h-40 overflow-y-auto">
                   <code>{metric.response_body}</code>
                 </pre>
               </div>

--- a/ui/src/pages/Activity.tsx
+++ b/ui/src/pages/Activity.tsx
@@ -108,14 +108,14 @@ const ActivityPage = () => {
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-4">Activity</h1>
 
-      <div>
+      <div className="mb-4">
         <input
           type="checkbox"
           id="parse-json"
           checked={parseJson}
           onChange={(e) => setParseJson(e.target.checked)}
         />
-        <label htmlFor="parse-json">
+        <label htmlFor="parse-json" className="ml-2">
           Parse request data as JSON and beautify
         </label>
       </div>


### PR DESCRIPTION
Adds request, response data to the recorded metrics, which can be viewed in the Activity page. The data is only recorded if logHTTPRequests is set to true in the config.

Qwen 3 was used in this PR.

<img width="2324" height="1592" alt="http-request-log" src="https://github.com/user-attachments/assets/1f8c0a5c-1943-4fb0-9b95-92bba23123f8" />
