### PR TITLE
Add config monitor support for k8s configmap.

### DIFF
--- a/llama-swap.go
+++ b/llama-swap.go
@@ -132,6 +132,11 @@ func main() {
 						event.Emit(proxy.ConfigFileChangedEvent{
 							ReloadingState: proxy.ReloadingStateStart,
 						})
+					} else if changeEvent.Name == filepath.Join(configDir, "..data") && changeEvent.Has(fsnotify.Create) {
+						// the change for k8s configmap 
+						event.Emit(proxy.ConfigFileChangedEvent{
+							ReloadingState: proxy.ReloadingStateStart,
+						})
 					}
 
 				case err := <-watcher.Errors:


### PR DESCRIPTION
In https://github.com/mostlygeek/llama-swap/commit/6a058e4191d8c349bb0aa6566ff3440aa9dcfa92 this commit, the watcher switch to config directory instead of config file.

But in K8s, the configmap changes by "${configDir}/.data" instead of config file.
So this commit add support for k8s configmap, by check the `changeEvent.Name == filepath.join(configDir, "..data)` and the  `Op.Create` Event.

The event for configmap of k8s:
```plain
# /tmp/llama-swap-linux-amd64 --config /app/config.yaml --watch-config --listen :8001
Watching Configuration for changes
llama-swap listening on :8001
Change event (CREATE) detect for file: /app/..2025_08_03_07_02_24.1383724309.
Change event (CHMOD) detect for file: /app/..2025_08_03_07_02_24.1383724309.
Change event (CREATE) detect for file: /app/..data_tmp.
Change event (RENAME) detect for file: /app/..data_tmp.
Change event (CREATE) detect for file: /app/..data.
Change event (REMOVE) detect for file: /app/..2025_08_03_06_54_24.1343939978.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for Kubernetes by automatically detecting and reloading configuration changes triggered by configmap updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->