### PR TITLE
in the /v1/models endpoint, sort by id

### DIFF
--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -8,6 +8,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -332,6 +333,13 @@ func (pm *ProxyManager) listModelsHandler(c *gin.Context) {
 
 		data = append(data, record)
 	}
+
+	// Sort by the "id" key
+	sort.Slice(data, func(i, j int) bool {
+		si, _ := data[i]["id"].(string)
+		sj, _ := data[j]["id"].(string)
+		return si < sj
+	})
 
 	// Set CORS headers if origin exists
 	if origin := c.GetHeader("Origin"); origin != "" {


### PR DESCRIPTION
Currently, when you hit /v1/models, the models are returned in an arbitrary order. With this change, they will be returned in alphabetical order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model listings are now consistently sorted by their ID in ascending order when viewing available models.

* **Tests**
  * Added a test to ensure models are correctly sorted and unlisted models are excluded from the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->