### PR TITLE
Add support for ${MODEL_ID} macro

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -49,6 +49,7 @@ macros:
 # - required
 # - each key is the model's ID, used in API requests
 # - model settings have default values that are used if they are not defined here
+# - the model's ID is available in the ${MODEL_ID} macro, also available in macros defined above
 # - below are examples of the various settings a model can have:
 # - available model settings: env, cmd, cmdStop, proxy, aliases, checkEndpoint, ttl, unlisted
 models:
@@ -148,12 +149,12 @@ models:
     cmd: llama-server --port ${PORT} -m Llama-3.2-1B-Instruct-Q4_K_M.gguf -ngl 0
 
   # Docker example:
-  # container run times like Docker and Podman can be used reliably with a
-  # a combination of cmd and cmdStop.
+  # container runtimes like Docker and Podman can be used reliably with
+  # a combination of cmd, cmdStop, and ${MODEL_ID}
   "docker-llama":
     proxy: "http://127.0.0.1:${PORT}"
     cmd: |
-      docker run --name dockertest
+      docker run --name ${MODEL_ID}
       --init --rm -p ${PORT}:8080 -v /mnt/nvme/models:/models
       ghcr.io/ggml-org/llama.cpp:server
       --model '/models/Qwen2.5-Coder-0.5B-Instruct-Q4_K_M.gguf'
@@ -167,7 +168,7 @@ models:
     # - on POSIX systems: a SIGTERM signal is sent
     # - on Windows, calls taskkill to stop the process
     # - processes have 5 seconds to shutdown until forceful termination is attempted
-    cmdStop: docker stop dockertest
+    cmdStop: docker stop ${MODEL_ID}
 
 # groups: a dictionary of group settings
 # - optional, default: empty dictionary

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -237,7 +237,7 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 
 	- name must fit the regex ^[a-zA-Z0-9_-]+$
 	- names must be less than 64 characters (no reason, just cause)
-	- name can not be any reserved macros: PORT
+	- name can not be any reserved macros: PORT, MODEL_ID
 	- macro values must be less than 1024 characters
 	*/
 	macroNameRegex := regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
@@ -253,6 +253,7 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		}
 		switch macroName {
 		case "PORT":
+		case "MODEL_ID":
 			return Config{}, fmt.Errorf("macro name '%s' is reserved and cannot be used", macroName)
 		}
 	}
@@ -294,6 +295,11 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 			modelConfig.CmdStop = strings.ReplaceAll(modelConfig.CmdStop, "${PORT}", nextPortStr)
 			modelConfig.Proxy = strings.ReplaceAll(modelConfig.Proxy, "${PORT}", nextPortStr)
 			nextPort++
+		}
+
+		if strings.Contains(modelConfig.Cmd, "${MODEL_ID}") || strings.Contains(modelConfig.CmdStop, "${MODEL_ID}") {
+			modelConfig.Cmd = strings.ReplaceAll(modelConfig.Cmd, "${MODEL_ID}", modelId)
+			modelConfig.CmdStop = strings.ReplaceAll(modelConfig.CmdStop, "${MODEL_ID}", modelId)
 		}
 
 		// make sure there are no unknown macros that have not been replaced


### PR DESCRIPTION
This adds `${MODEL_ID}` support in commands and user-defined macros to simplify config. For example, this common config for docker:

```
macros:
  "docker-llama": docker run -v /models:/models -p ${PORT}:8080

models:
  gpt-oss-20b-GGUF:
    cmd: |
      ${docker-llama} 
      --name gpt-oss-20b-GGUF
      ghcr.io/ggml-org/llama.cpp:server-cuda
    cmdStop: docker stop gpt-oss-20b-GGUF

  Qwen3-Coder-30B-A3B-Instruct-GGUF:
    cmd: ${docker-llama} --name Qwen3-Coder-30B-A3B-Instruct-GGUF ghcr.io/ggml-org/llama.cpp:server-cuda
    cmdStop: docker stop Qwen3-Coder-30B-A3B-Instruct-GGUF
```

...can now be simplified to be more readable and less prone to copy and paste errors:

```
macros:
  "docker-llama": |
    docker run -v /models:/models 
    -p ${PORT}:8080 
    --name ${MODEL_ID} 
    ghcr.io/ggml-org/llama.cpp:server-cuda
  "docker-stop": |
    docker stop ${MODEL_ID}

models:
  gpt-oss-20b-GGUF:
    cmd: ${docker-llama} -hf unsloth/gpt-oss-20b-GGUF:F16
    useModelName: unsloth/gpt-oss-20b-GGUF:F16
    cmdStop: ${docker-stop}

  Qwen3-Coder-30B-A3B-Instruct-GGUF:
    cmd: ${docker-llama} -hf unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Q4_K_XL
    useModelName: unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF:Q4_K_XL
    cmdStop: ${docker-stop}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified `${MODEL_ID}` usage in macros and examples (updated docker-llama example and notes).

* **New Features**
  * `${MODEL_ID}` now expands in per-model commands (`cmd`/`cmdStop`) so container commands are tied to each model.

* **Bug Fixes**
  * `MODEL_ID` reserved to avoid conflicts with user-defined macros.

* **Tests**
  * Added tests verifying `${MODEL_ID}` and `${PORT}` expand correctly and produce expected per-model commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->