### PR TITLE
Fix model alias usage in upstream path

### DIFF
--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -361,7 +361,7 @@ func (pm *ProxyManager) proxyToUpstream(c *gin.Context) {
 		return
 	}
 
-	processGroup, _, err := pm.swapProcessGroup(requestedModel)
+	processGroup, realModelName, err := pm.swapProcessGroup(requestedModel)
 	if err != nil {
 		pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error swapping process group: %s", err.Error()))
 		return
@@ -369,7 +369,7 @@ func (pm *ProxyManager) proxyToUpstream(c *gin.Context) {
 
 	// rewrite the path
 	c.Request.URL.Path = c.Param("upstreamPath")
-	processGroup.ProxyRequest(requestedModel, c.Writer, c.Request)
+	processGroup.ProxyRequest(realModelName, c.Writer, c.Request)
 }
 
 func (pm *ProxyManager) proxyOAIHandler(c *gin.Context) {


### PR DESCRIPTION
Model alias values are not properly resolved and work in upstream/ path.

Related to #229.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that requests to proxied models use the resolved real model name instead of any alias, improving accuracy when handling model aliases.

* **Tests**
  * Updated and expanded tests to verify correct behavior when accessing models by both their main name and alias, ensuring consistent responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->