### PR TITLE
Add barebones but working implementation of model preload (#209)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 dist/
 .vscode
 .DS_Store
+.dev/

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ Written in golang, it is very easy to install (single binary with no dependencie
 - ✅ Run multiple models at once with `Groups` ([#107](https://github.com/mostlygeek/llama-swap/issues/107))
 - ✅ Automatic unloading of models after timeout by setting a `ttl`
 - ✅ Use any local OpenAI compatible server (llama.cpp, vllm, tabbyAPI, etc)
-- ✅ Docker and Podman support
+- ✅ Reliable Docker and Podman support with `cmdStart` and `cmdStop`
 - ✅ Full control over server settings per model
+- ✅ Preload models on startup with `hooks` ([#235](https://github.com/mostlygeek/llama-swap/pull/235))
 
 ## How does llama-swap work?
 
@@ -42,9 +43,9 @@ In the most basic configuration llama-swap handles one model at a time. For more
 
 ## config.yaml
 
-llama-swap is managed entirely through a yaml configuration file. 
+llama-swap is managed entirely through a yaml configuration file.
 
-It can be very minimal to start: 
+It can be very minimal to start:
 
 ```yaml
 models:
@@ -55,7 +56,7 @@ models:
       --port ${PORT}
 ```
 
-However, there are many more capabilities that llama-swap supports: 
+However, there are many more capabilities that llama-swap supports:
 
 - `groups` to run multiple models at once
 - `ttl` to automatically unload models
@@ -90,7 +91,7 @@ llama-swap can be installed in multiple ways
 
 ### Docker Install ([download images](https://github.com/mostlygeek/llama-swap/pkgs/container/llama-swap))
 
-Docker images with llama-swap and llama-server are built nightly. 
+Docker images with llama-swap and llama-server are built nightly.
 
 ```shell
 # use CPU inference comes with the example config above
@@ -137,10 +138,10 @@ $ docker run -it --rm --runtime nvidia -p 9292:8080 \
 
 ### Homebrew Install (macOS/Linux)
 
-The latest release of `llama-swap` can be installed via [Homebrew](https://brew.sh). 
+The latest release of `llama-swap` can be installed via [Homebrew](https://brew.sh).
 
 ```shell
-# Set up tap and install formula 
+# Set up tap and install formula
 brew tap mostlygeek/llama-swap
 brew install llama-swap
 # Run llama-swap

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,6 +1,13 @@
 # llama-swap YAML configuration example
 # -------------------------------------
 #
+# 💡 Tip - Use an LLM with this file!
+# ====================================
+#  This example configuration is written to be LLM friendly! Try
+#  copying this file into an LLM and asking it to explain or generate
+#  sections for you.
+# ====================================
+#
 # - Below are all the available configuration options for llama-swap.
 # - Settings with a default value, or noted as optional can be omitted.
 # - Settings that are marked required must be in your configuration file
@@ -207,3 +214,19 @@ groups:
       - "forever-modelA"
       - "forever-modelB"
       - "forever-modelc"
+
+# hooks: a dictionary of event triggers and actions
+# - optional, default: empty dictionary
+# - the only supported hook is on_startup
+hooks:
+  # on_startup: a dictionary of actions to perform on startup
+  # - optional, default: empty dictionar
+  # - the only supported action is preload
+  on_startup:
+        # preload: a list of model ids to load on startup
+        # - optional, default: empty list
+        # - model names must match keys in the models sections
+        # - when preloading multiple models at once, define a group
+        #   otherwise models will be loaded and swapped out
+    preload:
+      - "llama"

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -138,6 +138,12 @@ func (c *GroupConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+type HooksConfig struct {
+	OnStartup struct {
+		Preload []string `yaml:"preload"`
+	} `yaml:"on_startup"`
+}
+
 type Config struct {
 	HealthCheckTimeout int                    `yaml:"healthCheckTimeout"`
 	LogRequests        bool                   `yaml:"logRequests"`
@@ -155,6 +161,9 @@ type Config struct {
 
 	// automatic port assignments
 	StartPort int `yaml:"startPort"`
+
+	// hooks, see: #209
+	Hooks HooksConfig `yaml:"hooks"`
 }
 
 func (c *Config) RealModelName(search string) (string, bool) {
@@ -328,6 +337,22 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 			}
 			memberUsage[member] = groupID
 		}
+	}
+
+	// clean up hooks preload
+	if len(config.Hooks.OnStartup.Preload) > 0 {
+		var toPreload []string
+		for _, modelID := range config.Hooks.OnStartup.Preload {
+			modelID = strings.TrimSpace(modelID)
+			if modelID == "" {
+				continue
+			}
+			if real, found := config.RealModelName(modelID); found {
+				toPreload = append(toPreload, real)
+			}
+		}
+
+		config.Hooks.OnStartup.Preload = toPreload
 	}
 
 	return config, nil

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -139,9 +139,11 @@ func (c *GroupConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 type HooksConfig struct {
-	OnStartup struct {
-		Preload []string `yaml:"preload"`
-	} `yaml:"on_startup"`
+	OnStartup HookOnStartup `yaml:"on_startup"`
+}
+
+type HookOnStartup struct {
+	Preload []string `yaml:"preload"`
 }
 
 type Config struct {

--- a/proxy/config_posix_test.go
+++ b/proxy/config_posix_test.go
@@ -100,6 +100,9 @@ func TestConfig_LoadPosix(t *testing.T) {
 	content := `
 macros:
   svr-path: "path/to/server"
+hooks:
+  on_startup:
+    preload: ["model1", "model2"]
 models:
   model1:
     cmd: path/to/cmd --arg1 one
@@ -162,6 +165,11 @@ groups:
 		StartPort: 5800,
 		Macros: map[string]string{
 			"svr-path": "path/to/server",
+		},
+		Hooks: HooksConfig{
+			OnStartup: HookOnStartup{
+				Preload: []string{"model1", "model2"},
+			},
 		},
 		Models: map[string]ModelConfig{
 			"model1": {

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -440,3 +440,11 @@ models:
 	expectedCmd := "/user/llama.cpp/build/bin/llama-server --port 9990 --model /path/to/model.gguf -ngl 99"
 	assert.Equal(t, expectedCmd, cmdStr, "Final command does not match expected structure")
 }
+
+func TestConfig_HooksOnStartup(t *testing.T) {
+	/* Placeholder to test
+	- that real model names are resolved in hooks
+	- everything that is not in models: is removed
+	*/
+
+}

--- a/proxy/config_test.go
+++ b/proxy/config_test.go
@@ -440,11 +440,3 @@ models:
 	expectedCmd := "/user/llama.cpp/build/bin/llama-server --port 9990 --model /path/to/model.gguf -ngl 99"
 	assert.Equal(t, expectedCmd, cmdStr, "Final command does not match expected structure")
 }
-
-func TestConfig_HooksOnStartup(t *testing.T) {
-	/* Placeholder to test
-	- that real model names are resolved in hooks
-	- everything that is not in models: is removed
-	*/
-
-}

--- a/proxy/discardWriter.go
+++ b/proxy/discardWriter.go
@@ -1,0 +1,18 @@
+package proxy
+
+import "net/http"
+
+// Custom discard writer that implements http.ResponseWriter but just discards everything
+type DiscardWriter struct{}
+
+func (w *DiscardWriter) Header() http.Header {
+	return make(http.Header)
+}
+
+func (w *DiscardWriter) Write([]byte) (int, error) {
+	return 0, nil // Discard all writes
+}
+
+func (w *DiscardWriter) WriteHeader(int) {
+	// Ignore status codes
+}

--- a/proxy/discardWriter.go
+++ b/proxy/discardWriter.go
@@ -3,16 +3,25 @@ package proxy
 import "net/http"
 
 // Custom discard writer that implements http.ResponseWriter but just discards everything
-type DiscardWriter struct{}
+type DiscardWriter struct {
+	header http.Header
+	status int
+}
 
 func (w *DiscardWriter) Header() http.Header {
-	return make(http.Header)
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
 }
 
-func (w *DiscardWriter) Write([]byte) (int, error) {
-	return 0, nil // Discard all writes
+func (w *DiscardWriter) Write(data []byte) (int, error) {
+	return len(data), nil
 }
 
-func (w *DiscardWriter) WriteHeader(int) {
-	// Ignore status codes
+func (w *DiscardWriter) WriteHeader(code int) {
+	w.status = code
 }
+
+// Satisfy the http.Flusher interface for streaming responses
+func (w *DiscardWriter) Flush() {}

--- a/proxy/events.go
+++ b/proxy/events.go
@@ -7,6 +7,7 @@ const ChatCompletionStatsEventID = 0x02
 const ConfigFileChangedEventID = 0x03
 const LogDataEventID = 0x04
 const TokenMetricsEventID = 0x05
+const ModelPreloadedEventID = 0x06
 
 type ProcessStateChangeEvent struct {
 	ProcessName string
@@ -47,4 +48,13 @@ type LogDataEvent struct {
 
 func (e LogDataEvent) Type() uint32 {
 	return LogDataEventID
+}
+
+type ModelPreloadedEvent struct {
+	ModelName string
+	Success   bool
+}
+
+func (e ModelPreloadedEvent) Type() uint32 {
+	return ModelPreloadedEventID
 }

--- a/proxy/helpers_test.go
+++ b/proxy/helpers_test.go
@@ -13,9 +13,10 @@ import (
 )
 
 var (
-	nextTestPort int = 12000
-	portMutex    sync.Mutex
-	testLogger   = NewLogMonitorWriter(os.Stdout)
+	nextTestPort        int = 12000
+	portMutex           sync.Mutex
+	testLogger          = NewLogMonitorWriter(os.Stdout)
+	simpleResponderPath = getSimpleResponderPath()
 )
 
 // Check if the binary exists
@@ -69,13 +70,11 @@ func getTestSimpleResponderConfig(expectedMessage string) ModelConfig {
 }
 
 func getTestSimpleResponderConfigPort(expectedMessage string, port int) ModelConfig {
-	binaryPath := getSimpleResponderPath()
-
 	// Create a YAML string with just the values we want to set
 	yamlStr := fmt.Sprintf(`
 cmd: '%s --port %d --silent --respond %s'
 proxy: "http://127.0.0.1:%d"
-`, binaryPath, port, expectedMessage, port)
+`, simpleResponderPath, port, expectedMessage, port)
 
 	var cfg ModelConfig
 	if err := yaml.Unmarshal([]byte(yamlStr), &cfg); err != nil {

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -879,6 +879,10 @@ models:
 	w.Wait()
 
 	// make sure they are both loaded
+	_, foundGroup := proxy.processGroups["test"]
+	if !assert.True(t, foundGroup, "test group should exist") {
+		return
+	}
 	assert.Equal(t, StateReady, proxy.processGroups["test"].processes["model1"].CurrentState())
 	assert.Equal(t, StateReady, proxy.processGroups["test"].processes["model2"].CurrentState())
 }


### PR DESCRIPTION
- add hooks.on_startup.preload (array)
- implement in ProxyManager to load models
- todo: tests, docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optional non-blocking startup hooks to preload models via configuration (hooks.on_startup.preload); preload runs in background.
- **Events**
  - Emits model preload status events to report success/failure for monitoring and readiness.
- **Tests**
  - Added tests for startup preload behavior and config parsing; updated test helpers.
- **Documentation**
  - README and example config updated to document startup preload option.
- **Chores**
  - Added .dev/ to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->