### PR TITLE
Add a config editor page

### DIFF
--- a/proxy/fileutil.go
+++ b/proxy/fileutil.go
@@ -1,0 +1,92 @@
+package proxy
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// WriteFileAtomic writes data to path atomically.
+// It writes to a temporary file in the same directory, fsyncs it,
+// sets the desired mode, closes it, fsyncs the directory (best-effort),
+// then renames over the destination.
+//
+// Mode preservation:
+// - If the destination path already exists, its mode is preserved regardless of the provided mode.
+// - If the destination does not exist and the provided mode is non-zero, that mode is used.
+// - Otherwise, 0644 is used.
+func WriteFileAtomic(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+
+	// Determine effective mode
+	effectiveMode := mode
+	if fi, err := os.Stat(path); err == nil {
+		effectiveMode = fi.Mode()
+	} else {
+		if effectiveMode == 0 {
+			effectiveMode = 0o644
+		}
+	}
+
+	// Create a temp file in the same directory for atomic rename
+	tmpFile, err := os.CreateTemp(dir, ".tmp-config-*.yaml")
+	if err != nil {
+		return err
+	}
+
+	tmpName := tmpFile.Name()
+	cleanup := func() {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmpName)
+	}
+
+	// Ensure cleanup on any failure path
+	defer func() {
+		// If tmpFile still exists (e.g., rename failed), best-effort remove it
+		_ = os.Remove(tmpName)
+	}()
+
+	// Write data
+	if _, err = tmpFile.Write(data); err != nil {
+		cleanup()
+		return err
+	}
+
+	// Flush file contents
+	if err = tmpFile.Sync(); err != nil {
+		cleanup()
+		return err
+	}
+
+	// Set mode
+	if err = tmpFile.Chmod(effectiveMode); err != nil {
+		cleanup()
+		return err
+	}
+
+	// Close the temp file before rename
+	if err = tmpFile.Close(); err != nil {
+		cleanup()
+		return err
+	}
+
+	// Best-effort fsync the directory before rename (not strictly required)
+	if dirFD, err := os.Open(dir); err == nil {
+		_ = dirFD.Sync()
+		_ = dirFD.Close()
+	}
+
+	// Atomic rename
+	if err = os.Rename(tmpName, path); err != nil {
+		// best-effort cleanup
+		_ = os.Remove(tmpName)
+		return err
+	}
+
+	// Best-effort fsync the directory after rename to strengthen durability
+	if dirFD, err := os.Open(dir); err == nil {
+		_ = dirFD.Sync()
+		_ = dirFD.Close()
+	}
+
+	return nil
+}

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -42,6 +42,11 @@ type ProxyManager struct {
 	// shutdown signaling
 	shutdownCtx    context.Context
 	shutdownCancel context.CancelFunc
+
+	// admin controls wiring
+	configPath         string
+	reloadCallback     func()
+	watchConfigEnabled bool
 }
 
 func New(config Config) *ProxyManager {
@@ -621,4 +626,12 @@ func (pm *ProxyManager) findGroupByModelName(modelName string) *ProcessGroup {
 		}
 	}
 	return nil
+}
+
+// SetAdminControls wires admin-related controls into the ProxyManager.
+// These are carried for future admin APIs and safe reload operations.
+func (pm *ProxyManager) SetAdminControls(configPath string, watchEnabled bool, reload func()) {
+	pm.configPath = configPath
+	pm.watchConfigEnabled = watchEnabled
+	pm.reloadCallback = reload
 }

--- a/proxy/proxymanager_api.go
+++ b/proxy/proxymanager_api.go
@@ -25,6 +25,8 @@ func addApiHandlers(pm *ProxyManager) {
 		apiGroup.POST("/models/unload", pm.apiUnloadAllModels)
 		apiGroup.GET("/events", pm.apiSendEvents)
 		apiGroup.GET("/metrics", pm.apiGetMetrics)
+		apiGroup.GET("/config", pm.apiGetConfig)
+		apiGroup.PUT("/config", pm.apiPutConfig)
 	}
 }
 

--- a/proxy/proxymanager_config_api.go
+++ b/proxy/proxymanager_config_api.go
@@ -1,0 +1,65 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mostlygeek/llama-swap/event"
+)
+
+// apiGetConfig returns the raw YAML configuration file contents.
+func (pm *ProxyManager) apiGetConfig(c *gin.Context) {
+	data, err := os.ReadFile(pm.configPath)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Data(http.StatusOK, "text/plain; charset=utf-8", data)
+}
+
+// apiPutConfig validates and atomically writes the configuration file.
+// It triggers reload behavior based on the watchConfigEnabled setting.
+func (pm *ProxyManager) apiPutConfig(c *gin.Context) {
+	// Read entire body as text (accept text/plain or application/x-yaml, but don't hard fail on content-type)
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read request body"})
+		return
+	}
+
+	// Validate YAML using existing loader
+	if _, err := LoadConfigFromReader(bytes.NewReader(body)); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Preserve existing file mode when possible; default to 0644
+	var mode os.FileMode = 0o644
+	if fi, err := os.Stat(pm.configPath); err == nil {
+		mode = fi.Mode()
+	}
+
+	// Atomic write
+	if err := WriteFileAtomic(pm.configPath, body, mode); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to write config file"})
+		return
+	}
+
+	// Trigger reload based on watch behavior
+	if pm.watchConfigEnabled {
+		// Do not call reloadCallback; fsnotify watcher will emit start event and handle reload
+	} else {
+		// Emit start event then call reload callback
+		event.Emit(ConfigFileChangedEvent{
+			ReloadingState: ReloadingStateStart,
+		})
+		if pm.reloadCallback != nil {
+			pm.reloadCallback()
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"msg": "ok"})
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, type FocusEvent, type KeyboardEvent } from "react";
 import { BrowserRouter as Router, Routes, Route, Navigate, NavLink } from "react-router-dom";
 import { useTheme } from "./contexts/ThemeProvider";
 import { useAPI } from "./contexts/APIProvider";
@@ -7,6 +7,7 @@ import ModelPage from "./pages/Models";
 import ActivityPage from "./pages/Activity";
 import ConnectionStatusIcon from "./components/ConnectionStatus";
 import { RiSunFill, RiMoonFill } from "react-icons/ri";
+import ConfigEditor from "./pages/ConfigEditor";
 
 function App() {
   const { isNarrow, toggleTheme, isDarkMode, appTitle, setAppTitle, setConnectionState } = useTheme();
@@ -22,7 +23,7 @@ function App() {
   // Synchronize the window.title connections state with the actual connection state
   useEffect(() => {
     setConnectionState(connectionStatus);
-  }, [connectionStatus]);
+  }, [connectionStatus, setConnectionState]);
 
   return (
     <Router basename="/ui/">
@@ -34,12 +35,14 @@ function App() {
                 contentEditable
                 suppressContentEditableWarning
                 className="flex items-center p-0 outline-none hover:bg-gray-100 dark:hover:bg-gray-700 rounded px-1"
-                onBlur={(e) => handleTitleChange(e.currentTarget.textContent || "(set title)")}
-                onKeyDown={(e) => {
+                onBlur={(e: FocusEvent<HTMLHeadingElement>) =>
+                  handleTitleChange(e.currentTarget.textContent || "(set title)")
+                }
+                onKeyDown={(e: KeyboardEvent<HTMLHeadingElement>) => {
                   if (e.key === "Enter") {
                     e.preventDefault();
                     handleTitleChange(e.currentTarget.textContent || "(set title)");
-                    e.currentTarget.blur();
+                    (e.currentTarget as HTMLElement).blur();
                   }
                 }}
               >
@@ -47,13 +50,28 @@ function App() {
               </h1>
             )}
             <div className="flex items-center space-x-4">
-              <NavLink to="/" className={({ isActive }) => (isActive ? "navlink active" : "navlink")}>
+              <NavLink
+                to="/"
+                className={({ isActive }: { isActive: boolean }) => (isActive ? "navlink active" : "navlink")}
+              >
                 Logs
               </NavLink>
-              <NavLink to="/models" className={({ isActive }) => (isActive ? "navlink active" : "navlink")}>
+              <NavLink
+                to="/models"
+                className={({ isActive }: { isActive: boolean }) => (isActive ? "navlink active" : "navlink")}
+              >
                 Models
               </NavLink>
-              <NavLink to="/activity" className={({ isActive }) => (isActive ? "navlink active" : "navlink")}>
+              <NavLink
+                to="/config"
+                className={({ isActive }: { isActive: boolean }) => (isActive ? "navlink active" : "navlink")}
+              >
+                Config
+              </NavLink>
+              <NavLink
+                to="/activity"
+                className={({ isActive }: { isActive: boolean }) => (isActive ? "navlink active" : "navlink")}
+              >
                 Activity
               </NavLink>
               <button className="" onClick={toggleTheme}>
@@ -68,6 +86,7 @@ function App() {
           <Routes>
             <Route path="/" element={<LogViewerPage />} />
             <Route path="/models" element={<ModelPage />} />
+            <Route path="/config" element={<ConfigEditor />} />
             <Route path="/activity" element={<ActivityPage />} />
             <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>

--- a/ui/src/pages/ConfigEditor.tsx
+++ b/ui/src/pages/ConfigEditor.tsx
@@ -132,12 +132,13 @@ const ConfigEditor = () => {
     setSuccessMsg(null);
 
     try {
+      const payload = content; // capture exactly what we send
       const res = await fetch("/api/config", {
         method: "PUT",
         headers: {
           "Content-Type": "text/plain",
         },
-        body: content,
+        body: payload,
       });
 
       if (!res.ok) {
@@ -145,8 +146,8 @@ const ConfigEditor = () => {
         throw new Error(msg);
       }
 
-      // success
-      setOriginalContent(content);
+      // success: mark exactly what was persisted
+      setOriginalContent(payload);
       setSuccessMsg("Saved");
       // transient success
       setTimeout(() => setSuccessMsg(null), 1500);

--- a/ui/src/pages/ConfigEditor.tsx
+++ b/ui/src/pages/ConfigEditor.tsx
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { RiAlignJustify, RiFontSize, RiTextWrap } from "react-icons/ri";
+import { usePersistentState } from "../hooks/usePersistentState";
+import { useAPI } from "../contexts/APIProvider";
+
+type FontSize = "xxs" | "xs" | "small" | "normal";
+
+const ConfigEditor = () => {
+  const { connectionStatus } = useAPI();
+
+  // Editor state
+  const [content, setContent] = useState("");
+  const [originalContent, setOriginalContent] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  // UI prefs (persisted like LogPanel)
+  const [wrapText, setWrapText] = usePersistentState("configEditor-wrapText", false);
+  const [fontSize, setFontSize] = usePersistentState<FontSize>("configEditor-fontSize", "normal");
+
+  const isDirty = useMemo(() => content !== originalContent, [content, originalContent]);
+
+  // abort controller for fetches
+  const loadAbortRef = useRef<AbortController | null>(null);
+  const prevConnRef = useRef(connectionStatus);
+
+  const fontSizeClass = useMemo(() => {
+    switch (fontSize) {
+      case "xxs":
+        return "text-[0.5rem]";
+      case "xs":
+        return "text-[0.75rem]";
+      case "small":
+        return "text-[0.875rem]";
+      case "normal":
+        return "text-base";
+    }
+    return "text-base";
+  }, [fontSize]);
+
+  const toggleFontSize = useCallback(() => {
+    setFontSize((prev) => {
+      switch (prev) {
+        case "xxs":
+          return "xs";
+        case "xs":
+          return "small";
+        case "small":
+          return "normal";
+        case "normal":
+          return "xxs";
+      }
+    });
+  }, [setFontSize]);
+
+  const toggleWrap = useCallback(() => setWrapText((prev) => !prev), [setWrapText]);
+
+  const readErrorResponse = useCallback(async (res: Response) => {
+    try {
+      const ct = res.headers.get("content-type") || "";
+      if (ct.includes("application/json")) {
+        const data = await res.json();
+        if (data && typeof data.error === "string") {
+          return data.error as string;
+        }
+        return JSON.stringify(data);
+      }
+      const txt = await res.text();
+      return txt || `Request failed with status ${res.status}`;
+    } catch (e: unknown) {
+      return `Request failed with status ${res.status}`;
+    }
+  }, []);
+
+  const fetchConfig = useCallback(async () => {
+    setLoading(true);
+    setErrorMsg(null);
+    setSuccessMsg(null);
+
+    loadAbortRef.current?.abort();
+    const controller = new AbortController();
+    loadAbortRef.current = controller;
+
+    try {
+      const res = await fetch("/api/config", {
+        method: "GET",
+        signal: controller.signal,
+      });
+      if (!res.ok) {
+        const msg = await readErrorResponse(res);
+        throw new Error(msg);
+      }
+      const text = await res.text();
+      setContent(text);
+      setOriginalContent(text);
+    } catch (e: any) {
+      if (e?.name === "AbortError") {
+        // ignore aborts
+      } else {
+        setErrorMsg(e?.message || "Failed to load config");
+      }
+    } finally {
+      if (!controller.signal.aborted) {
+        setLoading(false);
+      }
+    }
+  }, [readErrorResponse]);
+
+  // Initial load
+  useEffect(() => {
+    fetchConfig();
+    return () => {
+      loadAbortRef.current?.abort();
+    };
+  }, [fetchConfig]);
+
+  // Re-fetch when reconnects and editor is clean
+  useEffect(() => {
+    const prev = prevConnRef.current;
+    if (prev !== "connected" && connectionStatus === "connected" && !isDirty) {
+      fetchConfig();
+    }
+    prevConnRef.current = connectionStatus;
+  }, [connectionStatus, isDirty, fetchConfig]);
+
+  const handleSave = useCallback(async () => {
+    if (!isDirty || saving) return;
+    setSaving(true);
+    setErrorMsg(null);
+    setSuccessMsg(null);
+
+    try {
+      const res = await fetch("/api/config", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "text/plain",
+        },
+        body: content,
+      });
+
+      if (!res.ok) {
+        const msg = await readErrorResponse(res);
+        throw new Error(msg);
+      }
+
+      // success
+      setOriginalContent(content);
+      setSuccessMsg("Saved");
+      // transient success
+      setTimeout(() => setSuccessMsg(null), 1500);
+    } catch (e: any) {
+      setErrorMsg(e?.message || "Failed to save config");
+    } finally {
+      setSaving(false);
+    }
+  }, [content, isDirty, saving, readErrorResponse]);
+
+  return (
+    <div className="card h-full flex flex-col">
+      <div className="shrink-0">
+        <div className="flex items-center justify-between">
+          <h2>Config</h2>
+
+          <div className="flex items-center gap-2">
+            <button className="btn" onClick={toggleFontSize} title="Font size">
+              <RiFontSize />
+            </button>
+            <button className="btn" onClick={toggleWrap} title={wrapText ? "Disable wrap" : "Enable wrap"}>
+              {wrapText ? <RiTextWrap /> : <RiAlignJustify />}
+            </button>
+            <button
+              className="btn"
+              onClick={handleSave}
+              disabled={!isDirty || saving || loading}
+              title="Save configuration"
+            >
+              {saving ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-2 min-h-[24px]">
+          {loading && <span className="text-txtsecondary">Loading...</span>}
+          {!loading && successMsg && <span className="text-success">{successMsg}</span>}
+          {!loading && errorMsg && <span className="text-error">{errorMsg}</span>}
+          {!loading && !successMsg && !errorMsg && (
+            <span className="text-txtsecondary">{isDirty ? "Unsaved changes" : "Up to date"}</span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 mt-2">
+        <textarea
+          className={`w-full h-full font-mono ${fontSizeClass} bg-background text-foreground border border-border rounded p-3 outline-none focus:border-primary focus:ring-0 resize-none`}
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          spellCheck={false}
+          wrap={wrapText ? "soft" : "off"}
+          disabled={loading}
+          aria-label="YAML configuration editor"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ConfigEditor;


### PR DESCRIPTION
Adds a page to live edit the config.yaml :).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an in-app Config page to view and edit the YAML configuration with load/save, validation, unsaved-change indicator, status messages, font-size and wrap controls, and accessible editor.
  * New server endpoints to GET and PUT the config (/api/config).

* **Reliability**
  * Safer atomic saves that preserve file permissions and reduce corruption risk.
  * More consistent admin-controlled reload behavior after config updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->