### PR TITLE
Improvements? to -watch-config loading behaviour

### DIFF
--- a/llama-swap.go
+++ b/llama-swap.go
@@ -103,8 +103,8 @@ func main() {
 	}
 
 	// load the initial proxy manager
+	reloadProxyManager()
 	debouncedReload := debounce(time.Second, reloadProxyManager)
-	debouncedReload()
 	if *watchConfig {
 		defer event.On(func(e proxy.ConfigFileChangedEvent) {
 			if e.ReloadingState == proxy.ReloadingStateStart {

--- a/proxy/config.go
+++ b/proxy/config.go
@@ -186,6 +186,20 @@ func (c *Config) FindConfig(modelName string) (ModelConfig, string, bool) {
 	}
 }
 
+// GetLogLevel returns the LogLevel in the configuration
+func (c *Config) GetLogLevel() LogLevel {
+	switch strings.ToLower(c.LogLevel) {
+	case "debug":
+		return LevelDebug
+	case "warn":
+		return LevelWarn
+	case "error":
+		return LevelError
+	default:
+		return LevelInfo
+	}
+}
+
 func LoadConfig(path string) (Config, error) {
 	file, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
Reported in #281 that llama-swap can load multiple child processes. I wasn't able to reproduce this but this may improve the situation. Leaving as an open PR for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable log level via settings (Debug, Info, Warn, Error).
  - Default logs start at Debug after launch to aid diagnostics.
  - More informative messages for configuration reloads, startup, shutdown, and file watching.
  - Additional debug details for debounced actions.
- Refactor
  - Replaced scattered print statements with centralized, structured logging for clearer, consistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->