### PR TITLE
add auto reasoning_effort when model includes -high

### DIFF
--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -435,30 +435,30 @@ func (pm *ProxyManager) proxyOAIHandler(c *gin.Context) {
 		pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error swapping process group: %s", err.Error()))
 		return
 	}
-	
+
 	// If the model name ends with "-high", add chat_template_kwargs
 	if strings.HasSuffix(requestedModel, "-high") {
-	    // map[string]string is automatically converted to a JSON object
-	    bodyBytes, err = sjson.SetBytes(bodyBytes, "chat_template_kwargs", map[string]string{
-	        "reasoning_effort": "high",
-	    })
-	    if err != nil {
-	        pm.sendErrorResponse(c, http.StatusInternalServerError,
-	            fmt.Sprintf("error adding chat_template_kwargs: %s", err.Error()))
-	        return
-	    }
+		// map[string]string is automatically converted to a JSON object
+		bodyBytes, err = sjson.SetBytes(bodyBytes, "chat_template_kwargs", map[string]string{
+			"reasoning_effort": "high",
+		})
+		if err != nil {
+			pm.sendErrorResponse(c, http.StatusInternalServerError,
+				fmt.Sprintf("error adding chat_template_kwargs: %s", err.Error()))
+			return
+		}
 	} else if strings.HasSuffix(requestedModel, "-low") {
-	    // map[string]string is automatically converted to a JSON object
-	    bodyBytes, err = sjson.SetBytes(bodyBytes, "chat_template_kwargs", map[string]string{
-	        "reasoning_effort": "low",
-	    })
-	    if err != nil {
-	        pm.sendErrorResponse(c, http.StatusInternalServerError,
-	            fmt.Sprintf("error adding chat_template_kwargs: %s", err.Error()))
-	        return
-	    }
+		// map[string]string is automatically converted to a JSON object
+		bodyBytes, err = sjson.SetBytes(bodyBytes, "chat_template_kwargs", map[string]string{
+			"reasoning_effort": "low",
+		})
+		if err != nil {
+			pm.sendErrorResponse(c, http.StatusInternalServerError,
+				fmt.Sprintf("error adding chat_template_kwargs: %s", err.Error()))
+			return
+		}
 	}
-	
+
 	// issue #69 allow custom model names to be sent to upstream
 	useModelName := pm.config.Models[realModelName].UseModelName
 	if useModelName != "" {

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -435,7 +435,30 @@ func (pm *ProxyManager) proxyOAIHandler(c *gin.Context) {
 		pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error swapping process group: %s", err.Error()))
 		return
 	}
-
+	
+	// If the model name ends with "-high", add chat_template_kwargs
+	if strings.HasSuffix(requestedModel, "-high") {
+	    // map[string]string is automatically converted to a JSON object
+	    bodyBytes, err = sjson.SetBytes(bodyBytes, "chat_template_kwargs", map[string]string{
+	        "reasoning_effort": "high",
+	    })
+	    if err != nil {
+	        pm.sendErrorResponse(c, http.StatusInternalServerError,
+	            fmt.Sprintf("error adding chat_template_kwargs: %s", err.Error()))
+	        return
+	    }
+	} else if strings.HasSuffix(requestedModel, "-low") {
+	    // map[string]string is automatically converted to a JSON object
+	    bodyBytes, err = sjson.SetBytes(bodyBytes, "chat_template_kwargs", map[string]string{
+	        "reasoning_effort": "low",
+	    })
+	    if err != nil {
+	        pm.sendErrorResponse(c, http.StatusInternalServerError,
+	            fmt.Sprintf("error adding chat_template_kwargs: %s", err.Error()))
+	        return
+	    }
+	}
+	
 	// issue #69 allow custom model names to be sent to upstream
 	useModelName := pm.config.Models[realModelName].UseModelName
 	if useModelName != "" {


### PR DESCRIPTION
This commit enables automatic insertion of reasoning_effort when calling llama.cpp via llama-swap from frontends such as continue.dev that cannot explicitly specify reasoning_effort.
If the model name ends with -high or -low, the request message will be automatically appended with:

chat_template_kwargs: { "reasoning_effort": "high" }


For example, if the model name is gpt-oss:20b-high, the reasoning_effort will be set to high.
(This model name should be registered in the aliases section of config.yaml.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Requests for models ending with “-high” or “-low” now automatically include a reasoning level hint upstream (high or low), affecting response depth.
  * Models without those suffixes behave unchanged; this operates transparently during request processing with no configuration required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->