### PR TITLE
Add mlx_lm.server example

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -174,7 +174,7 @@ models:
     cmd: |
       mlx_lm.server --port ${PORT}
       --model /models/mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit
-      useModelName: "/models/mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit"
+    useModelName: "/models/mlx-community/Qwen3-Next-80B-A3B-Thinking-4bit"
 
 # groups: a dictionary of group settings
 # - optional, default: empty dictionary


### PR DESCRIPTION
This one took me longer than I liked to figure out, so I wanted to add an example for anyone else who is coming across the same problem. Which was that without `useModelName` being the file path, `mlx_lm.server` is using the model name, which causes it to download the model to the huggingface cache path, instead of using the one I manually downloaded to the specified `--model` path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a new model option: “Qwen3-Next-80B-A3B-Thinking-4bit.”
  * Includes a ready-to-use launch command (with port configuration) and an explicit model-name override for easier setup and reference.
  * Expands the public model registry without affecting existing models or startup/shutdown behavior.
* **Chores**
  * Minor formatting cleanup (added end-of-file newline).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->