### PR TITLE
proxyToUpstream: add redirect with trailing slash to upstream endpoint

### DIFF
--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -419,6 +419,15 @@ func (pm *ProxyManager) proxyToUpstream(c *gin.Context) {
 			modelName = real
 			remainingPath = "/" + strings.Join(parts[i+1:], "/")
 			modelFound = true
+
+			// Check if this is exactly a model name with no additional path
+			// and doesn't end with a trailing slash
+			if remainingPath == "/" && !strings.HasSuffix(upstreamPath, "/") {
+				// Redirect to add trailing slash
+				newPath := "/upstream/" + searchModelName + "/"
+				c.Redirect(http.StatusMovedPermanently, newPath)
+				return
+			}
 			break
 		}
 	}
@@ -438,6 +447,7 @@ func (pm *ProxyManager) proxyToUpstream(c *gin.Context) {
 	c.Request.URL.Path = remainingPath
 	processGroup.ProxyRequest(realModelName, c.Writer, c.Request)
 }
+
 func (pm *ProxyManager) proxyOAIHandler(c *gin.Context) {
 	bodyBytes, err := io.ReadAll(c.Request.Body)
 	if err != nil {

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -423,9 +423,18 @@ func (pm *ProxyManager) proxyToUpstream(c *gin.Context) {
 			// Check if this is exactly a model name with no additional path
 			// and doesn't end with a trailing slash
 			if remainingPath == "/" && !strings.HasSuffix(upstreamPath, "/") {
-				// Redirect to add trailing slash
+				// Build new URL with query parameters preserved
 				newPath := "/upstream/" + searchModelName + "/"
-				c.Redirect(http.StatusMovedPermanently, newPath)
+				if c.Request.URL.RawQuery != "" {
+					newPath += "?" + c.Request.URL.RawQuery
+				}
+
+				// Use 308 for non-GET/HEAD requests to preserve method
+				if c.Request.Method == http.MethodGet || c.Request.Method == http.MethodHead {
+					c.Redirect(http.StatusMovedPermanently, newPath)
+				} else {
+					c.Redirect(http.StatusPermanentRedirect, newPath)
+				}
 				return
 			}
 			break


### PR DESCRIPTION
Fixes #321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Requests to a model’s root path without a trailing slash now redirect to the canonical URL with a trailing slash (e.g., /upstream/model → /upstream/model/).
  * Query parameters are preserved during the redirect.
  * Redirects use permanent status codes (301 for GET/HEAD, 308 for other methods) to improve compatibility with bookmarks and external links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->