### PR TITLE
Add optional TLS support

### DIFF
--- a/llama-swap.go
+++ b/llama-swap.go
@@ -58,14 +58,13 @@ func main() {
 	}
 
 	// Validate TLS flags.
-	var useTLS bool
+	var useTLS = (*certFile != "" && *keyFile != "")
 	if (*certFile != "" && *keyFile == "") ||
 		(*certFile == "" && *keyFile != "") {
 		fmt.Println("Error: Both --tls-cert-file and --tls-key-file must be provided for TLS.")
 		os.Exit(1)
-	} else {
-		useTLS = true
 	}
+
 	// Set default ports.
 	if *listenStr == "" {
 		defaultPort := ":8080"


### PR DESCRIPTION
Introduce HTTPS support with net/http Server.ListenAndServeTLS.

This should enable the option of serving via HTTPS without a reverse proxy.

Add two flags:
- tls-cert-file (path to the TLS certificate file)
- tls-key-file (path to the TLS private key file)

Both flags must be supplied together; otherwise exit with error.

If both flags are present, call srv.ListenAndServeTLS. If not, fall back to the existing srv.ListenAndServe (HTTP); no changes to existing non‑TLS behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional TLS/HTTPS support via certificate and key flags; service chooses HTTPS port when enabled and logs the correct protocol and listening URL.

* **Bug Fixes**
  * Validates certificate/key pair and exits with a clear error if only one is provided.
  * Server now fails fast on TLS misconfiguration and consistently logs the active listening URL and port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->