### PR TITLE
refactor: update Containerfile to support non-root user execution and improve security

### DIFF
--- a/docker/llama-swap.Containerfile
+++ b/docker/llama-swap.Containerfile
@@ -5,9 +5,9 @@ FROM ghcr.io/ggml-org/llama.cpp:${BASE_TAG}
 ARG LS_VER=170
 
 # Set default UID/GID arguments
-ARG UID=0
-ARG GID=0
-ARG USER_HOME=/root
+ARG UID=10001
+ARG GID=10001
+ARG USER_HOME=/app
 
 # Add user/group
 ENV HOME=$USER_HOME


### PR DESCRIPTION
### Summary
- Updated LS_VER argument from 89 to 170 to use the latest version
- Added UID/GID arguments with default values of 0 (root) for backward compatibility
- Added USER_HOME environment variable set to /root
- Implemented conditional user/group creation logic that only runs when UID/GID are not 0
- Created necessary directory structure with proper ownership using mkdir and chown commands
- Switched to non-root user execution for improved security posture
- Updated COPY instruction to use --chown flag for proper file ownership

### Example usage
The user defaults to root with a home directory of `/root` so hopefully this won't affect any existing builds. These changes make possible building the container with a dedicated UID/GID. Personally I prefer a rootless Podman setup, with limited container user, using a build command like:

```bash
time podman build -t llama-swap --no-cache --build-arg="BASE_TAG=server-cuda" --build-arg="LS_VER=${ curl -s https://api.github.com/repos/mostlygeek/llama-swap/releases/latest | jq -r .tag_name | sed 's/v//'; }" --build-arg="UID=123" --build-arg="GID=123" --build-arg="USER_HOME=/app" -f docker/llama-swap.Containerfile
```

And run with:

```bash
podman run --rm -d --replace -p 127.0.0.1:8080:8080 -v /ai/models:/models -v /ai/.cache:/app/.cache -v /ai/llama-swap-config.yaml:/app/config.yaml --gpus all --name llama-swap localhost/llama-swap:latest
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped version to 170.
  * Enabled non-root user execution for container deployments to improve security.
  * Ensured app files and configuration have correct ownership and permissions inside the container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->