### PR TITLE
feat: add optional -enrich-cot flag to stream swap progress in reasoning_content

### DIFF
--- a/llama-swap.go
+++ b/llama-swap.go
@@ -33,6 +33,7 @@ func main() {
 	keyFile := flag.String("tls-key-file", "", "TLS key file")
 	showVersion := flag.Bool("version", false, "show version of build")
 	watchConfig := flag.Bool("watch-config", false, "Automatically reload config file on change")
+	enrichCot := flag.Bool("enrich-cot", false, "Add swap progress logs to reasoning_content when streaming responses")
 
 	flag.Parse() // Parse the command-line flags
 
@@ -95,7 +96,9 @@ func main() {
 
 			fmt.Println("Configuration Changed")
 			currentPM.Shutdown()
-			srv.Handler = proxy.New(conf)
+			newPM := proxy.New(conf)
+			newPM.SetCoTEnrichment(*enrichCot)
+			srv.Handler = newPM
 			fmt.Println("Configuration Reloaded")
 
 			// wait a few seconds and tell any UI to reload
@@ -110,7 +113,9 @@ func main() {
 				fmt.Printf("Error, unable to load configuration: %v\n", err)
 				os.Exit(1)
 			}
-			srv.Handler = proxy.New(conf)
+			newPM := proxy.New(conf)
+			newPM.SetCoTEnrichment(*enrichCot)
+			srv.Handler = newPM
 		}
 	}
 

--- a/proxy/cot_enrichment.go
+++ b/proxy/cot_enrichment.go
@@ -1,0 +1,48 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+)
+
+type cotContextKey struct{}
+
+func withCoTEnrichment(ctx context.Context, enabled bool) context.Context {
+	if !enabled {
+		return ctx
+	}
+	return context.WithValue(ctx, cotContextKey{}, true)
+}
+
+func isCoTEnrichment(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	val, ok := ctx.Value(cotContextKey{}).(bool)
+	return ok && val
+}
+
+type cotRoundTripper struct {
+	base    http.RoundTripper
+	process *Process
+}
+
+func (rt *cotRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	transport := rt.base
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if rt.process == nil || !rt.process.shouldInjectCoT(req.Context(), resp) {
+		return resp, nil
+	}
+
+	resp.Header.Del("Content-Length")
+	resp.Body = rt.process.wrapCoTStream(resp.Body)
+	return resp, nil
+}

--- a/proxy/cot_session.go
+++ b/proxy/cot_session.go
@@ -1,0 +1,299 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+type cotEntry struct {
+	content       string
+	ensureNewline bool
+}
+
+type cotSession struct {
+	mu           sync.Mutex
+	lines        chan cotEntry
+	buffer       []cotEntry
+	attached     bool
+	finished     bool
+	aborted      bool
+	pendingBlank bool
+	inlineBreak  bool
+	writer       http.ResponseWriter
+	flusher      http.Flusher
+	writerReady  bool
+}
+
+func newCOTSession() *cotSession {
+	return &cotSession{
+		lines: make(chan cotEntry, 32),
+	}
+}
+
+func (s *cotSession) appendLine(line string) {
+	if s.consumeInlineBreak() {
+		s.appendEntry(cotEntry{content: "", ensureNewline: true})
+	}
+	s.appendEntry(cotEntry{content: line, ensureNewline: true})
+}
+
+func (s *cotSession) appendInline(content string) {
+	if content == "" {
+		return
+	}
+	s.markInlineBreakPending()
+	s.appendEntry(cotEntry{content: content, ensureNewline: false})
+}
+
+func (s *cotSession) appendEntry(entry cotEntry) {
+	s.mu.Lock()
+	if s.aborted || s.finished {
+		// Session closed before attachment; drop new lines.
+		s.mu.Unlock()
+		return
+	}
+
+	if s.writerReady {
+		writer := s.writer
+		flusher := s.flusher
+		s.mu.Unlock()
+		emitToWriter(writer, flusher, entry)
+		return
+	}
+
+	if s.attached {
+		ch := s.lines
+		s.mu.Unlock()
+		ch <- entry
+		return
+	}
+
+	s.buffer = append(s.buffer, entry)
+	s.mu.Unlock()
+}
+
+func (s *cotSession) attach(body io.ReadCloser) io.ReadCloser {
+	s.mu.Lock()
+	if s.aborted {
+		s.mu.Unlock()
+		return body
+	}
+	if s.attached {
+		s.mu.Unlock()
+		return body
+	}
+	s.attached = true
+	buffer := append([]cotEntry(nil), s.buffer...)
+	pendingBlank := s.pendingBlank
+	writerReady := s.writerReady
+	lines := s.lines
+	s.pendingBlank = false
+	s.buffer = nil
+	s.mu.Unlock()
+
+	if writerReady {
+		if pendingBlank {
+			emitToWriter(s.writer, s.flusher, cotEntry{content: "", ensureNewline: true})
+		}
+		return body
+	}
+
+	stream := newCoTStream(lines, body)
+	go func() {
+		defer func() {
+			_ = recover()
+		}()
+		for _, entry := range buffer {
+			lines <- entry
+		}
+		if pendingBlank {
+			defer func() { _ = recover() }()
+			lines <- cotEntry{content: "", ensureNewline: true}
+			close(lines)
+		}
+	}()
+
+	return stream
+}
+
+func (s *cotSession) finish() {
+	s.mu.Lock()
+	if s.aborted || s.finished {
+		s.mu.Unlock()
+		return
+	}
+	s.finished = true
+	s.inlineBreak = false
+	if s.writerReady {
+		writer := s.writer
+		flusher := s.flusher
+		s.mu.Unlock()
+		emitToWriter(writer, flusher, cotEntry{content: "", ensureNewline: true})
+		return
+	}
+	if s.attached {
+		lines := s.lines
+		s.mu.Unlock()
+		func() {
+			defer func() { _ = recover() }()
+			lines <- cotEntry{content: "", ensureNewline: true}
+			close(lines)
+		}()
+		return
+	}
+	s.pendingBlank = true
+	s.mu.Unlock()
+}
+
+func (s *cotSession) abort() {
+	s.mu.Lock()
+	if s.aborted {
+		s.mu.Unlock()
+		return
+	}
+	s.aborted = true
+	s.inlineBreak = false
+	if s.attached {
+		close(s.lines)
+	}
+	s.buffer = nil
+	s.writer = nil
+	s.flusher = nil
+	s.mu.Unlock()
+}
+
+func (s *cotSession) attachWriter(w http.ResponseWriter) bool {
+	if w == nil {
+		return false
+	}
+
+	flusher, _ := w.(http.Flusher)
+
+	s.mu.Lock()
+	if s.aborted || s.writerReady {
+		s.mu.Unlock()
+		return false
+	}
+	s.writerReady = true
+	s.writer = w
+	s.flusher = flusher
+	buffer := append([]cotEntry(nil), s.buffer...)
+	pendingBlank := s.pendingBlank
+	finished := s.finished
+	s.buffer = nil
+	s.pendingBlank = false
+	s.mu.Unlock()
+
+	for _, entry := range buffer {
+		emitToWriter(w, flusher, entry)
+	}
+
+	if pendingBlank || finished {
+		emitToWriter(w, flusher, cotEntry{content: "", ensureNewline: true})
+	}
+
+	return true
+}
+
+func (s *cotSession) consumeInlineBreak() bool {
+	s.mu.Lock()
+	if s.inlineBreak && !s.aborted && !s.finished {
+		s.inlineBreak = false
+		s.mu.Unlock()
+		return true
+	}
+	s.mu.Unlock()
+	return false
+}
+
+func (s *cotSession) markInlineBreakPending() {
+	s.mu.Lock()
+	if !s.aborted && !s.finished {
+		s.inlineBreak = true
+	}
+	s.mu.Unlock()
+}
+
+type cotStream struct {
+	reader *io.PipeReader
+	done   chan struct{}
+}
+
+func newCoTStream(lines <-chan cotEntry, body io.ReadCloser) io.ReadCloser {
+	pipeReader, pipeWriter := io.Pipe()
+	stream := &cotStream{
+		reader: pipeReader,
+		done:   make(chan struct{}),
+	}
+
+	go stream.run(lines, body, pipeWriter)
+	return stream
+}
+
+func (cs *cotStream) run(lines <-chan cotEntry, body io.ReadCloser, writer *io.PipeWriter) {
+	defer close(cs.done)
+	defer body.Close()
+
+	for entry := range lines {
+		payload := formatCoTEntry(entry)
+		if len(payload) == 0 {
+			continue
+		}
+		if _, err := writer.Write(payload); err != nil {
+			writer.CloseWithError(err)
+			return
+		}
+	}
+	if _, err := io.Copy(writer, body); err != nil {
+		writer.CloseWithError(err)
+		return
+	}
+	writer.Close()
+}
+
+func (cs *cotStream) Read(p []byte) (int, error) {
+	return cs.reader.Read(p)
+}
+
+func (cs *cotStream) Close() error {
+	err := cs.reader.Close()
+	<-cs.done
+	return err
+}
+
+func formatCoTEntry(entry cotEntry) []byte {
+	content := entry.content
+	if entry.ensureNewline {
+		if content == "" {
+			content = "\n"
+		} else if !strings.HasSuffix(content, "\n") {
+			content += "\n"
+		}
+	}
+
+	encoded, err := json.Marshal(content)
+	if err != nil {
+		return nil
+	}
+	return []byte(fmt.Sprintf("data: {\"choices\":[{\"delta\":{\"reasoning_content\":%s}}]}\n\n", string(encoded)))
+}
+
+func emitToWriter(w http.ResponseWriter, flusher http.Flusher, entry cotEntry) {
+	if w == nil {
+		return
+	}
+	payload := formatCoTEntry(entry)
+	if len(payload) == 0 {
+		return
+	}
+	if _, err := w.Write(payload); err != nil {
+		return
+	}
+	if flusher != nil {
+		flusher.Flush()
+	}
+}

--- a/proxy/cot_session_test.go
+++ b/proxy/cot_session_test.go
@@ -1,0 +1,185 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type recordingResponseWriter struct {
+	header http.Header
+	data   strings.Builder
+}
+
+func newRecordingResponseWriter() *recordingResponseWriter {
+	return &recordingResponseWriter{header: make(http.Header)}
+}
+
+func (rw *recordingResponseWriter) Header() http.Header {
+	return rw.header
+}
+
+func (rw *recordingResponseWriter) Write(p []byte) (int, error) {
+	return rw.data.WriteString(string(p))
+}
+
+func (rw *recordingResponseWriter) WriteHeader(statusCode int) {}
+
+func (rw *recordingResponseWriter) Flush() {}
+
+func TestCoTSessionAttachesAndStreamsLines(t *testing.T) {
+	session := newCOTSession()
+	session.appendLine("[llama-swap] Swapping backend process")
+	session.appendLine("[llama-swap] Starting inference with: Model")
+	session.finish()
+
+	body := io.NopCloser(strings.NewReader("data: {\"content\":\"from-body\"}\n\n"))
+	stream := session.attach(body)
+
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("failed to read stream: %v", err)
+	}
+
+	output := string(data)
+	first := "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"[llama-swap] Swapping backend process\\n\"}}]}\n\n"
+	second := "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"[llama-swap] Starting inference with: Model\\n\"}}]}\n\n"
+	blank := "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"\\n\"}}]}\n\n"
+
+	firstIdx := strings.Index(output, first)
+	if firstIdx == -1 {
+		t.Fatalf("missing first reasoning chunk in %q", output)
+	}
+	secondIdx := strings.Index(output, second)
+	if secondIdx == -1 {
+		t.Fatalf("missing second reasoning chunk in %q", output)
+	}
+	blankIdx := strings.Index(output, blank)
+	if blankIdx == -1 {
+		t.Fatalf("missing blank reasoning chunk in %q", output)
+	}
+	bodyIdx := strings.Index(output, "data: {\"content\":\"from-body\"}\n\n")
+	if bodyIdx == -1 {
+		t.Fatalf("missing body payload in %q", output)
+	}
+
+	if !(firstIdx < secondIdx && secondIdx < blankIdx && blankIdx < bodyIdx) {
+		t.Fatalf("unexpected ordering: first=%d second=%d blank=%d body=%d", firstIdx, secondIdx, blankIdx, bodyIdx)
+	}
+}
+
+func TestCoTSessionStreamsAfterAttach(t *testing.T) {
+	session := newCOTSession()
+	body := io.NopCloser(strings.NewReader(""))
+	stream := session.attach(body)
+
+	session.appendLine("[llama-swap] load_tensors: streaming")
+	session.finish()
+
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("failed to read stream: %v", err)
+	}
+
+	output := string(data)
+	expected := "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"[llama-swap] load_tensors: streaming\\n\"}}]}\n\n"
+	if !strings.Contains(output, expected) {
+		t.Fatalf("missing streamed line in %q", output)
+	}
+}
+
+func TestCoTSessionAttachWriterDeliversLinesImmediately(t *testing.T) {
+	session := newCOTSession()
+	session.appendLine("[llama-swap] Swapping backend process")
+
+	rw := newRecordingResponseWriter()
+	if !session.attachWriter(rw) {
+		t.Fatalf("attachWriter returned false")
+	}
+
+	first := "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"[llama-swap] Swapping backend process\\n\"}}]}\n\n"
+	if !strings.Contains(rw.data.String(), first) {
+		t.Fatalf("expected first line to stream immediately, got %q", rw.data.String())
+	}
+
+	session.appendLine("[llama-swap] load_tensors: streaming")
+	second := "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"[llama-swap] load_tensors: streaming\\n\"}}]}\n\n"
+	if !strings.Contains(rw.data.String(), second) {
+		t.Fatalf("expected second line to stream immediately, got %q", rw.data.String())
+	}
+
+	session.finish()
+	blank := "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"\\n\"}}]}\n\n"
+	if !strings.Contains(rw.data.String(), blank) {
+		t.Fatalf("expected blank separator after finish, got %q", rw.data.String())
+	}
+
+	// Attaching the body should not replay prior lines.
+	body := io.NopCloser(strings.NewReader("data: {\"content\":\"from-body\"}\n\n"))
+	stream := session.attach(body)
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	if strings.Contains(string(data), "[llama-swap]") {
+		t.Fatalf("body unexpectedly contained swap logs: %q", string(data))
+	}
+}
+
+func TestCoTSessionInlineSegmentsDoNotAppendNewlines(t *testing.T) {
+	session := newCOTSession()
+	session.appendLine("[llama-swap] load_tensors: streaming")
+	session.appendInline(".")
+	session.appendInline(".")
+	session.finish()
+
+	body := io.NopCloser(strings.NewReader(""))
+	stream := session.attach(body)
+
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("failed to read stream: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, "reasoning_content\":\".\"") {
+		t.Fatalf("expected dot segments in output: %q", output)
+	}
+	if strings.Contains(output, "reasoning_content\":\".\\n\"") {
+		t.Fatalf("unexpected newline appended to dot segments: %q", output)
+	}
+}
+
+func TestCoTSessionInsertsNewlineAfterInlineSegments(t *testing.T) {
+	session := newCOTSession()
+	session.appendLine("[llama-swap] load_tensors: streaming")
+	session.appendInline(".")
+	session.appendInline(".")
+	session.appendLine("[llama-swap] Starting inference with: Model")
+	session.finish()
+
+	body := io.NopCloser(strings.NewReader(""))
+	stream := session.attach(body)
+
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("failed to read stream: %v", err)
+	}
+
+	output := string(data)
+	newlineChunk := "data: {\"choices\":[{\"delta\":{\"reasoning_content\":\"\\n\"}}]}\n\n"
+	if strings.Count(output, newlineChunk) < 2 {
+		t.Fatalf("expected newline separator before and after inference start, got %q", output)
+	}
+
+	dotIndex := strings.Index(output, "reasoning_content\":\".\"")
+	newlineIndex := strings.Index(output, newlineChunk)
+	startIndex := strings.Index(output, "reasoning_content\":\"[llama-swap] Starting inference with: Model\\n\"")
+	if !(dotIndex != -1 && newlineIndex != -1 && startIndex != -1) {
+		t.Fatalf("missing expected segments in output: %q", output)
+	}
+	if !(dotIndex < newlineIndex && newlineIndex < startIndex) {
+		t.Fatalf("newline separator not emitted between dots and next line: dot=%d newline=%d start=%d", dotIndex, newlineIndex, startIndex)
+	}
+}

--- a/proxy/swap_progress_writer.go
+++ b/proxy/swap_progress_writer.go
@@ -1,0 +1,130 @@
+package proxy
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+)
+
+type swapProgressWriter struct {
+	mu            sync.Mutex
+	buffer        []byte
+	lineHandler   func(string)
+	inlineHandler func(string)
+}
+
+func newSwapProgressWriter(lineHandler func(string), inlineHandler func(string)) *swapProgressWriter {
+	if lineHandler == nil {
+		lineHandler = func(string) {}
+	}
+	if inlineHandler == nil {
+		inlineHandler = func(string) {}
+	}
+	return &swapProgressWriter{lineHandler: lineHandler, inlineHandler: inlineHandler}
+}
+
+func (w *swapProgressWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.buffer = append(w.buffer, p...)
+	for {
+		idx := bytes.IndexByte(w.buffer, '\n')
+		if idx != -1 {
+			raw := string(w.buffer[:idx])
+			w.buffer = w.buffer[idx+1:]
+
+			line := strings.TrimRight(raw, "\r")
+			if len(strings.TrimSpace(line)) != 0 {
+				if isDotLine(line) {
+					w.emitDots(line)
+				} else {
+					w.emitLine(line)
+				}
+			}
+			continue
+		}
+
+		if w.emitDotsFromBuffer() {
+			continue
+		}
+
+		break
+	}
+
+	return len(p), nil
+}
+
+func (w *swapProgressWriter) Flush() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if len(w.buffer) == 0 {
+		return
+	}
+	if w.emitDotsFromBuffer() {
+		return
+	}
+
+	line := strings.TrimRight(string(w.buffer), "\r")
+	w.buffer = nil
+	if len(strings.TrimSpace(line)) != 0 {
+		if isDotLine(line) {
+			w.emitDots(line)
+		} else {
+			w.emitLine(line)
+		}
+	}
+}
+
+func (w *swapProgressWriter) emitLine(line string) {
+	if strings.Contains(line, "load_tensors:") {
+		w.lineHandler(line)
+	}
+}
+
+func (w *swapProgressWriter) emitDots(line string) {
+	for _, r := range line {
+		if r == '.' {
+			w.inlineHandler(".")
+		}
+	}
+}
+
+func (w *swapProgressWriter) emitDotsFromBuffer() bool {
+	if len(w.buffer) == 0 {
+		return false
+	}
+
+	for _, b := range w.buffer {
+		if b == '.' || b == '\r' {
+			continue
+		}
+		return false
+	}
+
+	for len(w.buffer) > 0 {
+		b := w.buffer[0]
+		w.buffer = w.buffer[1:]
+		if b == '.' {
+			w.inlineHandler(".")
+		}
+	}
+	return true
+}
+
+func isDotLine(line string) bool {
+	if line == "" {
+		return false
+	}
+	for _, r := range line {
+		if r != '.' {
+			return false
+		}
+	}
+	return true
+}

--- a/proxy/swap_progress_writer_test.go
+++ b/proxy/swap_progress_writer_test.go
@@ -1,0 +1,87 @@
+package proxy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSwapProgressWriterFiltersLines(t *testing.T) {
+	var lines []string
+	writer := newSwapProgressWriter(func(line string) {
+		lines = append(lines, line)
+	}, nil)
+
+	input := "hello world\nload_tensors: loading model tensors\npartial"
+	if _, err := writer.Write([]byte(input)); err != nil {
+		t.Fatalf("unexpected error writing: %v", err)
+	}
+
+	// flush remaining partial line and ensure it is ignored
+	writer.Flush()
+
+	expected := []string{"load_tensors: loading model tensors"}
+	if len(lines) != len(expected) {
+		t.Fatalf("unexpected number of lines. got %d want %d", len(lines), len(expected))
+	}
+	for i, line := range lines {
+		if line != expected[i] {
+			t.Fatalf("unexpected line at %d. got %q want %q", i, line, expected[i])
+		}
+	}
+}
+
+func TestSwapProgressWriterPreservesSpacing(t *testing.T) {
+	var captured string
+	writer := newSwapProgressWriter(func(line string) {
+		captured = line
+	}, nil)
+
+	sample := "load_tensors:        CUDA0 model buffer size = 17917.21 MiB\n"
+	if _, err := writer.Write([]byte(sample)); err != nil {
+		t.Fatalf("unexpected error writing: %v", err)
+	}
+
+	expected := "load_tensors:        CUDA0 model buffer size = 17917.21 MiB"
+	if captured != expected {
+		t.Fatalf("unexpected captured line. got %q want %q", captured, expected)
+	}
+}
+
+func TestSwapProgressWriterStreamsDotsIndividually(t *testing.T) {
+	var dots []string
+	writer := newSwapProgressWriter(nil, func(dot string) {
+		dots = append(dots, dot)
+	})
+
+	sample := "............"
+	if _, err := writer.Write([]byte(sample)); err != nil {
+		t.Fatalf("unexpected error writing dots: %v", err)
+	}
+
+	expected := len(sample)
+	if len(dots) != expected {
+		t.Fatalf("unexpected number of dots. got %d want %d", len(dots), expected)
+	}
+	for i, dot := range dots {
+		if dot != "." {
+			t.Fatalf("dot at index %d was %q", i, dot)
+		}
+	}
+}
+
+func TestSwapProgressWriterStreamsDotLinesWithNewline(t *testing.T) {
+	var dots []string
+	writer := newSwapProgressWriter(nil, func(dot string) {
+		dots = append(dots, dot)
+	})
+
+	sample := "............\n"
+	if _, err := writer.Write([]byte(sample)); err != nil {
+		t.Fatalf("unexpected error writing dots: %v", err)
+	}
+
+	expected := len(strings.TrimSuffix(sample, "\n"))
+	if len(dots) != expected {
+		t.Fatalf("unexpected number of dots. got %d want %d", len(dots), expected)
+	}
+}


### PR DESCRIPTION
Proposal for issue #367 by adding an optional -enrich-cot flag to enrich streamed reasoning_content with live swap progress logs

When enabled, llama-swap injects swap-related log lines and progress dots into the streamed reasoning_content of /v1 responses, improving UX during model swaps without affecting model context or API compatibility

Key changes:
- Added CLI flag handling (-enrich-cot) in llama-swap.go
- Introduced cot_enrichment.go and cot_session.go for streaming logic
- Integrated CoT lifecycle in Process, ProcessGroup, and ProxyManager
- Added swap_progress_writer for real-time parsing of stdout/stderr
- Added full unit tests for CoT sessions and progress writer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new command-line flag to enable Chain-of-Thought (CoT) enrichment for HTTP responses.
  * Chain-of-Thought reasoning content is now streamed and injected into supported responses as structured data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->