### PR TITLE
fix: update containerfile user/group management commands

### DIFF
--- a/docker/llama-swap.Containerfile
+++ b/docker/llama-swap.Containerfile
@@ -13,9 +13,9 @@ ARG USER_HOME=/app
 ENV HOME=$USER_HOME
 RUN if [ $UID -ne 0 ]; then \
       if [ $GID -ne 0 ]; then \
-        addgroup --system --gid $GID app; \
+        groupadd --system --gid $GID app; \
       fi; \
-      adduser --system --no-create-home --uid $UID --gid $GID \
+      useradd --system --uid $UID --gid $GID \
       --home $USER_HOME app; \
     fi
 


### PR DESCRIPTION
This should fix the `vulkan` container build failures. The upstream vulkan containers use Ubuntu 24.04 and the others are still on 22.04. Apparently the `adduser` package is no longer installed by default.

- Replace `addgroup` with `groupadd` for system group creation
- Replace `adduser` with `useradd` for system user creation
- Maintain same functionality while using more standard POSIX commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container build process to use standard system utilities for creating container users and groups, improving build compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->