### PR TITLE
feat: improve llama.cpp base image tag for cpu

### DIFF
--- a/docker/build-container.sh
+++ b/docker/build-container.sh
@@ -25,31 +25,31 @@ fi
 LS_VER=$(curl -s https://api.github.com/repos/mostlygeek/llama-swap/releases/latest | jq -r .tag_name | sed 's/v//')
 
 if [ "$ARCH" == "cpu" ]; then
-    # cpu only containers just use the latest available
-    CONTAINER_LATEST="ghcr.io/mostlygeek/llama-swap:cpu"
-    echo "Building ${CONTAINER_LATEST} $LS_VER"
-    docker build -f llama-swap.Containerfile --build-arg BASE_TAG=server --build-arg LS_VER=${LS_VER} -t ${CONTAINER_LATEST} .
-    if [ "$PUSH_IMAGES" == "true" ]; then
-      docker push ${CONTAINER_LATEST}
-    fi
+    # cpu only containers just use the server tag
+    LCPP_TAG=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+        "https://api.github.com/users/ggml-org/packages/container/llama.cpp/versions" \
+        | jq -r '.[] | select(.metadata.container.tags[] | startswith("server")) | .metadata.container.tags[]' \
+        | sort -r | head -n1 | awk -F '-' '{print $3}')
+    BASE_TAG=server-${LCPP_TAG}
 else
     LCPP_TAG=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
         "https://api.github.com/users/ggml-org/packages/container/llama.cpp/versions" \
         | jq -r --arg arch "$ARCH" '.[] | select(.metadata.container.tags[] | startswith("server-\($arch)")) | .metadata.container.tags[]' \
         | sort -r | head -n1 | awk -F '-' '{print $3}')
+    BASE_TAG=server-${ARCH}-${LCPP_TAG}
+fi
 
-    # Abort if LCPP_TAG is empty.
-    if [[ -z "$LCPP_TAG" ]]; then
-        echo "Abort: Could not find llama-server container for arch: $ARCH"
-        exit 1
-    fi
+# Abort if LCPP_TAG is empty.
+if [[ -z "$LCPP_TAG" ]]; then
+    echo "Abort: Could not find llama-server container for arch: $ARCH"
+    exit 1
+fi
 
-    CONTAINER_TAG="ghcr.io/mostlygeek/llama-swap:v${LS_VER}-${ARCH}-${LCPP_TAG}"
-    CONTAINER_LATEST="ghcr.io/mostlygeek/llama-swap:${ARCH}"
-    echo "Building ${CONTAINER_TAG} $LS_VER"
-    docker build -f llama-swap.Containerfile --build-arg BASE_TAG=server-${ARCH}-${LCPP_TAG} --build-arg LS_VER=${LS_VER} -t ${CONTAINER_TAG} -t ${CONTAINER_LATEST} .
-    if [ "$PUSH_IMAGES" == "true" ]; then
-      docker push ${CONTAINER_TAG}
-      docker push ${CONTAINER_LATEST}
-    fi
+CONTAINER_TAG="ghcr.io/mostlygeek/llama-swap:v${LS_VER}-${ARCH}-${LCPP_TAG}"
+CONTAINER_LATEST="ghcr.io/mostlygeek/llama-swap:${ARCH}"
+echo "Building ${CONTAINER_TAG} $LS_VER"
+docker build -f llama-swap.Containerfile --build-arg BASE_TAG=${BASE_TAG} --build-arg LS_VER=${LS_VER} -t ${CONTAINER_TAG} -t ${CONTAINER_LATEST} .
+if [ "$PUSH_IMAGES" == "true" ]; then
+  docker push ${CONTAINER_TAG}
+  docker push ${CONTAINER_LATEST}
 fi


### PR DESCRIPTION
Refactor the container build script to resolve _llama.cpp_ base image for CPU, also tag these builds accordingly.

- For CPU containers, now fetch the latest `server` tagged llama.cpp image instead of using a generic `server` tag
- Cleans up the docker build command to use dynamic **BASE_TAG** variable
- Maintains existing push functionality for built images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container build automation to dynamically manage image tags and versions from the GitHub Container Registry, improving build consistency and reducing manual configuration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->