### PR TITLE
feat: add version endpoint and display version info in UI

### DIFF
--- a/llama-swap.go
+++ b/llama-swap.go
@@ -95,7 +95,9 @@ func main() {
 
 			fmt.Println("Configuration Changed")
 			currentPM.Shutdown()
-			srv.Handler = proxy.New(conf)
+			newPM := proxy.New(conf)
+			newPM.SetVersion(date, commit, version)
+			srv.Handler = newPM
 			fmt.Println("Configuration Reloaded")
 
 			// wait a few seconds and tell any UI to reload
@@ -110,7 +112,9 @@ func main() {
 				fmt.Printf("Error, unable to load configuration: %v\n", err)
 				os.Exit(1)
 			}
-			srv.Handler = proxy.New(conf)
+			newPM := proxy.New(conf)
+			newPM.SetVersion(date, commit, version)
+			srv.Handler = newPM
 		}
 	}
 

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -45,6 +45,11 @@ type ProxyManager struct {
 	// shutdown signaling
 	shutdownCtx    context.Context
 	shutdownCancel context.CancelFunc
+
+	// version info
+	buildDate string
+	commit    string
+	version   string
 }
 
 func New(config config.Config) *ProxyManager {
@@ -122,6 +127,10 @@ func New(config config.Config) *ProxyManager {
 
 		shutdownCtx:    shutdownCtx,
 		shutdownCancel: shutdownCancel,
+
+		buildDate: "unknown",
+		commit:    "abcd1234",
+		version:   "0",
 	}
 
 	// create the process groups
@@ -769,4 +778,12 @@ func (pm *ProxyManager) findGroupByModelName(modelName string) *ProcessGroup {
 		}
 	}
 	return nil
+}
+
+func (pm *ProxyManager) SetVersion(buildDate string, commit string, version string) {
+	pm.Lock()
+	defer pm.Unlock()
+	pm.buildDate = buildDate
+	pm.commit = commit
+	pm.version = version
 }

--- a/proxy/proxymanager_api.go
+++ b/proxy/proxymanager_api.go
@@ -28,6 +28,7 @@ func addApiHandlers(pm *ProxyManager) {
 		apiGroup.POST("/models/unload/*model", pm.apiUnloadSingleModelHandler)
 		apiGroup.GET("/events", pm.apiSendEvents)
 		apiGroup.GET("/metrics", pm.apiGetMetrics)
+		apiGroup.GET("/version", pm.apiGetVersion)
 	}
 }
 
@@ -226,4 +227,12 @@ func (pm *ProxyManager) apiUnloadSingleModelHandler(c *gin.Context) {
 	} else {
 		c.String(http.StatusOK, "OK")
 	}
+}
+
+func (pm *ProxyManager) apiGetVersion(c *gin.Context) {
+	c.JSON(http.StatusOK, map[string]string{
+		"version":    pm.version,
+		"commit":     pm.commit,
+		"build_date": pm.buildDate,
+	})
 }

--- a/ui/src/components/ConnectionStatus.tsx
+++ b/ui/src/components/ConnectionStatus.tsx
@@ -2,7 +2,7 @@ import { useAPI } from "../contexts/APIProvider";
 import { useMemo } from "react";
 
 const ConnectionStatusIcon = () => {
-  const { connectionStatus } = useAPI();
+  const { connectionStatus, versionInfo } = useAPI();
 
   const eventStatusColor = useMemo(() => {
     switch (connectionStatus) {
@@ -17,7 +17,7 @@ const ConnectionStatusIcon = () => {
   }, [connectionStatus]);
 
   return (
-    <div className="flex items-center" title={`event stream: ${connectionStatus}`}>
+    <div className="flex items-center" title={`Event Stream: ${connectionStatus ?? 'unknown'}\nAPI Version: ${versionInfo?.version ?? 'unknown'}\nCommit Hash: ${versionInfo?.commit?.substring(0,7) ?? 'unknown'}\nBuild Date: ${versionInfo?.build_date ?? 'unknown'}`}>
       <span className={`inline-block w-3 h-3 rounded-full ${eventStatusColor} mr-2`}></span>
     </div>
   );

--- a/ui/src/contexts/APIProvider.tsx
+++ b/ui/src/contexts/APIProvider.tsx
@@ -23,6 +23,7 @@ interface APIProviderType {
   upstreamLogs: string;
   metrics: Metrics[];
   connectionStatus: ConnectionState;
+  versionInfo: VersionInfo;
 }
 
 interface Metrics {
@@ -41,9 +42,16 @@ interface LogData {
   source: "upstream" | "proxy";
   data: string;
 }
+
 interface APIEventEnvelope {
   type: "modelStatus" | "logData" | "metrics";
   data: string;
+}
+
+interface VersionInfo {
+  build_date: string;
+  commit: string;
+  version: string;
 }
 
 const APIContext = createContext<APIProviderType | undefined>(undefined);
@@ -59,6 +67,11 @@ export function APIProvider({ children, autoStartAPIEvents = true }: APIProvider
   const [upstreamLogs, setUpstreamLogs] = useState("");
   const [metrics, setMetrics] = useState<Metrics[]>([]);
   const [connectionStatus, setConnectionState] = useState<ConnectionState>("disconnected");
+  const [versionInfo, setVersionInfo] = useState<VersionInfo>({
+    build_date: "unknown",
+    commit: "unknown",
+    version: "unknown"
+  });
   //const apiEventSource = useRef<EventSource | null>(null);
 
   const [models, setModels] = useState<Model[]>([]);
@@ -153,6 +166,26 @@ export function APIProvider({ children, autoStartAPIEvents = true }: APIProvider
   }, []);
 
   useEffect(() => {
+    // fetch version 
+    const fetchVersion = async () => {
+      try {
+        const response = await fetch("/api/version");
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const data: VersionInfo = await response.json();
+        setVersionInfo(data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
+    if (connectionStatus === 'connected') {
+      fetchVersion();
+    }
+  }, [connectionStatus]);
+
+  useEffect(() => {
     if (autoStartAPIEvents) {
       enableAPIEvents(true);
     }
@@ -230,8 +263,9 @@ export function APIProvider({ children, autoStartAPIEvents = true }: APIProvider
       upstreamLogs,
       metrics,
       connectionStatus,
+      versionInfo,
     }),
-    [models, listModels, unloadAllModels, loadModel, enableAPIEvents, proxyLogs, upstreamLogs, metrics]
+    [models, listModels, unloadAllModels, unloadSingleModel, loadModel, enableAPIEvents, proxyLogs, upstreamLogs, metrics, connectionStatus, versionInfo]
   );
 
   return <APIContext.Provider value={value}>{children}</APIContext.Provider>;


### PR DESCRIPTION
- Add /api/version endpoint to ProxyManager that returns build date, commit hash, and version
- Implement SetVersion method to configure version info in ProxyManager
- Add version info fetching to APIProvider and display in ConnectionStatus component
- Include version info in UI context and update dependencies
- Add tests for version endpoint functionality

**The UI tooltip:**
<img width="354" height="239" alt="image" src="https://github.com/user-attachments/assets/e4a87dfa-1dde-4bf8-a6ec-e406ab326ebe" />

**CLI:**
```bash
$ /app/llama-swap -version
version: 173-dev4 (4b3c46592f09a53019074454b10b4fa8615c3e3c), built at 2025-11-16T05:27:24Z
```

**API:**
```bash
$ curl -s https://internal.domain:8447/api/version | jq
{
  "build_date": "2025-11-16T05:27:24Z",
  "commit": "4b3c46592f09a53019074454b10b4fa8615c3e3c",
  "version": "173-dev4"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GET /api/version to expose version, commit, and build date.
  * Connection status now shows API Version, Commit (short), and Build Date.
  * Version info is fetched automatically on connect and refreshed after configuration reloads.

* **Bug Fixes**
  * Version information is preserved and displayed consistently after configuration reloads.

* **Tests**
  * Added tests validating the version endpoint and its returned fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->