### PR TITLE
feat: enhance model listing to include aliases

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -74,6 +74,11 @@
             "default": false,
             "description": "Inject loading status updates into the reasoning field. When true, a stream of loading messages will be sent to the client."
         },
+        "includeAliasesInList": {
+            "type": "boolean",
+            "default": false,
+            "description": "Present aliases within the /v1/models OpenAI API listing. when true, model aliases will be output to the API model listing duplicating all fields except for Id so chat UIs can use the alias equivalent to the original."
+        },
         "macros": {
             "$ref": "#/definitions/macros"
         },

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -46,6 +46,12 @@ startPort: 10001
 # - see #366 for more details
 sendLoadingState: true
 
+# includeAliasesInList: present aliases within the /v1/models OpenAI API listing
+# - optional, default: false
+# - when true, model aliases will be output to the API model listing duplicating
+#   all fields except for Id so chat UIs can use the alias equivalent to the original.
+includeAliasesInList: false
+
 # macros: a dictionary of string substitutions
 # - optional, default: empty dictionary
 # - macros are reusable snippets

--- a/proxy/config/config.go
+++ b/proxy/config/config.go
@@ -132,6 +132,9 @@ type Config struct {
 
 	// send loading state in reasoning
 	SendLoadingState bool `yaml:"sendLoadingState"`
+
+	// present aliases to /v1/models OpenAI API listing
+	IncludeAliasesInList bool `yaml:"includeAliasesInList"`
 }
 
 func (c *Config) RealModelName(search string) (string, bool) {

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -403,9 +403,11 @@ func (pm *ProxyManager) listModelsHandler(c *gin.Context) {
 		data = append(data, newRecord(id))
 
 		// Include aliases
-		for _, alias := range modelConfig.Aliases {
-			if alias := strings.TrimSpace(alias); alias != "" {
-				data = append(data, newRecord(alias))
+		if pm.config.IncludeAliasesInList {
+			for _, alias := range modelConfig.Aliases {
+				if alias := strings.TrimSpace(alias); alias != "" {
+					data = append(data, newRecord(alias))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR refactors the listModelsHandler to improve how models are represented in the API response. The key changes include:

- Extracted model record creation into a reusable `newRecord` function that encapsulates all model properties
- Added support for including model aliases in the response by iterating through modelConfig.Aliases and creating separate records for each alias
- Added a new configuration option to control this behavior, `includeAliasesInList`, disabled by default
- Maintained the existing sorting behavior by "id" key
- Improved code organization by encapsulating record creation logic in a dedicated function
- Added comprehensive test case verifying alias inclusion functionality

The changes ensure that models with aliases are properly represented as distinct entries in the API response while preserving all existing model metadata and properties. This provides better compatibility and discoverability for clients consuming the model listing endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined model record construction to ensure names, descriptions, and metadata are consistently populated in API responses.
* **New Features**
  * Optional setting to include model aliases in the /v1/models listing so aliases appear alongside base models.
* **Tests**
  * Added tests verifying aliases appear in model listings and share expected name fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->