### PR TITLE
feat: add platform-specific process attributes support

### DIFF
--- a/proxy/process.go
+++ b/proxy/process.go
@@ -256,6 +256,7 @@ func (p *Process) start() error {
 	p.cmd.Env = append(p.cmd.Environ(), p.config.Env...)
 	p.cmd.Cancel = p.cmdStopUpstreamProcess
 	p.cmd.WaitDelay = p.gracefulStopTimeout
+	setProcAttributes(p.cmd)
 
 	p.cmdMutex.Lock()
 	p.cancelUpstream = ctxCancelUpstream
@@ -625,6 +626,7 @@ func (p *Process) cmdStopUpstreamProcess() error {
 		stopCmd := exec.Command(stopArgs[0], stopArgs[1:]...)
 		stopCmd.Stdout = p.processLogger
 		stopCmd.Stderr = p.processLogger
+		setProcAttributes(stopCmd)
 		stopCmd.Env = p.cmd.Env
 
 		if err := stopCmd.Run(); err != nil {

--- a/proxy/process_unix.go
+++ b/proxy/process_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package proxy
+
+import (
+	"os/exec"
+)
+
+// setProcAttributes sets platform-specific process attributes
+func setProcAttributes(cmd *exec.Cmd) {
+	// No-op on Unix systems
+}

--- a/proxy/process_windows.go
+++ b/proxy/process_windows.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package proxy
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcAttributes sets platform-specific process attributes
+func setProcAttributes(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow:    true,
+		CreationFlags: 0x08000000, // CREATE_NO_WINDOW
+	}
+}


### PR DESCRIPTION
## Add platform-specific process attributes support

### Problem
When llama-swap spawns child processes on Windows (such as llama-server instances), console windows appear and remain visible throughout the process lifetime, resulting in a poor user experience. On Windows, .exe processes display console windows by default unless explicitly hidden.


### Solution
This PR adds platform-specific process attributes using Go build tags:
- process_windows.go: Sets HideWindow: true and CREATE_NO_WINDOW flag to hide console windows on Windows
- process_unix.go: No-op implementation for Unix systems (no changes needed)
- process.go: Calls setProcAttributes() when spawning processes


### Changes
- Add setProcAttributes() function with platform-specific implementations
- Apply process attributes to both main command and stop command execution
- No configuration changes required - works automatically per platform


### Testing
Tested on Windows 11. Console windows are now completely hidden during model operations.


Thank you for maintaining this project!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added platform-specific process attribute configuration to optimize startup and shutdown operations across all systems. Windows systems now receive enhanced process initialization handling, while Unix systems benefit from streamlined attribute configuration. This ensures consistent and appropriate system-level configurations are properly applied during both command startup procedures and graceful termination sequences across all supported environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->