### PR TITLE
feat: reload config on SIGHUP

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -465,3 +465,14 @@ peers:
       - moonshotai/kimi-k2-0905
       - minimax/minimax-m2.1
 ```
+
+## Hot Reloading Configuration
+
+Trigger a configuration reload by sending `SIGHUP` to the process:
+
+- **With Docker** (if container is named `llama-swap`):
+  ```bash
+  docker kill -s SIGHUP llama-swap
+  ```
+
+For real-time file system monitoring and automatic restarts on config changes, see [restart-on-config-change](./examples/restart-on-config-change/README.md).

--- a/docs/examples/restart-on-config-change/README.md
+++ b/docs/examples/restart-on-config-change/README.md
@@ -1,6 +1,6 @@
 # Restart llama-swap on config change
 
-Sometimes editing the configuration file can take a bit of trail and error to get a model configuration tuned just right. The `watch-and-restart.sh` script can be used to watch `config.yaml` for changes and restart `llama-swap` when it detects a change.
+Sometimes editing the configuration file can take a bit of trial and error to get a model configuration tuned just right. The `watch-and-restart.sh` script can be used to watch `config.yaml` for changes and send the `SIGHUP` signal to `llama-swap` to trigger a config file reload when it detects a change.
 
 ```bash
 #!/bin/bash
@@ -8,27 +8,34 @@ Sometimes editing the configuration file can take a bit of trail and error to ge
 # A simple watch and restart llama-swap when its configuration
 # file changes. Useful for trying out configuration changes
 # without manually restarting the server each time.
+
+# For docker users, consider replacing:
+# `kill -USR1 $PID` with `docker kill -s SIGHUP container_name`
+
 if [ -z "$1" ]; then
     echo "Usage: $0 <path to config.yaml>"
     exit 1
 fi
 
-while true; do
-    # Start the process again
-    ./llama-swap-linux-amd64 -config $1 -listen :1867 &
-    PID=$!
-    echo "Started llama-swap with PID $PID"
+# Start the process once
+./llama-swap-linux-amd64 -config $1 -listen :1867 &
+PID=$!
+echo "Started llama-swap with PID $PID"
 
+while true; do
     # Wait for modifications in the specified directory or file
-    inotifywait -e modify "$1"
+    if ! inotifywait -e modify "$1" 2>/dev/null; then
+        echo "Error: Failed to monitor file changes"
+        break
+    fi
 
     # Check if process exists before sending signal
     if kill -0 $PID 2>/dev/null; then
-        echo "Sending SIGTERM to $PID"
-        kill -SIGTERM $PID
-        wait $PID
+        echo "Sending SIGHUP to $PID"
+        kill -USR1 $PID
     else
         echo "Process $PID no longer exists"
+        break
     fi
     sleep 1
 done
@@ -42,10 +49,10 @@ Started llama-swap with PID 495455
 Setting up watches.
 Watches established.
 llama-swap listening on :1867
-Sending SIGTERM to 495455
-Shutting down llama-swap
-Started llama-swap with PID 495486
-Setting up watches.
-Watches established.
-llama-swap listening on :1867
+...
+Sending SIGHUP to 495455
+Received SIGHUP. Reloading configuration...
+Configuration Changed
+Configuration Reloaded
+...
 ```


### PR DESCRIPTION
- Allows quick reloading with SIGHUP without when filesytem watch is
  not available like on a default docker setup `docker kill -s SIGHUP`
- Also refactored the signal handling in a single logical unit
- Updated the config readme and the script for reloading on changes