### PR TITLE
docker: add /app to $PATH

### DIFF
--- a/docker/llama-swap.Containerfile
+++ b/docker/llama-swap.Containerfile
@@ -29,6 +29,10 @@ RUN chown --recursive $UID:$GID $HOME /app
 USER $UID:$GID
 
 WORKDIR /app
+
+# Add /app to PATH
+ENV PATH="/app:${PATH}"
+
 RUN \
     curl -LO "https://github.com/${LS_REPO}/releases/download/v${LS_VER}/llama-swap_${LS_VER}_linux_amd64.tar.gz" && \
     tar -zxf "llama-swap_${LS_VER}_linux_amd64.tar.gz" && \


### PR DESCRIPTION
Make it so llama-server can be called directly instead of with the full path at /app/llama-server.

Fixes #423
Ref: #233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container configuration to ensure application binaries and scripts are properly resolved at runtime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->