### PR TITLE
proxy: support /v1/images/generations

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
   - `v1/embeddings`
   - `v1/audio/speech` ([#36](https://github.com/mostlygeek/llama-swap/issues/36))
   - `v1/audio/transcriptions` ([docs](https://github.com/mostlygeek/llama-swap/issues/41#issuecomment-2722637867))
+  - `v1/images/generations`
 - ✅ Anthropic API supported endpoints:
   - `v1/messages`
 - ✅ llama-server (llama.cpp) supported endpoints

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -299,6 +299,7 @@ func (pm *ProxyManager) setupGinEngine() {
 	// Support audio/speech endpoint
 	pm.ginEngine.POST("/v1/audio/speech", pm.apiKeyAuth(), pm.proxyInferenceHandler)
 	pm.ginEngine.POST("/v1/audio/transcriptions", pm.apiKeyAuth(), pm.proxyOAIPostFormHandler)
+	pm.ginEngine.POST("/v1/images/generations", pm.apiKeyAuth(), pm.proxyInferenceHandler)
 
 	pm.ginEngine.GET("/v1/models", pm.apiKeyAuth(), pm.listModelsHandler)
 


### PR DESCRIPTION
Add support for the /v1/images/generations endpoint

Updates #433 
Closes #191 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image generation endpoint now available to use with local OpenAI-compatible servers, featuring API key authentication and seamless integration with existing generation workflows.

* **Documentation**
  * Documentation expanded to include the new image generation endpoint and configuration details for local server setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->