### PR TITLE
ci: free up disk space before ROCm container build

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -27,6 +27,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Free up disk space
+        if: matrix.platform == 'rocm'
+        run: |
+          echo "Before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker system prune -af
+          echo "After cleanup:"
+          df -h
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
Add disk cleanup step to clear space before building the ROCm container
to prevent out-of-disk-space errors during the build process.

- Remove .NET framework files (~20-30GB)
- Remove Android SDK (~10-15GB)
- Remove GHC tooling (~5-10GB)
- Remove CodeQL tools (~5-10GB)
- Prune Docker system to remove unused images

This cleanup runs only for the rocm platform build to minimize impact
on other builds.

fixes mostlygeek/llama-swap/actions/runs/21021128343

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline disk management for improved build efficiency on specific platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->