### PR TITLE
config: support environment variable macros in apiKeys

### DIFF
--- a/proxy/config/config.go
+++ b/proxy/config/config.go
@@ -485,8 +485,14 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		config.Hooks.OnStartup.Preload = toPreload
 	}
 
-	// check api keys validatity
-	for _, apikey := range config.RequiredAPIKeys {
+	// check api keys validity and substitute env macros
+	for i, apikey := range config.RequiredAPIKeys {
+		apikey, err = substituteEnvMacros(apikey)
+		if err != nil {
+			return Config{}, fmt.Errorf("apiKeys[%d]: %w", i, err)
+		}
+		config.RequiredAPIKeys[i] = apikey
+
 		if apikey == "" {
 			return Config{}, fmt.Errorf("empty api key found in apiKeys")
 		}


### PR DESCRIPTION
## Summary
- Add `${env.VAR_NAME}` macro support for `apiKeys` configuration field
- Apply env macro substitution before validation checks
- Add tests for env macro substitution in apiKeys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API keys now support environment variable substitution within configuration files.
  * Added validation to ensure API keys do not contain spaces following environment variable substitution.

* **Tests**
  * Added comprehensive test suite covering environment variable substitution in API keys, including error handling validation for missing variables and empty keys after substitution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->