### PR TITLE
feat: add peer pathRewrite support

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -346,6 +346,11 @@
                         "additionalProperties": false,
                         "default": {},
                         "description": "Dictionary of filter settings for peer requests. Supports stripParams and setParams."
+                    },
+                    "pathRewrite": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Optional path rewriting rule. Formats: 'strip:/v1' removes the /v1 prefix from request paths, 'replace:/v1:/api/v4' replaces /v1 with /api/v4. Useful for API providers that don't follow OpenAI's standard /v1/* path convention."
                     }
                 }
             },

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -415,3 +415,22 @@ peers:
         provider:
           data_collection: "deny"
           zdr: true
+  # Example: z.ai endpoint that doesn't use /v1/ prefix
+  z-ai-provider:
+    proxy: https://api.z.ai/api/coding/paas/v4
+    # pathRewrite: optional path transformation rule
+    # - optional, default: ""
+    # - "strip:/v1" removes the /v1 prefix from requests
+    # - "replace:/v1:/api/v4" replaces /v1 with /api/v4
+    # Example: /v1/chat/completions becomes /chat/completions with "strip:/v1"
+    pathRewrite: "strip:/v1"
+    apiKey: ${env.ZAI_API_KEY}
+    models:
+      - glm-4.7
+  # Example: Replace path prefix instead of stripping
+  custom-api:
+    proxy: https://api.example.com
+    pathRewrite: "replace:/v1:/api/v2"
+    apiKey: ${env.CUSTOM_API_KEY}
+    models:
+      - custom-model

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -464,4 +464,22 @@ peers:
       - z-ai/glm-4.7
       - moonshotai/kimi-k2-0905
       - minimax/minimax-m2.1
+  # Example: z.ai endpoint that doesn't use /v1/ prefix
+  z-ai-provider:
+    proxy: https://api.z.ai/api/coding/paas/v4
+    # pathRewrite: optional path transformation rule
+    # - optional, default: ""
+    # - "strip:/v1" removes the /v1 prefix from requests
+    # - "replace:/v1:/api/v4" replaces /v1 with /api/v4
+    # Example: /v1/chat/completions becomes /chat/completions with "strip:/v1"
+    pathRewrite: "strip:/v1"
+    apiKey: your-zai-token
+    models:
+      - glm-4.7
+  # Example: Replace path prefix instead of stripping
+  custom-api:
+    proxy: https://api.example.com
+    pathRewrite: "replace:/v1:/api/v2"
+    models:
+      - custom-model
 ```

--- a/proxy/config/peer_test.go
+++ b/proxy/config/peer_test.go
@@ -73,6 +73,46 @@ models: []
 `,
 			wantErr: "peer models can not be empty",
 		},
+		{
+			name: "valid pathRewrite strip",
+			yaml: `
+proxy: http://localhost:8080
+pathRewrite: strip:/v1
+models:
+  - model_a
+`,
+			wantErr: "",
+		},
+		{
+			name: "valid pathRewrite replace",
+			yaml: `
+proxy: http://localhost:8080
+pathRewrite: replace:/v1:/api
+models:
+  - model_a
+`,
+			wantErr: "",
+		},
+		{
+			name: "invalid pathRewrite format",
+			yaml: `
+proxy: http://localhost:8080
+pathRewrite: invalid-format
+models:
+  - model_a
+`,
+			wantErr: "invalid pathRewrite format",
+		},
+		{
+			name: "invalid pathRewrite unknown action",
+			yaml: `
+proxy: http://localhost:8080
+pathRewrite: delete:/v1
+models:
+  - model_a
+`,
+			wantErr: "invalid pathRewrite format",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds pathRewrite configuration for peer proxies to transform request paths before forwarding. It supports strip and replace actions for API providers that don't follow OpenAI's standard /v1/* path convention - for example z.ai API is exposed via `/api/coding/paas/v4/`, which throws an error "Not Found" for the model with the current implementation of llama-swap.

- Adds PathRewrite field to PeerConfig with strip: and replace: actions
- Implements applyPathRewrite function for path transformation
- Adds validation for pathRewrite format at config load time
- Updates config schema, examples, and documentation

---
### Testing samples:

##### Test with no pathRewrite - fails as of current main
```
$ curl -s -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "GLM-4.7",
    "messages": [{"role": "user", "content": "Say hi"}]
  }' | jq .
{
  "timestamp": "2026-01-24T14:20:48.195+00:00",
  "status": 404,
  "error": "Not Found",
  "path": "/v4/v1/chat/completions"
}
```


##### Test with replace pathRewrite
```
$ curl -s -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "GLM-4.7",
    "messages": [{"role": "user", "content": "Say hi with replace"}]
  }' | jq .
{
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "Here is \"Hi\" using a replace operation in Python:\n\n`\"Hello\".replace(\"Hello\", \"Hi\")`\n\nResult: `Hi`",
        "reasoning_content": "too much reasoning to include in here",
        "role": "assistant"
      }
    }
  ],
  "created": 1769264279,
  "id": "20260124221744129937d56617445d",
  "model": "GLM-4.7",
  "object": "chat.completion",
  "request_id": "20260124221744129937d56617445d",
  "usage": {
    "completion_tokens": 719,
    "completion_tokens_details": {
      "reasoning_tokens": 688
    },
    "prompt_tokens": 9,
    "prompt_tokens_details": {
      "cached_tokens": 2
    },
    "total_tokens": 728
  }
}
```

##### Test with strip 
```
$ curl -s -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "GLM-4.7",
    "messages": [{"role": "user", "content": "Say hi with strip"}]
  }' | jq .
{
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "Here is a \"Hi\" comic strip ....",
        "reasoning_content": "1.  **Analyze the Request:**\n........",
        "role": "assistant"
      }
    }
  ],
  "created": 1769264188,
  "id": "202601242216099277946ce4e343f6",
  "model": "GLM-4.7",
  "object": "chat.completion",
  "request_id": "202601242216099277946ce4e343f6",
  "usage": {
    "completion_tokens": 1479,
    "completion_tokens_details": {
      "reasoning_tokens": 1282
    },
    "prompt_tokens": 9,
    "prompt_tokens_details": {
      "cached_tokens": 3
    },
    "total_tokens": 1488
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added path rewriting support for peer configurations. Enable optional URL path transformations (strip prefix or replace patterns) for requests to non-standard API providers.

* **Documentation**
  * Updated configuration documentation with pathRewrite usage examples and peer provider configurations.

* **Tests**
  * Added comprehensive test coverage for path rewriting functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->