### PR TITLE
ui-svelte: add Playground page with chat interface

### DIFF
--- a/ui-svelte/src/components/playground/ChatInterface.svelte
+++ b/ui-svelte/src/components/playground/ChatInterface.svelte
@@ -195,9 +195,9 @@
 
 <div class="flex flex-col h-full">
   <!-- Model selector and controls -->
-  <div class="shrink-0 flex gap-2 mb-4">
+  <div class="shrink-0 flex flex-wrap gap-2 mb-4">
     <select
-      class="flex-1 px-3 py-2 rounded border border-gray-200 dark:border-white/10 bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
+      class="min-w-0 flex-1 basis-48 px-3 py-2 rounded border border-gray-200 dark:border-white/10 bg-surface focus:outline-none focus:ring-2 focus:ring-primary"
       bind:value={$selectedModelStore}
       disabled={isStreaming}
     >
@@ -217,18 +217,20 @@
         </optgroup>
       {/each}
     </select>
-    <button
-      class="btn"
-      onclick={() => (showSettings = !showSettings)}
-      title="Settings"
-    >
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5">
-        <path fill-rule="evenodd" d="M8.34 1.804A1 1 0 0 1 9.32 1h1.36a1 1 0 0 1 .98.804l.295 1.473c.497.144.971.342 1.416.587l1.25-.834a1 1 0 0 1 1.262.125l.962.962a1 1 0 0 1 .125 1.262l-.834 1.25c.245.445.443.919.587 1.416l1.473.295a1 1 0 0 1 .804.98v1.36a1 1 0 0 1-.804.98l-1.473.295a6.95 6.95 0 0 1-.587 1.416l.834 1.25a1 1 0 0 1-.125 1.262l-.962.962a1 1 0 0 1-1.262.125l-1.25-.834a6.953 6.953 0 0 1-1.416.587l-.295 1.473a1 1 0 0 1-.98.804H9.32a1 1 0 0 1-.98-.804l-.295-1.473a6.957 6.957 0 0 1-1.416-.587l-1.25.834a1 1 0 0 1-1.262-.125l-.962-.962a1 1 0 0 1-.125-1.262l.834-1.25a6.957 6.957 0 0 1-.587-1.416l-1.473-.295A1 1 0 0 1 1 10.68V9.32a1 1 0 0 1 .804-.98l1.473-.295c.144-.497.342-.971.587-1.416l-.834-1.25a1 1 0 0 1 .125-1.262l.962-.962A1 1 0 0 1 5.38 3.03l1.25.834a6.957 6.957 0 0 1 1.416-.587l.294-1.473ZM13 10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" clip-rule="evenodd" />
-      </svg>
-    </button>
-    <button class="btn" onclick={newChat} disabled={messages.length === 0 && !isStreaming}>
-      New Chat
-    </button>
+    <div class="flex gap-2">
+      <button
+        class="btn"
+        onclick={() => (showSettings = !showSettings)}
+        title="Settings"
+      >
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5">
+          <path fill-rule="evenodd" d="M8.34 1.804A1 1 0 0 1 9.32 1h1.36a1 1 0 0 1 .98.804l.295 1.473c.497.144.971.342 1.416.587l1.25-.834a1 1 0 0 1 1.262.125l.962.962a1 1 0 0 1 .125 1.262l-.834 1.25c.245.445.443.919.587 1.416l1.473.295a1 1 0 0 1 .804.98v1.36a1 1 0 0 1-.804.98l-1.473.295a6.95 6.95 0 0 1-.587 1.416l.834 1.25a1 1 0 0 1-.125 1.262l-.962.962a1 1 0 0 1-1.262.125l-1.25-.834a6.953 6.953 0 0 1-1.416.587l-.295 1.473a1 1 0 0 1-.98.804H9.32a1 1 0 0 1-.98-.804l-.295-1.473a6.957 6.957 0 0 1-1.416-.587l-1.25.834a1 1 0 0 1-1.262-.125l-.962-.962a1 1 0 0 1-.125-1.262l.834-1.25a6.957 6.957 0 0 1-.587-1.416l-1.473-.295A1 1 0 0 1 1 10.68V9.32a1 1 0 0 1 .804-.98l1.473-.295c.144-.497.342-.971.587-1.416l-.834-1.25a1 1 0 0 1 .125-1.262l.962-.962A1 1 0 0 1 5.38 3.03l1.25.834a6.957 6.957 0 0 1 1.416-.587l.294-1.473ZM13 10a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" clip-rule="evenodd" />
+        </svg>
+      </button>
+      <button class="btn" onclick={newChat} disabled={messages.length === 0 && !isStreaming}>
+        New Chat
+      </button>
+    </div>
   </div>
 
   <!-- Settings panel -->

--- a/ui-svelte/src/components/playground/ChatMessage.svelte
+++ b/ui-svelte/src/components/playground/ChatMessage.svelte
@@ -121,10 +121,10 @@
         {/if}
       </div>
       {#if !isStreaming}
-        <div class="absolute top-2 right-2 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity bg-surface/90 dark:bg-surface/90 rounded-lg p-1 shadow-sm border border-gray-200 dark:border-white/10">
+        <div class="flex gap-1 mt-2 pt-1 border-t border-gray-200 dark:border-white/10">
           {#if onRegenerate}
             <button
-              class="p-1 rounded hover:bg-black/10 dark:hover:bg-white/10"
+              class="p-1 rounded hover:bg-black/10 dark:hover:bg-white/10 text-txtsecondary"
               onclick={onRegenerate}
               title="Regenerate response"
             >
@@ -132,7 +132,7 @@
             </button>
           {/if}
           <button
-            class="p-1 rounded hover:bg-black/10 dark:hover:bg-white/10"
+            class="p-1 rounded hover:bg-black/10 dark:hover:bg-white/10 text-txtsecondary"
             onclick={copyToClipboard}
             title={copied ? "Copied!" : "Copy to clipboard"}
           >

--- a/ui-svelte/src/routes/Playground.svelte
+++ b/ui-svelte/src/routes/Playground.svelte
@@ -16,7 +16,7 @@
 
 <div class="card h-full flex flex-col">
   <!-- Tab navigation -->
-  <div class="shrink-0 flex gap-2 mb-4">
+  <div class="shrink-0 flex flex-wrap gap-2 mb-4">
     <button
       class="px-4 py-2 rounded font-medium transition-colors {$selectedTabStore === 'chat'
         ? 'bg-primary text-btn-primary-text'


### PR DESCRIPTION
Add a new Playground page with tabbed interface for Chat, Images, and
Audio. The Chat tab is fully functional with streaming responses and
markdown rendering.

- Add Chat tab with model selection and streaming responses
- Add markdown rendering with syntax highlighting (marked + highlight.js)
- Add Images and Audio placeholder tabs
- Persist selected model and tab in localStorage
- Support streaming cancellation and new chat functionality

https://claude.ai/code/session_01AKRAvCcarx2kKLVTsCcbfD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive Playground UI with four tabs: Chat (with streaming model selection), Image Generation, Speech Synthesis, and Audio Transcription.
  * Added audio voices API endpoint for model-aware voice selection.
  * Implemented streaming chat with message history and model selection.

* **Improvements**
  * Enhanced environment variable handling in configuration with improved comment processing and validation.

* **Tests**
  * Added tests for audio endpoint and configuration comment handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->