### PR TITLE
docs: add stable-diffusion.cpp references

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ llama-swap can be installed in multiple ways
 
 ### Docker Install ([download images](https://github.com/mostlygeek/llama-swap/pkgs/container/llama-swap))
 
-Nightly container images with llama-swap, llama-server and stable-diffusion.cpp server are built for multiple platforms (cuda, vulkan, intel, etc.) including [non-root variants with improved security](docs/container-security.md).
+Nightly container images with llama-swap and llama-server are built for multiple platforms (cuda, vulkan, intel, etc.) including [non-root variants with improved security](docs/container-security.md).
+The stable-diffusion.cpp server is also included for the musa and vulkan platforms.
 
 ```shell
 $ docker pull ghcr.io/mostlygeek/llama-swap:cuda


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added stable-diffusion.cpp as an additional local OpenAI-compatible server option in the feature list.
  * Updated Docker installation guidance to mention the stable-diffusion.cpp server alongside existing options for nightly images.
  * Noted that the stable-diffusion.cpp server is included for the musa and vulkan platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->