### PR TITLE
ui-svelte: implement incremental markdown rendering (KIMI 2.5)

### DIFF
--- a/ui-svelte/src/components/playground/ChatMessage.svelte
+++ b/ui-svelte/src/components/playground/ChatMessage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { renderMarkdown, escapeHtml } from "../../lib/markdown";
+  import { renderMarkdown, renderStreamingMarkdown, escapeHtml } from "../../lib/markdown";
   import { Copy, Check, Pencil, X, Save, RefreshCw, ChevronDown, ChevronRight, Brain, Code } from "lucide-svelte";
   import { getTextContent, getImageUrls } from "../../lib/types";
   import type { ContentPart } from "../../lib/types";
@@ -23,8 +23,10 @@
   let canEdit = $derived(onEdit !== undefined && !hasImages);
 
   let renderedContent = $derived(
-    role === "assistant" && !isStreaming
-      ? renderMarkdown(textContent)
+    role === "assistant"
+      ? isStreaming
+        ? renderStreamingMarkdown(textContent)
+        : renderMarkdown(textContent)
       : escapeHtml(textContent).replace(/\n/g, '<br>')
   );
   let copied = $state(false);

--- a/ui-svelte/src/lib/markdown.test.ts
+++ b/ui-svelte/src/lib/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { renderMarkdown, escapeHtml } from "./markdown";
+import { renderMarkdown, renderStreamingMarkdown, escapeHtml } from "./markdown";
 
 describe("renderMarkdown", () => {
   describe("basic markdown", () => {
@@ -155,6 +155,321 @@ More text here.
       // Very large or malformed input should be handled
       const result = renderMarkdown("$" + "a".repeat(10000) + "$");
       expect(result).toBeTruthy();
+    });
+  });
+});
+
+describe("renderStreamingMarkdown", () => {
+  describe("fenced code blocks", () => {
+    it("renders complete fenced code blocks with highlighting", () => {
+      const content = "```js\nconst x = 1;\n```";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("hljs");
+      expect(result).toContain("const");
+      expect(result).toContain("<pre");
+    });
+
+    it("renders complete fenced code blocks with tildes", () => {
+      const content = "~~~python\nprint('hello')\n~~~";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("hljs");
+      expect(result).toContain("print");
+    });
+
+    it("escapes incomplete fenced code blocks", () => {
+      const content = "```js\nconst x = 1;\n// still typing";
+      const result = renderStreamingMarkdown(content);
+      // Incomplete code block should not be rendered with highlighting
+      expect(result).not.toContain("hljs");
+      expect(result).not.toContain("<pre");
+      // Should contain the raw content with line breaks
+      expect(result).toContain("<br>");
+      expect(result).toContain("const x = 1");
+    });
+
+    it("renders multiple complete code blocks", () => {
+      const content = "```js\nconst a = 1;\n```\n\n```py\nb = 2\n```";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("hljs");
+      // Should have two code blocks
+      const preMatches = result.match(/<pre/g);
+      expect(preMatches?.length).toBe(2);
+    });
+
+    it("handles code block with backticks inside", () => {
+      const content = "```\nconst s = `template`;\n```";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("hljs");
+    });
+  });
+
+  describe("headers", () => {
+    it("renders headers immediately at end of line", () => {
+      const content = "# Heading 1\nSome text";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("<h1>Heading 1</h1>");
+    });
+
+    it("renders all header levels", () => {
+      for (let i = 1; i <= 6; i++) {
+        const content = `${"#".repeat(i)} Heading ${i}\n\nNext paragraph`;
+        const result = renderStreamingMarkdown(content);
+        expect(result).toContain(`<h${i}>Heading ${i}</h${i}>`);
+      }
+    });
+
+    it("renders multiple headers", () => {
+      const content = "# First\n\n## Second\n\n### Third";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("<h1>First</h1>");
+      expect(result).toContain("<h2>Second</h2>");
+      expect(result).toContain("<h3>Third</h3>");
+    });
+  });
+
+  describe("paragraphs", () => {
+    it("renders paragraphs when followed by empty line", () => {
+      const content = "First paragraph\n\nSecond paragraph";
+      const result = renderStreamingMarkdown(content);
+      // First paragraph should be rendered (followed by empty line)
+      expect(result).toContain("<p>First paragraph</p>");
+      // Second paragraph is incomplete (at end of content), so escaped
+      expect(result).toContain("Second paragraph");
+    });
+
+    it("renders paragraphs when followed by new block", () => {
+      const content = "First paragraph\n# Header";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("<p>First paragraph</p>");
+      expect(result).toContain("<h1>Header</h1>");
+    });
+
+    it("escapes incomplete paragraphs", () => {
+      const content = "This is an incomplete paragraph still typing";
+      const result = renderStreamingMarkdown(content);
+      expect(result).not.toContain("<p>");
+      expect(result).toContain("incomplete paragraph");
+    });
+  });
+
+  describe("blockquotes", () => {
+    it("renders complete blockquotes", () => {
+      const content = "> Line 1\n> Line 2\n\nNext paragraph";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("<blockquote>");
+      expect(result).toContain("</blockquote>");
+    });
+
+    it("escapes incomplete blockquotes", () => {
+      const content = "> Line 1\n> Line 2";
+      const result = renderStreamingMarkdown(content);
+      // Blockquote at end of content should be escaped (incomplete)
+      expect(result).toContain("&gt;");
+    });
+  });
+
+  describe("unordered lists", () => {
+    it("renders complete unordered lists", () => {
+      const content = "- Item 1\n- Item 2\n\nNext paragraph";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("<ul>");
+      expect(result).toContain("<li>Item 1</li>");
+      expect(result).toContain("<li>Item 2</li>");
+    });
+
+    it("renders lists with asterisks", () => {
+      const content = "* Item 1\n* Item 2\n\nDone";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("<ul>");
+      expect(result).toContain("<li>Item 1</li>");
+    });
+
+    it("renders lists with plus signs", () => {
+      const content = "+ Item 1\n+ Item 2\n\nDone";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("<ul>");
+      expect(result).toContain("<li>Item 1</li>");
+    });
+
+    it("escapes incomplete lists", () => {
+      const content = "- Item 1\n- Item 2";
+      const result = renderStreamingMarkdown(content);
+      // Should be escaped since list isn't complete
+      expect(result).toContain("- Item");
+      expect(result).not.toContain("<ul>");
+    });
+  });
+
+  describe("ordered lists", () => {
+    it("renders complete ordered lists", () => {
+      const content = "1. First\n2. Second\n\nNext paragraph";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("<ol>");
+      expect(result).toContain("<li>First</li>");
+      expect(result).toContain("<li>Second</li>");
+    });
+
+    it("escapes incomplete ordered lists", () => {
+      const content = "1. First\n2. Second";
+      const result = renderStreamingMarkdown(content);
+      // Should be escaped
+      expect(result).toContain("1. First");
+      expect(result).not.toContain("<ol>");
+    });
+  });
+
+  describe("horizontal rules", () => {
+    it("renders horizontal rules immediately", () => {
+      const content = "---\n\nNext paragraph";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("<hr>");
+    });
+
+    it("renders horizontal rules with asterisks", () => {
+      const content = "***\n\nNext";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("<hr>");
+    });
+
+    it("renders horizontal rules with underscores", () => {
+      const content = "___\n\nNext";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("<hr>");
+    });
+  });
+
+  describe("tables", () => {
+    it("renders complete tables", () => {
+      const content = "| Col1 | Col2 |\n|------|------|\n| A    | B    |\n\nNext";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("<table>");
+      expect(result).toContain("<th>Col1</th>");
+      expect(result).toContain("<td>A</td>");
+    });
+
+    it("escapes incomplete tables", () => {
+      const content = "| Col1 | Col2 |\n|------|------|\n| A    | B    |";
+      const result = renderStreamingMarkdown(content);
+      // Should be escaped since table isn't complete
+      expect(result).toContain("| Col1");
+      expect(result).not.toContain("<table>");
+    });
+  });
+
+  describe("math blocks", () => {
+    it("renders complete math blocks", () => {
+      const content = "$$\nE = mc^2\n$$";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("katex");
+    });
+
+    it("escapes incomplete math blocks", () => {
+      const content = "$$\nE = mc^2";
+      const result = renderStreamingMarkdown(content);
+      // Should be escaped
+      expect(result).toContain("$$");
+      expect(result).toContain("<br>");
+      expect(result).not.toContain("katex");
+    });
+  });
+
+  describe("mixed content", () => {
+    it("renders complete blocks and escapes incomplete ones", () => {
+      const content = "# Complete Header\n\n```js\nconst x = 1;\n```\n\nIncomplete paragraph";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("<h1>Complete Header</h1>");
+      expect(result).toContain("hljs");
+      // Last part should be escaped
+      expect(result).toContain("Incomplete paragraph");
+    });
+
+    it("handles streaming simulation - progressively completing content", () => {
+      // Simulate streaming: incomplete -> complete
+      const incomplete = "```js\nconst x = 1;";
+      const complete = "```js\nconst x = 1;\n```";
+
+      const incompleteResult = renderStreamingMarkdown(incomplete);
+      const completeResult = renderStreamingMarkdown(complete);
+
+      expect(incompleteResult).not.toContain("hljs");
+      expect(completeResult).toContain("hljs");
+    });
+
+    it("handles complex mixed document", () => {
+      const content = `# Document Title
+
+This is a complete paragraph.
+
+\`\`\`python
+def hello():
+    return "world"
+\`\`\`
+
+> A blockquote
+> with two lines
+
+- List item 1
+- List item 2
+
+Incomplete`;
+
+      const result = renderStreamingMarkdown(content);
+
+      // All complete blocks should be rendered
+      expect(result).toContain("<h1>Document Title</h1>");
+      expect(result).toContain("<p>This is a complete paragraph.</p>");
+      expect(result).toContain("hljs");
+      expect(result).toContain("<blockquote>");
+      expect(result).toContain("<ul>");
+
+      // Incomplete part should be escaped
+      expect(result).toContain("Incomplete");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty content", () => {
+      const result = renderStreamingMarkdown("");
+      expect(result).toBe("");
+    });
+
+    it("handles only whitespace", () => {
+      const result = renderStreamingMarkdown("   \n\n   ");
+      // Whitespace-only content should return empty or whitespace
+      expect(result !== undefined).toBe(true);
+    });
+
+    it("handles single line", () => {
+      const result = renderStreamingMarkdown("Just one line");
+      expect(result).toContain("Just one line");
+    });
+
+    it("handles code block with language specifier", () => {
+      const content = "```typescript\nconst x: number = 1;\n```";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("hljs");
+    });
+
+    it("handles nested markdown in blockquotes", () => {
+      const content = "> # Header in quote\n> **bold text**\n\nDone";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain("<blockquote>");
+      expect(result).toContain("<h1>Header in quote</h1>");
+      expect(result).toContain("<strong>bold text</strong>");
+    });
+
+    it("handles inline code in paragraphs", () => {
+      const content = "Use `console.log()` for debugging.\n\nNext paragraph";
+      const result = renderStreamingMarkdown(content);
+      // Inline code gets highlight.js treatment
+      expect(result).toContain("<code");
+      expect(result).toContain("console.log()");
+    });
+
+    it("handles links in paragraphs", () => {
+      const content = "Visit [example](https://example.com) for more.\n\nNext";
+      const result = renderStreamingMarkdown(content);
+      expect(result).toContain('<a href="https://example.com">example</a>');
     });
   });
 });

--- a/ui-svelte/src/lib/markdown.ts
+++ b/ui-svelte/src/lib/markdown.ts
@@ -82,3 +82,253 @@ export function renderMarkdown(content: string): string {
     return `<p>${escapeHtml(content)}</p>`;
   }
 }
+
+// Regex patterns for block detection
+const PATTERNS = {
+  // Fenced code block start: ``` or ~~~ followed by optional language
+  fencedCodeStart: /^(```+|~~~+)(.*)$/,
+  // Header: 1-6 # followed by space
+  header: /^(#{1,6})\s/,
+  // Blockquote: > followed by optional space
+  blockquote: /^>\s?/,
+  // Unordered list: -, *, or + followed by space
+  unorderedList: /^(\s*)([-*+])\s/,
+  // Ordered list: number followed by . and space
+  orderedList: /^(\s*)(\d+)\.\s/,
+  // Horizontal rule: ---, ***, or ___ on their own line
+  horizontalRule: /^(---+|\*\*\*+|___+)\s*$/,
+  // Math block: $$ on its own line
+  mathBlockStart: /^\$\$\s*$/,
+  mathBlockEnd: /^\$\$\s*$/,
+  // Table row: | ... | with optional trailing |
+  tableRow: /^\|.*\|$/,
+  // Table separator: | --- | --- | etc
+  tableSeparator: /^\|?(\s*:?-+:?\s*\|)+\s*:?-+:?\s*\|?$/,
+  // Empty line
+  emptyLine: /^\s*$/,
+};
+
+/**
+ * Render markdown incrementally during streaming.
+ * Complete blocks are rendered as markdown, incomplete blocks are escaped.
+ *
+ * Algorithm:
+ * 1. Parse content line by line
+ * 2. Track current block type and buffer
+ * 3. For each line, determine if it continues current block or starts new block
+ * 4. When a block is determined to be complete, render it via renderMarkdown()
+ * 5. Remaining buffer (incomplete block) is escaped and added to output
+ */
+export function renderStreamingMarkdown(content: string): string {
+  if (!content) {
+    return "";
+  }
+
+  const lines = content.split("\n");
+  const result: string[] = [];
+
+  // Block state tracking
+  type BlockType =
+    | "none"
+    | "fenced_code"
+    | "math_block"
+    | "header"
+    | "blockquote"
+    | "unordered_list"
+    | "ordered_list"
+    | "horizontal_rule"
+    | "table"
+    | "paragraph";
+
+  interface BlockState {
+    type: BlockType;
+    lines: string[];
+    fenceChar?: string;
+    fenceLength?: number;
+  }
+
+  let state: BlockState | null = null;
+
+  // Helper to check if a line is a fence matching the opening fence
+  const isClosingFence = (line: string, fenceChar: string, fenceLength: number): boolean => {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith(fenceChar)) return false;
+    // Must be only fence chars
+    if (!new RegExp(`^[${fenceChar}]+$`).test(trimmed)) return false;
+    // Must be at least as long as opening fence
+    return trimmed.length >= fenceLength;
+  };
+
+  // Helper to detect block type from line
+  const detectBlockType = (line: string): BlockType => {
+    if (PATTERNS.fencedCodeStart.test(line)) return "fenced_code";
+    if (PATTERNS.mathBlockStart.test(line)) return "math_block";
+    if (PATTERNS.horizontalRule.test(line)) return "horizontal_rule";
+    if (PATTERNS.header.test(line)) return "header";
+    if (PATTERNS.blockquote.test(line)) return "blockquote";
+    if (PATTERNS.unorderedList.test(line)) return "unordered_list";
+    if (PATTERNS.orderedList.test(line)) return "ordered_list";
+    if (PATTERNS.tableRow.test(line)) return "table";
+    if (PATTERNS.emptyLine.test(line)) return "none";
+    return "paragraph";
+  };
+
+  // Helper to render a block and add to result
+  const renderBlock = (blockLines: string[]) => {
+    if (blockLines.length === 0) return;
+    const blockContent = blockLines.join("\n");
+    try {
+      result.push(renderMarkdown(blockContent));
+    } catch {
+      result.push(`<p>${escapeHtml(blockContent)}</p>`);
+    }
+  };
+
+  // Helper to escape incomplete content
+  const escapeBlock = (blockLines: string[]) => {
+    if (blockLines.length === 0) return;
+    const escaped = escapeHtml(blockLines.join("\n")).replace(/\n/g, "<br>");
+    result.push(escaped);
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (state === null) {
+      // Start a new block
+      const blockType = detectBlockType(line);
+
+      if (blockType === "none") {
+        // Empty line - add spacing if we have content
+        if (result.length > 0) {
+          result.push("\n");
+        }
+        continue;
+      }
+
+      state = { type: blockType, lines: [line] };
+
+      // Extract fence info for fenced code
+      if (blockType === "fenced_code") {
+        const match = line.match(PATTERNS.fencedCodeStart);
+        if (match) {
+          state.fenceChar = match[1][0];
+          state.fenceLength = match[1].length;
+        }
+      }
+
+      // Headers and horizontal rules are immediately complete
+      if (blockType === "header" || blockType === "horizontal_rule") {
+        renderBlock(state.lines);
+        state = null;
+      }
+    } else {
+      // We have an active block - check if this line continues or ends it
+      const blockType = state.type;
+
+      switch (blockType) {
+        case "fenced_code": {
+          state.lines.push(line);
+          // Check if this is the closing fence
+          if (state.fenceChar && state.fenceLength &&
+              isClosingFence(line, state.fenceChar, state.fenceLength)) {
+            renderBlock(state.lines);
+            state = null;
+          }
+          break;
+        }
+
+        case "math_block": {
+          state.lines.push(line);
+          if (PATTERNS.mathBlockEnd.test(line)) {
+            renderBlock(state.lines);
+            state = null;
+          }
+          break;
+        }
+
+        case "blockquote": {
+          // Blockquote continues if line starts with > or is empty (lazy continuation)
+          if (PATTERNS.blockquote.test(line) || PATTERNS.emptyLine.test(line)) {
+            state.lines.push(line);
+          } else {
+            // Line doesn't continue blockquote - render the blockquote since it's complete
+            // (followed by non-blockquote content)
+            renderBlock(state.lines);
+            state = null;
+            i--; // Reprocess this line
+          }
+          break;
+        }
+
+        case "unordered_list":
+        case "ordered_list": {
+          const listPattern = blockType === "unordered_list" ?
+            PATTERNS.unorderedList : PATTERNS.orderedList;
+
+          if (PATTERNS.emptyLine.test(line)) {
+            state.lines.push(line);
+          } else if (listPattern.test(line) || /^\s+/.test(line)) {
+            // Continues list (new item or indented content)
+            state.lines.push(line);
+          } else {
+            // New block starts - render list and reprocess
+            renderBlock(state.lines);
+            state = null;
+            i--; // Reprocess this line
+          }
+          break;
+        }
+
+        case "table": {
+          if (PATTERNS.tableRow.test(line) || PATTERNS.tableSeparator.test(line)) {
+            state.lines.push(line);
+          } else if (PATTERNS.emptyLine.test(line)) {
+            // Empty line ends table
+            renderBlock(state.lines);
+            state = null;
+          } else {
+            // Non-table line - render and reprocess
+            renderBlock(state.lines);
+            state = null;
+            i--; // Reprocess this line
+          }
+          break;
+        }
+
+        case "paragraph": {
+          // Paragraph ends on empty line or start of new block
+          if (PATTERNS.emptyLine.test(line)) {
+            // Empty line ends paragraph
+            renderBlock(state.lines);
+            state = null;
+          } else {
+            const newBlockType = detectBlockType(line);
+            if (newBlockType !== "paragraph" && newBlockType !== "none") {
+              // New block type starts - render paragraph and reprocess
+              renderBlock(state.lines);
+              state = null;
+              i--; // Reprocess this line
+            } else {
+              // Continue paragraph
+              state.lines.push(line);
+            }
+          }
+          break;
+        }
+
+        default:
+          // Unknown state - escape and reset
+          escapeBlock(state.lines);
+          state = null;
+      }
+    }
+  }
+
+  // Handle any remaining incomplete block
+  if (state !== null) {
+    escapeBlock(state.lines);
+  }
+
+  return result.join("");
+}


### PR DESCRIPTION
Create with Claude Code (2.1.33) and Kimi 2.5: 

---

Add renderStreamingMarkdown() function that renders complete markdown blocks incrementally during streaming while keeping incomplete blocks as escaped text.

Key changes:
- Add renderStreamingMarkdown() in markdown.ts with block-level parsing
- Support fenced code blocks, headers, paragraphs, lists, blockquotes, tables, horizontal rules, and math blocks
- Update ChatMessage.svelte to use new function during streaming
- Add comprehensive unit tests for all block types

Complete blocks render with full markdown support including syntax highlighting, while incomplete content at the end of the stream remains escaped for safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented streaming markdown rendering for chat messages, enabling real-time formatting of markdown content as it arrives, including support for code blocks, headers, lists, and tables.

* **Tests**
  * Added comprehensive test coverage for streaming markdown rendering across various markdown elements and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->