### PR TITLE
ui-svelte: add incremental markdown rendering during streaming (OPUS 4.6)

### DIFF
--- a/ui-svelte/src/components/playground/ChatMessage.svelte
+++ b/ui-svelte/src/components/playground/ChatMessage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { renderMarkdown, escapeHtml } from "../../lib/markdown";
+  import { renderMarkdown, escapeHtml, renderStreamingMarkdown } from "../../lib/markdown";
   import { Copy, Check, Pencil, X, Save, RefreshCw, ChevronDown, ChevronRight, Brain, Code } from "lucide-svelte";
   import { getTextContent, getImageUrls } from "../../lib/types";
   import type { ContentPart } from "../../lib/types";
@@ -22,11 +22,17 @@
   let hasImages = $derived(imageUrls.length > 0);
   let canEdit = $derived(onEdit !== undefined && !hasImages);
 
-  let renderedContent = $derived(
-    role === "assistant" && !isStreaming
-      ? renderMarkdown(textContent)
-      : escapeHtml(textContent).replace(/\n/g, '<br>')
-  );
+  let streamingCache = { key: "", html: "" };
+  let renderedContent = $derived.by(() => {
+    if (role !== "assistant") {
+      return escapeHtml(textContent).replace(/\n/g, '<br>');
+    }
+    if (!isStreaming) {
+      streamingCache = { key: "", html: "" };
+      return renderMarkdown(textContent);
+    }
+    return renderStreamingMarkdown(textContent, streamingCache);
+  });
   let copied = $state(false);
   let showRaw = $state(false);
   let isEditing = $state(false);

--- a/ui-svelte/src/lib/markdown.test.ts
+++ b/ui-svelte/src/lib/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { renderMarkdown, escapeHtml } from "./markdown";
+import { renderMarkdown, escapeHtml, splitCompleteBlocks, renderStreamingMarkdown } from "./markdown";
 
 describe("renderMarkdown", () => {
   describe("basic markdown", () => {
@@ -156,5 +156,141 @@ More text here.
       const result = renderMarkdown("$" + "a".repeat(10000) + "$");
       expect(result).toBeTruthy();
     });
+  });
+});
+
+describe("splitCompleteBlocks", () => {
+  it("returns everything as pending when no blank line", () => {
+    const result = splitCompleteBlocks("Hello world");
+    expect(result.complete).toBe("");
+    expect(result.pending).toBe("Hello world");
+  });
+
+  it("returns empty for empty input", () => {
+    const result = splitCompleteBlocks("");
+    expect(result.complete).toBe("");
+    expect(result.pending).toBe("");
+  });
+
+  it("splits on blank line between paragraphs", () => {
+    const result = splitCompleteBlocks("First paragraph.\n\nSecond paragraph");
+    expect(result.complete).toBe("First paragraph.\n");
+    expect(result.pending).toBe("Second paragraph");
+  });
+
+  it("splits multiple paragraphs at last blank line", () => {
+    const result = splitCompleteBlocks("Para 1.\n\nPara 2.\n\nPara 3");
+    expect(result.complete).toBe("Para 1.\n\nPara 2.\n");
+    expect(result.pending).toBe("Para 3");
+  });
+
+  it("treats closed code fence as complete boundary", () => {
+    const text = "```js\nconst x = 1;\n```\nMore text";
+    const result = splitCompleteBlocks(text);
+    expect(result.complete).toBe("```js\nconst x = 1;\n```");
+    expect(result.pending).toBe("More text");
+  });
+
+  it("treats unclosed code fence as pending", () => {
+    const text = "Done paragraph.\n\n```js\nconst x = 1;";
+    const result = splitCompleteBlocks(text);
+    expect(result.complete).toBe("Done paragraph.\n");
+    expect(result.pending).toBe("```js\nconst x = 1;");
+  });
+
+  it("does not split on blank lines inside code fences", () => {
+    const text = "```\nline1\n\nline2\n```";
+    const result = splitCompleteBlocks(text);
+    expect(result.complete).toBe("```\nline1\n\nline2\n```");
+    expect(result.pending).toBe("");
+  });
+
+  it("handles tilde fences", () => {
+    const text = "~~~py\nprint('hi')\n~~~\nAfter";
+    const result = splitCompleteBlocks(text);
+    expect(result.complete).toBe("~~~py\nprint('hi')\n~~~");
+    expect(result.pending).toBe("After");
+  });
+
+  it("does not close backtick fence with tilde fence", () => {
+    const text = "```\ncode\n~~~\nstill code";
+    const result = splitCompleteBlocks(text);
+    // The ~~~ should not close a backtick fence, so everything from ``` onward is pending
+    expect(result.complete).toBe("");
+    expect(result.pending).toBe("```\ncode\n~~~\nstill code");
+  });
+
+  it("treats closed math block as complete boundary", () => {
+    const text = "$$\nx^2\n$$\nAfter";
+    const result = splitCompleteBlocks(text);
+    expect(result.complete).toBe("$$\nx^2\n$$");
+    expect(result.pending).toBe("After");
+  });
+
+  it("treats unclosed math block as pending", () => {
+    const text = "Before.\n\n$$\nx^2";
+    const result = splitCompleteBlocks(text);
+    expect(result.complete).toBe("Before.\n");
+    expect(result.pending).toBe("$$\nx^2");
+  });
+
+  it("handles trailing blank line making everything complete", () => {
+    const text = "Hello world.\n";
+    const result = splitCompleteBlocks(text);
+    // Last line is empty string after split, which is a blank line
+    expect(result.complete).toBe("Hello world.\n");
+    expect(result.pending).toBe("");
+  });
+});
+
+describe("renderStreamingMarkdown", () => {
+  it("renders complete blocks as markdown and pending as escaped text", () => {
+    const cache = { key: "", html: "" };
+    const text = "# Hello\n\nWorld";
+    const result = renderStreamingMarkdown(text, cache);
+    expect(result).toContain("<h1>Hello</h1>");
+    expect(result).toContain("World");
+    // "World" should be escaped, not wrapped in <p>
+    expect(result).toMatch(/World(?!<\/p>)/);
+  });
+
+  it("uses cache when complete portion is unchanged", () => {
+    const cache = { key: "", html: "" };
+    const text1 = "# Hello\n\nWor";
+    renderStreamingMarkdown(text1, cache);
+    const cachedHtml = cache.html;
+
+    const text2 = "# Hello\n\nWorld";
+    renderStreamingMarkdown(text2, cache);
+    // Cache key should still be the same complete portion
+    expect(cache.html).toBe(cachedHtml);
+    expect(cache.key).toBe("# Hello\n");
+  });
+
+  it("updates cache when new block completes", () => {
+    const cache = { key: "", html: "" };
+    const text1 = "# Hello\n\nParagraph";
+    renderStreamingMarkdown(text1, cache);
+    const firstKey = cache.key;
+
+    const text2 = "# Hello\n\nParagraph.\n\nMore";
+    renderStreamingMarkdown(text2, cache);
+    expect(cache.key).not.toBe(firstKey);
+    expect(cache.key).toBe("# Hello\n\nParagraph.\n");
+  });
+
+  it("escapes HTML in pending portion", () => {
+    const cache = { key: "", html: "" };
+    const text = "Done.\n\n<script>alert('xss')</script>";
+    const result = renderStreamingMarkdown(text, cache);
+    expect(result).toContain("&lt;script&gt;");
+    expect(result).not.toContain("<script>");
+  });
+
+  it("converts newlines to <br> in pending portion", () => {
+    const cache = { key: "", html: "" };
+    const text = "Done.\n\nline1\nline2";
+    const result = renderStreamingMarkdown(text, cache);
+    expect(result).toContain("line1<br>line2");
   });
 });

--- a/ui-svelte/src/lib/markdown.ts
+++ b/ui-svelte/src/lib/markdown.ts
@@ -69,6 +69,98 @@ const processor = unified()
   .use(rehypeHighlight)
   .use(rehypeStringify, { allowDangerousHtml: true });
 
+export function splitCompleteBlocks(text: string): { complete: string; pending: string } {
+  if (!text) {
+    return { complete: "", pending: "" };
+  }
+
+  const lines = text.split("\n");
+  let lastCompleteBoundary = -1; // index of last line that ends a complete block
+  let inFence = false;
+  let fenceChar = "";
+  let inMathBlock = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trimEnd();
+
+    if (inFence) {
+      // Check for closing fence: same character, at least 3, no other content
+      if (new RegExp(`^\\s*${fenceChar.replace(/~/g, "\\~")}{3,}\\s*$`).test(trimmed)) {
+        inFence = false;
+        fenceChar = "";
+        lastCompleteBoundary = i;
+      }
+      continue;
+    }
+
+    if (inMathBlock) {
+      if (trimmed === "$$") {
+        inMathBlock = false;
+        lastCompleteBoundary = i;
+      }
+      continue;
+    }
+
+    // Check for opening fence
+    const fenceMatch = trimmed.match(/^(\s*)(```|~~~)/);
+    if (fenceMatch) {
+      // Check if it's an opening fence (may have language info after)
+      // A line with just ``` or ~~~ could be opening or closing, but since we're not in a fence it's opening
+      fenceChar = fenceMatch[2][0]; // '`' or '~'
+      inFence = true;
+      continue;
+    }
+
+    // Check for opening math block
+    if (trimmed === "$$") {
+      inMathBlock = true;
+      continue;
+    }
+
+    // Outside fences/math: blank line marks a complete boundary
+    if (trimmed === "") {
+      lastCompleteBoundary = i;
+    }
+  }
+
+  if (lastCompleteBoundary < 0) {
+    return { complete: "", pending: text };
+  }
+
+  const completeLines = lines.slice(0, lastCompleteBoundary + 1);
+  const pendingLines = lines.slice(lastCompleteBoundary + 1);
+
+  return {
+    complete: completeLines.join("\n"),
+    pending: pendingLines.join("\n"),
+  };
+}
+
+export function renderStreamingMarkdown(
+  text: string,
+  cache: { key: string; html: string },
+): string {
+  const { complete, pending } = splitCompleteBlocks(text);
+
+  let completeHtml = "";
+  if (complete) {
+    if (cache.key === complete) {
+      completeHtml = cache.html;
+    } else {
+      completeHtml = renderMarkdown(complete);
+      cache.key = complete;
+      cache.html = completeHtml;
+    }
+  }
+
+  let pendingHtml = "";
+  if (pending) {
+    pendingHtml = escapeHtml(pending).replace(/\n/g, "<br>");
+  }
+
+  return completeHtml + pendingHtml;
+}
+
 export function renderMarkdown(content: string): string {
   if (!content) {
     return "";


### PR DESCRIPTION
Created with Claude Code 2.1.33 with Opus 4.6

Render completed markdown blocks incrementally as they arrive during streaming instead of showing raw markdown syntax until the stream ends.

- Add splitCompleteBlocks to split text into complete/pending portions
- Add renderStreamingMarkdown with caching to avoid re-rendering
- Update ChatMessage to use incremental rendering during streaming
- Add tests for splitCompleteBlocks and renderStreamingMarkdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat messages now support progressive streaming rendering for assistant responses, displaying content as it arrives rather than waiting for completion.
  * Enhanced markdown rendering with caching to efficiently handle streaming content updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->