### PR TITLE
proxy: fix UI deep-link routing

### DIFF
--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -358,6 +358,20 @@ func (pm *ProxyManager) setupGinEngine() {
 				filepath = "index.html"
 			}
 
+			// For SPA routes like /ui/models, serve index.html unless a real file exists.
+			if !strings.Contains(filepath, ".") {
+				if f, err := reactFS.Open(filepath); err != nil {
+					ServeCompressedFile(reactFS, c.Writer, c.Request, "index.html")
+					return
+				} else {
+					defer f.Close()
+					if stat, err := f.Stat(); err != nil || stat.IsDir() {
+						ServeCompressedFile(reactFS, c.Writer, c.Request, "index.html")
+						return
+					}
+				}
+			}
+
 			ServeCompressedFile(reactFS, c.Writer, c.Request, filepath)
 		})
 

--- a/proxy/proxymanager_ui_test.go
+++ b/proxy/proxymanager_ui_test.go
@@ -1,0 +1,57 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mostlygeek/llama-swap/proxy/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProxyManager_UIRouteDeepLinkServesSPA(t *testing.T) {
+	reactFS, err := GetReactFS()
+	if err != nil {
+		t.Skip("ui assets not built; skipping UI integration test")
+	}
+	indexFile, err := reactFS.Open("index.html")
+	if err != nil {
+		t.Skip("ui assets not built; skipping UI integration test")
+	}
+	indexFile.Close()
+
+	proxy := New(config.Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]config.ModelConfig{
+			"model1": getTestSimpleResponderConfig("model1"),
+		},
+		LogLevel: "error",
+	})
+	defer proxy.Shutdown()
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/models", nil)
+	w := httptest.NewRecorder()
+	proxy.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, strings.ToLower(w.Body.String()), "<!doctype html>")
+	assert.Contains(t, w.Body.String(), "<title>llama-swap</title>")
+}
+
+func TestProxyManager_UIRouteMissingAssetReturnsNotFound(t *testing.T) {
+	proxy := New(config.Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]config.ModelConfig{
+			"model1": getTestSimpleResponderConfig("model1"),
+		},
+		LogLevel: "error",
+	})
+	defer proxy.Shutdown()
+
+	req := httptest.NewRequest(http.MethodGet, "/ui/assets/does-not-exist.js", nil)
+	w := httptest.NewRecorder()
+	proxy.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}


### PR DESCRIPTION
I upgraded to the newest version of llama-swap, and my bookmark broke. I like to go straight to /ui/models. Now, I had to visit /ui, then navigate to models, which would show /ui/models in the URL bar, but refreshing on that link would just return an error. It seems like https://github.com/mostlygeek/llama-swap/commit/20738f3 is the commit that changed this behavior.

-----

Serve index.html for extensionless /ui routes when no file exists, so bookmarked deep links load correctly.

- fallback to SPA index for /ui/models-style routes
- keep missing static assets returning 404
- add proxy tests for deep-link and missing-asset behavior