### PR TITLE
feat: api key feature in the playground tab

### DIFF
--- a/ui-svelte/src/components/playground/ChatInterface.svelte
+++ b/ui-svelte/src/components/playground/ChatInterface.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { models } from "../../stores/api";
   import { persistentStore } from "../../stores/persistent";
+  import { apiKey } from "../../stores/auth";
   import { streamChatCompletion } from "../../lib/chatApi";
   import { playgroundStores } from "../../stores/playgroundActivity";
   import type { ChatMessage, ContentPart } from "../../lib/types";
@@ -329,6 +330,26 @@
           bind:value={$systemPromptStore}
           disabled={isStreaming}
         ></textarea>
+      </div>
+      <div class="mb-4">
+        <label class="block text-sm font-medium mb-1" for="api-key">API Key</label>
+        <div class="flex gap-2">
+          <input
+            id="api-key"
+            type="password"
+            class="w-full px-3 py-2 rounded border border-gray-200 dark:border-white/10 bg-card focus:outline-none focus:ring-2 focus:ring-primary"
+            placeholder="sk-..."
+            bind:value={$apiKey}
+            disabled={isStreaming}
+          />
+          <button
+            class="btn"
+            onclick={() => apiKey.set("")}
+            disabled={!$apiKey}
+          >
+            Clear
+          </button>
+        </div>
       </div>
       <div>
         <label class="block text-sm font-medium mb-1" for="temperature">

--- a/ui-svelte/src/components/playground/SpeechInterface.svelte
+++ b/ui-svelte/src/components/playground/SpeechInterface.svelte
@@ -2,6 +2,7 @@
   import { models } from "../../stores/api";
   import { persistentStore } from "../../stores/persistent";
   import { generateSpeech } from "../../lib/speechApi";
+  import { getAuthHeaders } from "../../stores/auth";
   import { playgroundStores } from "../../stores/playgroundActivity";
   import ModelSelector from "./ModelSelector.svelte";
   import ExpandableTextarea from "./ExpandableTextarea.svelte";
@@ -72,7 +73,9 @@
     isLoadingVoices = true;
 
     try {
-      const response = await fetch(`/v1/audio/voices?model=${encodeURIComponent(model)}`);
+      const response = await fetch(`/v1/audio/voices?model=${encodeURIComponent(model)}`, {
+        headers: { ...getAuthHeaders() },
+      });
       if (!response.ok) {
         // Fall back to default voices if API call fails
         availableVoices = defaultVoices;

--- a/ui-svelte/src/lib/audioApi.ts
+++ b/ui-svelte/src/lib/audioApi.ts
@@ -1,4 +1,5 @@
 import type { AudioTranscriptionResponse } from "./types";
+import { getAuthHeaders } from "../stores/auth";
 
 export async function transcribeAudio(
   model: string,
@@ -11,6 +12,9 @@ export async function transcribeAudio(
 
   const response = await fetch("/v1/audio/transcriptions", {
     method: "POST",
+    headers: {
+      ...getAuthHeaders(),
+    },
     body: formData,
     signal,
   });

--- a/ui-svelte/src/lib/chatApi.ts
+++ b/ui-svelte/src/lib/chatApi.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage, ChatCompletionRequest } from "./types";
+import { getAuthHeaders } from "../stores/auth";
 
 export interface StreamChunk {
   content: string;
@@ -53,6 +54,7 @@ export async function* streamChatCompletion(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      ...getAuthHeaders(),
     },
     body: JSON.stringify(request),
     signal,

--- a/ui-svelte/src/lib/imageApi.ts
+++ b/ui-svelte/src/lib/imageApi.ts
@@ -1,4 +1,5 @@
 import type { ImageGenerationRequest, ImageGenerationResponse } from "./types";
+import { getAuthHeaders } from "../stores/auth";
 
 export async function generateImage(
   model: string,
@@ -17,6 +18,7 @@ export async function generateImage(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      ...getAuthHeaders(),
     },
     body: JSON.stringify(request),
     signal,

--- a/ui-svelte/src/lib/speechApi.ts
+++ b/ui-svelte/src/lib/speechApi.ts
@@ -1,4 +1,5 @@
 import type { SpeechGenerationRequest } from "./types";
+import { getAuthHeaders } from "../stores/auth";
 
 export async function generateSpeech(
   model: string,
@@ -16,6 +17,7 @@ export async function generateSpeech(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      ...getAuthHeaders(),
     },
     body: JSON.stringify(request),
     signal,

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -1,6 +1,7 @@
 import { writable } from "svelte/store";
 import type { Model, Metrics, VersionInfo, LogData, APIEventEnvelope, ReqRespCapture, InFlightStats } from "../lib/types";
 import { connectionState } from "./theme";
+import { getAuthHeaders } from "./auth";
 
 const LOG_LENGTH_LIMIT = 1024 * 100; /* 100KB of log data */
 
@@ -113,7 +114,9 @@ export function enableAPIEvents(enabled: boolean): void {
 connectionState.subscribe(async (status) => {
   if (status === "connected") {
     try {
-      const response = await fetch("/api/version");
+      const response = await fetch("/api/version", {
+        headers: { ...getAuthHeaders() },
+      });
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -127,7 +130,9 @@ connectionState.subscribe(async (status) => {
 
 export async function listModels(): Promise<Model[]> {
   try {
-    const response = await fetch("/api/models/");
+    const response = await fetch("/api/models/", {
+      headers: { ...getAuthHeaders() },
+    });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -143,6 +148,7 @@ export async function unloadAllModels(): Promise<void> {
   try {
     const response = await fetch(`/api/models/unload`, {
       method: "POST",
+      headers: { ...getAuthHeaders() },
     });
     if (!response.ok) {
       throw new Error(`Failed to unload models: ${response.status}`);
@@ -157,6 +163,7 @@ export async function unloadSingleModel(model: string): Promise<void> {
   try {
     const response = await fetch(`/api/models/unload/${model}`, {
       method: "POST",
+      headers: { ...getAuthHeaders() },
     });
     if (!response.ok) {
       throw new Error(`Failed to unload model: ${response.status}`);
@@ -171,6 +178,7 @@ export async function loadModel(model: string): Promise<void> {
   try {
     const response = await fetch(`/upstream/${model}/`, {
       method: "GET",
+      headers: { ...getAuthHeaders() },
     });
     if (!response.ok) {
       throw new Error(`Failed to load model: ${response.status}`);
@@ -183,7 +191,9 @@ export async function loadModel(model: string): Promise<void> {
 
 export async function getCapture(id: number): Promise<ReqRespCapture | null> {
   try {
-    const response = await fetch(`/api/captures/${id}`);
+    const response = await fetch(`/api/captures/${id}`, {
+      headers: { ...getAuthHeaders() },
+    });
     if (response.status === 404) {
       return null;
     }

--- a/ui-svelte/src/stores/auth.ts
+++ b/ui-svelte/src/stores/auth.ts
@@ -1,0 +1,10 @@
+import { persistentStore } from "./persistent";
+import { get } from "svelte/store";
+
+export const apiKey = persistentStore<string>("playground-api-key", "");
+
+export function getAuthHeaders(): Record<string, string> {
+  const key = get(apiKey);
+  if (!key) return {};
+  return { Authorization: `Bearer ${key}` };
+}


### PR DESCRIPTION
 ## Description
- Add an API key field to the playground tab and wire auth headers into UI API calls.

## Major changes
- dccc2a7cfe08011867ceccf2bf73a7bfb6f4831e ui: add playground API key input
- f9d04d94da269bcf703095e26fe928363febb591 feat: auth header injection

## Screenshots
<img width="1508" height="736" alt="tobe" src="https://github.com/user-attachments/assets/1bdc6915-968f-426e-bf18-f867d61726a4" />

## Test env
  1. Open the Playground and open Settings.
  2. Enter an API key and confirm the field is masked and persists after reload.
  3. Send a chat request and verify it succeeds with the provided key.
  4. Clear the key and confirm requests fail when auth is required.
  5. Check if there's any other regressions or side effects