### PR TITLE
feat: add configured model context size to models API

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -159,10 +159,13 @@ models:
     # - if not set, it will be omitted in the JSON model record
     description: "A thinking model from OpenAI"
 
-    # context_length: automatically detected from cmd
-    # - if --ctx-size, -c (llama.cpp) or --max-model-len (vLLM) is found
-    #   in cmd, its value is exposed as context_length in /v1/models
-    # - if not found, the field is omitted
+    # The following fields are automatically detected from cmd and exposed
+    # in the /v1/models response. If not detected, the field is omitted.
+    # Values set via macros (e.g. --ctx-size ${env.LLAMA_ARG_CTX_SIZE}) are supported.
+    #
+    # context_length: parsed from --ctx-size / -c (llama.cpp) or --max-model-len (vLLM)
+    #   divided by --parallel / -np if set (per-slot context)
+    # supports_vision: true when --mmproj is present in cmd (llama.cpp)
 
     # env: define an array of environment variables to inject into cmd's environment
     # - optional, default: empty array

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -159,6 +159,11 @@ models:
     # - if not set, it will be omitted in the JSON model record
     description: "A thinking model from OpenAI"
 
+    # context_length: automatically detected from cmd
+    # - if --ctx-size, -c (llama.cpp) or --max-model-len (vLLM) is found
+    #   in cmd, its value is exposed as context_length in /v1/models
+    # - if not found, the field is omitted
+
     # env: define an array of environment variables to inject into cmd's environment
     # - optional, default: empty array
     # - each value is a single string

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -234,10 +234,13 @@ models:
     # - if not set, it will be omitted in the JSON model record
     description: "A small but capable model used for quick testing"
 
-    # context_length: automatically detected from cmd
-    # - if --ctx-size, -c (llama.cpp) or --max-model-len (vLLM) is found
-    #   in cmd, its value is exposed as context_length in /v1/models
-    # - if not found, the field is omitted
+    # The following fields are automatically detected from cmd and exposed
+    # in the /v1/models response. If not detected, the field is omitted.
+    # Values set via macros (e.g. --ctx-size ${env.LLAMA_ARG_CTX_SIZE}) are supported.
+    #
+    # context_length: parsed from --ctx-size / -c (llama.cpp) or --max-model-len (vLLM)
+    #   divided by --parallel / -np if set (per-slot context)
+    # supports_vision: true when --mmproj is present in cmd (llama.cpp)
 
     # env: define an array of environment variables to inject into cmd's environment
     # - optional, default: empty array

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -234,6 +234,11 @@ models:
     # - if not set, it will be omitted in the JSON model record
     description: "A small but capable model used for quick testing"
 
+    # context_length: automatically detected from cmd
+    # - if --ctx-size, -c (llama.cpp) or --max-model-len (vLLM) is found
+    #   in cmd, its value is exposed as context_length in /v1/models
+    # - if not found, the field is omitted
+
     # env: define an array of environment variables to inject into cmd's environment
     # - optional, default: empty array
     # - each value is a single string

--- a/proxy/config/model_config.go
+++ b/proxy/config/model_config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"errors"
 	"runtime"
+	"strconv"
+	"strings"
 )
 
 type ModelConfig struct {
@@ -70,6 +72,44 @@ func (m *ModelConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 func (m *ModelConfig) SanitizedCommand() ([]string, error) {
 	return SanitizeCommand(m.Cmd)
+}
+
+// ContextSize extracts the context size from the model's cmd arguments.
+// It looks for --ctx-size / -c (llama.cpp) and --max-model-len (vLLM) flags.
+// Returns 0 if no context size is found or the value is not a valid positive integer.
+// If specified multiple times, the last occurrence wins.
+func (m *ModelConfig) ContextSize() int {
+	args, err := SanitizeCommand(m.Cmd)
+	if err != nil || len(args) == 0 {
+		return 0
+	}
+
+	ctxSize := 0
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+
+		switch {
+		case arg == "--ctx-size" || arg == "-c" || arg == "--max-model-len":
+			if i+1 < len(args) {
+				if n, err := strconv.Atoi(args[i+1]); err == nil && n > 0 {
+					ctxSize = n
+				}
+				i++ // skip the value
+			}
+		case strings.HasPrefix(arg, "--ctx-size="):
+			val := strings.TrimPrefix(arg, "--ctx-size=")
+			if n, err := strconv.Atoi(val); err == nil && n > 0 {
+				ctxSize = n
+			}
+		case strings.HasPrefix(arg, "--max-model-len="):
+			val := strings.TrimPrefix(arg, "--max-model-len=")
+			if n, err := strconv.Atoi(val); err == nil && n > 0 {
+				ctxSize = n
+			}
+		}
+	}
+
+	return ctxSize
 }
 
 // ModelFilters embeds Filters and adds legacy support for strip_params field

--- a/proxy/config/model_config.go
+++ b/proxy/config/model_config.go
@@ -74,8 +74,10 @@ func (m *ModelConfig) SanitizedCommand() ([]string, error) {
 	return SanitizeCommand(m.Cmd)
 }
 
-// ContextSize extracts the context size from the model's cmd arguments.
+// ContextSize extracts the effective per-request context size from the model's cmd arguments.
 // It looks for --ctx-size / -c (llama.cpp) and --max-model-len (vLLM) flags.
+// If --parallel / -np is also set, the context is divided by the parallel count
+// since llama.cpp splits the KV cache across slots.
 // Returns 0 if no context size is found or the value is not a valid positive integer.
 // If specified multiple times, the last occurrence wins.
 func (m *ModelConfig) ContextSize() int {
@@ -85,6 +87,7 @@ func (m *ModelConfig) ContextSize() int {
 	}
 
 	ctxSize := 0
+	parallel := 0
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 
@@ -94,7 +97,14 @@ func (m *ModelConfig) ContextSize() int {
 				if n, err := strconv.Atoi(args[i+1]); err == nil && n > 0 {
 					ctxSize = n
 				}
-				i++ // skip the value
+				i++
+			}
+		case arg == "--parallel" || arg == "-np":
+			if i+1 < len(args) {
+				if n, err := strconv.Atoi(args[i+1]); err == nil && n > 1 {
+					parallel = n
+				}
+				i++
 			}
 		case strings.HasPrefix(arg, "--ctx-size="):
 			val := strings.TrimPrefix(arg, "--ctx-size=")
@@ -106,10 +116,34 @@ func (m *ModelConfig) ContextSize() int {
 			if n, err := strconv.Atoi(val); err == nil && n > 0 {
 				ctxSize = n
 			}
+		case strings.HasPrefix(arg, "--parallel="):
+			val := strings.TrimPrefix(arg, "--parallel=")
+			if n, err := strconv.Atoi(val); err == nil && n > 1 {
+				parallel = n
+			}
 		}
 	}
 
+	if ctxSize > 0 && parallel > 1 {
+		ctxSize = ctxSize / parallel
+	}
+
 	return ctxSize
+}
+
+// SupportsVision checks if the model's cmd includes a multimodal projector flag.
+// Returns true if --mmproj is found in the command arguments (llama.cpp vision support).
+func (m *ModelConfig) SupportsVision() bool {
+	args, err := SanitizeCommand(m.Cmd)
+	if err != nil {
+		return false
+	}
+	for _, arg := range args {
+		if arg == "--mmproj" || strings.HasPrefix(arg, "--mmproj=") {
+			return true
+		}
+	}
+	return false
 }
 
 // ModelFilters embeds Filters and adds legacy support for strip_params field

--- a/proxy/config/model_config_test.go
+++ b/proxy/config/model_config_test.go
@@ -20,6 +20,32 @@ func TestConfig_ModelConfigSanitizedCommand(t *testing.T) {
 	assert.Equal(t, []string{"python", "model1.py", "--arg1", "value1", "--arg2", "value2"}, args)
 }
 
+func TestModelConfig_ContextSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      string
+		expected int
+	}{
+		{"long flag", "llama-server --port 8080 --ctx-size 4096 --model foo.gguf", 4096},
+		{"equals syntax", "llama-server --ctx-size=196608 --port 8080", 196608},
+		{"short flag", "llama-server -p 8080 -c 8192 -m foo.gguf", 8192},
+		{"no context size", "llama-server --port 8080 --model foo.gguf", 0},
+		{"short flag non-numeric", "python -c 'print(1)' --ctx-size 2048", 2048},
+		{"last occurrence wins", "llama-server --ctx-size 1024 --ctx-size 2048", 2048},
+		{"empty cmd", "", 0},
+		{"large context", "llama-server -c 131072", 131072},
+		{"vllm max-model-len", "vllm serve model --max-model-len 32768 --port 8080", 32768},
+		{"vllm max-model-len equals", "vllm serve model --max-model-len=65536", 65536},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &ModelConfig{Cmd: tt.cmd}
+			assert.Equal(t, tt.expected, m.ContextSize())
+		})
+	}
+}
+
 func TestConfig_ModelFilters(t *testing.T) {
 	content := `
 macros:

--- a/proxy/config/model_config_test.go
+++ b/proxy/config/model_config_test.go
@@ -36,12 +36,51 @@ func TestModelConfig_ContextSize(t *testing.T) {
 		{"large context", "llama-server -c 131072", 131072},
 		{"vllm max-model-len", "vllm serve model --max-model-len 32768 --port 8080", 32768},
 		{"vllm max-model-len equals", "vllm serve model --max-model-len=65536", 65536},
+		{"shell var not resolved", "llama-server --ctx-size $CTX_SIZE", 0},
+		{"parallel divides context", "llama-server --ctx-size 128000 --parallel 4", 32000},
+		{"parallel short flag", "llama-server -c 128000 -np 4", 32000},
+		{"parallel equals syntax", "llama-server --ctx-size=64000 --parallel=2", 32000},
+		{"parallel 1 no division", "llama-server --ctx-size 128000 --parallel 1", 128000},
+		{"parallel without ctx", "llama-server --parallel 4", 0},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &ModelConfig{Cmd: tt.cmd}
 			assert.Equal(t, tt.expected, m.ContextSize())
+		})
+	}
+}
+
+func TestModelConfig_ContextSize_EnvMacro(t *testing.T) {
+	t.Setenv("LLAMA_ARG_CTX_SIZE", "65536")
+	configYaml := `
+models:
+  model1:
+    cmd: llama-server --port ${PORT} --ctx-size ${env.LLAMA_ARG_CTX_SIZE}
+`
+	cfg, err := LoadConfigFromReader(strings.NewReader(configYaml))
+	assert.NoError(t, err)
+	model1 := cfg.Models["model1"]
+	assert.Equal(t, 65536, model1.ContextSize())
+}
+
+func TestModelConfig_SupportsVision(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      string
+		expected bool
+	}{
+		{"with mmproj", "llama-server --port 8080 --mmproj vision.gguf --model foo.gguf", true},
+		{"with mmproj equals", "llama-server --mmproj=vision.gguf --port 8080", true},
+		{"without mmproj", "llama-server --port 8080 --model foo.gguf", false},
+		{"empty cmd", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &ModelConfig{Cmd: tt.cmd}
+			assert.Equal(t, tt.expected, m.SupportsVision())
 		})
 	}
 }

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -522,6 +522,10 @@ func (pm *ProxyManager) listModelsHandler(c *gin.Context) {
 			record["context_length"] = ctxSize
 		}
 
+		if modelConfig.SupportsVision() {
+			record["supports_vision"] = true
+		}
+
 		// Add metadata if present
 		if len(modelConfig.Metadata) > 0 {
 			record["meta"] = gin.H{

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -518,6 +518,10 @@ func (pm *ProxyManager) listModelsHandler(c *gin.Context) {
 			record["description"] = desc
 		}
 
+		if ctxSize := modelConfig.ContextSize(); ctxSize > 0 {
+			record["context_length"] = ctxSize
+		}
+
 		// Add metadata if present
 		if len(modelConfig.Metadata) > 0 {
 			record["meta"] = gin.H{

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -410,6 +410,45 @@ models:
 	assert.False(t, exists, "model2 should not have llamaswap_meta")
 }
 
+func TestProxyManager_ListModelsHandler_MaxInputTokens(t *testing.T) {
+	configYaml := `
+healthCheckTimeout: 15
+logLevel: error
+startPort: 10100
+models:
+  with-ctx:
+    cmd: llama-server --port ${PORT} --ctx-size 131072 --model foo.gguf
+  with-ctx-short:
+    cmd: llama-server --port ${PORT} -c 4096 --model bar.gguf
+  without-ctx:
+    cmd: llama-server --port ${PORT} --model baz.gguf
+`
+	processedConfig, err := config.LoadConfigFromReader(strings.NewReader(configYaml))
+	assert.NoError(t, err)
+
+	proxy := New(processedConfig)
+
+	req := httptest.NewRequest("GET", "/v1/models", nil)
+	w := CreateTestResponseRecorder()
+	proxy.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	result := gjson.ParseBytes(w.Body.Bytes())
+
+	for _, model := range result.Get("data").Array() {
+		id := model.Get("id").String()
+		switch id {
+		case "with-ctx":
+			assert.Equal(t, int64(131072), model.Get("context_length").Int())
+		case "with-ctx-short":
+			assert.Equal(t, int64(4096), model.Get("context_length").Int())
+		case "without-ctx":
+			assert.False(t, model.Get("context_length").Exists(), "without-ctx should not have context_length")
+		}
+	}
+}
+
 func TestProxyManager_ListModelsHandler_SortedByID(t *testing.T) {
 	// Intentionally add models in non-sorted order and with an unlisted model
 	config := config.Config{

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -410,7 +410,7 @@ models:
 	assert.False(t, exists, "model2 should not have llamaswap_meta")
 }
 
-func TestProxyManager_ListModelsHandler_MaxInputTokens(t *testing.T) {
+func TestProxyManager_ListModelsHandler_CmdDerivedFields(t *testing.T) {
 	configYaml := `
 healthCheckTimeout: 15
 logLevel: error
@@ -420,7 +420,9 @@ models:
     cmd: llama-server --port ${PORT} --ctx-size 131072 --model foo.gguf
   with-ctx-short:
     cmd: llama-server --port ${PORT} -c 4096 --model bar.gguf
-  without-ctx:
+  vision-model:
+    cmd: llama-server --port ${PORT} -c 8192 --mmproj vision.gguf --model viz.gguf
+  plain-model:
     cmd: llama-server --port ${PORT} --model baz.gguf
 `
 	processedConfig, err := config.LoadConfigFromReader(strings.NewReader(configYaml))
@@ -441,10 +443,16 @@ models:
 		switch id {
 		case "with-ctx":
 			assert.Equal(t, int64(131072), model.Get("context_length").Int())
+			assert.False(t, model.Get("supports_vision").Exists())
 		case "with-ctx-short":
 			assert.Equal(t, int64(4096), model.Get("context_length").Int())
-		case "without-ctx":
-			assert.False(t, model.Get("context_length").Exists(), "without-ctx should not have context_length")
+			assert.False(t, model.Get("supports_vision").Exists())
+		case "vision-model":
+			assert.Equal(t, int64(8192), model.Get("context_length").Int())
+			assert.True(t, model.Get("supports_vision").Bool())
+		case "plain-model":
+			assert.False(t, model.Get("context_length").Exists(), "plain-model should not have context_length")
+			assert.False(t, model.Get("supports_vision").Exists(), "plain-model should not have supports_vision")
 		}
 	}
 }


### PR DESCRIPTION
@mostlygeek - What are your thoughts on llamaswap exposing the configured model context size (if detected) (and potentially other information?) on the /models endpoint?

The problem right now is that as far as I can tell the only way to get model configuration information is by querying the upstream server, which means the upstream server has to start and load the model, then passing that information with some middleware e.g
`https://llamaswap.your.domain/upstream/<model_name>/slots`

The reason this would be useful is that this would allow clients to properly configure their settings to the models configured context window (and potentially other parameters).

This change would have /v1/models endpoint would return:

```
{
  "data": [
    {
      "context_length": 131072,      <-- new
      "created": 1772705823,
      "id": "qwen3-5-4b-ud-q6kxl-128k:general-instruct-reasoning",
      "object": "model",
      "owned_by": "llama-swap",
      "supports_vision": true        <-- new
    },
```

This is roughly in line with what many model providers such as [OpenRouter](https://openrouter.ai/docs/api/api-reference/models/get-models) and LLM proxies such as Bifrost (`context_length` and other parameters) provide.

e.g.

```
curl https://bifrost.your.domain/v1/models|jq

{
  "data": [
    {
      "id": "mistral/pixtral-large-latest",
      "name": "pixtral-large-2411",
      "context_length": 131072,
      ...
    },
```

Thoughts?