### PR TITLE
Add visionModel for content-based image routing

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -237,6 +237,11 @@
                         "type": "boolean",
                         "description": "Overrides the global sendLoadingState for this model. Ommitting this property will use the global setting."
                     },
+                    "visionModel": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Reroute to this model when images are detected in /v1/chat/completions requests. Must be a valid model ID."
+                    },
                     "unlisted": {
                         "type": "boolean",
                         "default": false,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -284,6 +284,12 @@ models:
     # - optional, default: undefined (use global setting)
     sendLoadingState: false
 
+    # visionModel: automatically route to a vision-capable model when images are detected
+    # - optional, default: "" (disabled)
+    # - only applies to /v1/chat/completions requests
+    # - the target must be a valid model ID defined in the models section
+    # visionModel: "qwen-vision"
+
   # Unlisted model example:
   "qwen-unlisted":
     # unlisted: boolean, true or false

--- a/proxy/config/config.go
+++ b/proxy/config/config.go
@@ -432,6 +432,18 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		config.Models[modelId] = modelConfig
 	}
 
+	// Validate visionModel references
+	for modelId, modelConfig := range config.Models {
+		if modelConfig.VisionModel != "" {
+			if _, found := config.Models[modelConfig.VisionModel]; !found {
+				return Config{}, fmt.Errorf("model %s: visionModel '%s' is not a valid model ID", modelId, modelConfig.VisionModel)
+			}
+			if modelConfig.VisionModel == modelId {
+				return Config{}, fmt.Errorf("model %s: visionModel cannot reference itself", modelId)
+			}
+		}
+	}
+
 	config = AddDefaultGroupToConfig(config)
 
 	// Validate group members

--- a/proxy/config/config_test.go
+++ b/proxy/config/config_test.go
@@ -1438,3 +1438,54 @@ models:
 	})
 
 }
+
+func TestConfig_VisionModelValidation(t *testing.T) {
+	t.Run("valid visionModel reference", func(t *testing.T) {
+		content := `
+models:
+  text-model:
+    cmd: llama-server --port ${PORT} -m model.gguf
+    visionModel: "vision-model"
+  vision-model:
+    cmd: llama-server --port ${PORT} -m model.gguf --mmproj mmproj.gguf
+`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NoError(t, err)
+		assert.Equal(t, "vision-model", config.Models["text-model"].VisionModel)
+	})
+
+	t.Run("visionModel references non-existent model", func(t *testing.T) {
+		content := `
+models:
+  text-model:
+    cmd: llama-server --port ${PORT} -m model.gguf
+    visionModel: "does-not-exist"
+`
+		_, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "visionModel 'does-not-exist' is not a valid model ID")
+	})
+
+	t.Run("visionModel references itself", func(t *testing.T) {
+		content := `
+models:
+  text-model:
+    cmd: llama-server --port ${PORT} -m model.gguf
+    visionModel: "text-model"
+`
+		_, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "visionModel cannot reference itself")
+	})
+
+	t.Run("empty visionModel is fine", func(t *testing.T) {
+		content := `
+models:
+  text-model:
+    cmd: llama-server --port ${PORT} -m model.gguf
+`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NoError(t, err)
+		assert.Equal(t, "", config.Models["text-model"].VisionModel)
+	})
+}

--- a/proxy/config/model_config.go
+++ b/proxy/config/model_config.go
@@ -40,6 +40,9 @@ type ModelConfig struct {
 
 	// override global setting
 	SendLoadingState *bool `yaml:"sendLoadingState"`
+
+	// VisionModel: reroute to this model when images detected in /v1/chat/completions
+	VisionModel string `yaml:"visionModel"`
 }
 
 func (m *ModelConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -57,6 +60,7 @@ func (m *ModelConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		ConcurrencyLimit: 0,
 		Name:             "",
 		Description:      "",
+		VisionModel:      "",
 	}
 
 	// the default cmdStop to taskkill /f /t /pid ${PID}

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -660,6 +660,25 @@ func (pm *ProxyManager) proxyToUpstream(c *gin.Context) {
 	}
 }
 
+// hasImageContent checks if the request body contains image_url content parts
+// in the OpenAI chat completions message format.
+func hasImageContent(bodyBytes []byte) bool {
+	found := false
+	gjson.GetBytes(bodyBytes, "messages.#.content").ForEach(func(_, value gjson.Result) bool {
+		if value.IsArray() {
+			value.ForEach(func(_, item gjson.Result) bool {
+				if item.Get("type").String() == "image_url" {
+					found = true
+					return false
+				}
+				return true
+			})
+		}
+		return !found
+	})
+	return found
+}
+
 func (pm *ProxyManager) proxyInferenceHandler(c *gin.Context) {
 	bodyBytes, err := io.ReadAll(c.Request.Body)
 	if err != nil {
@@ -678,6 +697,15 @@ func (pm *ProxyManager) proxyInferenceHandler(c *gin.Context) {
 
 	modelID, found := pm.config.RealModelName(requestedModel)
 	if found {
+		// Content-based vision routing: if the resolved model has a visionModel
+		// configured and this is a chat completions request with images, reroute.
+		if visionTarget := pm.config.Models[modelID].VisionModel; visionTarget != "" {
+			if c.FullPath() == "/v1/chat/completions" && hasImageContent(bodyBytes) {
+				pm.proxyLogger.Infof("<%s> image content detected, routing to vision model: %s", modelID, visionTarget)
+				modelID = visionTarget
+			}
+		}
+
 		processGroup, err := pm.swapProcessGroup(modelID)
 		if err != nil {
 			pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error swapping process group: %s", err.Error()))

--- a/proxy/vision_routing_test.go
+++ b/proxy/vision_routing_test.go
@@ -1,0 +1,52 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProxyManager_HasImageContent(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			"text only - string content",
+			`{"model":"test","messages":[{"role":"user","content":"hello"}]}`,
+			false,
+		},
+		{
+			"text only - array content",
+			`{"model":"test","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`,
+			false,
+		},
+		{
+			"with image_url",
+			`{"model":"test","messages":[{"role":"user","content":[{"type":"text","text":"describe"},{"type":"image_url","image_url":{"url":"data:image/png;base64,abc"}}]}]}`,
+			true,
+		},
+		{
+			"empty messages",
+			`{"model":"test","messages":[]}`,
+			false,
+		},
+		{
+			"no messages key",
+			`{"model":"test"}`,
+			false,
+		},
+		{
+			"image in earlier message",
+			`{"model":"test","messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"x"}}]},{"role":"assistant","content":"ok"},{"role":"user","content":"more?"}]}`,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasImageContent([]byte(tt.body))
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/proxy/vision_routing_test.go
+++ b/proxy/vision_routing_test.go
@@ -1,8 +1,13 @@
 package proxy
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/mostlygeek/llama-swap/proxy/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,4 +54,64 @@ func TestProxyManager_HasImageContent(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestProxyManager_VisionModelRouting(t *testing.T) {
+	textModel := getTestSimpleResponderConfig("text-response")
+	visionModel := getTestSimpleResponderConfig("vision-response")
+	textModel.VisionModel = "vision-model"
+
+	conf := config.AddDefaultGroupToConfig(config.Config{
+		HealthCheckTimeout: 15,
+		LogLevel:           "error",
+		Models: map[string]config.ModelConfig{
+			"text-model":   textModel,
+			"vision-model": visionModel,
+		},
+	})
+
+	proxy := New(conf)
+	defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+	t.Run("text request stays on text model", func(t *testing.T) {
+		reqBody := `{"model":"text-model","messages":[{"role":"user","content":"hello"}]}`
+		req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+		w := CreateTestResponseRecorder()
+
+		proxy.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response map[string]interface{}
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		// simple-responder echoes its --respond arg; text model responds with "text-response"
+		assert.Equal(t, "text-response", response["responseMessage"])
+	})
+
+	t.Run("image request routes to vision model", func(t *testing.T) {
+		reqBody := `{"model":"text-model","messages":[{"role":"user","content":[{"type":"text","text":"describe"},{"type":"image_url","image_url":{"url":"data:image/png;base64,abc"}}]}]}`
+		req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+		w := CreateTestResponseRecorder()
+
+		proxy.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response map[string]interface{}
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		// should have been routed to vision model which responds with "vision-response"
+		assert.Equal(t, "vision-response", response["responseMessage"])
+	})
+
+	t.Run("image request on non-chat endpoint stays on text model", func(t *testing.T) {
+		reqBody := `{"model":"text-model","messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"x"}}]}]}`
+		req := httptest.NewRequest("POST", "/v1/completions", bytes.NewBufferString(reqBody))
+		w := CreateTestResponseRecorder()
+
+		proxy.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response map[string]interface{}
+		assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+		// /v1/completions should NOT trigger vision routing
+		assert.Equal(t, "text-response", response["responseMessage"])
+	})
 }


### PR DESCRIPTION
## Summary

- Adds a `visionModel` field to `ModelConfig` that automatically reroutes `/v1/chat/completions` requests to a vision-capable model when `image_url` content parts are detected in the payload
- Enables a single model name for clients while transparently hot-swapping between text-only (large context) and vision (with mmproj) backends based on request content
- Validates `visionModel` references at config load time

## Example config

```yaml
models:
  qwen:
    cmd: llama-server --port ${PORT} -m model.gguf -c 220000
    visionModel: "qwen-vision"

  qwen-vision:
    cmd: llama-server --port ${PORT} -m model.gguf --mmproj mmproj.gguf -c 8192
    unlisted: true
```

Clients always send `model: "qwen"`. When images are in the request, llama-swap logs `image content detected, routing to vision model: qwen-vision` and swaps to the vision backend.

Fixes #566