### PR TITLE
feat: add status and ttl to /v1/models endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
   - `/ui` - web UI
   - `/upstream/:model_id` - direct access to upstream server ([demo](https://github.com/mostlygeek/llama-swap/pull/31))
   - `/api/models/unload` - manually unload running models ([#58](https://github.com/mostlygeek/llama-swap/issues/58))
+  - `/api/models/unload/:model_id` - manually unload a specific model ([#58](https://github.com/mostlygeek/llama-swap/issues/58))
   - `/api/models` - list models and their state ([#569](https://github.com/mostlygeek/llama-swap/pull/569))
   - `/running` - list currently running models ([#61](https://github.com/mostlygeek/llama-swap/issues/61))
   - `/log` - remote log monitoring

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
 - ✅ llama-swap API
   - `/ui` - web UI
   - `/upstream/:model_id` - direct access to upstream server ([demo](https://github.com/mostlygeek/llama-swap/pull/31))
-  - `/models/unload` - manually unload running models ([#58](https://github.com/mostlygeek/llama-swap/issues/58))
+  - `/api/models/unload` - manually unload running models ([#58](https://github.com/mostlygeek/llama-swap/issues/58))
   - `/api/models` - list models and their state ([#569](https://github.com/mostlygeek/llama-swap/pull/569))
   - `/running` - list currently running models ([#61](https://github.com/mostlygeek/llama-swap/issues/61))
   - `/log` - remote log monitoring

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
   - `/ui` - web UI
   - `/upstream/:model_id` - direct access to upstream server ([demo](https://github.com/mostlygeek/llama-swap/pull/31))
   - `/models/unload` - manually unload running models ([#58](https://github.com/mostlygeek/llama-swap/issues/58))
+  - `/api/models` - list models and their state ([#569](https://github.com/mostlygeek/llama-swap/pull/569))
   - `/running` - list currently running models ([#61](https://github.com/mostlygeek/llama-swap/issues/61))
   - `/log` - remote log monitoring
   - `/health` - just returns "OK"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
   - `/upstream/:model_id` - direct access to upstream server ([demo](https://github.com/mostlygeek/llama-swap/pull/31))
   - `/api/models/unload` - manually unload running models ([#58](https://github.com/mostlygeek/llama-swap/issues/58))
   - `/api/models/unload/:model_id` - manually unload a specific model ([#58](https://github.com/mostlygeek/llama-swap/issues/58))
-  - `/api/models` - list models and their state ([#569](https://github.com/mostlygeek/llama-swap/pull/569))
+  - `/v1/models` - list models with their state, TTL, and metadata ([#569](https://github.com/mostlygeek/llama-swap/pull/569))
   - `/running` - list currently running models ([#61](https://github.com/mostlygeek/llama-swap/issues/61))
   - `/log` - remote log monitoring
   - `/health` - just returns "OK"

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -146,6 +146,22 @@ func (p *Process) getLastRequestHandled() time.Time {
 	return p.lastRequestHandled
 }
 
+func (p *Process) GetTTL() (ttl *int, ttlRemaining *int) {
+	ttlSeconds := p.config.UnloadAfter
+	if ttlSeconds <= 0 {
+		return nil, nil
+	}
+
+	if p.CurrentState() != StateReady {
+		return &ttlSeconds, nil
+	}
+
+	remaining := time.Since(p.getLastRequestHandled())
+	remainingVal := max(0, ttlSeconds-int(remaining.Seconds()))
+
+	return &ttlSeconds, &remainingVal
+}
+
 // custom error types for swapping state
 var (
 	ErrExpectedStateMismatch  = errors.New("expected state mismatch")

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"maps"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -514,16 +515,35 @@ func (pm *ProxyManager) listModelsHandler(c *gin.Context) {
 		if name := strings.TrimSpace(modelConfig.Name); name != "" {
 			record["name"] = name
 		}
+
 		if desc := strings.TrimSpace(modelConfig.Description); desc != "" {
 			record["description"] = desc
 		}
 
-		// Add metadata if present
-		if len(modelConfig.Metadata) > 0 {
-			record["meta"] = gin.H{
-				"llamaswap": modelConfig.Metadata,
-			}
+		// Build meta.llamaswap with runtime state and config metadata
+		meta := make(map[string]any)
+
+		// Copy all user provided metadata to the meta map
+		if modelConfig.Metadata != nil {
+			maps.Copy(meta, modelConfig.Metadata)
 		}
+
+		// Handle model state
+		if state := pm.getModelState(modelId); state != "" {
+			meta["state"] = state
+		}
+
+		// Handle model ttl/ttl remaining
+		if ttl, ttlRemaining := pm.getModelTTL(modelId); ttl != nil {
+			meta["ttl"] = ttl
+			meta["ttlRemaining"] = ttlRemaining
+		}
+
+		// Copy the final meta object if it has anything
+		if len(meta) > 0 {
+			record["meta"] = gin.H{"llamaswap": meta}
+		}
+
 		return record
 	}
 

--- a/proxy/proxymanager_api.go
+++ b/proxy/proxymanager_api.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/mostlygeek/llama-swap/event"
@@ -44,9 +45,11 @@ func (pm *ProxyManager) apiUnloadAllModels(c *gin.Context) {
 }
 
 type apiModel struct {
-	Name  string `json:"name"`
-	Id    string `json:"id"`
-	State string `json:"state"`
+	Name         string `json:"name"`
+	Id           string `json:"id"`
+	State        string `json:"state"`
+	TTL          *int   `json:"ttl"`
+	TTLRemaining *int   `json:"ttlRemaining"`
 }
 
 func (pm *ProxyManager) apiGetModels(c *gin.Context) {
@@ -58,13 +61,43 @@ func (pm *ProxyManager) apiGetModels(c *gin.Context) {
 			name = m.Id
 		}
 
+		ttl, ttlRemaining := pm.getModelTTL(m.Id, m.State)
+
 		result[i] = apiModel{
-			Name:  name,
-			Id:    m.Id,
-			State: m.State,
+			Name:         name,
+			Id:           m.Id,
+			State:        m.State,
+			TTL:          ttl,
+			TTLRemaining: ttlRemaining,
 		}
 	}
 	c.JSON(http.StatusOK, result)
+}
+
+func (pm *ProxyManager) getModelTTL(modelID, state string) (*int, *int) {
+	ttlSeconds := pm.config.Models[modelID].UnloadAfter
+	if ttlSeconds <= 0 {
+		return nil, nil
+	}
+
+	if state != "ready" {
+		return &ttlSeconds, new(int)
+	}
+
+	processGroup := pm.findGroupByModelName(modelID)
+	if processGroup == nil {
+		return &ttlSeconds, new(int)
+	}
+
+	process := processGroup.processes[modelID]
+	if process == nil {
+		return &ttlSeconds, new(int)
+	}
+
+	remaining := time.Since(process.getLastRequestHandled())
+	ttlRemainingVal := max(0, ttlSeconds-int(remaining.Seconds()))
+
+	return &ttlSeconds, &ttlRemainingVal
 }
 
 func (pm *ProxyManager) getModelStatus() []Model {
@@ -82,6 +115,7 @@ func (pm *ProxyManager) getModelStatus() []Model {
 		// Get process state
 		processGroup := pm.findGroupByModelName(modelID)
 		state := "unknown"
+
 		if processGroup != nil {
 			process := processGroup.processes[modelID]
 			if process != nil {

--- a/proxy/proxymanager_api.go
+++ b/proxy/proxymanager_api.go
@@ -30,6 +30,7 @@ func addApiHandlers(pm *ProxyManager) {
 	{
 		apiGroup.POST("/models/unload", pm.apiUnloadAllModels)
 		apiGroup.POST("/models/unload/*model", pm.apiUnloadSingleModelHandler)
+		apiGroup.GET("/models", pm.apiGetModels)
 		apiGroup.GET("/events", pm.apiSendEvents)
 		apiGroup.GET("/metrics", pm.apiGetMetrics)
 		apiGroup.GET("/version", pm.apiGetVersion)
@@ -40,6 +41,25 @@ func addApiHandlers(pm *ProxyManager) {
 func (pm *ProxyManager) apiUnloadAllModels(c *gin.Context) {
 	pm.StopProcesses(StopImmediately)
 	c.JSON(http.StatusOK, gin.H{"msg": "ok"})
+}
+
+type apiModel struct {
+	Name  string `json:"name"`
+	Id    string `json:"id"`
+	State string `json:"state"`
+}
+
+func (pm *ProxyManager) apiGetModels(c *gin.Context) {
+	models := pm.getModelStatus()
+	result := make([]apiModel, len(models))
+	for i, m := range models {
+		result[i] = apiModel{
+			Name:  m.Name,
+			Id:    m.Id,
+			State: m.State,
+		}
+	}
+	c.JSON(http.StatusOK, result)
 }
 
 func (pm *ProxyManager) getModelStatus() []Model {

--- a/proxy/proxymanager_api.go
+++ b/proxy/proxymanager_api.go
@@ -30,7 +30,6 @@ func addApiHandlers(pm *ProxyManager) {
 	{
 		apiGroup.POST("/models/unload", pm.apiUnloadAllModels)
 		apiGroup.POST("/models/unload/*model", pm.apiUnloadSingleModelHandler)
-		apiGroup.GET("/models", pm.apiGetModels)
 		apiGroup.GET("/events", pm.apiSendEvents)
 		apiGroup.GET("/metrics", pm.apiGetMetrics)
 		apiGroup.GET("/version", pm.apiGetVersion)
@@ -41,36 +40,6 @@ func addApiHandlers(pm *ProxyManager) {
 func (pm *ProxyManager) apiUnloadAllModels(c *gin.Context) {
 	pm.StopProcesses(StopImmediately)
 	c.JSON(http.StatusOK, gin.H{"msg": "ok"})
-}
-
-type apiModel struct {
-	Name         string `json:"name"`
-	Id           string `json:"id"`
-	State        string `json:"state"`
-	TTL          *int   `json:"ttl"`
-	TTLRemaining *int   `json:"ttlRemaining"`
-}
-
-func (pm *ProxyManager) apiGetModels(c *gin.Context) {
-	models := pm.getModelStatus()
-	result := make([]apiModel, len(models))
-	for i, m := range models {
-		name := m.Name
-		if name == "" {
-			name = m.Id
-		}
-
-		ttl, ttlRemaining := pm.getModelTTL(m.Id)
-
-		result[i] = apiModel{
-			Name:         name,
-			Id:           m.Id,
-			State:        m.State,
-			TTL:          ttl,
-			TTLRemaining: ttlRemaining,
-		}
-	}
-	c.JSON(http.StatusOK, result)
 }
 
 func (pm *ProxyManager) getModelTTL(modelID string) (ttl *int, ttlRemaining *int) {
@@ -87,6 +56,33 @@ func (pm *ProxyManager) getModelTTL(modelID string) (ttl *int, ttlRemaining *int
 	return process.GetTTL()
 }
 
+func (pm *ProxyManager) getModelState(modelID string) string {
+	processGroup := pm.findGroupByModelName(modelID)
+	state := "unknown"
+
+	if processGroup != nil {
+		process := processGroup.processes[modelID]
+		if process != nil {
+			switch process.CurrentState() {
+			case StateReady:
+				state = "ready"
+			case StateStarting:
+				state = "starting"
+			case StateStopping:
+				state = "stopping"
+			case StateShutdown:
+				state = "shutdown"
+			case StateStopped:
+				state = "stopped"
+			default:
+				state = "unknown"
+			}
+		}
+	}
+
+	return state
+}
+
 func (pm *ProxyManager) getModelStatus() []Model {
 	// Extract keys and sort them
 	models := []Model{}
@@ -99,36 +95,11 @@ func (pm *ProxyManager) getModelStatus() []Model {
 
 	// Iterate over sorted keys
 	for _, modelID := range modelIDs {
-		// Get process state
-		processGroup := pm.findGroupByModelName(modelID)
-		state := "unknown"
-
-		if processGroup != nil {
-			process := processGroup.processes[modelID]
-			if process != nil {
-				var stateStr string
-				switch process.CurrentState() {
-				case StateReady:
-					stateStr = "ready"
-				case StateStarting:
-					stateStr = "starting"
-				case StateStopping:
-					stateStr = "stopping"
-				case StateShutdown:
-					stateStr = "shutdown"
-				case StateStopped:
-					stateStr = "stopped"
-				default:
-					stateStr = "unknown"
-				}
-				state = stateStr
-			}
-		}
 		models = append(models, Model{
 			Id:          modelID,
 			Name:        pm.config.Models[modelID].Name,
 			Description: pm.config.Models[modelID].Description,
-			State:       state,
+			State:       pm.getModelState(modelID),
 			Unlisted:    pm.config.Models[modelID].Unlisted,
 			Aliases:     pm.config.Models[modelID].Aliases,
 		})

--- a/proxy/proxymanager_api.go
+++ b/proxy/proxymanager_api.go
@@ -53,8 +53,13 @@ func (pm *ProxyManager) apiGetModels(c *gin.Context) {
 	models := pm.getModelStatus()
 	result := make([]apiModel, len(models))
 	for i, m := range models {
+		name := m.Name
+		if name == "" {
+			name = m.Id
+		}
+
 		result[i] = apiModel{
-			Name:  m.Name,
+			Name:  name,
 			Id:    m.Id,
 			State: m.State,
 		}

--- a/proxy/proxymanager_api.go
+++ b/proxy/proxymanager_api.go
@@ -8,7 +8,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/mostlygeek/llama-swap/event"
@@ -61,7 +60,7 @@ func (pm *ProxyManager) apiGetModels(c *gin.Context) {
 			name = m.Id
 		}
 
-		ttl, ttlRemaining := pm.getModelTTL(m.Id, m.State)
+		ttl, ttlRemaining := pm.getModelTTL(m.Id)
 
 		result[i] = apiModel{
 			Name:         name,
@@ -74,30 +73,18 @@ func (pm *ProxyManager) apiGetModels(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
-func (pm *ProxyManager) getModelTTL(modelID, state string) (*int, *int) {
-	ttlSeconds := pm.config.Models[modelID].UnloadAfter
-	if ttlSeconds <= 0 {
-		return nil, nil
-	}
-
-	if state != "ready" {
-		return &ttlSeconds, new(int)
-	}
-
+func (pm *ProxyManager) getModelTTL(modelID string) (ttl *int, ttlRemaining *int) {
 	processGroup := pm.findGroupByModelName(modelID)
 	if processGroup == nil {
-		return &ttlSeconds, new(int)
+		return nil, nil
 	}
 
 	process := processGroup.processes[modelID]
 	if process == nil {
-		return &ttlSeconds, new(int)
+		return nil, nil
 	}
 
-	remaining := time.Since(process.getLastRequestHandled())
-	ttlRemainingVal := max(0, ttlSeconds-int(remaining.Seconds()))
-
-	return &ttlSeconds, &ttlRemainingVal
+	return process.GetTTL()
 }
 
 func (pm *ProxyManager) getModelStatus() []Model {

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -1314,6 +1314,56 @@ func TestProxyManager_ApiGetVersion(t *testing.T) {
 	}
 }
 
+func TestProxyManager_ApiGetModels(t *testing.T) {
+	testConfig := config.AddDefaultGroupToConfig(config.Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]config.ModelConfig{
+			"model1": {
+				Cmd:   "echo test",
+				Proxy: "http://localhost:8080",
+				Name:  "Model One",
+			},
+			"model2": {
+				Cmd:   "echo test",
+				Proxy: "http://localhost:8081",
+				Name:  "Model Two",
+			},
+		},
+		LogLevel: "error",
+	})
+
+	proxy := New(testConfig)
+	defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+	req := httptest.NewRequest("GET", "/api/models", nil)
+	w := CreateTestResponseRecorder()
+
+	proxy.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+
+	var response []map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Len(t, response, 2)
+
+	// Find model1 and model2 in response
+	modelMap := make(map[string]map[string]string)
+	for _, m := range response {
+		modelMap[m["id"]] = m
+	}
+
+	assert.Contains(t, modelMap, "model1")
+	assert.Contains(t, modelMap, "model2")
+	assert.Equal(t, "Model One", modelMap["model1"]["name"])
+	assert.Equal(t, "Model Two", modelMap["model2"]["name"])
+	assert.Equal(t, "model1", modelMap["model1"]["id"])
+	assert.Equal(t, "model2", modelMap["model2"]["id"])
+	assert.Equal(t, "stopped", modelMap["model1"]["state"])
+	assert.Equal(t, "stopped", modelMap["model2"]["state"])
+}
+
 func TestProxyManager_APIKeyAuth(t *testing.T) {
 	testConfig := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -1328,6 +1328,11 @@ func TestProxyManager_ApiGetModels(t *testing.T) {
 				Proxy: "http://localhost:8081",
 				Name:  "Model Two",
 			},
+			"model3": {
+				Cmd:   "echo test",
+				Proxy: "http://localhost:8082",
+				Name:  "",
+			},
 		},
 		LogLevel: "error",
 	})
@@ -1346,7 +1351,7 @@ func TestProxyManager_ApiGetModels(t *testing.T) {
 	var response []map[string]string
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
-	assert.Len(t, response, 2)
+	assert.Len(t, response, 3)
 
 	// Find model1 and model2 in response
 	modelMap := make(map[string]map[string]string)
@@ -1356,12 +1361,16 @@ func TestProxyManager_ApiGetModels(t *testing.T) {
 
 	assert.Contains(t, modelMap, "model1")
 	assert.Contains(t, modelMap, "model2")
+	assert.Contains(t, modelMap, "model3")
 	assert.Equal(t, "Model One", modelMap["model1"]["name"])
 	assert.Equal(t, "Model Two", modelMap["model2"]["name"])
+	assert.Equal(t, "model3", modelMap["model3"]["name"])
 	assert.Equal(t, "model1", modelMap["model1"]["id"])
 	assert.Equal(t, "model2", modelMap["model2"]["id"])
+	assert.Equal(t, "model3", modelMap["model3"]["id"])
 	assert.Equal(t, "stopped", modelMap["model1"]["state"])
 	assert.Equal(t, "stopped", modelMap["model2"]["state"])
+	assert.Equal(t, "stopped", modelMap["model3"]["state"])
 }
 
 func TestProxyManager_APIKeyAuth(t *testing.T) {

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -1348,15 +1348,15 @@ func TestProxyManager_ApiGetModels(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
 
-	var response []map[string]string
+	var response []map[string]interface{}
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Len(t, response, 3)
 
 	// Find model1 and model2 in response
-	modelMap := make(map[string]map[string]string)
+	modelMap := make(map[string]map[string]interface{})
 	for _, m := range response {
-		modelMap[m["id"]] = m
+		modelMap[m["id"].(string)] = m
 	}
 
 	assert.Contains(t, modelMap, "model1")
@@ -1371,6 +1371,56 @@ func TestProxyManager_ApiGetModels(t *testing.T) {
 	assert.Equal(t, "stopped", modelMap["model1"]["state"])
 	assert.Equal(t, "stopped", modelMap["model2"]["state"])
 	assert.Equal(t, "stopped", modelMap["model3"]["state"])
+}
+
+func TestProxyManager_ApiGetModels_WithTTL(t *testing.T) {
+	testConfig := config.AddDefaultGroupToConfig(config.Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]config.ModelConfig{
+			"model1": func() config.ModelConfig {
+				c := getTestSimpleResponderConfig("model1")
+				c.UnloadAfter = 60
+				return c
+			}(),
+			"model2": getTestSimpleResponderConfig("model2"),
+		},
+		LogLevel: "error",
+	})
+
+	proxy := New(testConfig)
+	defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+	reqBody := `{"model":"model1"}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+	w := CreateTestResponseRecorder()
+
+	proxy.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "request should succeed")
+
+	time.Sleep(100 * time.Millisecond)
+
+	req = httptest.NewRequest("GET", "/api/models", nil)
+	w = CreateTestResponseRecorder()
+
+	proxy.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response []map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+
+	modelMap := make(map[string]map[string]interface{})
+	for _, m := range response {
+		modelMap[m["id"].(string)] = m
+	}
+
+	assert.Equal(t, float64(60), modelMap["model1"]["ttl"])
+	ttlRemaining1 := modelMap["model1"]["ttlRemaining"].(float64)
+	assert.True(t, ttlRemaining1 > 0 && ttlRemaining1 <= 60)
+
+	assert.Nil(t, modelMap["model2"]["ttl"], "model2 ttl should be null when UnloadAfter is 0")
+	assert.Nil(t, modelMap["model2"]["ttlRemaining"], "model2 ttlRemaining should be null when UnloadAfter is 0")
 }
 
 func TestProxyManager_APIKeyAuth(t *testing.T) {

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -1340,7 +1340,7 @@ func TestProxyManager_ApiGetModels(t *testing.T) {
 	proxy := New(testConfig)
 	defer proxy.StopProcesses(StopWaitForInflightRequest)
 
-	req := httptest.NewRequest("GET", "/api/models", nil)
+	req := httptest.NewRequest("GET", "/v1/models", nil)
 	w := CreateTestResponseRecorder()
 
 	proxy.ServeHTTP(w, req)
@@ -1348,14 +1348,16 @@ func TestProxyManager_ApiGetModels(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
 
-	var response []map[string]interface{}
+	var response struct {
+		Data []map[string]interface{} `json:"data"`
+	}
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
-	assert.Len(t, response, 3)
+	assert.Len(t, response.Data, 3)
 
 	// Find model1 and model2 in response
 	modelMap := make(map[string]map[string]interface{})
-	for _, m := range response {
+	for _, m := range response.Data {
 		modelMap[m["id"].(string)] = m
 	}
 
@@ -1364,13 +1366,21 @@ func TestProxyManager_ApiGetModels(t *testing.T) {
 	assert.Contains(t, modelMap, "model3")
 	assert.Equal(t, "Model One", modelMap["model1"]["name"])
 	assert.Equal(t, "Model Two", modelMap["model2"]["name"])
-	assert.Equal(t, "model3", modelMap["model3"]["name"])
+	_, hasName := modelMap["model3"]["name"]
+	assert.False(t, hasName, "model3 should not have name field when empty")
 	assert.Equal(t, "model1", modelMap["model1"]["id"])
 	assert.Equal(t, "model2", modelMap["model2"]["id"])
 	assert.Equal(t, "model3", modelMap["model3"]["id"])
-	assert.Equal(t, "stopped", modelMap["model1"]["state"])
-	assert.Equal(t, "stopped", modelMap["model2"]["state"])
-	assert.Equal(t, "stopped", modelMap["model3"]["state"])
+
+	getState := func(m map[string]interface{}) string {
+		meta := m["meta"].(map[string]interface{})
+		llamaSwap := meta["llamaswap"].(map[string]interface{})
+		return llamaSwap["state"].(string)
+	}
+
+	assert.Equal(t, "stopped", getState(modelMap["model1"]))
+	assert.Equal(t, "stopped", getState(modelMap["model2"]))
+	assert.Equal(t, "stopped", getState(modelMap["model3"]))
 }
 
 func TestProxyManager_ApiGetModels_WithTTL(t *testing.T) {
@@ -1399,28 +1409,96 @@ func TestProxyManager_ApiGetModels_WithTTL(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	req = httptest.NewRequest("GET", "/api/models", nil)
+	req = httptest.NewRequest("GET", "/v1/models", nil)
 	w = CreateTestResponseRecorder()
 
 	proxy.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var response []map[string]interface{}
+	var response struct {
+		Data []map[string]interface{} `json:"data"`
+	}
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 
 	modelMap := make(map[string]map[string]interface{})
-	for _, m := range response {
+	for _, m := range response.Data {
 		modelMap[m["id"].(string)] = m
 	}
 
-	assert.Equal(t, float64(60), modelMap["model1"]["ttl"])
-	ttlRemaining1 := modelMap["model1"]["ttlRemaining"].(float64)
-	assert.True(t, ttlRemaining1 > 0 && ttlRemaining1 <= 60)
+	getTTL := func(m map[string]interface{}) (interface{}, interface{}) {
+		meta := m["meta"].(map[string]interface{})
+		llamaSwap := meta["llamaswap"].(map[string]interface{})
+		return llamaSwap["ttl"], llamaSwap["ttlRemaining"]
+	}
 
-	assert.Nil(t, modelMap["model2"]["ttl"], "model2 ttl should be null when UnloadAfter is 0")
-	assert.Nil(t, modelMap["model2"]["ttlRemaining"], "model2 ttlRemaining should be null when UnloadAfter is 0")
+	ttl1, ttlRemaining1 := getTTL(modelMap["model1"])
+	assert.Equal(t, float64(60), ttl1.(float64))
+	assert.True(t, ttlRemaining1.(float64) > 0 && ttlRemaining1.(float64) <= 60)
+
+	ttl2, ttlRemaining2 := getTTL(modelMap["model2"])
+	assert.Nil(t, ttl2, "model2 ttl should be null when UnloadAfter is 0")
+	assert.Nil(t, ttlRemaining2, "model2 ttlRemaining should be null when UnloadAfter is 0")
+}
+
+func TestProxyManager_ListModelsHandler_UserMetadata(t *testing.T) {
+	c := getTestSimpleResponderConfig("model1")
+	c.Metadata = map[string]any{"category": "vision", "version": 1.0}
+
+	testConfig := config.AddDefaultGroupToConfig(config.Config{
+		HealthCheckTimeout: 15,
+		Models:             map[string]config.ModelConfig{"model1": c},
+		LogLevel:           "error",
+	})
+
+	proxy := New(testConfig)
+	defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+	req := httptest.NewRequest("GET", "/v1/models", nil)
+	w := CreateTestResponseRecorder()
+	proxy.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct{ Data []map[string]any }
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	meta := resp.Data[0]["meta"].(map[string]any)["llamaswap"].(map[string]any)
+	assert.Equal(t, "vision", meta["category"])
+	assert.Equal(t, float64(1.0), meta["version"])
+}
+
+func TestProxyManager_ListModelsHandler_RuntimeMetadataOverridesUserMetadata(t *testing.T) {
+	c := getTestSimpleResponderConfig("model1")
+	c.UnloadAfter = 60
+	c.Metadata = map[string]any{"state": "user-state", "ttl": 999}
+
+	testConfig := config.AddDefaultGroupToConfig(config.Config{
+		HealthCheckTimeout: 15,
+		Models:             map[string]config.ModelConfig{"model1": c},
+		LogLevel:           "error",
+	})
+
+	proxy := New(testConfig)
+	defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(`{"model":"model1"}`))
+	w := CreateTestResponseRecorder()
+	proxy.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	time.Sleep(100 * time.Millisecond)
+
+	req = httptest.NewRequest("GET", "/v1/models", nil)
+	w = CreateTestResponseRecorder()
+	proxy.ServeHTTP(w, req)
+
+	var resp struct{ Data []map[string]any }
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	meta := resp.Data[0]["meta"].(map[string]any)["llamaswap"].(map[string]any)
+	assert.Equal(t, "ready", meta["state"], "runtime state overrides user metadata")
+	assert.Equal(t, float64(60), meta["ttl"], "runtime ttl overrides user metadata")
 }
 
 func TestProxyManager_APIKeyAuth(t *testing.T) {


### PR DESCRIPTION
Closes #541
Closes #564

Update the `/v1/models` to return the model `state`, `ttl`, and `ttlRemaining` under the meta.llamaswap field. For example:

```json
{
  "data": [
    {
      "created": 1775097337,
      "id": "llama-3.1-8b-instruct",
      "meta": {
        "llamaswap": {
          "state": "stopped",
          "ttl": 30,
          "ttlRemaining": null
        }
      },
      "name": "Llama 3.1 8b Instruct",
      "object": "model",
      "owned_by": "llama-swap"
    }
  ],
  "object": "list"
}
```

The following states are used ([from proxymanager_api](https://github.com/mostlygeek/llama-swap/blob/cc77139ff86da7055798c8b5dead414752e0b2f4/proxy/proxymanager_api.go#L65-L76)):

- `ready`
- `starting`
- `stopping`
- `stopped`
- `shutdown`
- `unknown`

I also updated the README for `/api/models/unload` as it was stale