### PR TITLE
ci: fix matrix exclude for scheduled docker workflow

### DIFF
--- a/.github/workflows/unified-docker.yml
+++ b/.github/workflows/unified-docker.yml
@@ -47,10 +47,10 @@ jobs:
         run: |
           backends=()
           # schedule uses defaults (build both); workflow_dispatch respects inputs
-          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]] || [[ "${{ inputs.build_cuda }}" == "true" ]]; then
+          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ inputs.build_cuda }}" == "true" ]]; then
             backends+=("cuda")
           fi
-          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]] || [[ "${{ inputs.build_vulkan }}" == "true" ]]; then
+          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ inputs.build_vulkan }}" == "true" ]]; then
             backends+=("vulkan")
           fi
           matrix=$(printf '%s\n' "${backends[@]}" | jq -R . | jq -sc .)


### PR DESCRIPTION
Replace broken matrix exclude expressions with a job-level if condition.
The inputs context is null for schedule events, causing the exclude
expressions to fail. The if condition correctly handles both scheduled
runs (always build both backends) and workflow_dispatch (respect the
build_cuda/build_vulkan inputs).