### PR TITLE
feat: Implement configurable model priority and unload delay

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -237,6 +237,18 @@
                         "type": "boolean",
                         "description": "Overrides the global sendLoadingState for this model. Ommitting this property will use the global setting."
                     },
+                    "priority": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 0,
+                        "description": "Controls swap order within a group (swap: true). Higher values are served before lower values. A higher-priority model preempts lower-priority models after their current in-flight request completes. Models with equal priority compete fairly."
+                    },
+                    "unloadDelay": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 0,
+                        "description": "Seconds to keep a model loaded after its last request completes. While active, lower-or-equal-priority models wait before swapping in. A strictly higher-priority model bypasses the delay. Most useful combined with priority. A new request for this model resets the delay."
+                    },
                     "unlisted": {
                         "type": "boolean",
                         "default": false,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -284,6 +284,26 @@ models:
     # - optional, default: undefined (use global setting)
     sendLoadingState: false
 
+    # priority: controls swap order within a group when swap is true
+    # - optional, default: 0
+    # - higher values are served before lower values
+    # - when a higher-priority model has pending requests, lower-priority models
+    #   yield after their current in-flight request completes (never aborted)
+    # - models with equal priority compete fairly
+    priority: 0
+
+    # unloadDelay: seconds to keep a model loaded after its last request
+    # - optional, default: 0 (disabled)
+    # - while the delay is active, lower-or-equal-priority models wait before
+    #   swapping in, letting follow-up requests reuse an already-loaded model
+    # - a model with strictly higher priority bypasses the delay immediately
+    #   and this bypass is logged at INFO level
+    # - if a new request for this model arrives while the delay is active, the
+    #   timer resets: the full delay runs again from when that request finishes
+    # - most useful when combined with priority; has little practical effect
+    #   without it, since equal-priority models also wait for the delay
+    unloadDelay: 0
+
   # Unlisted model example:
   "qwen-unlisted":
     # unlisted: boolean, true or false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -323,6 +323,26 @@ models:
     # - optional, default: undefined (use global setting)
     sendLoadingState: false
 
+    # priority: controls swap order within a group when swap is true
+    # - optional, default: 0
+    # - higher values are served before lower values
+    # - when a higher-priority model has pending requests, lower-priority models
+    #   yield after their current in-flight request completes (never aborted)
+    # - models with equal priority compete fairly
+    priority: 0
+
+    # unloadDelay: seconds to keep a model loaded after its last request
+    # - optional, default: 0 (disabled)
+    # - while the delay is active, lower-or-equal-priority models wait before
+    #   swapping in, letting follow-up requests reuse an already-loaded model
+    # - a model with strictly higher priority bypasses the delay immediately
+    #   and this bypass is logged at INFO level
+    # - if a new request for this model arrives while the delay is active, the
+    #   timer resets: the full delay runs again from when that request finishes
+    # - most useful when combined with priority; has little practical effect
+    #   without it, since equal-priority models also wait for the delay
+    unloadDelay: 0
+
   # Unlisted model example:
   "qwen-unlisted":
     # unlisted: boolean, true or false

--- a/proxy/config/model_config.go
+++ b/proxy/config/model_config.go
@@ -40,6 +40,24 @@ type ModelConfig struct {
 
 	// override global setting
 	SendLoadingState *bool `yaml:"sendLoadingState"`
+
+	// Priority controls swap order within a group (swap: true).
+	// Higher values win. Default is 0. A higher-priority model preempts
+	// a lower-priority model after the lower-priority model's current
+	// in-flight request completes.
+	Priority int `yaml:"priority"`
+
+	// UnloadDelay keeps a model loaded for the given number of seconds after
+	// its last in-flight request completes, so that follow-up requests can
+	// reuse the already-loaded model without paying a cold-start penalty.
+	// While the delay is active, lower-or-equal-priority models wait before
+	// swapping in. A model with strictly higher priority bypasses the delay
+	// immediately (logged at INFO level). If a new request for this model
+	// arrives while the delay is active, the timer resets: the full delay
+	// runs again from when that request finishes. Only meaningful in swap
+	// groups with priority set; equal-priority models also wait for the delay.
+	// Default 0 (disabled).
+	UnloadDelay int `yaml:"unloadDelay"`
 }
 
 func (m *ModelConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/proxy/processgroup.go
+++ b/proxy/processgroup.go
@@ -5,12 +5,14 @@ import (
 	"net/http"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/mostlygeek/llama-swap/proxy/config"
 )
 
 type ProcessGroup struct {
-	sync.Mutex
+	mu   sync.Mutex
+	cond *sync.Cond
 
 	config     config.Config
 	id         string
@@ -22,8 +24,13 @@ type ProcessGroup struct {
 	upstreamLogger *LogMonitor
 
 	// map of current processes
-	processes       map[string]*Process
-	lastUsedProcess string
+	processes map[string]*Process
+
+	// swap coordination state (only used when swap == true)
+	activeModel     string         // currently loaded model
+	inFlight        int            // in-flight request count for activeModel
+	pendingCount    map[string]int // goroutines waiting to use each model
+	unloadDelayCh   chan struct{}   // non-nil while an unload delay is active; close to cancel
 }
 
 func NewProcessGroup(id string, config config.Config, proxyLogger *LogMonitor, upstreamLogger *LogMonitor) *ProcessGroup {
@@ -41,7 +48,9 @@ func NewProcessGroup(id string, config config.Config, proxyLogger *LogMonitor, u
 		proxyLogger:    proxyLogger,
 		upstreamLogger: upstreamLogger,
 		processes:      make(map[string]*Process),
+		pendingCount:   make(map[string]int),
 	}
+	pg.cond = sync.NewCond(&pg.mu)
 
 	// Create a Process for each member in the group
 	for _, modelID := range groupConfig.Members {
@@ -54,35 +63,192 @@ func NewProcessGroup(id string, config config.Config, proxyLogger *LogMonitor, u
 	return pg
 }
 
-// ProxyRequest proxies a request to the specified model
+// ProxyRequest proxies a request to the specified model.
+//
+// When swap is true, requests are serialized through a priority-aware
+// coordination layer:
+//   - Models with a higher Priority value preempt lower-priority models
+//     once the currently in-flight request for the lower-priority model
+//     completes (the in-flight request is never aborted).
+//   - Models with equal priority compete fairly; the currently loaded
+//     model keeps running until all its pending requests drain before a
+//     different model of the same priority can swap in.
+//   - A model with UnloadDelay > 0 stays loaded for that many seconds
+//     after its last request, blocking lower-or-equal-priority swaps.
+//     A strictly higher-priority model bypasses the delay immediately.
 func (pg *ProcessGroup) ProxyRequest(modelID string, writer http.ResponseWriter, request *http.Request) error {
 	if !pg.HasMember(modelID) {
 		return fmt.Errorf("model %s not part of group %s", modelID, pg.id)
 	}
 
-	if pg.swap {
-		pg.Lock()
-		if pg.lastUsedProcess != modelID {
-
-			// is there something already running?
-			if pg.lastUsedProcess != "" {
-				pg.processes[pg.lastUsedProcess].Stop()
-			}
-
-			// wait for the request to the new model to be fully handled
-			// and prevent race conditions see issue #277
-			pg.processes[modelID].ProxyRequest(writer, request)
-			pg.lastUsedProcess = modelID
-
-			// short circuit and exit
-			pg.Unlock()
-			return nil
-		}
-		pg.Unlock()
+	if !pg.swap {
+		pg.processes[modelID].ProxyRequest(writer, request)
+		return nil
 	}
 
+	pg.mu.Lock()
+	pg.pendingCount[modelID]++
+
+	loggedWait := false
+	for {
+		canProceed := false
+
+		if pg.activeModel == modelID {
+			// Already the active model. Proceed unless a higher-priority model
+			// is waiting — in that case yield so it can swap in after the
+			// current in-flight request finishes.
+			if !pg.hasHigherPriorityPendingLocked(modelID) {
+				// A new request for the active model cancels any running delay
+				// (the delay timer resets when this request finishes).
+				pg.cancelUnloadDelayLocked()
+				canProceed = true
+			}
+		} else if pg.inFlight == 0 && pg.isHighestPriorityLocked(modelID) {
+			// Candidate for a swap. Check whether the active model is within
+			// its unload delay.
+			if pg.unloadDelayCh != nil {
+				myPriority := pg.getModelPriorityLocked(modelID)
+				activePriority := pg.getModelPriorityLocked(pg.activeModel)
+				if myPriority > activePriority {
+					// Strictly higher priority: bypass the delay.
+					pg.proxyLogger.Infof(
+						"<%s> bypassing %ds unload delay for %q: higher priority (%d > %d)",
+						modelID, pg.getModelUnloadDelayLocked(pg.activeModel),
+						pg.activeModel, myPriority, activePriority,
+					)
+					pg.cancelUnloadDelayLocked()
+					canProceed = true
+				}
+				// equal/lower priority: fall through to Wait
+			} else {
+				canProceed = true
+			}
+
+			if canProceed {
+				if pg.activeModel != "" {
+					// Stop the previous model while holding the lock.
+					// inFlight == 0 means the process's own WaitGroup is also
+					// zero, so Stop's internal Wait returns immediately.
+					pg.processes[pg.activeModel].Stop()
+				}
+				pg.activeModel = modelID
+			}
+		}
+
+		if canProceed {
+			break
+		}
+
+		if !loggedWait {
+			if blocker := pg.highestPriorityPendingLocked(modelID); blocker != "" {
+				pg.proxyLogger.Infof("<%s> waiting: higher priority model %q (priority %d) is pending",
+					modelID, blocker, pg.getModelPriorityLocked(blocker))
+			} else if pg.unloadDelayCh != nil && pg.activeModel != modelID {
+				pg.proxyLogger.Infof("<%s> waiting: %q has an active %ds unload delay",
+					modelID, pg.activeModel, pg.getModelUnloadDelayLocked(pg.activeModel))
+			}
+			loggedWait = true
+		}
+		pg.cond.Wait()
+	}
+
+	pg.inFlight++
+	pg.pendingCount[modelID]--
+	pg.mu.Unlock()
+
+	// Serve the request. process.ProxyRequest starts the process lazily if
+	// it is not yet running. The lock is not held during serving so that
+	// concurrent requests to the same model can proceed in parallel.
 	pg.processes[modelID].ProxyRequest(writer, request)
+
+	pg.mu.Lock()
+	pg.inFlight--
+	if pg.inFlight == 0 {
+		delay := pg.getModelUnloadDelayLocked(pg.activeModel)
+		if delay > 0 {
+			pg.proxyLogger.Debugf("<%s> starting %ds unload delay", pg.activeModel, delay)
+			ch := make(chan struct{})
+			pg.unloadDelayCh = ch
+			captured := pg.activeModel
+			go func() {
+				select {
+				case <-time.After(time.Duration(delay) * time.Second):
+					pg.mu.Lock()
+					if pg.unloadDelayCh == ch {
+						pg.unloadDelayCh = nil
+						pg.proxyLogger.Debugf("<%s> unload delay expired", captured)
+						pg.cond.Broadcast()
+					}
+					pg.mu.Unlock()
+				case <-ch:
+					// cancelled: new same-model request or higher-priority bypass
+				}
+			}()
+		}
+		pg.cond.Broadcast()
+	}
+	pg.mu.Unlock()
+
 	return nil
+}
+
+// cancelUnloadDelayLocked cancels any active unload delay.
+// Must be called with pg.mu held.
+func (pg *ProcessGroup) cancelUnloadDelayLocked() {
+	if pg.unloadDelayCh != nil {
+		close(pg.unloadDelayCh)
+		pg.unloadDelayCh = nil
+	}
+}
+
+// isHighestPriorityLocked returns true when no other pending model has a
+// strictly higher priority than modelID. Must be called with pg.mu held.
+func (pg *ProcessGroup) isHighestPriorityLocked(modelID string) bool {
+	return pg.highestPriorityPendingLocked(modelID) == ""
+}
+
+// hasHigherPriorityPendingLocked returns true when at least one other pending
+// model has a strictly higher priority than modelID. Must be called with
+// pg.mu held.
+func (pg *ProcessGroup) hasHigherPriorityPendingLocked(modelID string) bool {
+	return pg.highestPriorityPendingLocked(modelID) != ""
+}
+
+// highestPriorityPendingLocked returns the model ID of the highest-priority
+// pending model that has strictly higher priority than modelID, or "" if none.
+// Must be called with pg.mu held.
+func (pg *ProcessGroup) highestPriorityPendingLocked(modelID string) string {
+	myPriority := pg.getModelPriorityLocked(modelID)
+	bestID := ""
+	bestPriority := myPriority
+	for otherID, count := range pg.pendingCount {
+		if otherID == modelID || count == 0 {
+			continue
+		}
+		if p := pg.getModelPriorityLocked(otherID); p > bestPriority {
+			bestPriority = p
+			bestID = otherID
+		}
+	}
+	return bestID
+}
+
+// getModelPriorityLocked returns the configured priority for a model.
+// Must be called with pg.mu held.
+func (pg *ProcessGroup) getModelPriorityLocked(modelID string) int {
+	if mc, _, ok := pg.config.FindConfig(modelID); ok {
+		return mc.Priority
+	}
+	return 0
+}
+
+// getModelUnloadDelayLocked returns the configured unload delay in seconds.
+// Must be called with pg.mu held.
+func (pg *ProcessGroup) getModelUnloadDelayLocked(modelID string) int {
+	if mc, _, ok := pg.config.FindConfig(modelID); ok {
+		return mc.UnloadDelay
+	}
+	return 0
 }
 
 func (pg *ProcessGroup) HasMember(modelName string) bool {
@@ -97,18 +263,19 @@ func (pg *ProcessGroup) GetMember(modelName string) (*Process, bool) {
 }
 
 func (pg *ProcessGroup) StopProcess(modelID string, strategy StopStrategy) error {
-	pg.Lock()
+	pg.mu.Lock()
 
 	process, exists := pg.processes[modelID]
 	if !exists {
-		pg.Unlock()
+		pg.mu.Unlock()
 		return fmt.Errorf("process not found for %s", modelID)
 	}
 
-	if pg.lastUsedProcess == modelID {
-		pg.lastUsedProcess = ""
+	if pg.activeModel == modelID {
+		pg.cancelUnloadDelayLocked()
+		pg.activeModel = ""
 	}
-	pg.Unlock()
+	pg.mu.Unlock()
 
 	switch strategy {
 	case StopImmediately:
@@ -116,12 +283,22 @@ func (pg *ProcessGroup) StopProcess(modelID string, strategy StopStrategy) error
 	default:
 		process.Stop()
 	}
+
+	pg.mu.Lock()
+	pg.cond.Broadcast()
+	pg.mu.Unlock()
+
 	return nil
 }
 
 func (pg *ProcessGroup) StopProcesses(strategy StopStrategy) {
-	pg.Lock()
-	defer pg.Unlock()
+	pg.mu.Lock()
+	defer func() {
+		pg.cancelUnloadDelayLocked()
+		pg.activeModel = ""
+		pg.cond.Broadcast()
+		pg.mu.Unlock()
+	}()
 
 	if len(pg.processes) == 0 {
 		return
@@ -154,4 +331,10 @@ func (pg *ProcessGroup) Shutdown() {
 		}(process)
 	}
 	wg.Wait()
+
+	pg.mu.Lock()
+	pg.cancelUnloadDelayLocked()
+	pg.activeModel = ""
+	pg.cond.Broadcast()
+	pg.mu.Unlock()
 }

--- a/proxy/processgroup.go
+++ b/proxy/processgroup.go
@@ -27,10 +27,10 @@ type ProcessGroup struct {
 	processes map[string]*Process
 
 	// swap coordination state (only used when swap == true)
-	activeModel     string         // currently loaded model
-	inFlight        int            // in-flight request count for activeModel
-	pendingCount    map[string]int // goroutines waiting to use each model
-	unloadDelayCh   chan struct{}   // non-nil while an unload delay is active; close to cancel
+	activeModel   string         // currently loaded model
+	inFlight      int            // in-flight request count for activeModel
+	pendingCount  map[string]int // goroutines waiting to use each model
+	unloadDelayCh chan struct{}  // non-nil while an unload delay is active; close to cancel
 }
 
 func NewProcessGroup(id string, config config.Config, proxyLogger *LogMonitor, upstreamLogger *LogMonitor) *ProcessGroup {

--- a/proxy/processgroup_test.go
+++ b/proxy/processgroup_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/mostlygeek/llama-swap/proxy/config"
 	"github.com/stretchr/testify/assert"
@@ -93,6 +94,366 @@ func TestProcessGroup_ProxyRequestSwapIsTrueParallel(t *testing.T) {
 		}(modelName)
 	}
 	wg.Wait()
+}
+
+// TestProcessGroup_isHighestPriorityLocked verifies the priority comparison
+// logic without starting any actual processes.
+func TestProcessGroup_isHighestPriorityLocked(t *testing.T) {
+	lowCfg := getTestSimpleResponderConfig("low")
+	lowCfg.Priority = 0
+	highCfg := getTestSimpleResponderConfig("high")
+	highCfg.Priority = 5
+
+	cfg := config.AddDefaultGroupToConfig(config.Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]config.ModelConfig{
+			"low":  lowCfg,
+			"high": highCfg,
+		},
+		Groups: map[string]config.GroupConfig{
+			"G": {Swap: true, Members: []string{"low", "high"}},
+		},
+	})
+	pg := NewProcessGroup("G", cfg, testLogger, testLogger)
+
+	// No pending requests: both are considered highest priority.
+	assert.True(t, pg.isHighestPriorityLocked("low"))
+	assert.True(t, pg.isHighestPriorityLocked("high"))
+
+	// Only high pending: low is no longer highest priority.
+	pg.pendingCount["high"] = 1
+	assert.False(t, pg.isHighestPriorityLocked("low"))
+	assert.True(t, pg.isHighestPriorityLocked("high"))
+
+	// Both pending: high wins, low loses.
+	pg.pendingCount["low"] = 1
+	assert.False(t, pg.isHighestPriorityLocked("low"))
+	assert.True(t, pg.isHighestPriorityLocked("high"))
+
+	// Only low pending: low is highest priority again.
+	pg.pendingCount["high"] = 0
+	assert.True(t, pg.isHighestPriorityLocked("low"))
+}
+
+// TestProcessGroup_PriorityPreemptsAfterCurrentRequest verifies that:
+//   - A higher-priority model does NOT abort a currently in-flight request of
+//     a lower-priority model.
+//   - After the lower-priority model's request completes, the higher-priority
+//     model runs before any additional lower-priority requests.
+func TestProcessGroup_PriorityPreemptsAfterCurrentRequest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow test")
+	}
+
+	lowCfg := getTestSimpleResponderConfig("low")
+	lowCfg.Priority = 0
+	highCfg := getTestSimpleResponderConfig("high")
+	highCfg.Priority = 5
+
+	cfg := config.AddDefaultGroupToConfig(config.Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]config.ModelConfig{
+			"low":  lowCfg,
+			"high": highCfg,
+		},
+		Groups: map[string]config.GroupConfig{
+			"swap-group": {Swap: true, Members: []string{"low", "high"}},
+		},
+	})
+
+	pg := NewProcessGroup("swap-group", cfg, testLogger, testLogger)
+	defer pg.StopProcesses(StopWaitForInflightRequest)
+
+	var order []string
+	var orderMu sync.Mutex
+	appendOrder := func(name string) {
+		orderMu.Lock()
+		order = append(order, name)
+		orderMu.Unlock()
+	}
+
+	var wg sync.WaitGroup
+
+	// 1. Start a slow "low" request (300 ms).
+	lowStarted := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		req := httptest.NewRequest("POST", "/v1/chat/completions?wait=300ms", nil)
+		w := httptest.NewRecorder()
+		close(lowStarted)
+		pg.ProxyRequest("low", w, req)
+		appendOrder("low1")
+	}()
+
+	// Wait until the slow "low" request is in-flight before queueing the rest.
+	<-lowStarted
+	time.Sleep(50 * time.Millisecond)
+
+	// 2. Queue a "high" request while "low" is still processing.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+		w := httptest.NewRecorder()
+		pg.ProxyRequest("high", w, req)
+		appendOrder("high1")
+	}()
+
+	// Give "high" time to register in pendingCount before "low2" arrives.
+	time.Sleep(20 * time.Millisecond)
+
+	// 3. Queue a second "low" request; it should run after "high" due to priority.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+		w := httptest.NewRecorder()
+		pg.ProxyRequest("low", w, req)
+		appendOrder("low2")
+	}()
+
+	wg.Wait()
+
+	// "low1" runs to completion (not aborted), then "high1" (higher priority),
+	// then "low2" (no more high-priority competition).
+	assert.Equal(t, []string{"low1", "high1", "low2"}, order)
+}
+
+// TestProcessGroup_UnloadDelay_HoldsLowerPriority verifies that a model with
+// unloadDelay keeps its slot long enough that a lower-priority model must wait
+// for the delay to expire before swapping in.
+func TestProcessGroup_UnloadDelay_HoldsLowerPriority(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow test")
+	}
+
+	const delaySeconds = 1
+
+	highCfg := getTestSimpleResponderConfig("high")
+	highCfg.Priority = 5
+	highCfg.UnloadDelay = delaySeconds
+	lowCfg := getTestSimpleResponderConfig("low")
+	lowCfg.Priority = 0
+
+	cfg := config.AddDefaultGroupToConfig(config.Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]config.ModelConfig{
+			"high": highCfg,
+			"low":  lowCfg,
+		},
+		Groups: map[string]config.GroupConfig{
+			"G": {Swap: true, Members: []string{"high", "low"}},
+		},
+	})
+
+	pg := NewProcessGroup("G", cfg, testLogger, testLogger)
+	defer pg.StopProcesses(StopWaitForInflightRequest)
+
+	// Serve one fast request to "high" so its unload delay starts.
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	w := httptest.NewRecorder()
+	assert.NoError(t, pg.ProxyRequest("high", w, req))
+
+	// Now send a request to "low". It must wait for high's delay to expire.
+	start := time.Now()
+	req2 := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	w2 := httptest.NewRecorder()
+	assert.NoError(t, pg.ProxyRequest("low", w2, req2))
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, time.Duration(delaySeconds)*time.Second-100*time.Millisecond,
+		"low-priority model should have waited for the unload delay")
+}
+
+// TestProcessGroup_UnloadDelay_HigherPriorityBypasses verifies that a model
+// with strictly higher priority does not wait for a lower-priority model's
+// unload delay.
+func TestProcessGroup_UnloadDelay_HigherPriorityBypasses(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow test")
+	}
+
+	const delaySeconds = 10 // intentionally long; high must not wait this long
+
+	lowCfg := getTestSimpleResponderConfig("low")
+	lowCfg.Priority = 0
+	lowCfg.UnloadDelay = delaySeconds
+	highCfg := getTestSimpleResponderConfig("high")
+	highCfg.Priority = 5
+
+	cfg := config.AddDefaultGroupToConfig(config.Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]config.ModelConfig{
+			"low":  lowCfg,
+			"high": highCfg,
+		},
+		Groups: map[string]config.GroupConfig{
+			"G": {Swap: true, Members: []string{"low", "high"}},
+		},
+	})
+
+	pg := NewProcessGroup("G", cfg, testLogger, testLogger)
+	defer pg.StopProcesses(StopWaitForInflightRequest)
+
+	// Serve one fast request to "low" so its unload delay starts.
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	w := httptest.NewRecorder()
+	assert.NoError(t, pg.ProxyRequest("low", w, req))
+
+	// "high" arrives while "low" is in its delay. It should bypass immediately.
+	start := time.Now()
+	req2 := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	w2 := httptest.NewRecorder()
+	assert.NoError(t, pg.ProxyRequest("high", w2, req2))
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, time.Duration(delaySeconds)*time.Second/2,
+		"high-priority model should have bypassed the unload delay")
+}
+
+// TestProcessGroup_UnloadDelay_TimerReset verifies that a new request arriving
+// for the active model while its unload delay is running cancels the current
+// timer and starts a fresh one when that request finishes.  A lower-priority
+// model must therefore wait for the full delay period from the end of the
+// second request, not from the end of the first.
+func TestProcessGroup_UnloadDelay_TimerReset(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow test")
+	}
+
+	const delaySeconds = 1
+
+	highCfg := getTestSimpleResponderConfig("high")
+	highCfg.Priority = 5
+	highCfg.UnloadDelay = delaySeconds
+	lowCfg := getTestSimpleResponderConfig("low")
+	lowCfg.Priority = 0
+
+	cfg := config.AddDefaultGroupToConfig(config.Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]config.ModelConfig{
+			"high": highCfg,
+			"low":  lowCfg,
+		},
+		Groups: map[string]config.GroupConfig{
+			"G": {Swap: true, Members: []string{"high", "low"}},
+		},
+	})
+
+	pg := NewProcessGroup("G", cfg, testLogger, testLogger)
+	defer pg.StopProcesses(StopWaitForInflightRequest)
+
+	// First "high" request — after it finishes the delay timer starts.
+	assert.NoError(t, pg.ProxyRequest("high",
+		httptest.NewRecorder(),
+		httptest.NewRequest("POST", "/v1/chat/completions", nil)))
+
+	// Wait 200ms into the delay, then send a second "high" request.  This
+	// cancels the running timer and starts a fresh one when the request ends.
+	time.Sleep(200 * time.Millisecond)
+	assert.NoError(t, pg.ProxyRequest("high",
+		httptest.NewRecorder(),
+		httptest.NewRequest("POST", "/v1/chat/completions", nil)))
+
+	// "low" arrives right after the second "high" finishes.  It must wait for
+	// the full reset delay (1 s), not just the remaining ~800 ms of the first.
+	start := time.Now()
+	assert.NoError(t, pg.ProxyRequest("low",
+		httptest.NewRecorder(),
+		httptest.NewRequest("POST", "/v1/chat/completions", nil)))
+
+	assert.GreaterOrEqual(t, time.Since(start),
+		time.Duration(delaySeconds)*time.Second-100*time.Millisecond,
+		"low should wait for the full delay after the timer was reset by a second high request")
+}
+
+// TestProcessGroup_UnloadDelay_EqualPriorityWaits verifies that a model with
+// the same priority as the active model does NOT bypass the unload delay.
+// Only a strictly higher priority bypasses it.
+func TestProcessGroup_UnloadDelay_EqualPriorityWaits(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow test")
+	}
+
+	const delaySeconds = 1
+
+	aCfg := getTestSimpleResponderConfig("a")
+	aCfg.Priority = 5
+	aCfg.UnloadDelay = delaySeconds
+	bCfg := getTestSimpleResponderConfig("b")
+	bCfg.Priority = 5 // same priority as "a"
+
+	cfg := config.AddDefaultGroupToConfig(config.Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]config.ModelConfig{
+			"a": aCfg,
+			"b": bCfg,
+		},
+		Groups: map[string]config.GroupConfig{
+			"G": {Swap: true, Members: []string{"a", "b"}},
+		},
+	})
+
+	pg := NewProcessGroup("G", cfg, testLogger, testLogger)
+	defer pg.StopProcesses(StopWaitForInflightRequest)
+
+	assert.NoError(t, pg.ProxyRequest("a",
+		httptest.NewRecorder(),
+		httptest.NewRequest("POST", "/v1/chat/completions", nil)))
+
+	// "b" has the same priority as "a"; it must still wait for the delay.
+	start := time.Now()
+	assert.NoError(t, pg.ProxyRequest("b",
+		httptest.NewRecorder(),
+		httptest.NewRequest("POST", "/v1/chat/completions", nil)))
+
+	assert.GreaterOrEqual(t, time.Since(start),
+		time.Duration(delaySeconds)*time.Second-100*time.Millisecond,
+		"equal-priority model should wait for the unload delay, not bypass it")
+}
+
+// TestProcessGroup_UnloadDelay_ZeroMeansNoDelay verifies that unloadDelay: 0
+// (the default) produces no artificial hold — a waiting model swaps in as
+// soon as the active model's request finishes.
+func TestProcessGroup_UnloadDelay_ZeroMeansNoDelay(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow test")
+	}
+
+	aCfg := getTestSimpleResponderConfig("a")
+	aCfg.Priority = 5
+	aCfg.UnloadDelay = 0 // explicitly disabled
+	bCfg := getTestSimpleResponderConfig("b")
+	bCfg.Priority = 0
+
+	cfg := config.AddDefaultGroupToConfig(config.Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]config.ModelConfig{
+			"a": aCfg,
+			"b": bCfg,
+		},
+		Groups: map[string]config.GroupConfig{
+			"G": {Swap: true, Members: []string{"a", "b"}},
+		},
+	})
+
+	pg := NewProcessGroup("G", cfg, testLogger, testLogger)
+	defer pg.StopProcesses(StopWaitForInflightRequest)
+
+	assert.NoError(t, pg.ProxyRequest("a",
+		httptest.NewRecorder(),
+		httptest.NewRequest("POST", "/v1/chat/completions", nil)))
+
+	// With unloadDelay=0, "b" should swap in without any added wait.
+	// The only time spent is process startup; we allow generous headroom.
+	start := time.Now()
+	assert.NoError(t, pg.ProxyRequest("b",
+		httptest.NewRecorder(),
+		httptest.NewRequest("POST", "/v1/chat/completions", nil)))
+
+	assert.Less(t, time.Since(start), 3*time.Second,
+		"with unloadDelay=0 there should be no artificial hold before swapping")
 }
 
 func TestProcessGroup_ProxyRequestSwapIsFalse(t *testing.T) {


### PR DESCRIPTION
Hi!

First of all I want to give thanks for llama-swap, it's truly a fantastic piece of software for us gpu starved people experimenting at home!

I have used it extensively with my local llm setup, always been working great.

These days however many agentic frameworks have a concept of background workers, which causes some sub-optimal behavior with llama-swap.

Specifically, the situation I'm running into is something like this with for instance opencode or similar tooling;

Orchestrator Agent - Model1 
Explorer Agent - Model2
Coder - Model3

Orchestrator starts with some task, is loaded in by llama-swap and starts reasoning to build a plan. Generally it might end up launching something like 2 explorers and one coder agent in parallel, commonly as 'background workers'. This sends several incoming requests to llama-swap for different model, including the orchestrator model. The current behavior of the queue is something like FIFO, and the first request arriving for Model2 is just a system prompt, as soon as that is done processing it's swap out for model3 which was some other background task, which is then quickly swapped out back to the orchestrator model1 which tends to just give up on the agents after a while since no progress is made. I guess the TLDR is that the majority of the time is spent just swapping model, with little actual processing happening at all.

Therefore, here is a feature implementation that supports configurable priority per model (higher priority wins). This way, it's possible to configure for instance the explorer model with priority 3, coder model with priority 2 and orchestrator model with priority 1. What happens then in the scenario above is instead;
* Orchestrator starts with some task, is loaded in by llama-swap and starts reasoning to build a plan.
* Orchestrator launches two explorers and one coder
* Since the explorer model has the highest priority, llama-swap will keep processing requests for this model until it has finished its tasks
* The coder model has second highest priority, and will be loaded in next and be able to fully finish its task
* Finally the orchestrator is loaded in again and can gather the result of all agents.

I had to add one more thing to make this work well though; `unloadDelay`. This works as a 'debounce' feature that keeps models with higher priority loaded for a configurable time if all other requests in the queue has lower priority. If a new request arrive for the currently loaded model before unload delay has expired, the timer resets and the model stays loaded and process the request. If a request for a higher priority model arrives though, the unloadDelay is ignored. This was required as there is usually a small delay in the agentic frameworks before the next request is triggered, and that was causing similar problems as the original situation. I have `unloadDelay` set to 5 for my agent models which works great. 

I'm not sure `unloadDelay` is a great term, it might be better with `debounce`, `debounceTimer`, `debounceDelay` or something to keep it clearly separate from `ttl` which works differently. Open to suggestions.

I'm not used to Golang and had Claude code helped me implement this, I have reviewed the code to the best of my ability and also tested the feature manually. But in case there is any slop in the code I apologize in advance.