### PR TITLE
proxy: make exclusive groups bidirectional

### DIFF
--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -499,6 +499,13 @@ func (pm *ProxyManager) swapProcessGroup(realModelName string) (*ProcessGroup, e
 				otherGroup.StopProcesses(StopWaitForInflightRequest)
 			}
 		}
+	} else {
+		for groupId, otherGroup := range pm.processGroups {
+			if groupId != processGroup.id && otherGroup.exclusive && !otherGroup.persistent {
+				pm.proxyLogger.Debugf("Unloading exclusive group %s for non-exclusive group %s", groupId, processGroup.id)
+				otherGroup.StopProcesses(StopWaitForInflightRequest)
+			}
+		}
 	}
 
 	return processGroup, nil

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -150,6 +150,94 @@ func TestProxyManager_PersistentGroupsAreNotSwapped(t *testing.T) {
 	assert.Equal(t, proxy.findGroupByModelName("model1").processes["model1"].CurrentState(), StateReady)
 }
 
+// Test that loading a model in a non-exclusive group evicts running exclusive groups.
+func TestProxyManager_ExclusiveGroupEvictedByNonExclusive(t *testing.T) {
+	config := config.AddDefaultGroupToConfig(config.Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]config.ModelConfig{
+			"model1": getTestSimpleResponderConfig("model1"),
+			"model2": getTestSimpleResponderConfig("model2"),
+		},
+		LogLevel: "error",
+		Groups: map[string]config.GroupConfig{
+			"G1": {
+				Swap:      true,
+				Exclusive: true,
+				Members:   []string{"model1"},
+			},
+			"G2": {
+				Swap:      true,
+				Exclusive: false,
+				Members:   []string{"model2"},
+			},
+		},
+	})
+
+	proxy := New(config)
+	defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+	// load model1 in the exclusive group
+	reqBody := fmt.Sprintf(`{"model":"%s"}`, "model1")
+	req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+	w := CreateTestResponseRecorder()
+	proxy.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, proxy.findGroupByModelName("model1").processes["model1"].CurrentState(), StateReady)
+
+	// load model2 in the non-exclusive group, this should evict the exclusive group
+	reqBody = fmt.Sprintf(`{"model":"%s"}`, "model2")
+	req = httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+	w = CreateTestResponseRecorder()
+	proxy.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	assert.Equal(t, proxy.findGroupByModelName("model2").processes["model2"].CurrentState(), StateReady)
+	assert.Equal(t, proxy.findGroupByModelName("model1").processes["model1"].CurrentState(), StateStopped)
+}
+
+// Test that a persistent exclusive group is not evicted when a non-exclusive group loads.
+func TestProxyManager_PersistentExclusiveGroupNotEvicted(t *testing.T) {
+	config := config.AddDefaultGroupToConfig(config.Config{
+		HealthCheckTimeout: 15,
+		Models: map[string]config.ModelConfig{
+			"model1": getTestSimpleResponderConfig("model1"),
+			"model2": getTestSimpleResponderConfig("model2"),
+		},
+		LogLevel: "error",
+		Groups: map[string]config.GroupConfig{
+			"G1": {
+				Swap:       true,
+				Exclusive:  true,
+				Persistent: true,
+				Members:    []string{"model1"},
+			},
+			"G2": {
+				Swap:      true,
+				Exclusive: false,
+				Members:   []string{"model2"},
+			},
+		},
+	})
+
+	proxy := New(config)
+	defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+	// load model1 in the persistent exclusive group, then model2 in non-exclusive
+	for _, requestedModel := range []string{"model1", "model2"} {
+		reqBody := fmt.Sprintf(`{"model":"%s"}`, requestedModel)
+		req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+		w := CreateTestResponseRecorder()
+
+		proxy.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), requestedModel)
+	}
+
+	// both should remain running since G1 is persistent
+	assert.Equal(t, proxy.findGroupByModelName("model1").processes["model1"].CurrentState(), StateReady)
+	assert.Equal(t, proxy.findGroupByModelName("model2").processes["model2"].CurrentState(), StateReady)
+}
+
 // When a request for a different model comes in ProxyManager should wait until
 // the first request is complete before swapping. Both requests should complete
 func TestProxyManager_SwapMultiProcessParallelRequests(t *testing.T) {


### PR DESCRIPTION
Make `exclusive: true` work in both directions. Previously, loading a model
into an exclusive group would unload other groups, but loading a model into
a non-exclusive group would not unload running exclusive groups.

- add reverse exclusive check in swapProcessGroup()
- persistent exclusive groups are still protected from eviction
- add TestProxyManager_ExclusiveGroupEvictedByNonExclusive
- add TestProxyManager_PersistentExclusiveGroupNotEvicted

fixes #215