### PR TITLE
proxy: rewrite alias model name in proxied requests

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -151,6 +151,11 @@
             "default": false,
             "description": "Present aliases within the /v1/models OpenAI API listing. when true, model aliases will be output to the API model listing duplicating all fields except for Id so chat UIs can use the alias equivalent to the original."
         },
+        "sendRealModelID": {
+            "type": "boolean",
+            "default": false,
+            "description": "Send the real model ID to the upstream server when an alias is used. When false (default), the alias name is forwarded as-is. When true, the resolved real model ID is sent to the backend."
+        },
         "macros": {
             "$ref": "#/definitions/macros"
         },

--- a/proxy/config/config.go
+++ b/proxy/config/config.go
@@ -147,6 +147,9 @@ type Config struct {
 	// present aliases to /v1/models OpenAI API listing
 	IncludeAliasesInList bool `yaml:"includeAliasesInList"`
 
+	// send real model ID to upstream when alias is used
+	SendRealModelID bool `yaml:"sendRealModelID"`
+
 	// support API keys, see issue #433, #50, #251
 	RequiredAPIKeys []string `yaml:"apiKeys"`
 

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -697,6 +697,13 @@ func (pm *ProxyManager) proxyInferenceHandler(c *gin.Context) {
 				pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error rewriting model name in JSON: %s", err.Error()))
 				return
 			}
+		} else if requestedModel != modelID && pm.config.SendRealModelID {
+			// Rewrite alias to real model name so the backend recognizes it
+			bodyBytes, err = sjson.SetBytes(bodyBytes, "model", modelID)
+			if err != nil {
+				pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error rewriting model name in JSON: %s", err.Error()))
+				return
+			}
 		}
 
 		// issue #174 strip parameters from the JSON body
@@ -857,8 +864,9 @@ func (pm *ProxyManager) proxyOAIPostFormHandler(c *gin.Context) {
 				// # issue #69 allow custom model names to be sent to upstream
 				if useModelName != "" {
 					fieldValue = useModelName
-				} else {
-					fieldValue = requestedModel
+				} else if requestedModel != modelID && pm.config.SendRealModelID {
+					// Rewrite alias to real model name so the backend recognizes it
+					fieldValue = modelID
 				}
 			}
 			field, err := multipartWriter.CreateFormField(key)

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -850,6 +850,113 @@ func TestProxyManager_UseModelName(t *testing.T) {
 	})
 }
 
+// TestProxyManager_SendRealModelID tests the sendRealModelID config option
+func TestProxyManager_SendRealModelID(t *testing.T) {
+	// Create config YAML with an alias
+	configYAML := fmt.Sprintf(`
+logLevel: error
+healthCheckTimeout: 15
+models:
+  real-model:
+    cmd: %s -port ${PORT} -silent -respond real-model
+    aliases:
+      - my-alias
+`, getSimpleResponderPath())
+
+	conf, err := config.LoadConfigFromReader(strings.NewReader(configYAML))
+	assert.NoError(t, err)
+
+	t.Run("default false does not rewrite alias to real model ID", func(t *testing.T) {
+		conf.SendRealModelID = false
+		proxy := New(conf)
+		defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+		reqBody := `{"model":"my-alias"}`
+		req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+		w := CreateTestResponseRecorder()
+
+		proxy.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// simple-responder echoes back the model name it received
+		assert.Contains(t, w.Body.String(), "my-alias")
+	})
+
+	t.Run("true rewrites alias to real model ID in JSON body", func(t *testing.T) {
+		conf.SendRealModelID = true
+		proxy := New(conf)
+		defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+		reqBody := `{"model":"my-alias"}`
+		req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+		w := CreateTestResponseRecorder()
+
+		proxy.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// simple-responder echoes back the model name it received
+		assert.Contains(t, w.Body.String(), "real-model")
+	})
+
+	t.Run("true rewrites alias to real model ID in multipart form", func(t *testing.T) {
+		conf.SendRealModelID = true
+		proxy := New(conf)
+		defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+		// Create multipart form with alias
+		var b bytes.Buffer
+		w := multipart.NewWriter(&b)
+		fw, _ := w.CreateFormField("model")
+		fw.Write([]byte("my-alias"))
+		fw, _ = w.CreateFormFile("file", "test.mp3")
+		fw.Write([]byte("test"))
+		w.Close()
+
+		req := httptest.NewRequest("POST", "/v1/audio/transcriptions", &b)
+		req.Header.Set("Content-Type", w.FormDataContentType())
+		rec := CreateTestResponseRecorder()
+
+		proxy.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var response map[string]string
+		err := json.Unmarshal(rec.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "real-model", response["model"])
+	})
+
+	t.Run("useModelName takes precedence over sendRealModelID", func(t *testing.T) {
+		// Create config YAML with useModelName set
+		configYAML := fmt.Sprintf(`
+logLevel: error
+healthCheckTimeout: 15
+sendRealModelID: true
+models:
+  real-model:
+    cmd: %s -port ${PORT} -silent -respond real-model
+    aliases:
+      - my-alias
+    useModelName: custom-name
+`, getSimpleResponderPath())
+
+		confWithUseModelName, err := config.LoadConfigFromReader(strings.NewReader(configYAML))
+		assert.NoError(t, err)
+
+		proxy := New(confWithUseModelName)
+		defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+		reqBody := `{"model":"my-alias"}`
+		req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+		w := CreateTestResponseRecorder()
+
+		proxy.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// useModelName should override
+		assert.Contains(t, w.Body.String(), "custom-name")
+	})
+}
+
 func TestProxyManager_AudioVoicesGETHandler(t *testing.T) {
 	conf := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,


### PR DESCRIPTION
When a request uses an alias, llama-swap resolves it for routing but forwards the original alias name to the backend. Backends like vLLM reject this with 404 since they don't recognize the alias.

**Changes:**

1. **proxy: rewrite alias model name in proxied requests**
   - When an alias is used, rewrite the `model` field to the real model ID before proxying
   - Works for both JSON and multipart request bodies

2. **proxy: add sendRealModelID config option**
   - Added global config `sendRealModelID: true` (default: false)
   - At maintainer request - preserves existing behavior by default
   - When enabled, rewrites alias to real model ID
   - `useModelName` still takes precedence when set

3. **proxy: fix test to properly load aliases via LoadConfigFromReader**
   - Tests now properly load aliases via config loading

**Configuration:**
```yaml
sendRealModelID: true  # Enable alias rewriting (default: false)
```

Upstream PR: https://github.com/mostlygeek/llama-swap/pull/638