### PR TITLE
fix: expose context_length in /v1/model

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -251,6 +251,8 @@ models:
     # - optional, default: empty dictionary
     # - while metadata can contains complex types it is recommended to keep it simple
     # - metadata is only passed through in /v1/models responses
+    # - if you set `context_length`, llama-swap also exposes top-level `context_length`
+    #   so clients like Hermes can auto-detect the runtime context
     metadata:
       # port will remain an integer
       port: ${PORT}

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -534,6 +534,7 @@ func (pm *ProxyManager) swapProcessGroup(realModelName string) (*ProcessGroup, e
 	return processGroup, nil
 }
 
+// listModelsHandler returns the OpenAI-compatible /v1/models payload.
 func (pm *ProxyManager) listModelsHandler(c *gin.Context) {
 	data := make([]gin.H, 0, len(pm.config.Models))
 	createdTime := time.Now().Unix()
@@ -619,8 +620,7 @@ func (pm *ProxyManager) listModelsHandler(c *gin.Context) {
 	})
 }
 
-var ctxSizePattern = regexp.MustCompile(`(?:^|\s)(?:-c|--ctx-size)(?:=|\s+)(\d+)(?:\s|$)`)
-
+// modelContextLength returns the runtime context length for a model config.
 func modelContextLength(modelConfig config.ModelConfig) (int, bool) {
 	if modelConfig.Metadata != nil {
 		for _, key := range []string{"context_length", "max_context_length", "max_model_len"} {
@@ -637,6 +637,10 @@ func modelContextLength(modelConfig config.ModelConfig) (int, bool) {
 	return 0, false
 }
 
+// ctxSizePattern matches llama.cpp context-size flags in model commands.
+var ctxSizePattern = regexp.MustCompile(`(?:^|\s)(?:-c|--ctx-size)(?:=|\s+)(\d+)(?:\s|$)`)
+
+// contextLengthFromCmd extracts the runtime context length from a command.
 func contextLengthFromCmd(cmd string) (int, bool) {
 	matches := ctxSizePattern.FindStringSubmatch(cmd)
 	if len(matches) != 2 {
@@ -651,6 +655,7 @@ func contextLengthFromCmd(cmd string) (int, bool) {
 	return contextLength, true
 }
 
+// scalarToInt converts supported scalar metadata values to a positive int.
 func scalarToInt(value any) (int, bool) {
 	switch v := value.(type) {
 	case int:
@@ -694,12 +699,12 @@ func scalarToInt(value any) (int, bool) {
 			return int(v), true
 		}
 	case float32:
-		if v > 0 {
-			return int(v), true
+		if n := int(v); n > 0 {
+			return n, true
 		}
 	case float64:
-		if v > 0 {
-			return int(v), true
+		if n := int(v); n > 0 {
+			return n, true
 		}
 	case string:
 		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -545,6 +546,10 @@ func (pm *ProxyManager) listModelsHandler(c *gin.Context) {
 			"owned_by": "llama-swap",
 		}
 
+		if contextLength, ok := modelContextLength(modelConfig); ok {
+			record["context_length"] = contextLength
+		}
+
 		if name := strings.TrimSpace(modelConfig.Name); name != "" {
 			record["name"] = name
 		}
@@ -612,6 +617,97 @@ func (pm *ProxyManager) listModelsHandler(c *gin.Context) {
 		"object": "list",
 		"data":   data,
 	})
+}
+
+var ctxSizePattern = regexp.MustCompile(`(?:^|\s)(?:-c|--ctx-size)(?:=|\s+)(\d+)(?:\s|$)`)
+
+func modelContextLength(modelConfig config.ModelConfig) (int, bool) {
+	if modelConfig.Metadata != nil {
+		for _, key := range []string{"context_length", "max_context_length", "max_model_len"} {
+			if contextLength, ok := scalarToInt(modelConfig.Metadata[key]); ok {
+				return contextLength, true
+			}
+		}
+	}
+
+	if contextLength, ok := contextLengthFromCmd(modelConfig.Cmd); ok {
+		return contextLength, true
+	}
+
+	return 0, false
+}
+
+func contextLengthFromCmd(cmd string) (int, bool) {
+	matches := ctxSizePattern.FindStringSubmatch(cmd)
+	if len(matches) != 2 {
+		return 0, false
+	}
+
+	contextLength, err := strconv.Atoi(matches[1])
+	if err != nil || contextLength <= 0 {
+		return 0, false
+	}
+
+	return contextLength, true
+}
+
+func scalarToInt(value any) (int, bool) {
+	switch v := value.(type) {
+	case int:
+		if v > 0 {
+			return v, true
+		}
+	case int8:
+		if v > 0 {
+			return int(v), true
+		}
+	case int16:
+		if v > 0 {
+			return int(v), true
+		}
+	case int32:
+		if v > 0 {
+			return int(v), true
+		}
+	case int64:
+		if v > 0 {
+			return int(v), true
+		}
+	case uint:
+		if v > 0 {
+			return int(v), true
+		}
+	case uint8:
+		if v > 0 {
+			return int(v), true
+		}
+	case uint16:
+		if v > 0 {
+			return int(v), true
+		}
+	case uint32:
+		if v > 0 {
+			return int(v), true
+		}
+	case uint64:
+		if v > 0 {
+			return int(v), true
+		}
+	case float32:
+		if v > 0 {
+			return int(v), true
+		}
+	case float64:
+		if v > 0 {
+			return int(v), true
+		}
+	case string:
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {
+			return n, true
+		}
+	}
+
+	return 0, false
 }
 
 // findModelInPath searches for a valid model name in a path with slashes.

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -410,6 +410,64 @@ models:
 	assert.False(t, exists, "model2 should not have llamaswap_meta")
 }
 
+func TestProxyManager_ListModelsHandler_ContextLength(t *testing.T) {
+	configYaml := `
+healthCheckTimeout: 15
+logLevel: error
+startPort: 10000
+models:
+  model1:
+    cmd: /path/to/server --port ${PORT} -c 98304
+  model2:
+    cmd: /path/to/server --port ${PORT} --ctx-size 32768
+  model3:
+    cmd: /path/to/server --port ${PORT}
+    metadata:
+      context_length: 65536
+`
+
+	processedConfig, err := config.LoadConfigFromReader(strings.NewReader(configYaml))
+	assert.NoError(t, err)
+
+	proxy := New(processedConfig)
+	req := httptest.NewRequest("GET", "/v1/models", nil)
+	w := CreateTestResponseRecorder()
+	proxy.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response struct {
+		Data []map[string]any `json:"data"`
+	}
+	err = json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Len(t, response.Data, 3)
+
+	byID := map[string]map[string]any{}
+	for _, model := range response.Data {
+		id, _ := model["id"].(string)
+		byID[id] = model
+	}
+
+	ctx1, ok := byID["model1"]["context_length"].(float64)
+	if !assert.True(t, ok, "model1 should expose context_length") {
+		t.FailNow()
+	}
+	assert.Equal(t, float64(98304), ctx1)
+
+	ctx2, ok := byID["model2"]["context_length"].(float64)
+	if !assert.True(t, ok, "model2 should expose context_length") {
+		t.FailNow()
+	}
+	assert.Equal(t, float64(32768), ctx2)
+
+	ctx3, ok := byID["model3"]["context_length"].(float64)
+	if !assert.True(t, ok, "model3 should expose context_length") {
+		t.FailNow()
+	}
+	assert.Equal(t, float64(65536), ctx3)
+}
+
 func TestProxyManager_ListModelsHandler_SortedByID(t *testing.T) {
 	// Intentionally add models in non-sorted order and with an unlisted model
 	cfg := testConfigFromYAML(t, `

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -424,6 +424,10 @@ models:
     cmd: /path/to/server --port ${PORT}
     metadata:
       context_length: 65536
+  model4:
+    cmd: /path/to/server --port ${PORT}
+  model5:
+    cmd: /path/to/server --port ${PORT} --ctx-size=32768
 `
 
 	processedConfig, err := config.LoadConfigFromReader(strings.NewReader(configYaml))
@@ -441,7 +445,7 @@ models:
 	}
 	err = json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
-	assert.Len(t, response.Data, 3)
+	assert.Len(t, response.Data, 5)
 
 	byID := map[string]map[string]any{}
 	for _, model := range response.Data {
@@ -466,6 +470,15 @@ models:
 		t.FailNow()
 	}
 	assert.Equal(t, float64(65536), ctx3)
+
+	_, ok = byID["model4"]["context_length"]
+	assert.False(t, ok, "model4 should not expose context_length")
+
+	ctx5, ok := byID["model5"]["context_length"].(float64)
+	if !assert.True(t, ok, "model5 should expose context_length") {
+		t.FailNow()
+	}
+	assert.Equal(t, float64(32768), ctx5)
 }
 
 func TestProxyManager_ListModelsHandler_SortedByID(t *testing.T) {


### PR DESCRIPTION

## Summary
Expose runtime context length through llama-swap’s `/v1/models` response so Hermes and other OpenAI-compatible clients can auto-detect it for local models.

## Changes
- Add `context_length` to `/v1/models` when model config provides it
- Fall back to parsing `-c` / `--ctx-size` from the model command
- Keep existing metadata passthrough behavior
- Add proxy tests for metadata-based and cmd-based detection
- Update the config example to document `context_length`
att 


## Testing:
- `go test ./proxy`
- rebuilt the backend with `go build -o build/llama-swap-linux-amd64 .`
- restarted `llama-swap.service`
- confirmed `/v1/models` now returns `context_length` for all models stated in `./llama-swap/config.yaml`


