### PR TITLE
proxy: include StateStopping in resolveAliasRuntime alive check

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -151,6 +151,11 @@
             "default": false,
             "description": "Present aliases within the /v1/models OpenAI API listing. when true, model aliases will be output to the API model listing duplicating all fields except for Id so chat UIs can use the alias equivalent to the original."
         },
+        "sendRealModelID": {
+            "type": "boolean",
+            "default": false,
+            "description": "Send the real model ID to the upstream server when an alias is used. When false (default), the alias name is forwarded as-is. When true, the resolved real model ID is sent to the backend."
+        },
         "macros": {
             "$ref": "#/definitions/macros"
         },

--- a/proxy/config/config.go
+++ b/proxy/config/config.go
@@ -116,8 +116,16 @@ type HookOnStartup struct {
 	Preload []string `yaml:"preload"`
 }
 
+// AliasEntry holds all model IDs that claim an alias and the preferred fallback.
+// Candidates are checked in declaration order for runtime resolution.
+type AliasEntry struct {
+	Candidates []string // all model IDs that registered this alias
+	Preferred  string   // the model to use when nothing is loaded (marked with * in config)
+}
+
 type Config struct {
 	HealthCheckTimeout int                    `yaml:"healthCheckTimeout"`
+	StartupTimeout     int                    `yaml:"startupTimeout"`
 	LogRequests        bool                   `yaml:"logRequests"`
 	LogLevel           string                 `yaml:"logLevel"`
 	LogTimeFormat      string                 `yaml:"logTimeFormat"`
@@ -132,8 +140,8 @@ type Config struct {
 	// for key/value replacements in model's cmd, cmdStop, proxy, checkEndPoint
 	Macros MacroList `yaml:"macros"`
 
-	// map aliases to actual model IDs
-	aliases map[string]string
+	// map aliases to candidate models and preferred fallback
+	aliases map[string]AliasEntry
 
 	// automatic port assignments
 	StartPort int `yaml:"startPort"`
@@ -157,14 +165,24 @@ type Config struct {
 	Peers PeerDictionaryConfig `yaml:"peers"`
 }
 
-func (c *Config) RealModelName(search string) (string, bool) {
-	if _, found := c.Models[search]; found {
-		return search, true
-	} else if name, found := c.aliases[search]; found {
-		return name, found
-	} else {
-		return "", false
+// ResolveAlias returns all candidate model IDs for a given alias or model ID,
+// plus the preferred (fallback) model ID. Use this for runtime resolution.
+func (c *Config) ResolveAlias(search string) (candidates []string, preferred string, found bool) {
+	if _, ok := c.Models[search]; ok {
+		return []string{search}, search, true
 	}
+	if entry, ok := c.aliases[search]; ok {
+		return entry.Candidates, entry.Preferred, true
+	}
+	return nil, "", false
+}
+
+// RealModelName resolves an alias or model ID to a single model ID.
+// Always returns the preferred (starred) model. Use for static resolution
+// (startup preload, config validation) where no process state is available.
+func (c *Config) RealModelName(search string) (string, bool) {
+	_, preferred, found := c.ResolveAlias(search)
+	return preferred, found
 }
 
 func (c *Config) FindConfig(modelName string) (ModelConfig, string, bool) {
@@ -217,6 +235,12 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		config.HealthCheckTimeout = 15
 	}
 
+	// StartupTimeout defaults to 30 minutes (1800s) for vLLM container startup
+	// Minimum 60s to prevent premature timeout during model loading
+	if config.StartupTimeout < 60 {
+		config.StartupTimeout = 1800
+	}
+
 	if config.StartPort < 1 {
 		return Config{}, fmt.Errorf("startPort must be greater than 1")
 	}
@@ -232,13 +256,32 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 	}
 
 	// Populate the aliases map
-	config.aliases = make(map[string]string)
+	config.aliases = make(map[string]AliasEntry)
 	for modelName, modelConfig := range config.Models {
-		for _, alias := range modelConfig.Aliases {
-			if _, found := config.aliases[alias]; found {
-				return Config{}, fmt.Errorf("duplicate alias %s found in model: %s", alias, modelName)
+		for _, rawAlias := range modelConfig.Aliases {
+			isPreferred := strings.HasSuffix(rawAlias, "*")
+			alias := strings.TrimSuffix(rawAlias, "*")
+
+			entry := config.aliases[alias]
+			entry.Candidates = append(entry.Candidates, modelName)
+			if isPreferred {
+				if entry.Preferred != "" {
+					return Config{}, fmt.Errorf("alias %s has multiple preferred (*) models: %s and %s", alias, entry.Preferred, modelName)
+				}
+				entry.Preferred = modelName
 			}
-			config.aliases[alias] = modelName
+			config.aliases[alias] = entry
+		}
+	}
+	// Validate: multi-candidate aliases must have exactly one preferred; set implicit preferred for single-candidate aliases
+	for alias, entry := range config.aliases {
+		if len(entry.Candidates) > 1 && entry.Preferred == "" {
+			return Config{}, fmt.Errorf("alias %s has multiple models but no preferred (*) model", alias)
+		}
+		if entry.Preferred == "" {
+			// single-candidate alias — set preferred implicitly
+			entry.Preferred = entry.Candidates[0]
+			config.aliases[alias] = entry
 		}
 	}
 
@@ -419,13 +462,16 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 			if _, exists := config.Models[key]; exists {
 				return Config{}, fmt.Errorf("model %s filters.setParamsByID: key '%s' conflicts with an existing model ID", modelId, key)
 			}
-			if existingModel, exists := config.aliases[key]; exists {
-				if existingModel != modelId {
-					return Config{}, fmt.Errorf("duplicate alias '%s' in model %s filters.setParamsByID, already used by model %s", key, modelId, existingModel)
+			if existingEntry, exists := config.aliases[key]; exists {
+				if existingEntry.Preferred != modelId {
+					return Config{}, fmt.Errorf("duplicate alias '%s' in model %s filters.setParamsByID, already used by model %s", key, modelId, existingEntry.Preferred)
 				}
 				continue // already registered as explicit alias for this model
 			}
-			config.aliases[key] = modelId
+			config.aliases[key] = AliasEntry{
+				Candidates: []string{modelId},
+				Preferred:  modelId,
+			}
 			modelConfig.Aliases = append(modelConfig.Aliases, key)
 		}
 

--- a/proxy/config/config.go
+++ b/proxy/config/config.go
@@ -147,6 +147,9 @@ type Config struct {
 	// present aliases to /v1/models OpenAI API listing
 	IncludeAliasesInList bool `yaml:"includeAliasesInList"`
 
+	// send real model ID to upstream when alias is used
+	SendRealModelID bool `yaml:"sendRealModelID"`
+
 	// support API keys, see issue #433, #50, #251
 	RequiredAPIKeys []string `yaml:"apiKeys"`
 

--- a/proxy/config/config_posix_test.go
+++ b/proxy/config/config_posix_test.go
@@ -242,16 +242,17 @@ groups:
 			},
 		},
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		MetricsMaxInMemory: 1000,
 		CaptureBuffer:      5,
 		Profiles: map[string][]string{
 			"test": {"model1", "model2"},
 		},
-		aliases: map[string]string{
-			"m1":        "model1",
-			"model-one": "model1",
-			"m2":        "model2",
-			"mthree":    "model3",
+		aliases: map[string]AliasEntry{
+			"m1":        {Candidates: []string{"model1"}, Preferred: "model1"},
+			"model-one": {Candidates: []string{"model1"}, Preferred: "model1"},
+			"m2":        {Candidates: []string{"model2"}, Preferred: "model2"},
+			"mthree":    {Candidates: []string{"model3"}, Preferred: "model3"},
 		},
 		Groups: map[string]GroupConfig{
 			DEFAULT_GROUP_ID: {

--- a/proxy/config/config_test.go
+++ b/proxy/config/config_test.go
@@ -63,7 +63,7 @@ models:
 
 	// this is a contains because it could be `model1` or `model2` depending on the order
 	// go decided on the order of the map
-	assert.Contains(t, err.Error(), "duplicate alias m1 found in model: model")
+	assert.Contains(t, err.Error(), "alias m1 has multiple models but no preferred")
 }
 
 func TestConfig_FindConfig(t *testing.T) {
@@ -88,10 +88,10 @@ func TestConfig_FindConfig(t *testing.T) {
 			},
 		},
 		HealthCheckTimeout: 10,
-		aliases: map[string]string{
-			"m1":        "model1",
-			"model-one": "model1",
-			"m2":        "model2",
+		aliases: map[string]AliasEntry{
+			"m1":        {Candidates: []string{"model1"}, Preferred: "model1"},
+			"model-one": {Candidates: []string{"model1"}, Preferred: "model1"},
+			"m2":        {Candidates: []string{"model2"}, Preferred: "model2"},
 		},
 	}
 

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -57,6 +57,7 @@ type Process struct {
 	proxyLogger   *LogMonitor
 
 	healthCheckTimeout      int
+	startupTimeout          int
 	healthCheckLoopInterval time.Duration
 
 	lastRequestHandledMutex sync.RWMutex
@@ -81,7 +82,7 @@ type Process struct {
 	failedStartCount int
 }
 
-func NewProcess(ID string, healthCheckTimeout int, config config.ModelConfig, processLogger *LogMonitor, proxyLogger *LogMonitor) *Process {
+func NewProcess(ID string, healthCheckTimeout int, startupTimeout int, config config.ModelConfig, processLogger *LogMonitor, proxyLogger *LogMonitor) *Process {
 	concurrentLimit := 10
 	if config.ConcurrencyLimit > 0 {
 		concurrentLimit = config.ConcurrencyLimit
@@ -132,6 +133,7 @@ func NewProcess(ID string, healthCheckTimeout int, config config.ModelConfig, pr
 		processLogger:           processLogger,
 		proxyLogger:             proxyLogger,
 		healthCheckTimeout:      healthCheckTimeout,
+		startupTimeout:          startupTimeout,
 		healthCheckLoopInterval: 5 * time.Second, /* default, can not be set by user - used for testing */
 		state:                   StateStopped,
 
@@ -310,7 +312,7 @@ func (p *Process) start() error {
 	<-time.After(250 * time.Millisecond) // give process a bit of time to start
 
 	checkStartTime := time.Now()
-	maxDuration := time.Second * time.Duration(p.healthCheckTimeout)
+	maxDuration := time.Second * time.Duration(p.startupTimeout)
 	checkEndpoint := strings.TrimSpace(p.config.CheckEndpoint)
 
 	// a "none" means don't check for health ... I could have picked a better word :facepalm:
@@ -615,6 +617,22 @@ func (p *Process) waitForCmd() {
 	case StateStopping:
 		if curState, err := p.swapState(StateStopping, StateStopped); err != nil {
 			p.proxyLogger.Errorf("<%s> Process exited but could not swap to StateStopped. curState=%s, err: %v", p.ID, curState, err)
+			p.forceState(StateStopped)
+		}
+	case StateReady:
+		// Process crashed during runtime - attempt auto-restart
+		const maxRestarts = 5
+		if p.failedStartCount < maxRestarts {
+			p.proxyLogger.Warnf("<%s> Process crashed in StateReady, attempting auto-restart (%d/%d)", p.ID, p.failedStartCount+1, maxRestarts)
+			// Brief sleep to avoid restart loops
+			time.Sleep(30 * time.Second)
+			// Restart the process (this will increment failedStartCount again if it fails)
+			if err := p.start(); err != nil {
+				p.proxyLogger.Errorf("<%s> Auto-restart failed: %v", p.ID, err)
+				p.forceState(StateStopped)
+			}
+		} else {
+			p.proxyLogger.Errorf("<%s> Process crashed in StateReady but max restarts (%d) reached, giving up", p.ID, maxRestarts)
 			p.forceState(StateStopped)
 		}
 	default:

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -353,9 +353,15 @@ func (p *Process) start() error {
 		}
 	}
 
+	if curState, err := p.swapState(StateStarting, StateReady); err != nil {
+		return fmt.Errorf("failed to set Process state to ready: current state: %v, error: %v", curState, err)
+	}
+	p.failedStartCount = 0
+
+	// Start TTL goroutine AFTER the model is in StateReady.
+	// If started before swapState, the goroutine ticks once, sees StateStarting,
+	// and returns — TTL never actually runs for models that take >1s to load.
 	if p.config.UnloadAfter > 0 {
-		// start a goroutine to check every second if
-		// the process should be stopped
 		go func() {
 			maxDuration := time.Duration(p.config.UnloadAfter) * time.Second
 
@@ -378,12 +384,7 @@ func (p *Process) start() error {
 		}()
 	}
 
-	if curState, err := p.swapState(StateStarting, StateReady); err != nil {
-		return fmt.Errorf("failed to set Process state to ready: current state: %v, error: %v", curState, err)
-	} else {
-		p.failedStartCount = 0
-		return nil
-	}
+	return nil
 }
 
 // Stop will wait for inflight requests to complete before stopping the process.

--- a/proxy/process_test.go
+++ b/proxy/process_test.go
@@ -34,7 +34,7 @@ func TestProcess_AutomaticallyStartsUpstream(t *testing.T) {
 	config := getTestSimpleResponderConfig(expectedMessage)
 
 	// Create a process
-	process := NewProcess("test-process", 5, config, debugLogger, debugLogger)
+	process := NewProcess("test-process", 5, 1800, config, debugLogger, debugLogger)
 	defer process.Stop()
 
 	req := httptest.NewRequest("GET", "/test", nil)
@@ -70,7 +70,7 @@ func TestProcess_WaitOnMultipleStarts(t *testing.T) {
 	expectedMessage := "testing91931"
 	config := getTestSimpleResponderConfig(expectedMessage)
 
-	process := NewProcess("test-process", 5, config, debugLogger, debugLogger)
+	process := NewProcess("test-process", 5, 1800, config, debugLogger, debugLogger)
 	defer process.Stop()
 
 	var wg sync.WaitGroup
@@ -98,7 +98,7 @@ func TestProcess_BrokenModelConfig(t *testing.T) {
 		CheckEndpoint: "/health",
 	}
 
-	process := NewProcess("broken", 1, config, debugLogger, debugLogger)
+	process := NewProcess("broken", 1, 1800, config, debugLogger, debugLogger)
 
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
@@ -123,7 +123,7 @@ func TestProcess_UnloadAfterTTL(t *testing.T) {
 	conf.UnloadAfter = 3 // seconds
 	assert.Equal(t, 3, conf.UnloadAfter)
 
-	process := NewProcess("ttl_test", 2, conf, debugLogger, debugLogger)
+	process := NewProcess("ttl_test", 2, 1800, conf, debugLogger, debugLogger)
 	defer process.Stop()
 
 	// this should take 4 seconds
@@ -165,7 +165,7 @@ func TestProcess_LowTTLValue(t *testing.T) {
 	conf.UnloadAfter = 1 // second
 	assert.Equal(t, 1, conf.UnloadAfter)
 
-	process := NewProcess("ttl", 2, conf, debugLogger, debugLogger)
+	process := NewProcess("ttl", 2, 1800, conf, debugLogger, debugLogger)
 	defer process.Stop()
 
 	for i := 0; i < 100; i++ {
@@ -192,7 +192,7 @@ func TestProcess_HTTPRequestsHaveTimeToFinish(t *testing.T) {
 
 	expectedMessage := "12345"
 	config := getTestSimpleResponderConfig(expectedMessage)
-	process := NewProcess("t", 10, config, debugLogger, debugLogger)
+	process := NewProcess("t", 10, 1800, config, debugLogger, debugLogger)
 	defer process.Stop()
 
 	results := map[string]string{
@@ -265,7 +265,7 @@ func TestProcess_SwapState(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			p := NewProcess("test", 10, getTestSimpleResponderConfig("test"), debugLogger, debugLogger)
+			p := NewProcess("test", 10, 1800, getTestSimpleResponderConfig("test"), debugLogger, debugLogger)
 			p.state = test.currentState
 
 			resultState, err := p.swapState(test.expectedState, test.newState)
@@ -298,7 +298,7 @@ func TestProcess_ShutdownInterruptsHealthCheck(t *testing.T) {
 	config.Proxy = "http://localhost:9998/test"
 
 	healthCheckTTLSeconds := 30
-	process := NewProcess("test-process", healthCheckTTLSeconds, config, debugLogger, debugLogger)
+	process := NewProcess("test-process", healthCheckTTLSeconds, 1800, config, debugLogger, debugLogger)
 
 	// make it a lot faster
 	process.healthCheckLoopInterval = time.Second
@@ -333,7 +333,7 @@ func TestProcess_ExitInterruptsHealthCheck(t *testing.T) {
 		CheckEndpoint: "/health",
 	}
 
-	process := NewProcess("sleepy", checkHealthTimeout, config, debugLogger, debugLogger)
+	process := NewProcess("sleepy", checkHealthTimeout, 1800, config, debugLogger, debugLogger)
 	process.healthCheckLoopInterval = time.Second // make it faster
 	err := process.start()
 	assert.Equal(t, "upstream command exited prematurely but successfully", err.Error())
@@ -351,7 +351,7 @@ func TestProcess_ConcurrencyLimit(t *testing.T) {
 	// only allow 1 concurrent request at a time
 	config.ConcurrencyLimit = 1
 
-	process := NewProcess("ttl_test", 2, config, debugLogger, debugLogger)
+	process := NewProcess("ttl_test", 2, 1800, config, debugLogger, debugLogger)
 	assert.Equal(t, 1, cap(process.concurrencyLimitSemaphore))
 	defer process.Stop()
 
@@ -376,7 +376,7 @@ func TestProcess_StopImmediately(t *testing.T) {
 	expectedMessage := "test_stop_immediate"
 	config := getTestSimpleResponderConfig(expectedMessage)
 
-	process := NewProcess("stop_immediate", 2, config, debugLogger, debugLogger)
+	process := NewProcess("stop_immediate", 2, 1800, config, debugLogger, debugLogger)
 	defer process.Stop()
 
 	err := process.start()
@@ -416,7 +416,7 @@ func TestProcess_ForceStopWithKill(t *testing.T) {
 		CheckEndpoint: "/health",
 	}
 
-	process := NewProcess("stop_immediate", 2, conf, debugLogger, debugLogger)
+	process := NewProcess("stop_immediate", 2, 1800, conf, debugLogger, debugLogger)
 	defer process.Stop()
 
 	// reduce to make testing go faster
@@ -466,7 +466,7 @@ func TestProcess_StopCmd(t *testing.T) {
 		conf.CmdStop = "kill -TERM ${PID}"
 	}
 
-	process := NewProcess("testStopCmd", 2, conf, debugLogger, debugLogger)
+	process := NewProcess("testStopCmd", 2, 1800, conf, debugLogger, debugLogger)
 	defer process.Stop()
 
 	err := process.start()
@@ -486,8 +486,8 @@ func TestProcess_EnvironmentSetCorrectly(t *testing.T) {
 	// ensure the additiona variables are appended to the process' environment
 	configWEnv.Env = append(configWEnv.Env, "TEST_ENV1=1", "TEST_ENV2=2")
 
-	process1 := NewProcess("env_test", 2, conf, debugLogger, debugLogger)
-	process2 := NewProcess("env_test", 2, configWEnv, debugLogger, debugLogger)
+	process1 := NewProcess("env_test", 2, 1800, conf, debugLogger, debugLogger)
+	process2 := NewProcess("env_test", 2, 1800, configWEnv, debugLogger, debugLogger)
 
 	process1.start()
 	defer process1.Stop()
@@ -522,7 +522,7 @@ func TestProcess_ReverseProxyPanicIsHandled(t *testing.T) {
 	expectedMessage := "panic_test"
 	config := getTestSimpleResponderConfig(expectedMessage)
 
-	process := NewProcess("panic-test", 5, config, debugLogger, debugLogger)
+	process := NewProcess("panic-test", 5, 1800, config, debugLogger, debugLogger)
 	defer process.Stop()
 
 	// Start the process
@@ -586,7 +586,7 @@ func TestProcess_CustomTimeouts(t *testing.T) {
 	}
 
 	debugLogger := NewLogMonitorWriter(io.Discard)
-	process := NewProcess("test-model", 30, modelConfig, debugLogger, debugLogger)
+	process := NewProcess("test-model", 30, 1800, modelConfig, debugLogger, debugLogger)
 
 	// Verify the process was created successfully
 	assert.NotNil(t, process)

--- a/proxy/processgroup.go
+++ b/proxy/processgroup.go
@@ -47,7 +47,7 @@ func NewProcessGroup(id string, config config.Config, proxyLogger *LogMonitor, u
 	for _, modelID := range groupConfig.Members {
 		modelConfig, modelID, _ := pg.config.FindConfig(modelID)
 		processLogger := NewLogMonitorWriter(upstreamLogger)
-		process := NewProcess(modelID, pg.config.HealthCheckTimeout, modelConfig, processLogger, pg.proxyLogger)
+		process := NewProcess(modelID, pg.config.HealthCheckTimeout, pg.config.StartupTimeout, modelConfig, processLogger, pg.proxyLogger)
 		pg.processes[modelID] = process
 	}
 

--- a/proxy/processgroup_test.go
+++ b/proxy/processgroup_test.go
@@ -13,6 +13,7 @@ import (
 
 var processGroupTestConfig = config.AddDefaultGroupToConfig(config.Config{
 	HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 	Models: map[string]config.ModelConfig{
 		"model1": getTestSimpleResponderConfig("model1"),
 		"model2": getTestSimpleResponderConfig("model2"),
@@ -55,6 +56,7 @@ func TestProcessGroup_ProxyRequestSwapIsTrueParallel(t *testing.T) {
 
 	var processGroupTestConfig = config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			// use the same listening so if a model is already running, it will fail
 			// this is a way to test that swap isolation is working

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -632,7 +632,7 @@ func (pm *ProxyManager) findModelInPath(path string) (searchName string, realNam
 			searchModelName = searchModelName + "/" + part
 		}
 
-		if modelID, ok := pm.config.RealModelName(searchModelName); ok {
+		if modelID := pm.resolveAliasRuntime(searchModelName); modelID != "" {
 			return searchModelName, modelID, "/" + strings.Join(parts[i+1:], "/"), true
 		}
 	}
@@ -708,9 +708,10 @@ func (pm *ProxyManager) proxyInferenceHandler(c *gin.Context) {
 
 	// Look for a matching local model first
 	var nextHandler func(modelID string, w http.ResponseWriter, r *http.Request) error
+	var modelID string
 
-	modelID, found := pm.config.RealModelName(requestedModel)
-	if found {
+	modelID = pm.resolveAliasRuntime(requestedModel)
+	if modelID != "" {
 		processGroup, err := pm.swapProcessGroup(modelID)
 		if err != nil {
 			pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error swapping process group: %s", err.Error()))
@@ -855,9 +856,10 @@ func (pm *ProxyManager) proxyOAIPostFormHandler(c *gin.Context) {
 	// Look for a matching local model first, then check peers
 	var nextHandler func(modelID string, w http.ResponseWriter, r *http.Request) error
 	var useModelName string
+	var modelID string
 
-	modelID, found := pm.config.RealModelName(requestedModel)
-	if found {
+	modelID = pm.resolveAliasRuntime(requestedModel)
+	if modelID != "" {
 		processGroup, err := pm.swapProcessGroup(modelID)
 		if err != nil {
 			pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error swapping process group: %s", err.Error()))
@@ -977,13 +979,13 @@ func (pm *ProxyManager) proxyGETModelHandler(c *gin.Context) {
 	var nextHandler func(modelID string, w http.ResponseWriter, r *http.Request) error
 	var modelID string
 
-	if realModelID, found := pm.config.RealModelName(requestedModel); found {
-		processGroup, err := pm.swapProcessGroup(realModelID)
+	modelID = pm.resolveAliasRuntime(requestedModel)
+	if modelID != "" {
+		processGroup, err := pm.swapProcessGroup(modelID)
 		if err != nil {
 			pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error swapping process group: %s", err.Error()))
 			return
 		}
-		modelID = realModelID
 		pm.proxyLogger.Debugf("ProxyManager using local Process for model: %s", requestedModel)
 		nextHandler = processGroup.ProxyRequest
 	} else if pm.peerProxy != nil && pm.peerProxy.HasPeerModel(requestedModel) {
@@ -1115,6 +1117,28 @@ func (pm *ProxyManager) findGroupByModelName(modelName string) *ProcessGroup {
 		}
 	}
 	return nil
+}
+
+// resolveAliasRuntime resolves an alias at runtime by checking StateReady or StateStarting first,
+// then falling back to the preferred model. Returns the model ID to use, or empty string if not found.
+func (pm *ProxyManager) resolveAliasRuntime(requestedModel string) string {
+	candidates, preferred, found := pm.config.ResolveAlias(requestedModel)
+	if !found {
+		return ""
+	}
+	// Check if any candidate is currently in StateReady or StateStarting
+	for _, candidate := range candidates {
+		if processGroup := pm.findGroupByModelName(candidate); processGroup != nil {
+			for _, proc := range processGroup.processes {
+				state := proc.CurrentState()
+				if state == StateReady || state == StateStarting {
+					return candidate
+				}
+			}
+		}
+	}
+	// Fall back to preferred
+	return preferred
 }
 
 func (pm *ProxyManager) SetVersion(buildDate string, commit string, version string) {

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -1126,12 +1126,12 @@ func (pm *ProxyManager) resolveAliasRuntime(requestedModel string) string {
 	if !found {
 		return ""
 	}
-	// Check if any candidate is currently in StateReady or StateStarting
+	// Check if any candidate is currently in StateReady, StateStarting, or StateStopping
 	for _, candidate := range candidates {
 		if processGroup := pm.findGroupByModelName(candidate); processGroup != nil {
 			for _, proc := range processGroup.processes {
 				state := proc.CurrentState()
-				if state == StateReady || state == StateStarting {
+				if state == StateReady || state == StateStarting || state == StateStopping {
 					return candidate
 				}
 			}

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -213,35 +213,63 @@ func New(proxyConfig config.Config) *ProxyManager {
 
 	// run any startup hooks
 	if len(proxyConfig.Hooks.OnStartup.Preload) > 0 {
-		// do it in the background, don't block startup -- not sure if good idea yet
+		// do it in the background, don't block startup
 		go func() {
-			discardWriter := &DiscardWriter{}
+			// Batch contiguous same-group models for parallel preload.
+			// Non-contiguous entries for the same group start separate batches,
+			// preserving the original preload sequence and exclusivity semantics.
+			type groupEntry struct {
+				id     string
+				models []string
+			}
+			var groupOrder []groupEntry
+			var lastGroupID string
+
 			for _, preloadModelName := range proxyConfig.Hooks.OnStartup.Preload {
 				modelID, ok := proxyConfig.RealModelName(preloadModelName)
-
 				if !ok {
 					proxyLogger.Warnf("Preload model %s not found in config", preloadModelName)
 					continue
 				}
-
-				proxyLogger.Infof("Preloading model: %s", modelID)
-				processGroup, err := pm.swapProcessGroup(modelID)
-
-				if err != nil {
-					event.Emit(ModelPreloadedEvent{
-						ModelName: modelID,
-						Success:   false,
-					})
-					proxyLogger.Errorf("Failed to preload model %s: %v", modelID, err)
+				pg := pm.findGroupByModelName(modelID)
+				if pg == nil {
+					proxyLogger.Warnf("Preload model %s has no process group", modelID)
 					continue
-				} else {
-					req, _ := http.NewRequest("GET", "/", nil)
-					processGroup.ProxyRequest(modelID, discardWriter, req)
-					event.Emit(ModelPreloadedEvent{
-						ModelName: modelID,
-						Success:   true,
-					})
 				}
+				if pg.id == lastGroupID {
+					groupOrder[len(groupOrder)-1].models = append(groupOrder[len(groupOrder)-1].models, modelID)
+				} else {
+					groupOrder = append(groupOrder, groupEntry{id: pg.id, models: []string{modelID}})
+					lastGroupID = pg.id
+				}
+			}
+
+			for _, ge := range groupOrder {
+				// Swap to this group (handles exclusivity — idles other groups)
+				processGroup, err := pm.swapProcessGroup(ge.models[0])
+				if err != nil {
+					for _, mid := range ge.models {
+						event.Emit(ModelPreloadedEvent{ModelName: mid, Success: false})
+						proxyLogger.Errorf("Failed to preload model %s: %v", mid, err)
+					}
+					continue
+				}
+
+				// Start all models in this group in parallel
+				var wg sync.WaitGroup
+				for _, modelID := range ge.models {
+					wg.Add(1)
+					go func(mid string) {
+						defer wg.Done()
+						proxyLogger.Infof("Preloading model: %s", mid)
+						req, _ := http.NewRequest("GET", "/", nil)
+						processGroup.ProxyRequest(mid, &DiscardWriter{}, req)
+						event.Emit(ModelPreloadedEvent{ModelName: mid, Success: true})
+						proxyLogger.Infof("Preloaded model: %s", mid)
+					}(modelID)
+				}
+				wg.Wait()
+				proxyLogger.Infof("Preloaded group %s (%d models)", ge.id, len(ge.models))
 			}
 		}()
 	}

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -725,6 +725,13 @@ func (pm *ProxyManager) proxyInferenceHandler(c *gin.Context) {
 				pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error rewriting model name in JSON: %s", err.Error()))
 				return
 			}
+		} else if requestedModel != modelID && pm.config.SendRealModelID {
+			// Rewrite alias to real model name so the backend recognizes it
+			bodyBytes, err = sjson.SetBytes(bodyBytes, "model", modelID)
+			if err != nil {
+				pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error rewriting model name in JSON: %s", err.Error()))
+				return
+			}
 		}
 
 		// issue #174 strip parameters from the JSON body
@@ -885,8 +892,9 @@ func (pm *ProxyManager) proxyOAIPostFormHandler(c *gin.Context) {
 				// # issue #69 allow custom model names to be sent to upstream
 				if useModelName != "" {
 					fieldValue = useModelName
-				} else {
-					fieldValue = requestedModel
+				} else if requestedModel != modelID && pm.config.SendRealModelID {
+					// Rewrite alias to real model name so the backend recognizes it
+					fieldValue = modelID
 				}
 			}
 			field, err := multipartWriter.CreateFormField(key)

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -850,6 +850,113 @@ func TestProxyManager_UseModelName(t *testing.T) {
 	})
 }
 
+// TestProxyManager_SendRealModelID tests the sendRealModelID config option
+func TestProxyManager_SendRealModelID(t *testing.T) {
+	// Create config YAML with an alias
+	configYAML := fmt.Sprintf(`
+logLevel: error
+healthCheckTimeout: 15
+models:
+  real-model:
+    cmd: %s -port ${PORT} -silent -respond real-model
+    aliases:
+      - my-alias
+`, getSimpleResponderPath())
+
+	conf, err := config.LoadConfigFromReader(strings.NewReader(configYAML))
+	assert.NoError(t, err)
+
+	t.Run("default false does not rewrite alias to real model ID", func(t *testing.T) {
+		conf.SendRealModelID = false
+		proxy := New(conf)
+		defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+		reqBody := `{"model":"my-alias"}`
+		req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+		w := CreateTestResponseRecorder()
+
+		proxy.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// simple-responder echoes back the model name it received
+		assert.Contains(t, w.Body.String(), "my-alias")
+	})
+
+	t.Run("true rewrites alias to real model ID in JSON body", func(t *testing.T) {
+		conf.SendRealModelID = true
+		proxy := New(conf)
+		defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+		reqBody := `{"model":"my-alias"}`
+		req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+		w := CreateTestResponseRecorder()
+
+		proxy.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// simple-responder echoes back the model name it received
+		assert.Contains(t, w.Body.String(), "real-model")
+	})
+
+	t.Run("true rewrites alias to real model ID in multipart form", func(t *testing.T) {
+		conf.SendRealModelID = true
+		proxy := New(conf)
+		defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+		// Create multipart form with alias
+		var b bytes.Buffer
+		w := multipart.NewWriter(&b)
+		fw, _ := w.CreateFormField("model")
+		fw.Write([]byte("my-alias"))
+		fw, _ = w.CreateFormFile("file", "test.mp3")
+		fw.Write([]byte("test"))
+		w.Close()
+
+		req := httptest.NewRequest("POST", "/v1/audio/transcriptions", &b)
+		req.Header.Set("Content-Type", w.FormDataContentType())
+		rec := CreateTestResponseRecorder()
+
+		proxy.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var response map[string]string
+		err := json.Unmarshal(rec.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		assert.Equal(t, "real-model", response["model"])
+	})
+
+	t.Run("useModelName takes precedence over sendRealModelID", func(t *testing.T) {
+		// Create config YAML with useModelName set
+		configYAML := fmt.Sprintf(`
+logLevel: error
+healthCheckTimeout: 15
+sendRealModelID: true
+models:
+  real-model:
+    cmd: %s -port ${PORT} -silent -respond real-model
+    aliases:
+      - my-alias
+    useModelName: custom-name
+`, getSimpleResponderPath())
+
+		confWithUseModelName, err := config.LoadConfigFromReader(strings.NewReader(configYAML))
+		assert.NoError(t, err)
+
+		proxy := New(confWithUseModelName)
+		defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+		reqBody := `{"model":"my-alias"}`
+		req := httptest.NewRequest("POST", "/v1/chat/completions", bytes.NewBufferString(reqBody))
+		w := CreateTestResponseRecorder()
+
+		proxy.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// useModelName should override
+		assert.Contains(t, w.Body.String(), "custom-name")
+	})
+}
+
 func TestProxyManager_AudioVoicesGETHandler(t *testing.T) {
 	conf := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -47,6 +47,7 @@ func CreateTestResponseRecorder() *TestResponseRecorder {
 func TestProxyManager_SwapProcessCorrectly(t *testing.T) {
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"),
 			"model2": getTestSimpleResponderConfig("model2"),
@@ -70,6 +71,7 @@ func TestProxyManager_SwapProcessCorrectly(t *testing.T) {
 func TestProxyManager_SwapMultiProcess(t *testing.T) {
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"),
 			"model2": getTestSimpleResponderConfig("model2"),
@@ -115,6 +117,7 @@ func TestProxyManager_SwapMultiProcess(t *testing.T) {
 func TestProxyManager_PersistentGroupsAreNotSwapped(t *testing.T) {
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"), // goes into the default group
 			"model2": getTestSimpleResponderConfig("model2"),
@@ -159,6 +162,7 @@ func TestProxyManager_SwapMultiProcessParallelRequests(t *testing.T) {
 
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"),
 			"model2": getTestSimpleResponderConfig("model2"),
@@ -222,6 +226,7 @@ func TestProxyManager_ListModelsHandler(t *testing.T) {
 
 	cfg := config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": model1Config,
 			"model2": model2Config,
@@ -414,6 +419,7 @@ func TestProxyManager_ListModelsHandler_SortedByID(t *testing.T) {
 	// Intentionally add models in non-sorted order and with an unlisted model
 	config := config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"zeta":  getTestSimpleResponderConfig("zeta"),
 			"alpha": getTestSimpleResponderConfig("alpha"),
@@ -536,6 +542,7 @@ func TestProxyManager_Shutdown(t *testing.T) {
 
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": model1Config,
 			"model2": model2Config,
@@ -579,6 +586,7 @@ func TestProxyManager_Shutdown(t *testing.T) {
 func TestProxyManager_Unload(t *testing.T) {
 	conf := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"),
 		},
@@ -611,6 +619,7 @@ func TestProxyManager_UnloadSingleModel(t *testing.T) {
 	const testGroupId = "testGroup"
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"),
 			"model2": getTestSimpleResponderConfig("model2"),
@@ -662,6 +671,7 @@ func TestProxyManager_RunningEndpoint(t *testing.T) {
 	// Shared configuration
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"),
 			"model2": getTestSimpleResponderConfig("model2"),
@@ -737,6 +747,7 @@ func TestProxyManager_RunningEndpoint(t *testing.T) {
 func TestProxyManager_AudioTranscriptionHandler(t *testing.T) {
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"TheExpectedModel": getTestSimpleResponderConfig("TheExpectedModel"),
 		},
@@ -790,6 +801,7 @@ func TestProxyManager_UseModelName(t *testing.T) {
 
 	conf := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": modelConfig,
 		},
@@ -960,6 +972,7 @@ models:
 func TestProxyManager_AudioVoicesGETHandler(t *testing.T) {
 	conf := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"),
 		},
@@ -997,6 +1010,7 @@ func TestProxyManager_AudioVoicesGETHandler(t *testing.T) {
 func TestProxyManager_CORSOptionsHandler(t *testing.T) {
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"),
 		},
@@ -1096,6 +1110,7 @@ models:
 func TestProxyManager_ChatContentLength(t *testing.T) {
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"),
 		},
@@ -1127,6 +1142,7 @@ func TestProxyManager_FiltersStripParams(t *testing.T) {
 
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		LogLevel:           "error",
 		Models: map[string]config.ModelConfig{
 			"model1": modelConfig,
@@ -1211,6 +1227,7 @@ models:
 func TestProxyManager_HealthEndpoint(t *testing.T) {
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"),
 		},
@@ -1230,6 +1247,7 @@ func TestProxyManager_HealthEndpoint(t *testing.T) {
 func TestProxyManager_CompletionEndpoint(t *testing.T) {
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"),
 		},
@@ -1310,6 +1328,7 @@ models:
 func TestProxyManager_StreamingEndpointsReturnNoBufferingHeader(t *testing.T) {
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1":       getTestSimpleResponderConfig("model1"),
 			"author/model": getTestSimpleResponderConfig("author/model"),
@@ -1361,6 +1380,7 @@ func TestProxyManager_StreamingEndpointsReturnNoBufferingHeader(t *testing.T) {
 func TestProxyManager_ProxiedStreamingEndpointReturnsNoBufferingHeader(t *testing.T) {
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"streaming-model": getTestSimpleResponderConfig("streaming-model"),
 		},
@@ -1386,6 +1406,7 @@ func TestProxyManager_ProxiedStreamingEndpointReturnsNoBufferingHeader(t *testin
 func TestProxyManager_ApiGetVersion(t *testing.T) {
 	config := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"),
 		},
@@ -1424,6 +1445,7 @@ func TestProxyManager_ApiGetVersion(t *testing.T) {
 func TestProxyManager_APIKeyAuth(t *testing.T) {
 	testConfig := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"),
 		},
@@ -1536,6 +1558,7 @@ func TestProxyManager_APIKeyAuth_Disabled(t *testing.T) {
 	// Config without RequiredAPIKeys - auth should be disabled
 	testConfig := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"model1": getTestSimpleResponderConfig("model1"),
 		},
@@ -1710,6 +1733,7 @@ models:
 	t.Run("no peers configured - unknown model returns error", func(t *testing.T) {
 		testConfig := config.AddDefaultGroupToConfig(config.Config{
 			HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 			Models: map[string]config.ModelConfig{
 				"local-model": getTestSimpleResponderConfig("local-model"),
 			},
@@ -1770,6 +1794,7 @@ models:
 func TestProxyManager_SdApiTxt2ImgRouting(t *testing.T) {
 	conf := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"sd-model": getTestSimpleResponderConfig("sd-model"),
 		},
@@ -1813,6 +1838,7 @@ func TestProxyManager_SdApiTxt2ImgRouting(t *testing.T) {
 func TestProxyManager_SdApiGetLoras(t *testing.T) {
 	conf := config.AddDefaultGroupToConfig(config.Config{
 		HealthCheckTimeout: 15,
+		StartupTimeout:     1800,
 		Models: map[string]config.ModelConfig{
 			"sd-model": getTestSimpleResponderConfig("sd-model"),
 		},
@@ -1844,4 +1870,74 @@ func TestProxyManager_SdApiGetLoras(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Contains(t, w.Body.String(), "could not find suitable handler")
 	})
+}
+
+// TestProxyManager_AliasWithStateStarting prevents regression of the infinite loop bug
+// where requests for an alias would trigger model swaps even when the preferred model
+// was already in StateStarting. The bug occurred because resolveAliasRuntime only
+// checked StateReady, not StateStarting.
+func TestProxyManager_AliasWithStateStarting(t *testing.T) {
+	// Use YAML config to properly test multi-alias with preferred model
+	yamlConfig := `
+healthCheckTimeout: 15
+startPort: 9990
+models:
+  qwen122b:
+    cmd: "sleep 1000"
+    proxy: "http://127.0.0.1:9999"
+    checkEndpoint: "/health"
+    aliases:
+      - "coding*"  # qwen is preferred for coding
+  minimax:
+    cmd: "sleep 1000"
+    proxy: "http://127.0.0.1:9998"
+    checkEndpoint: "/health"
+    aliases:
+      - "coding"   # minimax also claims coding alias
+groups:
+  _default_:
+    swap: true
+    exclusive: true
+    members: ["qwen122b", "minimax"]
+`
+
+	config, err := config.LoadConfigFromReader(strings.NewReader(yamlConfig))
+	assert.NoError(t, err)
+
+	proxy := New(config)
+	defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+	// Get the process group for qwen122b
+	qwenGroup := proxy.findGroupByModelName("qwen122b")
+	assert.NotNil(t, qwenGroup)
+
+	// Get the process for qwen122b
+	qwenProc := qwenGroup.processes["qwen122b"]
+	assert.NotNil(t, qwenProc)
+
+	// Manually set state to Starting to simulate a model that's loading
+	qwenProc.stateMutex.Lock()
+	qwenProc.state = StateStarting
+	qwenProc.stateMutex.Unlock()
+
+	// Now resolve the "coding" alias - it should return qwen122b (the one in StateStarting)
+	// NOT minimax (the preferred fallback), because qwen122b is already starting
+	result := proxy.resolveAliasRuntime("coding")
+	assert.Equal(t, "qwen122b", result, "Should return the model in StateStarting, not the preferred fallback")
+
+	// Test with StateReady too
+	qwenProc.stateMutex.Lock()
+	qwenProc.state = StateReady
+	qwenProc.stateMutex.Unlock()
+
+	result = proxy.resolveAliasRuntime("coding")
+	assert.Equal(t, "qwen122b", result, "Should return the model in StateReady")
+
+	// Test with both models stopped - should return preferred (qwen122b)
+	qwenProc.stateMutex.Lock()
+	qwenProc.state = StateStopped
+	qwenProc.stateMutex.Unlock()
+
+	result = proxy.resolveAliasRuntime("coding")
+	assert.Equal(t, "qwen122b", result, "Should return preferred when nothing is loaded")
 }


### PR DESCRIPTION
## Summary

Fix a race condition where `resolveAliasRuntime()` falls back to the preferred model when the candidate is in `StateStopping`, causing flip-flop during model shutdown.

## The Bug

`resolveAliasRuntime()` only checked for `StateReady` and `StateStarting`. When a model is being stopped (by TTL, manual swap, etc.), a new request for the same alias would:
1. Not find the candidate in a "live" state
2. Fall back to the preferred model
3. Race to restart the preferred model while shutdown is in progress
4. Result in flip-flop behavior

## The Fix

Include `StateStopping` in the alive check so `resolveAliasRuntime` returns the candidate even while it's being shut down, preventing the race.