### PR TITLE
proxy: translate chat requests between openai/anthropic/ollama protocols

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -280,6 +280,21 @@ models:
     # - recommended to be omitted and the default used
     concurrencyLimit: 0
 
+    # protocols: which wire-format(s) the model natively supports
+    # - optional, default: [openai, anthropic]
+    #   (preserves pre-translation behavior: /v1/messages and
+    #    /v1/chat/completions both pass through unchanged.)
+    # - valid values: openai, anthropic, ollama
+    # - when a client hits a chat endpoint whose protocol is NOT in this list,
+    #   llama-swap translates request+response between protocols so the client
+    #   sees a correct response in its own protocol.
+    # - only chat endpoints translate: /v1/chat/completions, /v1/messages,
+    #   /api/chat, /api/generate. Embeddings / audio / images / rerank pass
+    #   through as before.
+    # Example: Ollama-only model, reachable via /v1/chat/completions and /v1/messages
+    # via automatic translation.
+    # protocols: [ollama]
+
     # sendLoadingState: overrides the global sendLoadingState setting for this model
     # - optional, default: undefined (use global setting)
     sendLoadingState: false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,7 +81,52 @@ llama-swap supports many more features to customize how you want to manage your 
 | `env`     | define environment variables per model         |
 | `aliases` | serve a model with different names             |
 | `filters` | modify requests before sending to the upstream |
+| `protocols` | declare supported wire formats; enable OpenAI↔Anthropic↔Ollama translation |
 | `...`     | And many more tweaks                           |
+
+## Protocol translation
+
+llama-swap can translate chat requests and responses between OpenAI, Anthropic,
+and Ollama wire formats so that a single upstream can serve clients that speak
+different protocols.
+
+Each model may declare the wire formats it natively supports:
+
+```yaml
+models:
+  my-openai-only-model:
+    cmd: llama-server --port ${PORT} -m my-model.gguf
+    protocols: [openai]           # only speaks /v1/chat/completions natively
+
+  my-dual-protocol-model:
+    cmd: my-server --port ${PORT}
+    protocols: [openai, anthropic]  # (this is also the default)
+
+  my-ollama-model:
+    cmd: ollama serve --port ${PORT}
+    protocols: [ollama]           # only speaks /api/chat natively
+```
+
+Rules:
+
+- If omitted, `protocols` defaults to `[openai, anthropic]` — the behavior
+  llama-swap shipped with before translation existed.
+- Translation runs only on chat endpoints:
+  `/v1/chat/completions`, `/v1/messages`, `/api/chat`, `/api/generate`.
+  All other routes (embeddings, rerank, audio, images, infill, sdapi) are
+  pass-through regardless of `protocols`.
+- When a request arrives for a model that does not support the request's
+  protocol, llama-swap picks a supported protocol (preferring `openai`) and
+  translates request+response end-to-end.
+- The Ollama API surface (`/api/tags`, `/api/show`, `/api/version`) only
+  lists models whose `protocols` includes `ollama`.
+- Peer-routed models currently only accept their native protocol; cross-peer
+  translation is a known follow-up.
+
+Streaming translation and the full field-fidelity matrix (what is preserved,
+translated, dropped, or returns `501 Not Implemented`) are still being rolled
+out — see the protocol translation plan for details.
+
 
 ## Full Configuration Example
 

--- a/proxy/config/config.go
+++ b/proxy/config/config.go
@@ -276,6 +276,10 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 			return Config{}, fmt.Errorf("model %s: invalid TTL value %d", modelId, modelConfig.UnloadAfter)
 		}
 
+		if err := validateProtocols(modelConfig.Protocols); err != nil {
+			return Config{}, fmt.Errorf("model %s: %w", modelId, err)
+		}
+
 		// Validate model macros
 		for _, macro := range modelConfig.Macros {
 			if err = validateMacro(macro.Name, macro.Value); err != nil {

--- a/proxy/config/config_posix_test.go
+++ b/proxy/config/config_posix_test.go
@@ -197,6 +197,7 @@ groups:
 				Description:      "This is model 1",
 				SendLoadingState: &modelLoadingState,
 				Timeouts:         defaultTimeout,
+				Protocols:        []string{"openai", "anthropic"},
 			},
 			"model2": {
 				Cmd:              "path/to/server --arg1 one",
@@ -206,6 +207,7 @@ groups:
 				CheckEndpoint:    "/",
 				SendLoadingState: &modelLoadingState,
 				Timeouts:         defaultTimeout,
+				Protocols:        []string{"openai", "anthropic"},
 			},
 			"model3": {
 				Cmd:              "path/to/cmd --arg1 one",
@@ -215,6 +217,7 @@ groups:
 				CheckEndpoint:    "/",
 				SendLoadingState: &modelLoadingState,
 				Timeouts:         defaultTimeout,
+				Protocols:        []string{"openai", "anthropic"},
 			},
 			"model4": {
 				Cmd:              "path/to/cmd --arg1 one",
@@ -224,6 +227,7 @@ groups:
 				Env:              []string{},
 				SendLoadingState: &modelLoadingState,
 				Timeouts:         defaultTimeout,
+				Protocols:        []string{"openai", "anthropic"},
 			},
 		},
 		HealthCheckTimeout: 15,

--- a/proxy/config/config_windows_test.go
+++ b/proxy/config/config_windows_test.go
@@ -183,6 +183,7 @@ groups:
 				CheckEndpoint:    "/health",
 				SendLoadingState: &modelLoadingState,
 				Timeouts:         defaultTimeout,
+				Protocols:        []string{"openai", "anthropic"},
 			},
 			"model2": {
 				Cmd:              "path/to/server --arg1 one",
@@ -193,6 +194,7 @@ groups:
 				CheckEndpoint:    "/",
 				SendLoadingState: &modelLoadingState,
 				Timeouts:         defaultTimeout,
+				Protocols:        []string{"openai", "anthropic"},
 			},
 			"model3": {
 				Cmd:              "path/to/cmd --arg1 one",
@@ -203,6 +205,7 @@ groups:
 				CheckEndpoint:    "/",
 				SendLoadingState: &modelLoadingState,
 				Timeouts:         defaultTimeout,
+				Protocols:        []string{"openai", "anthropic"},
 			},
 			"model4": {
 				Cmd:              "path/to/cmd --arg1 one",
@@ -213,6 +216,7 @@ groups:
 				Env:              []string{},
 				SendLoadingState: &modelLoadingState,
 				Timeouts:         defaultTimeout,
+				Protocols:        []string{"openai", "anthropic"},
 			},
 		},
 		HealthCheckTimeout: 15,

--- a/proxy/config/model_config.go
+++ b/proxy/config/model_config.go
@@ -54,6 +54,12 @@ type ModelConfig struct {
 
 	// Timeout settings for proxy connections
 	Timeouts TimeoutsConfig `yaml:"timeouts"`
+
+	// Protocols declares which wire formats this model natively supports.
+	// Accepted values: openai, anthropic, ollama.
+	// Default: [openai, anthropic] — preserves pre-translation behavior where
+	// /v1/messages and /v1/chat/completions both pass-through unchanged.
+	Protocols []string `yaml:"protocols"`
 }
 
 func (m *ModelConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -71,6 +77,7 @@ func (m *ModelConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		ConcurrencyLimit: 0,
 		Name:             "",
 		Description:      "",
+		Protocols:        []string{"openai", "anthropic"},
 
 		// matches http.DefaultTransport
 		Timeouts: TimeoutsConfig{

--- a/proxy/config/protocols.go
+++ b/proxy/config/protocols.go
@@ -1,0 +1,29 @@
+package config
+
+import "fmt"
+
+// validProtocols is the closed set of wire-format names that may appear in
+// ModelConfig.Protocols. Kept in the config package so config does not
+// depend on the translate package.
+var validProtocols = map[string]bool{
+	"openai":    true,
+	"anthropic": true,
+	"ollama":    true,
+}
+
+func validateProtocols(ps []string) error {
+	if len(ps) == 0 {
+		return fmt.Errorf("protocols: must list at least one of openai, anthropic, ollama")
+	}
+	seen := map[string]bool{}
+	for _, p := range ps {
+		if !validProtocols[p] {
+			return fmt.Errorf("protocols: unknown value %q (valid: openai, anthropic, ollama)", p)
+		}
+		if seen[p] {
+			return fmt.Errorf("protocols: duplicate entry %q", p)
+		}
+		seen[p] = true
+	}
+	return nil
+}

--- a/proxy/matrix.go
+++ b/proxy/matrix.go
@@ -170,6 +170,15 @@ func NewMatrix(cfg config.Config, proxyLogger, upstreamLogger *LogMonitor) *Matr
 	}
 }
 
+// ProtocolsFor returns the declared native protocols for modelID. Matrix
+// models map 1:1 to real models in config, so this is just a direct lookup.
+func (m *Matrix) ProtocolsFor(modelID string) []string {
+	if mc, ok := m.config.Models[modelID]; ok {
+		return mc.Protocols
+	}
+	return nil
+}
+
 // ProxyRequest handles the swap logic and proxies the request to the model.
 func (m *Matrix) ProxyRequest(modelID string, w http.ResponseWriter, r *http.Request) error {
 	process, ok := m.processes[modelID]

--- a/proxy/ollama_api.go
+++ b/proxy/ollama_api.go
@@ -1,0 +1,90 @@
+package proxy
+
+import (
+	"net/http"
+	"slices"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// listOllamaTagsHandler implements GET /api/tags. Only models whose declared
+// protocols include "ollama" are listed so Ollama-native clients cannot pick
+// an incompatible model.
+func (pm *ProxyManager) listOllamaTagsHandler(c *gin.Context) {
+	var models []gin.H
+	for modelID, mc := range pm.config.Models {
+		if mc.Unlisted {
+			continue
+		}
+		if !slices.Contains(mc.Protocols, "ollama") {
+			continue
+		}
+		models = append(models, ollamaTagEntry(modelID, mc.Name))
+	}
+	c.JSON(http.StatusOK, gin.H{"models": models})
+}
+
+// showOllamaModelHandler implements POST /api/show. Returns a minimal show
+// payload for a single model, again only if that model supports ollama.
+func (pm *ProxyManager) showOllamaModelHandler(c *gin.Context) {
+	var req struct {
+		Name  string `json:"name"`
+		Model string `json:"model"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		pm.sendErrorResponse(c, http.StatusBadRequest, "invalid show payload")
+		return
+	}
+	name := req.Model
+	if name == "" {
+		name = req.Name
+	}
+	realName, ok := pm.config.RealModelName(name)
+	if !ok {
+		pm.sendErrorResponse(c, http.StatusNotFound, "model not found")
+		return
+	}
+	mc := pm.config.Models[realName]
+	if !slices.Contains(mc.Protocols, "ollama") {
+		pm.sendErrorResponse(c, http.StatusNotFound, "model does not expose the ollama protocol")
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"license":    "",
+		"modelfile":  "",
+		"parameters": "",
+		"template":   "",
+		"details": gin.H{
+			"format":             "gguf",
+			"family":             "unknown",
+			"families":           []string{"unknown"},
+			"parameter_size":     "",
+			"quantization_level": "",
+		},
+		"model_info":   gin.H{},
+		"capabilities": []string{"completion", "tools"},
+	})
+}
+
+func ollamaTagEntry(modelID, displayName string) gin.H {
+	name := modelID
+	if displayName != "" {
+		name = displayName
+	}
+	return gin.H{
+		"name":        modelID,
+		"model":       modelID,
+		"modified_at": time.Now().UTC().Format(time.RFC3339),
+		"size":        0,
+		"digest":      "",
+		"details": gin.H{
+			"format":             "gguf",
+			"family":             "unknown",
+			"families":           []string{"unknown"},
+			"parameter_size":     "",
+			"quantization_level": "",
+		},
+		"display_name": name,
+	}
+}

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -18,6 +18,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/mostlygeek/llama-swap/event"
 	"github.com/mostlygeek/llama-swap/proxy/config"
+	xl "github.com/mostlygeek/llama-swap/proxy/translate"
+	_ "github.com/mostlygeek/llama-swap/proxy/translate/adapters"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
@@ -370,6 +372,15 @@ func (pm *ProxyManager) setupGinEngine() {
 	pm.ginEngine.GET("/sdapi/v1/loras", pm.apiKeyAuth(), pm.trackInflight(), pm.proxyGETModelHandler)
 
 	pm.ginEngine.GET("/v1/models", pm.apiKeyAuth(), pm.listModelsHandler)
+
+	// Ollama API surface. Chat endpoints go through the translation pipeline;
+	// tags/show/version are synthesized from llama-swap's own config.
+	pm.ginEngine.POST("/api/chat", pm.apiKeyAuth(), pm.trackInflight(), pm.proxyInferenceHandler)
+	pm.ginEngine.POST("/api/generate", pm.apiKeyAuth(), pm.trackInflight(), pm.proxyInferenceHandler)
+	pm.ginEngine.GET("/api/tags", pm.apiKeyAuth(), pm.listOllamaTagsHandler)
+	pm.ginEngine.POST("/api/show", pm.apiKeyAuth(), pm.showOllamaModelHandler)
+	// /api/version is already served by addApiHandlers with a superset payload
+	// that includes the "version" field Ollama clients expect.
 
 	// in proxymanager_loghandlers.go
 	pm.ginEngine.GET("/logs", pm.apiKeyAuth(), pm.sendLogsHandlers)
@@ -816,6 +827,53 @@ func (pm *ProxyManager) proxyInferenceHandler(c *gin.Context) {
 		return
 	}
 
+	// Protocol translation: if this is a chat-family endpoint and the model
+	// does not natively support the inbound protocol, translate the body and
+	// rewrite the forwarded path. Streaming translation is handled in a
+	// separate step (task #7); for now a 501 is returned when a translated
+	// request also asks for streaming.
+	_, isLocalModel := pm.config.Models[modelID]
+	inboundProto, inboundKind, isChat := xl.DetectInbound(c.Request.Method, c.Request.URL.Path)
+	if isChat && !isLocalModel {
+		// Peer-routed model. v1: we do not translate across peers. If the
+		// inbound protocol is not one the peer is presumed to speak (we
+		// assume [openai, anthropic]) return 501 up-front.
+		if inboundProto == xl.ProtocolOllama {
+			pm.sendErrorResponse(c, http.StatusNotImplemented, "peer proxies do not support ollama translation yet")
+			return
+		}
+	}
+	if isChat && isLocalModel {
+		supported := resolveModelProtocols(pm, modelID)
+		target, needXlate := xl.Choose(inboundProto, supported)
+		if needXlate {
+			translated, err := xl.TranslateRequest(inboundProto, target, inboundKind, bodyBytes)
+			if err != nil {
+				pm.sendErrorResponse(c, http.StatusNotImplemented, fmt.Sprintf("translate request: %s", err.Error()))
+				return
+			}
+			bodyBytes = translated
+			c.Request.URL.Path = xl.CanonicalPath(target, inboundKind)
+			xl.TranslateHeaders(inboundProto, target, c.Request.Header)
+
+			wantStream := gjson.GetBytes(bodyBytes, "stream").Bool()
+			if wantStream {
+				st, err := newStreamTranslator(c.Writer, target, inboundProto)
+				if err != nil {
+					pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("stream translator: %s", err.Error()))
+					return
+				}
+				c.Writer = st
+				defer st.close()
+			} else {
+				origWriter := c.Writer
+				rt := &responseTranslator{ResponseWriter: origWriter, inbound: inboundProto, target: target, logger: pm.proxyLogger}
+				c.Writer = rt
+				defer rt.flushTo(origWriter)
+			}
+		}
+	}
+
 	c.Request.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 	// dechunk it as we already have all the body bytes see issue #11
@@ -1018,10 +1076,25 @@ func (pm *ProxyManager) proxyGETModelHandler(c *gin.Context) {
 }
 
 func (pm *ProxyManager) sendErrorResponse(c *gin.Context, statusCode int, message string) {
-	acceptHeader := c.GetHeader("Accept")
-
-	if strings.Contains(acceptHeader, "application/json") {
+	// Shape the error body in the client's protocol so a /v1/messages client
+	// sees an Anthropic-style envelope and an /api/chat client sees an
+	// Ollama-style body.
+	proto, _, _ := xl.DetectInbound(c.Request.Method, c.Request.URL.Path)
+	switch proto {
+	case xl.ProtocolAnthropic:
+		c.JSON(statusCode, gin.H{
+			"type":  "error",
+			"error": gin.H{"type": "api_error", "message": message},
+		})
+		return
+	case xl.ProtocolOllama:
 		c.JSON(statusCode, gin.H{"error": message})
+		return
+	}
+	// Default / OpenAI / non-chat path.
+	acceptHeader := c.GetHeader("Accept")
+	if strings.Contains(acceptHeader, "application/json") {
+		c.JSON(statusCode, gin.H{"error": gin.H{"message": message, "type": "api_error"}})
 	} else {
 		c.String(statusCode, message)
 	}

--- a/proxy/translate/adapters/adapters.go
+++ b/proxy/translate/adapters/adapters.go
@@ -1,0 +1,21 @@
+// Package adapters registers all protocol adapter implementations with the
+// translate default registry. Import this package for side-effects from the
+// proxy package to make translation functional.
+package adapters
+
+import (
+	xl "github.com/mostlygeek/llama-swap/proxy/translate"
+	"github.com/mostlygeek/llama-swap/proxy/translate/anthropic"
+	"github.com/mostlygeek/llama-swap/proxy/translate/ollama"
+	"github.com/mostlygeek/llama-swap/proxy/translate/openai"
+)
+
+func init() {
+	xl.Register(xl.ProtocolOpenAI, openai.Parser{}, openai.Emitter{})
+	xl.Register(xl.ProtocolAnthropic, anthropic.Parser{}, anthropic.Emitter{})
+	xl.Register(xl.ProtocolOllama, ollama.Parser{}, ollama.Emitter{})
+
+	xl.RegisterStream(xl.ProtocolOpenAI, openai.NewStreamParser, openai.NewStreamEmitter)
+	xl.RegisterStream(xl.ProtocolAnthropic, anthropic.NewStreamParser, anthropic.NewStreamEmitter)
+	xl.RegisterStream(xl.ProtocolOllama, ollama.NewStreamParser, ollama.NewStreamEmitter)
+}

--- a/proxy/translate/anthropic/anthropic.go
+++ b/proxy/translate/anthropic/anthropic.go
@@ -1,0 +1,436 @@
+// Package anthropic implements the Anthropic Messages wire format.
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	xl "github.com/mostlygeek/llama-swap/proxy/translate"
+)
+
+type Parser struct{}
+type Emitter struct{}
+
+// --- Request ---
+
+type contentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
+	// Images / documents / thinking fall through here.
+	Source json.RawMessage `json:"source,omitempty"`
+	// cache_control is stripped.
+}
+
+type anthMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+type anthTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema"`
+}
+
+type anthRequest struct {
+	Model       string          `json:"model"`
+	System      json.RawMessage `json:"system,omitempty"`
+	Messages    []anthMessage   `json:"messages"`
+	Tools       []anthTool      `json:"tools,omitempty"`
+	ToolChoice  json.RawMessage `json:"tool_choice,omitempty"`
+	MaxTokens   *int            `json:"max_tokens,omitempty"`
+	Temperature *float64        `json:"temperature,omitempty"`
+	TopP        *float64        `json:"top_p,omitempty"`
+	TopK        *int            `json:"top_k,omitempty"`
+	Stream      bool            `json:"stream,omitempty"`
+	Stop        []string        `json:"stop_sequences,omitempty"`
+}
+
+func (Parser) ParseChatRequest(body []byte, _ xl.EndpointKind) (*xl.ChatRequest, error) {
+	var req anthRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("anthropic: parse request: %w", err)
+	}
+	ir := &xl.ChatRequest{
+		Model:       req.Model,
+		Stream:      req.Stream,
+		Temperature: req.Temperature,
+		TopP:        req.TopP,
+		TopK:        req.TopK,
+		MaxTokens:   req.MaxTokens,
+		Stop:        req.Stop,
+	}
+	if len(req.System) > 0 {
+		sys, err := parseSystem(req.System)
+		if err != nil {
+			return nil, err
+		}
+		ir.System = sys
+	}
+	if len(req.ToolChoice) > 0 {
+		var tc any
+		_ = json.Unmarshal(req.ToolChoice, &tc)
+		ir.ToolChoice = tc
+	}
+	for _, t := range req.Tools {
+		ir.Tools = append(ir.Tools, xl.Tool{
+			Name:        t.Name,
+			Description: t.Description,
+			Schema:      t.InputSchema,
+		})
+	}
+	for _, m := range req.Messages {
+		msg := xl.Message{Role: xl.Role(m.Role)}
+		parts, err := parseContent(m.Content)
+		if err != nil {
+			return nil, err
+		}
+		msg.Content = parts
+		ir.Messages = append(ir.Messages, msg)
+	}
+	return ir, nil
+}
+
+func parseSystem(raw json.RawMessage) (string, error) {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s, nil
+	}
+	var arr []contentBlock
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return "", fmt.Errorf("anthropic: system: %w", err)
+	}
+	var b strings.Builder
+	for _, c := range arr {
+		if c.Type == "text" {
+			b.WriteString(c.Text)
+		}
+	}
+	return b.String(), nil
+}
+
+func parseContent(raw json.RawMessage) ([]xl.Part, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		if s == "" {
+			return nil, nil
+		}
+		return []xl.Part{{Type: xl.PartText, Text: s}}, nil
+	}
+	var arr []contentBlock
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return nil, fmt.Errorf("anthropic: content: %w", err)
+	}
+	var parts []xl.Part
+	for _, c := range arr {
+		switch c.Type {
+		case "text":
+			parts = append(parts, xl.Part{Type: xl.PartText, Text: c.Text})
+		case "tool_use":
+			parts = append(parts, xl.Part{
+				Type:      xl.PartToolUse,
+				ToolUseID: c.ID,
+				ToolName:  c.Name,
+				Input:     c.Input,
+			})
+		case "tool_result":
+			out, err := flattenResult(c.Content)
+			if err != nil {
+				return nil, err
+			}
+			parts = append(parts, xl.Part{
+				Type:      xl.PartToolResult,
+				ToolUseID: c.ToolUseID,
+				Output:    out,
+				IsError:   c.IsError,
+			})
+		case "thinking":
+			parts = append(parts, xl.Part{Type: xl.PartThinking, Text: c.Text})
+		case "image", "document":
+			return nil, fmt.Errorf("anthropic: images/documents not supported (501)")
+		}
+	}
+	return parts, nil
+}
+
+func flattenResult(raw json.RawMessage) (string, error) {
+	if len(raw) == 0 {
+		return "", nil
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s, nil
+	}
+	var arr []contentBlock
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return "", fmt.Errorf("anthropic: tool_result content: %w", err)
+	}
+	var b strings.Builder
+	for _, c := range arr {
+		if c.Type == "text" {
+			b.WriteString(c.Text)
+		}
+	}
+	return b.String(), nil
+}
+
+// --- Response ---
+
+type anthResponse struct {
+	ID         string         `json:"id"`
+	Type       string         `json:"type"`
+	Role       string         `json:"role"`
+	Model      string         `json:"model"`
+	Content    []contentBlock `json:"content"`
+	StopReason string         `json:"stop_reason"`
+	Usage      struct {
+		InputTokens  int `json:"input_tokens"`
+		OutputTokens int `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+func (Parser) ParseChatResponse(body []byte) (*xl.ChatResponse, error) {
+	var r anthResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("anthropic: parse response: %w", err)
+	}
+	msg := xl.Message{Role: xl.RoleAssistant}
+	for _, c := range r.Content {
+		switch c.Type {
+		case "text":
+			msg.Content = append(msg.Content, xl.Part{Type: xl.PartText, Text: c.Text})
+		case "tool_use":
+			msg.Content = append(msg.Content, xl.Part{
+				Type:      xl.PartToolUse,
+				ToolUseID: c.ID,
+				ToolName:  c.Name,
+				Input:     c.Input,
+			})
+		case "thinking":
+			msg.Content = append(msg.Content, xl.Part{Type: xl.PartThinking, Text: c.Text})
+		}
+	}
+	return &xl.ChatResponse{
+		ID:           r.ID,
+		Model:        r.Model,
+		Message:      msg,
+		FinishReason: normStop(r.StopReason),
+		Usage: xl.Usage{
+			PromptTokens:     r.Usage.InputTokens,
+			CompletionTokens: r.Usage.OutputTokens,
+			TotalTokens:      r.Usage.InputTokens + r.Usage.OutputTokens,
+		},
+	}, nil
+}
+
+func normStop(s string) xl.FinishReason {
+	switch s {
+	case "end_turn", "stop_sequence", "":
+		return xl.FinishStop
+	case "max_tokens":
+		return xl.FinishLength
+	case "tool_use":
+		return xl.FinishToolCalls
+	}
+	return xl.FinishStop
+}
+
+// --- Emitter ---
+
+func (Emitter) EmitChatRequest(req *xl.ChatRequest, _ xl.EndpointKind) ([]byte, error) {
+	out := map[string]any{
+		"model":    req.Model,
+		"messages": []any{},
+	}
+	if req.System != "" {
+		out["system"] = req.System
+	}
+	var msgs []map[string]any
+	for _, m := range req.Messages {
+		role := string(m.Role)
+		// Anthropic only accepts user/assistant. Tool role → user with tool_result.
+		if role == "tool" {
+			blocks := []map[string]any{}
+			for _, p := range m.Content {
+				if p.Type == xl.PartToolResult {
+					blocks = append(blocks, toolResultBlock(p))
+				}
+			}
+			if len(blocks) == 0 && m.ToolCallID != "" {
+				blocks = append(blocks, map[string]any{
+					"type":        "tool_result",
+					"tool_use_id": m.ToolCallID,
+					"content":     "",
+				})
+			}
+			msgs = append(msgs, map[string]any{"role": "user", "content": blocks})
+			continue
+		}
+		blocks := []map[string]any{}
+		for _, p := range m.Content {
+			switch p.Type {
+			case xl.PartText:
+				if p.Text != "" {
+					blocks = append(blocks, map[string]any{"type": "text", "text": p.Text})
+				}
+			case xl.PartToolUse:
+				input := p.Input
+				if len(input) == 0 {
+					input = json.RawMessage(`{}`)
+				}
+				blocks = append(blocks, map[string]any{
+					"type":  "tool_use",
+					"id":    p.ToolUseID,
+					"name":  p.ToolName,
+					"input": input,
+				})
+			case xl.PartToolResult:
+				blocks = append(blocks, toolResultBlock(p))
+			case xl.PartThinking:
+				// Drop: can't safely re-sign; Anthropic requires signature.
+			}
+		}
+		// OpenAI-style ToolCalls on assistant → tool_use blocks
+		if role == "assistant" {
+			for _, tc := range m.ToolCalls {
+				input := tc.Arguments
+				if len(input) == 0 {
+					input = json.RawMessage(`{}`)
+				}
+				blocks = append(blocks, map[string]any{
+					"type":  "tool_use",
+					"id":    tc.ID,
+					"name":  tc.Name,
+					"input": input,
+				})
+			}
+		}
+		msgs = append(msgs, map[string]any{"role": role, "content": blocks})
+	}
+	out["messages"] = msgs
+
+	if req.MaxTokens != nil {
+		out["max_tokens"] = *req.MaxTokens
+	} else {
+		// Anthropic requires max_tokens; pick a safe default.
+		out["max_tokens"] = 4096
+	}
+	if req.Temperature != nil {
+		out["temperature"] = *req.Temperature
+	}
+	if req.TopP != nil {
+		out["top_p"] = *req.TopP
+	}
+	if req.TopK != nil {
+		out["top_k"] = *req.TopK
+	}
+	if req.Stream {
+		out["stream"] = true
+	}
+	if len(req.Stop) > 0 {
+		out["stop_sequences"] = req.Stop
+	}
+	if len(req.Tools) > 0 {
+		var tools []map[string]any
+		for _, t := range req.Tools {
+			tools = append(tools, map[string]any{
+				"name":         t.Name,
+				"description":  t.Description,
+				"input_schema": t.Schema,
+			})
+		}
+		out["tools"] = tools
+	}
+	if req.ToolChoice != nil {
+		out["tool_choice"] = req.ToolChoice
+	}
+	return json.Marshal(out)
+}
+
+func toolResultBlock(p xl.Part) map[string]any {
+	b := map[string]any{
+		"type":        "tool_result",
+		"tool_use_id": p.ToolUseID,
+		"content":     p.Output,
+	}
+	if p.IsError {
+		b["is_error"] = true
+	}
+	return b
+}
+
+func (Emitter) EmitChatResponse(r *xl.ChatResponse) ([]byte, error) {
+	var blocks []map[string]any
+	for _, p := range r.Message.Content {
+		switch p.Type {
+		case xl.PartText:
+			blocks = append(blocks, map[string]any{"type": "text", "text": p.Text})
+		case xl.PartToolUse:
+			input := p.Input
+			if len(input) == 0 {
+				input = json.RawMessage(`{}`)
+			}
+			blocks = append(blocks, map[string]any{
+				"type":  "tool_use",
+				"id":    p.ToolUseID,
+				"name":  p.ToolName,
+				"input": input,
+			})
+		}
+	}
+	for _, tc := range r.Message.ToolCalls {
+		input := tc.Arguments
+		if len(input) == 0 {
+			input = json.RawMessage(`{}`)
+		}
+		blocks = append(blocks, map[string]any{
+			"type":  "tool_use",
+			"id":    tc.ID,
+			"name":  tc.Name,
+			"input": input,
+		})
+	}
+	stop := "end_turn"
+	switch r.FinishReason {
+	case xl.FinishLength:
+		stop = "max_tokens"
+	case xl.FinishToolCalls:
+		stop = "tool_use"
+	}
+	out := map[string]any{
+		"id":            r.ID,
+		"type":          "message",
+		"role":          "assistant",
+		"model":         r.Model,
+		"content":       blocks,
+		"stop_reason":   stop,
+		"stop_sequence": nil,
+		"usage": map[string]any{
+			"input_tokens":  r.Usage.PromptTokens,
+			"output_tokens": r.Usage.CompletionTokens,
+		},
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(out); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+var (
+	_ xl.Parser  = Parser{}
+	_ xl.Emitter = Emitter{}
+)

--- a/proxy/translate/anthropic/stream.go
+++ b/proxy/translate/anthropic/stream.go
@@ -1,0 +1,336 @@
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	xl "github.com/mostlygeek/llama-swap/proxy/translate"
+)
+
+// --- StreamParser ---
+
+// StreamParser decodes an Anthropic SSE stream with typed events.
+type StreamParser struct {
+	buf bytes.Buffer
+	// track per-content-block what kind it is so we can translate deltas.
+	blocks map[int]*blockState
+}
+
+type blockState struct {
+	kind  string // "text" | "tool_use"
+	id    string
+	name  string
+	index int
+}
+
+func NewStreamParser() xl.StreamParser {
+	return &StreamParser{blocks: map[int]*blockState{}}
+}
+
+func (p *StreamParser) Feed(chunk []byte) ([]xl.StreamEvent, error) {
+	p.buf.Write(chunk)
+	var events []xl.StreamEvent
+	for {
+		data := p.buf.Bytes()
+		idx := bytes.Index(data, []byte("\n\n"))
+		if idx < 0 {
+			idx = bytes.Index(data, []byte("\r\n\r\n"))
+			if idx < 0 {
+				return events, nil
+			}
+			frame := data[:idx]
+			p.buf.Next(idx + 4)
+			evs, err := p.parseFrame(frame)
+			if err != nil {
+				return events, err
+			}
+			events = append(events, evs...)
+			continue
+		}
+		frame := data[:idx]
+		p.buf.Next(idx + 2)
+		evs, err := p.parseFrame(frame)
+		if err != nil {
+			return events, err
+		}
+		events = append(events, evs...)
+	}
+}
+
+func (p *StreamParser) Close() ([]xl.StreamEvent, error) { return nil, nil }
+
+func (p *StreamParser) parseFrame(frame []byte) ([]xl.StreamEvent, error) {
+	frame = bytes.TrimSpace(frame)
+	if len(frame) == 0 {
+		return nil, nil
+	}
+	var eventName string
+	var dataBuf bytes.Buffer
+	for _, line := range bytes.Split(frame, []byte("\n")) {
+		line = bytes.TrimRight(line, "\r")
+		switch {
+		case bytes.HasPrefix(line, []byte("event:")):
+			eventName = string(bytes.TrimSpace(line[len("event:"):]))
+		case bytes.HasPrefix(line, []byte("data:")):
+			dataBuf.Write(bytes.TrimSpace(line[len("data:"):]))
+		}
+	}
+	if dataBuf.Len() == 0 {
+		return nil, nil
+	}
+	payload := dataBuf.Bytes()
+
+	var events []xl.StreamEvent
+	switch eventName {
+	case "message_start":
+		var m struct {
+			Message struct {
+				ID    string `json:"id"`
+				Model string `json:"model"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(payload, &m); err != nil {
+			return nil, fmt.Errorf("anthropic stream message_start: %w", err)
+		}
+		events = append(events, xl.StreamEvent{Type: xl.StreamStart, ID: m.Message.ID, Model: m.Message.Model})
+	case "content_block_start":
+		var b struct {
+			Index        int `json:"index"`
+			ContentBlock struct {
+				Type  string          `json:"type"`
+				Text  string          `json:"text"`
+				ID    string          `json:"id"`
+				Name  string          `json:"name"`
+				Input json.RawMessage `json:"input"`
+			} `json:"content_block"`
+		}
+		if err := json.Unmarshal(payload, &b); err != nil {
+			return nil, fmt.Errorf("anthropic stream content_block_start: %w", err)
+		}
+		p.blocks[b.Index] = &blockState{
+			kind:  b.ContentBlock.Type,
+			id:    b.ContentBlock.ID,
+			name:  b.ContentBlock.Name,
+			index: b.Index,
+		}
+		if b.ContentBlock.Type == "tool_use" {
+			events = append(events, xl.StreamEvent{
+				Type:  xl.StreamToolUseStart,
+				Index: b.Index,
+				ToolCall: &xl.ToolCall{
+					ID:   b.ContentBlock.ID,
+					Name: b.ContentBlock.Name,
+				},
+			})
+		} else if b.ContentBlock.Type == "text" && b.ContentBlock.Text != "" {
+			events = append(events, xl.StreamEvent{
+				Type:  xl.StreamTextDelta,
+				Index: b.Index,
+				Text:  b.ContentBlock.Text,
+			})
+		}
+	case "content_block_delta":
+		var d struct {
+			Index int `json:"index"`
+			Delta struct {
+				Type        string `json:"type"`
+				Text        string `json:"text"`
+				PartialJSON string `json:"partial_json"`
+			} `json:"delta"`
+		}
+		if err := json.Unmarshal(payload, &d); err != nil {
+			return nil, fmt.Errorf("anthropic stream content_block_delta: %w", err)
+		}
+		switch d.Delta.Type {
+		case "text_delta":
+			events = append(events, xl.StreamEvent{Type: xl.StreamTextDelta, Index: d.Index, Text: d.Delta.Text})
+		case "input_json_delta":
+			events = append(events, xl.StreamEvent{Type: xl.StreamToolArgsDelta, Index: d.Index, ArgsDelta: d.Delta.PartialJSON})
+		}
+	case "content_block_stop":
+		var b struct {
+			Index int `json:"index"`
+		}
+		_ = json.Unmarshal(payload, &b)
+		if st, ok := p.blocks[b.Index]; ok && st.kind == "tool_use" {
+			events = append(events, xl.StreamEvent{Type: xl.StreamToolUseStop, Index: b.Index})
+		}
+	case "message_delta":
+		var m struct {
+			Delta struct {
+				StopReason string `json:"stop_reason"`
+			} `json:"delta"`
+			Usage *struct {
+				OutputTokens int `json:"output_tokens"`
+			} `json:"usage,omitempty"`
+		}
+		if err := json.Unmarshal(payload, &m); err != nil {
+			return nil, fmt.Errorf("anthropic stream message_delta: %w", err)
+		}
+		if m.Usage != nil {
+			events = append(events, xl.StreamEvent{
+				Type:  xl.StreamUsage,
+				Usage: &xl.Usage{CompletionTokens: m.Usage.OutputTokens, TotalTokens: m.Usage.OutputTokens},
+			})
+		}
+		events = append(events, xl.StreamEvent{
+			Type:         xl.StreamStop,
+			FinishReason: normStop(m.Delta.StopReason),
+		})
+	case "message_stop":
+		// final terminator; StreamStop already emitted on message_delta
+	case "error":
+		var e struct {
+			Error struct {
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		_ = json.Unmarshal(payload, &e)
+		events = append(events, xl.StreamEvent{Type: xl.StreamError, Err: e.Error.Message})
+	case "ping":
+		// ignore
+	}
+	return events, nil
+}
+
+// --- StreamEmitter ---
+
+type StreamEmitter struct {
+	id      string
+	model   string
+	started bool
+	// per-tool index: tracks whether we've already emitted content_block_start
+	toolStarted map[int]bool
+	// which content block index is "open" as a text block (0 is conventional)
+	textOpen bool
+}
+
+func NewStreamEmitter() xl.StreamEmitter {
+	return &StreamEmitter{toolStarted: map[int]bool{}}
+}
+
+func (e *StreamEmitter) ContentType() string { return "text/event-stream" }
+
+func (e *StreamEmitter) Emit(w io.Writer, ev xl.StreamEvent) error {
+	switch ev.Type {
+	case xl.StreamStart:
+		if ev.Model != "" {
+			e.model = ev.Model
+		}
+		if ev.ID != "" {
+			e.id = ev.ID
+		}
+		e.started = true
+		return writeSSE(w, "message_start", map[string]any{
+			"type": "message_start",
+			"message": map[string]any{
+				"id":            e.id,
+				"type":          "message",
+				"role":          "assistant",
+				"model":         e.model,
+				"content":       []any{},
+				"stop_reason":   nil,
+				"stop_sequence": nil,
+				"usage":         map[string]any{"input_tokens": 0, "output_tokens": 0},
+			},
+		})
+	case xl.StreamTextDelta:
+		if !e.textOpen {
+			e.textOpen = true
+			if err := writeSSE(w, "content_block_start", map[string]any{
+				"type":          "content_block_start",
+				"index":         0,
+				"content_block": map[string]any{"type": "text", "text": ""},
+			}); err != nil {
+				return err
+			}
+		}
+		return writeSSE(w, "content_block_delta", map[string]any{
+			"type":  "content_block_delta",
+			"index": 0,
+			"delta": map[string]any{"type": "text_delta", "text": ev.Text},
+		})
+	case xl.StreamToolUseStart:
+		if ev.ToolCall == nil {
+			return nil
+		}
+		idx := ev.Index + 1 // shift so text block can be index 0
+		if e.textOpen {
+			// close text block first
+		}
+		e.toolStarted[idx] = true
+		return writeSSE(w, "content_block_start", map[string]any{
+			"type":  "content_block_start",
+			"index": idx,
+			"content_block": map[string]any{
+				"type":  "tool_use",
+				"id":    ev.ToolCall.ID,
+				"name":  ev.ToolCall.Name,
+				"input": map[string]any{},
+			},
+		})
+	case xl.StreamToolArgsDelta:
+		idx := ev.Index + 1
+		return writeSSE(w, "content_block_delta", map[string]any{
+			"type":  "content_block_delta",
+			"index": idx,
+			"delta": map[string]any{"type": "input_json_delta", "partial_json": ev.ArgsDelta},
+		})
+	case xl.StreamToolUseStop:
+		idx := ev.Index + 1
+		return writeSSE(w, "content_block_stop", map[string]any{
+			"type":  "content_block_stop",
+			"index": idx,
+		})
+	case xl.StreamUsage:
+		return nil
+	case xl.StreamStop:
+		if e.textOpen {
+			if err := writeSSE(w, "content_block_stop", map[string]any{
+				"type":  "content_block_stop",
+				"index": 0,
+			}); err != nil {
+				return err
+			}
+			e.textOpen = false
+		}
+		stop := "end_turn"
+		switch ev.FinishReason {
+		case xl.FinishLength:
+			stop = "max_tokens"
+		case xl.FinishToolCalls:
+			stop = "tool_use"
+		}
+		if err := writeSSE(w, "message_delta", map[string]any{
+			"type":  "message_delta",
+			"delta": map[string]any{"stop_reason": stop, "stop_sequence": nil},
+			"usage": map[string]any{"output_tokens": 0},
+		}); err != nil {
+			return err
+		}
+		return writeSSE(w, "message_stop", map[string]any{"type": "message_stop"})
+	case xl.StreamError:
+		return writeSSE(w, "error", map[string]any{
+			"type":  "error",
+			"error": map[string]any{"type": "api_error", "message": ev.Err},
+		})
+	}
+	return nil
+}
+
+func writeSSE(w io.Writer, event string, obj any) error {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "event: %s\ndata: ", event); err != nil {
+		return err
+	}
+	if _, err := w.Write(b); err != nil {
+		return err
+	}
+	_, err = io.WriteString(w, "\n\n")
+	return err
+}

--- a/proxy/translate/dispatch.go
+++ b/proxy/translate/dispatch.go
@@ -1,0 +1,100 @@
+package translate
+
+import "strings"
+
+// Choose decides the target (upstream) protocol given the inbound client
+// protocol and the set of protocols the resolved model supports.
+//
+// Rules:
+//  1. If inbound is in supported → pass-through (needXlate=false).
+//  2. Else prefer OpenAI when supported.
+//  3. Else fall back to the first entry of supported.
+func Choose(inbound Protocol, supported []Protocol) (target Protocol, needXlate bool) {
+	for _, p := range supported {
+		if p == inbound {
+			return inbound, false
+		}
+	}
+	for _, p := range supported {
+		if p == ProtocolOpenAI {
+			return ProtocolOpenAI, true
+		}
+	}
+	if len(supported) > 0 {
+		return supported[0], true
+	}
+	// Degenerate: pretend pass-through; caller will 501 anyway.
+	return inbound, false
+}
+
+// --- Stateless tool-call ID mapping ---
+//
+// OpenAI ↔ Anthropic: reversible prefixed wrappers.
+//   OAI id "call_XYZ" → sent to Anth as "toolu_oa_XYZ" and back to OAI
+//   "call_XYZ" on tool_result.
+//   Anth id "toolu_XYZ" → sent to OAI as "call_anth_XYZ" and back to Anth
+//   "toolu_XYZ" on tool_result.
+//
+// Ollama has no IDs; upstream emission uses Ollama's positional tool_result
+// and no ID rewriting is needed on the wire.
+
+const (
+	prefixOAtoAnth = "toolu_oa_"
+	prefixAnthToOA = "call_anth_"
+)
+
+// MapToolIDOutbound rewrites a tool_use ID from sourceProto form to targetProto
+// form when forwarding an assistant's tool_use to the target side.
+func MapToolIDOutbound(source, target Protocol, id string) string {
+	if id == "" {
+		return id
+	}
+	if source == target {
+		return id
+	}
+	switch {
+	case source == ProtocolOpenAI && target == ProtocolAnthropic:
+		return prefixOAtoAnth + stripPrefix(id, "call_")
+	case source == ProtocolAnthropic && target == ProtocolOpenAI:
+		return prefixAnthToOA + stripPrefix(id, "toolu_")
+	}
+	return id
+}
+
+// MapToolIDInbound reverses the transformation applied on a tool_result as it
+// flows back through the proxy to the original protocol.
+func MapToolIDInbound(source, target Protocol, id string) string {
+	if id == "" {
+		return id
+	}
+	if source == target {
+		return id
+	}
+	switch {
+	case source == ProtocolOpenAI && target == ProtocolAnthropic:
+		// client is OpenAI, upstream is Anthropic: upstream's tool_use IDs
+		// were minted by us as toolu_oa_<X>; strip the prefix back to call_<X>.
+		if rest, ok := trimPrefix(id, prefixOAtoAnth); ok {
+			return "call_" + rest
+		}
+	case source == ProtocolAnthropic && target == ProtocolOpenAI:
+		if rest, ok := trimPrefix(id, prefixAnthToOA); ok {
+			return "toolu_" + rest
+		}
+	}
+	return id
+}
+
+func stripPrefix(s, prefix string) string {
+	if strings.HasPrefix(s, prefix) {
+		return s[len(prefix):]
+	}
+	return s
+}
+
+func trimPrefix(s, prefix string) (string, bool) {
+	if strings.HasPrefix(s, prefix) {
+		return s[len(prefix):], true
+	}
+	return s, false
+}

--- a/proxy/translate/headers.go
+++ b/proxy/translate/headers.go
@@ -1,0 +1,33 @@
+package translate
+
+import "net/http"
+
+// TranslateHeaders adjusts request headers when an inbound request is being
+// forwarded to an upstream that speaks a different protocol. Mostly this
+// means bridging the two common authentication conventions (Anthropic's
+// x-api-key vs OpenAI's Authorization: Bearer …) and defaulting any
+// protocol-specific headers the upstream expects.
+func TranslateHeaders(inbound, target Protocol, h http.Header) {
+	if inbound == target {
+		return
+	}
+	switch {
+	case inbound == ProtocolOpenAI && target == ProtocolAnthropic:
+		// OpenAI uses Authorization; Anthropic wants x-api-key.
+		if h.Get("x-api-key") == "" {
+			if auth := h.Get("Authorization"); len(auth) > 7 && auth[:7] == "Bearer " {
+				h.Set("x-api-key", auth[7:])
+			}
+		}
+		if h.Get("anthropic-version") == "" {
+			h.Set("anthropic-version", "2023-06-01")
+		}
+	case inbound == ProtocolAnthropic && target == ProtocolOpenAI:
+		if h.Get("Authorization") == "" {
+			if k := h.Get("x-api-key"); k != "" {
+				h.Set("Authorization", "Bearer "+k)
+			}
+		}
+	}
+	// Ollama does not authenticate by convention; no-op in its direction.
+}

--- a/proxy/translate/ir.go
+++ b/proxy/translate/ir.go
@@ -1,0 +1,151 @@
+// Package translate contains the canonical, OpenAI-shaped intermediate
+// representation used to translate chat requests and responses between
+// the OpenAI, Anthropic and Ollama wire protocols.
+//
+// Parsers turn a protocol-specific request/response (or single stream frame)
+// into IR. Emitters turn IR back into a target protocol's wire format.
+// Translators therefore run as O(N) adapters against the IR rather than
+// O(N^2) pairwise transformers.
+package translate
+
+import "encoding/json"
+
+// Role identifies who produced a chat message.
+type Role string
+
+const (
+	RoleSystem    Role = "system"
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+	RoleTool      Role = "tool"
+)
+
+// PartType discriminates entries in Message.Content.
+type PartType string
+
+const (
+	PartText       PartType = "text"
+	PartToolUse    PartType = "tool_use"
+	PartToolResult PartType = "tool_result"
+	PartThinking   PartType = "thinking"
+)
+
+// Part is a single content block in a Message. Text blocks use Text;
+// tool_use blocks use ToolUseID + ToolName + Input; tool_result blocks
+// use ToolUseID + Output (+ IsError). Thinking blocks carry Text.
+type Part struct {
+	Type      PartType        `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	ToolName  string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	Output    string          `json:"output,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
+}
+
+// ToolCall is a single assistant-issued tool invocation surfaced at the
+// Message level for OpenAI-style consumers; Anthropic and Ollama adapters
+// fold these into Part slices as needed.
+type ToolCall struct {
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// Message is a single entry in ChatRequest.Messages or the completion
+// carried by ChatResponse.
+type Message struct {
+	Role       Role       `json:"role"`
+	Content    []Part     `json:"content,omitempty"`
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string     `json:"tool_call_id,omitempty"`
+	Name       string     `json:"name,omitempty"`
+}
+
+// Tool is a function/tool the model may invoke.
+type Tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Schema      json.RawMessage `json:"schema"`
+}
+
+// ChatRequest is the canonical chat request shape.
+type ChatRequest struct {
+	Model       string    `json:"model"`
+	Messages    []Message `json:"messages"`
+	System      string    `json:"system,omitempty"`
+	Tools       []Tool    `json:"tools,omitempty"`
+	ToolChoice  any       `json:"tool_choice,omitempty"`
+	Stream      bool      `json:"stream,omitempty"`
+	Temperature *float64  `json:"temperature,omitempty"`
+	TopP        *float64  `json:"top_p,omitempty"`
+	TopK        *int      `json:"top_k,omitempty"`
+	MaxTokens   *int      `json:"max_tokens,omitempty"`
+	Stop        []string  `json:"stop,omitempty"`
+	Seed        *int64    `json:"seed,omitempty"`
+
+	// Extra holds wire-format-specific fields that the parser did not
+	// promote into typed IR. Emitters may copy these through when the
+	// target protocol understands them.
+	Extra map[string]any `json:"extra,omitempty"`
+}
+
+// Usage reports token accounting.
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// FinishReason is normalised across protocols.
+type FinishReason string
+
+const (
+	FinishStop      FinishReason = "stop"
+	FinishLength    FinishReason = "length"
+	FinishToolCalls FinishReason = "tool_calls"
+	FinishError     FinishReason = "error"
+)
+
+// ChatResponse is the canonical non-streaming chat response.
+type ChatResponse struct {
+	ID           string       `json:"id"`
+	Model        string       `json:"model"`
+	Created      int64        `json:"created"`
+	FinishReason FinishReason `json:"finish_reason"`
+	Message      Message      `json:"message"`
+	Usage        Usage        `json:"usage"`
+}
+
+// StreamEventType discriminates frames in a translated SSE/NDJSON stream.
+type StreamEventType string
+
+const (
+	StreamStart         StreamEventType = "start"
+	StreamTextDelta     StreamEventType = "text_delta"
+	StreamToolUseStart  StreamEventType = "tool_use_start"
+	StreamToolArgsDelta StreamEventType = "tool_args_delta"
+	StreamToolUseStop   StreamEventType = "tool_use_stop"
+	StreamUsage         StreamEventType = "usage"
+	StreamStop          StreamEventType = "stop"
+	StreamError         StreamEventType = "error"
+)
+
+// StreamEvent is one frame in a translated chat stream. It carries only
+// the fields relevant to its Type.
+type StreamEvent struct {
+	Type         StreamEventType `json:"type"`
+	Index        int             `json:"index,omitempty"`
+	Text         string          `json:"text,omitempty"`
+	ToolCall     *ToolCall       `json:"tool_call,omitempty"`
+	ArgsDelta    string          `json:"args_delta,omitempty"`
+	Usage        *Usage          `json:"usage,omitempty"`
+	FinishReason FinishReason    `json:"finish_reason,omitempty"`
+	Err          string          `json:"error,omitempty"`
+
+	// Model is set on StreamStart when known, to allow emitters that
+	// need a model name at frame-emission time.
+	Model string `json:"model,omitempty"`
+	// ID is set on StreamStart when known (e.g. chatcmpl-...).
+	ID string `json:"id,omitempty"`
+}

--- a/proxy/translate/ollama/ollama.go
+++ b/proxy/translate/ollama/ollama.go
@@ -1,0 +1,460 @@
+// Package ollama implements the Ollama /api/chat and /api/generate wire format.
+package ollama
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	xl "github.com/mostlygeek/llama-swap/proxy/translate"
+)
+
+// timeNow is a package-level hook so streaming tests can deterministically
+// produce `created_at` timestamps.
+var timeNow = func() string { return time.Now().UTC().Format(time.RFC3339Nano) }
+
+type Parser struct{}
+type Emitter struct{}
+
+// --- Request ---
+
+type olToolCall struct {
+	Function struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	} `json:"function"`
+}
+
+type olMessage struct {
+	Role      string       `json:"role"`
+	Content   string       `json:"content"`
+	ToolCalls []olToolCall `json:"tool_calls,omitempty"`
+	// For tool role Ollama has no tool_use_id; content is the result.
+}
+
+type olTool struct {
+	Type     string `json:"type"`
+	Function struct {
+		Name        string          `json:"name"`
+		Description string          `json:"description,omitempty"`
+		Parameters  json.RawMessage `json:"parameters,omitempty"`
+	} `json:"function"`
+}
+
+type olChatRequest struct {
+	Model     string                     `json:"model"`
+	Messages  []olMessage                `json:"messages"`
+	Tools     []olTool                   `json:"tools,omitempty"`
+	Stream    *bool                      `json:"stream,omitempty"`
+	Format    json.RawMessage            `json:"format,omitempty"`
+	KeepAlive json.RawMessage            `json:"keep_alive,omitempty"`
+	Options   map[string]json.RawMessage `json:"options,omitempty"`
+	System    string                     `json:"system,omitempty"`
+}
+
+type olGenerateRequest struct {
+	Model     string                     `json:"model"`
+	Prompt    string                     `json:"prompt"`
+	System    string                     `json:"system,omitempty"`
+	Stream    *bool                      `json:"stream,omitempty"`
+	Format    json.RawMessage            `json:"format,omitempty"`
+	KeepAlive json.RawMessage            `json:"keep_alive,omitempty"`
+	Options   map[string]json.RawMessage `json:"options,omitempty"`
+}
+
+func (Parser) ParseChatRequest(body []byte, kind xl.EndpointKind) (*xl.ChatRequest, error) {
+	if kind == xl.KindGenerate {
+		var g olGenerateRequest
+		if err := json.Unmarshal(body, &g); err != nil {
+			return nil, fmt.Errorf("ollama: parse generate: %w", err)
+		}
+		ir := &xl.ChatRequest{Model: g.Model, System: g.System}
+		if g.Stream != nil {
+			ir.Stream = *g.Stream
+		} else {
+			ir.Stream = true // Ollama default is stream
+		}
+		if g.Prompt != "" {
+			ir.Messages = []xl.Message{{
+				Role:    xl.RoleUser,
+				Content: []xl.Part{{Type: xl.PartText, Text: g.Prompt}},
+			}}
+		}
+		applyOptions(ir, g.Options)
+		return ir, nil
+	}
+	var r olChatRequest
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("ollama: parse chat: %w", err)
+	}
+	ir := &xl.ChatRequest{Model: r.Model, System: r.System}
+	if r.Stream != nil {
+		ir.Stream = *r.Stream
+	} else {
+		ir.Stream = true
+	}
+	applyOptions(ir, r.Options)
+	for _, t := range r.Tools {
+		ir.Tools = append(ir.Tools, xl.Tool{
+			Name:        t.Function.Name,
+			Description: t.Function.Description,
+			Schema:      t.Function.Parameters,
+		})
+	}
+	toolIdx := 0
+	for i, m := range r.Messages {
+		msg := xl.Message{Role: xl.Role(m.Role)}
+		if m.Role == "system" && ir.System == "" && i == 0 && len(m.ToolCalls) == 0 {
+			ir.System = m.Content
+			continue
+		}
+		if m.Role == "tool" {
+			// positional match to the preceding assistant tool_call
+			id := ""
+			toolName := ""
+			if len(ir.Messages) > 0 {
+				last := &ir.Messages[len(ir.Messages)-1]
+				if last.Role == xl.RoleAssistant && toolIdx < len(last.ToolCalls) {
+					id = last.ToolCalls[toolIdx].ID
+					toolName = last.ToolCalls[toolIdx].Name
+					toolIdx++
+				}
+			}
+			_ = toolName
+			msg.Role = xl.RoleTool
+			msg.ToolCallID = id
+			msg.Content = []xl.Part{{
+				Type:      xl.PartToolResult,
+				ToolUseID: id,
+				Output:    m.Content,
+			}}
+			ir.Messages = append(ir.Messages, msg)
+			continue
+		}
+		if m.Content != "" {
+			msg.Content = []xl.Part{{Type: xl.PartText, Text: m.Content}}
+		}
+		for idx, tc := range m.ToolCalls {
+			id := fmt.Sprintf("call_ol_%s_%d", tc.Function.Name, idx)
+			msg.ToolCalls = append(msg.ToolCalls, xl.ToolCall{
+				ID:        id,
+				Name:      tc.Function.Name,
+				Arguments: tc.Function.Arguments,
+			})
+		}
+		toolIdx = 0
+		ir.Messages = append(ir.Messages, msg)
+	}
+	return ir, nil
+}
+
+func applyOptions(ir *xl.ChatRequest, opts map[string]json.RawMessage) {
+	if v, ok := opts["temperature"]; ok {
+		var f float64
+		if json.Unmarshal(v, &f) == nil {
+			ir.Temperature = &f
+		}
+	}
+	if v, ok := opts["top_p"]; ok {
+		var f float64
+		if json.Unmarshal(v, &f) == nil {
+			ir.TopP = &f
+		}
+	}
+	if v, ok := opts["top_k"]; ok {
+		var i int
+		if json.Unmarshal(v, &i) == nil {
+			ir.TopK = &i
+		}
+	}
+	if v, ok := opts["num_predict"]; ok {
+		var i int
+		if json.Unmarshal(v, &i) == nil {
+			ir.MaxTokens = &i
+		}
+	}
+	if v, ok := opts["seed"]; ok {
+		var i int64
+		if json.Unmarshal(v, &i) == nil {
+			ir.Seed = &i
+		}
+	}
+	if v, ok := opts["stop"]; ok {
+		var arr []string
+		if json.Unmarshal(v, &arr) == nil {
+			ir.Stop = arr
+		} else {
+			var s string
+			if json.Unmarshal(v, &s) == nil {
+				ir.Stop = []string{s}
+			}
+		}
+	}
+}
+
+// --- Response ---
+
+type olChatResponse struct {
+	Model           string    `json:"model"`
+	CreatedAt       time.Time `json:"created_at"`
+	Message         olMessage `json:"message"`
+	Done            bool      `json:"done"`
+	DoneReason      string    `json:"done_reason,omitempty"`
+	PromptEvalCount int       `json:"prompt_eval_count,omitempty"`
+	EvalCount       int       `json:"eval_count,omitempty"`
+}
+
+func (Parser) ParseChatResponse(body []byte) (*xl.ChatResponse, error) {
+	var r olChatResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("ollama: parse response: %w", err)
+	}
+	msg := xl.Message{Role: xl.RoleAssistant}
+	if r.Message.Content != "" {
+		msg.Content = append(msg.Content, xl.Part{Type: xl.PartText, Text: r.Message.Content})
+	}
+	for idx, tc := range r.Message.ToolCalls {
+		id := fmt.Sprintf("call_ol_%s_%d", tc.Function.Name, idx)
+		msg.ToolCalls = append(msg.ToolCalls, xl.ToolCall{
+			ID:        id,
+			Name:      tc.Function.Name,
+			Arguments: tc.Function.Arguments,
+		})
+	}
+	finish := xl.FinishStop
+	switch r.DoneReason {
+	case "length":
+		finish = xl.FinishLength
+	case "tool_calls":
+		finish = xl.FinishToolCalls
+	}
+	if len(msg.ToolCalls) > 0 && finish == xl.FinishStop {
+		finish = xl.FinishToolCalls
+	}
+	return &xl.ChatResponse{
+		ID:           "",
+		Model:        r.Model,
+		Created:      r.CreatedAt.Unix(),
+		Message:      msg,
+		FinishReason: finish,
+		Usage: xl.Usage{
+			PromptTokens:     r.PromptEvalCount,
+			CompletionTokens: r.EvalCount,
+			TotalTokens:      r.PromptEvalCount + r.EvalCount,
+		},
+	}, nil
+}
+
+// --- Emitter ---
+
+func (Emitter) EmitChatRequest(req *xl.ChatRequest, kind xl.EndpointKind) ([]byte, error) {
+	options := map[string]any{}
+	if req.Temperature != nil {
+		options["temperature"] = *req.Temperature
+	}
+	if req.TopP != nil {
+		options["top_p"] = *req.TopP
+	}
+	if req.TopK != nil {
+		options["top_k"] = *req.TopK
+	}
+	if req.MaxTokens != nil {
+		options["num_predict"] = *req.MaxTokens
+	}
+	if req.Seed != nil {
+		options["seed"] = *req.Seed
+	}
+	if len(req.Stop) > 0 {
+		options["stop"] = req.Stop
+	}
+
+	if kind == xl.KindGenerate {
+		var prompt strings.Builder
+		for _, m := range req.Messages {
+			for _, p := range m.Content {
+				if p.Type == xl.PartText {
+					prompt.WriteString(p.Text)
+				}
+			}
+		}
+		out := map[string]any{
+			"model":  req.Model,
+			"prompt": prompt.String(),
+			"stream": req.Stream,
+		}
+		if req.System != "" {
+			out["system"] = req.System
+		}
+		if len(options) > 0 {
+			out["options"] = options
+		}
+		return json.Marshal(out)
+	}
+
+	var msgs []map[string]any
+	if req.System != "" {
+		msgs = append(msgs, map[string]any{"role": "system", "content": req.System})
+	}
+	for _, m := range req.Messages {
+		role := string(m.Role)
+		if role == "tool" {
+			// emit as role=tool with content = output
+			var outStr string
+			for _, p := range m.Content {
+				if p.Type == xl.PartToolResult {
+					outStr = p.Output
+				}
+			}
+			msgs = append(msgs, map[string]any{"role": "tool", "content": outStr})
+			continue
+		}
+		// user with tool_result parts (Anthropic style) → separate tool messages
+		hasTR := false
+		for _, p := range m.Content {
+			if p.Type == xl.PartToolResult {
+				hasTR = true
+				break
+			}
+		}
+		if hasTR && role == "user" {
+			for _, p := range m.Content {
+				switch p.Type {
+				case xl.PartToolResult:
+					msgs = append(msgs, map[string]any{"role": "tool", "content": p.Output})
+				case xl.PartText:
+					if p.Text != "" {
+						msgs = append(msgs, map[string]any{"role": "user", "content": p.Text})
+					}
+				}
+			}
+			continue
+		}
+		om := map[string]any{"role": role}
+		var text strings.Builder
+		var calls []map[string]any
+		for _, p := range m.Content {
+			switch p.Type {
+			case xl.PartText:
+				text.WriteString(p.Text)
+			case xl.PartToolUse:
+				input := p.Input
+				if len(input) == 0 {
+					input = json.RawMessage(`{}`)
+				}
+				calls = append(calls, map[string]any{
+					"function": map[string]any{
+						"name":      p.ToolName,
+						"arguments": input,
+					},
+				})
+			}
+		}
+		for _, tc := range m.ToolCalls {
+			input := tc.Arguments
+			if len(input) == 0 {
+				input = json.RawMessage(`{}`)
+			}
+			calls = append(calls, map[string]any{
+				"function": map[string]any{
+					"name":      tc.Name,
+					"arguments": input,
+				},
+			})
+		}
+		om["content"] = text.String()
+		if len(calls) > 0 {
+			om["tool_calls"] = calls
+		}
+		msgs = append(msgs, om)
+	}
+
+	out := map[string]any{
+		"model":    req.Model,
+		"messages": msgs,
+		"stream":   req.Stream,
+	}
+	if len(options) > 0 {
+		out["options"] = options
+	}
+	if len(req.Tools) > 0 {
+		var tools []map[string]any
+		for _, t := range req.Tools {
+			tools = append(tools, map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":        t.Name,
+					"description": t.Description,
+					"parameters":  t.Schema,
+				},
+			})
+		}
+		out["tools"] = tools
+	}
+	return json.Marshal(out)
+}
+
+func (Emitter) EmitChatResponse(r *xl.ChatResponse) ([]byte, error) {
+	msg := map[string]any{"role": "assistant", "content": ""}
+	var text strings.Builder
+	var calls []map[string]any
+	for _, p := range r.Message.Content {
+		switch p.Type {
+		case xl.PartText:
+			text.WriteString(p.Text)
+		case xl.PartToolUse:
+			input := p.Input
+			if len(input) == 0 {
+				input = json.RawMessage(`{}`)
+			}
+			calls = append(calls, map[string]any{
+				"function": map[string]any{
+					"name":      p.ToolName,
+					"arguments": input,
+				},
+			})
+		}
+	}
+	for _, tc := range r.Message.ToolCalls {
+		input := tc.Arguments
+		if len(input) == 0 {
+			input = json.RawMessage(`{}`)
+		}
+		calls = append(calls, map[string]any{
+			"function": map[string]any{
+				"name":      tc.Name,
+				"arguments": input,
+			},
+		})
+	}
+	msg["content"] = text.String()
+	if len(calls) > 0 {
+		msg["tool_calls"] = calls
+	}
+	doneReason := "stop"
+	switch r.FinishReason {
+	case xl.FinishLength:
+		doneReason = "length"
+	case xl.FinishToolCalls:
+		doneReason = "tool_calls"
+	}
+	created := time.Unix(r.Created, 0).UTC()
+	if r.Created == 0 {
+		created = time.Now().UTC()
+	}
+	out := map[string]any{
+		"model":             r.Model,
+		"created_at":        created.Format(time.RFC3339Nano),
+		"message":           msg,
+		"done":              true,
+		"done_reason":       doneReason,
+		"prompt_eval_count": r.Usage.PromptTokens,
+		"eval_count":        r.Usage.CompletionTokens,
+	}
+	return json.Marshal(out)
+}
+
+var (
+	_ xl.Parser  = Parser{}
+	_ xl.Emitter = Emitter{}
+)

--- a/proxy/translate/ollama/stream.go
+++ b/proxy/translate/ollama/stream.go
@@ -1,0 +1,243 @@
+package ollama
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	xl "github.com/mostlygeek/llama-swap/proxy/translate"
+)
+
+// --- StreamParser ---
+
+// StreamParser decodes an Ollama NDJSON stream. Each frame is a single
+// newline-terminated JSON object; a frame with `"done": true` is terminal.
+type StreamParser struct {
+	buf         bytes.Buffer
+	started     bool
+	toolNextIdx int
+}
+
+func NewStreamParser() xl.StreamParser { return &StreamParser{} }
+
+func (p *StreamParser) Feed(chunk []byte) ([]xl.StreamEvent, error) {
+	p.buf.Write(chunk)
+	var events []xl.StreamEvent
+	for {
+		data := p.buf.Bytes()
+		idx := bytes.IndexByte(data, '\n')
+		if idx < 0 {
+			return events, nil
+		}
+		line := data[:idx]
+		p.buf.Next(idx + 1)
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+		evs, err := p.parseLine(line)
+		if err != nil {
+			return events, err
+		}
+		events = append(events, evs...)
+	}
+}
+
+func (p *StreamParser) Close() ([]xl.StreamEvent, error) {
+	if p.buf.Len() == 0 {
+		return nil, nil
+	}
+	line := bytes.TrimSpace(p.buf.Bytes())
+	p.buf.Reset()
+	if len(line) == 0 {
+		return nil, nil
+	}
+	return p.parseLine(line)
+}
+
+func (p *StreamParser) parseLine(line []byte) ([]xl.StreamEvent, error) {
+	var frame struct {
+		Model   string `json:"model"`
+		Message struct {
+			Role      string `json:"role"`
+			Content   string `json:"content"`
+			ToolCalls []struct {
+				Function struct {
+					Name      string          `json:"name"`
+					Arguments json.RawMessage `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls,omitempty"`
+		} `json:"message"`
+		Done            bool   `json:"done"`
+		DoneReason      string `json:"done_reason"`
+		Response        string `json:"response"` // /api/generate
+		PromptEvalCount int    `json:"prompt_eval_count"`
+		EvalCount       int    `json:"eval_count"`
+	}
+	if err := json.Unmarshal(line, &frame); err != nil {
+		return nil, fmt.Errorf("ollama stream: %w", err)
+	}
+	var events []xl.StreamEvent
+	if !p.started {
+		p.started = true
+		events = append(events, xl.StreamEvent{Type: xl.StreamStart, Model: frame.Model})
+	}
+	if frame.Message.Content != "" {
+		events = append(events, xl.StreamEvent{Type: xl.StreamTextDelta, Text: frame.Message.Content})
+	}
+	if frame.Response != "" {
+		events = append(events, xl.StreamEvent{Type: xl.StreamTextDelta, Text: frame.Response})
+	}
+	for _, tc := range frame.Message.ToolCalls {
+		id := fmt.Sprintf("call_ol_%s_%d", tc.Function.Name, p.toolNextIdx)
+		idx := p.toolNextIdx
+		p.toolNextIdx++
+		events = append(events, xl.StreamEvent{
+			Type:     xl.StreamToolUseStart,
+			Index:    idx,
+			ToolCall: &xl.ToolCall{ID: id, Name: tc.Function.Name, Arguments: tc.Function.Arguments},
+		})
+		if len(tc.Function.Arguments) > 0 {
+			events = append(events, xl.StreamEvent{
+				Type:      xl.StreamToolArgsDelta,
+				Index:     idx,
+				ArgsDelta: string(tc.Function.Arguments),
+			})
+		}
+		events = append(events, xl.StreamEvent{Type: xl.StreamToolUseStop, Index: idx})
+	}
+	if frame.Done {
+		if frame.PromptEvalCount > 0 || frame.EvalCount > 0 {
+			events = append(events, xl.StreamEvent{
+				Type: xl.StreamUsage,
+				Usage: &xl.Usage{
+					PromptTokens:     frame.PromptEvalCount,
+					CompletionTokens: frame.EvalCount,
+					TotalTokens:      frame.PromptEvalCount + frame.EvalCount,
+				},
+			})
+		}
+		finish := xl.FinishStop
+		switch frame.DoneReason {
+		case "length":
+			finish = xl.FinishLength
+		case "tool_calls":
+			finish = xl.FinishToolCalls
+		}
+		events = append(events, xl.StreamEvent{Type: xl.StreamStop, FinishReason: finish})
+	}
+	return events, nil
+}
+
+// --- StreamEmitter ---
+
+type StreamEmitter struct {
+	model   string
+	started bool
+	// buffer per-tool arguments until StreamToolUseStop; Ollama emits full
+	// arguments JSON per frame and we can't emit partials.
+	toolName map[int]string
+	toolArgs map[int]*bytes.Buffer
+}
+
+func NewStreamEmitter() xl.StreamEmitter {
+	return &StreamEmitter{
+		toolName: map[int]string{},
+		toolArgs: map[int]*bytes.Buffer{},
+	}
+}
+
+func (e *StreamEmitter) ContentType() string { return "application/x-ndjson" }
+
+func (e *StreamEmitter) Emit(w io.Writer, ev xl.StreamEvent) error {
+	switch ev.Type {
+	case xl.StreamStart:
+		if ev.Model != "" {
+			e.model = ev.Model
+		}
+		e.started = true
+		return nil
+	case xl.StreamTextDelta:
+		return writeNDJSON(w, map[string]any{
+			"model":      e.model,
+			"created_at": nowRFC3339(),
+			"message":    map[string]any{"role": "assistant", "content": ev.Text},
+			"done":       false,
+		})
+	case xl.StreamToolUseStart:
+		if ev.ToolCall != nil {
+			e.toolName[ev.Index] = ev.ToolCall.Name
+			e.toolArgs[ev.Index] = &bytes.Buffer{}
+			if len(ev.ToolCall.Arguments) > 0 {
+				e.toolArgs[ev.Index].Write(ev.ToolCall.Arguments)
+			}
+		}
+		return nil
+	case xl.StreamToolArgsDelta:
+		if buf, ok := e.toolArgs[ev.Index]; ok {
+			buf.WriteString(ev.ArgsDelta)
+		}
+		return nil
+	case xl.StreamToolUseStop:
+		name := e.toolName[ev.Index]
+		args := json.RawMessage(`{}`)
+		if buf, ok := e.toolArgs[ev.Index]; ok && buf.Len() > 0 {
+			args = buf.Bytes()
+		}
+		delete(e.toolName, ev.Index)
+		delete(e.toolArgs, ev.Index)
+		return writeNDJSON(w, map[string]any{
+			"model":      e.model,
+			"created_at": nowRFC3339(),
+			"message": map[string]any{
+				"role":    "assistant",
+				"content": "",
+				"tool_calls": []map[string]any{{
+					"function": map[string]any{
+						"name":      name,
+						"arguments": args,
+					},
+				}},
+			},
+			"done": false,
+		})
+	case xl.StreamUsage:
+		return nil // folded into final done frame
+	case xl.StreamStop:
+		done := map[string]any{
+			"model":      e.model,
+			"created_at": nowRFC3339(),
+			"message":    map[string]any{"role": "assistant", "content": ""},
+			"done":       true,
+		}
+		switch ev.FinishReason {
+		case xl.FinishLength:
+			done["done_reason"] = "length"
+		case xl.FinishToolCalls:
+			done["done_reason"] = "tool_calls"
+		default:
+			done["done_reason"] = "stop"
+		}
+		return writeNDJSON(w, done)
+	case xl.StreamError:
+		return writeNDJSON(w, map[string]any{"error": ev.Err})
+	}
+	return nil
+}
+
+func writeNDJSON(w io.Writer, obj any) error {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(b); err != nil {
+		return err
+	}
+	_, err = io.WriteString(w, "\n")
+	return err
+}
+
+func nowRFC3339() string {
+	return timeNow()
+}

--- a/proxy/translate/openai/openai.go
+++ b/proxy/translate/openai/openai.go
@@ -1,0 +1,529 @@
+// Package openai implements the OpenAI wire-format Parser/Emitter/
+// StreamParser/StreamEmitter for the canonical translate IR.
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	xl "github.com/mostlygeek/llama-swap/proxy/translate"
+)
+
+// Parser parses OpenAI /v1/chat/completions request and response bodies.
+type Parser struct{}
+
+// Emitter emits OpenAI /v1/chat/completions request and response bodies.
+type Emitter struct{}
+
+// --- Request ---
+
+type oaiMessage struct {
+	Role       string          `json:"role"`
+	Content    json.RawMessage `json:"content,omitempty"`
+	Name       string          `json:"name,omitempty"`
+	ToolCalls  []oaiToolCall   `json:"tool_calls,omitempty"`
+	ToolCallID string          `json:"tool_call_id,omitempty"`
+}
+
+type oaiToolCall struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	} `json:"function"`
+}
+
+type oaiTool struct {
+	Type     string `json:"type"`
+	Function struct {
+		Name        string          `json:"name"`
+		Description string          `json:"description,omitempty"`
+		Parameters  json.RawMessage `json:"parameters,omitempty"`
+	} `json:"function"`
+}
+
+type oaiRequest struct {
+	Model       string          `json:"model"`
+	Messages    []oaiMessage    `json:"messages"`
+	Tools       []oaiTool       `json:"tools,omitempty"`
+	ToolChoice  json.RawMessage `json:"tool_choice,omitempty"`
+	Stream      bool            `json:"stream,omitempty"`
+	Temperature *float64        `json:"temperature,omitempty"`
+	TopP        *float64        `json:"top_p,omitempty"`
+	MaxTokens   *int            `json:"max_tokens,omitempty"`
+	Stop        json.RawMessage `json:"stop,omitempty"`
+	Seed        *int64          `json:"seed,omitempty"`
+
+	// Kept so round-trip emission preserves them.
+	Extra map[string]json.RawMessage `json:"-"`
+}
+
+var knownReqKeys = map[string]bool{
+	"model": true, "messages": true, "tools": true, "tool_choice": true,
+	"stream": true, "temperature": true, "top_p": true, "max_tokens": true,
+	"stop": true, "seed": true,
+}
+
+// ParseChatRequest turns an OpenAI request body into IR.
+func (Parser) ParseChatRequest(body []byte, _ xl.EndpointKind) (*xl.ChatRequest, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("openai: parse request: %w", err)
+	}
+	var req oaiRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("openai: parse request: %w", err)
+	}
+	extra := map[string]any{}
+	for k, v := range raw {
+		if !knownReqKeys[k] {
+			var decoded any
+			_ = json.Unmarshal(v, &decoded)
+			extra[k] = decoded
+		}
+	}
+
+	ir := &xl.ChatRequest{
+		Model:       req.Model,
+		Stream:      req.Stream,
+		Temperature: req.Temperature,
+		TopP:        req.TopP,
+		MaxTokens:   req.MaxTokens,
+		Seed:        req.Seed,
+	}
+	if len(extra) > 0 {
+		ir.Extra = extra
+	}
+	if len(req.Stop) > 0 {
+		ir.Stop = parseStop(req.Stop)
+	}
+	if len(req.ToolChoice) > 0 {
+		var tc any
+		_ = json.Unmarshal(req.ToolChoice, &tc)
+		ir.ToolChoice = tc
+	}
+	for _, t := range req.Tools {
+		ir.Tools = append(ir.Tools, xl.Tool{
+			Name:        t.Function.Name,
+			Description: t.Function.Description,
+			Schema:      t.Function.Parameters,
+		})
+	}
+	for _, m := range req.Messages {
+		msg := xl.Message{Role: xl.Role(m.Role), Name: m.Name, ToolCallID: m.ToolCallID}
+		if m.Role == "system" && ir.System == "" && len(m.ToolCalls) == 0 {
+			if s, ok := plainText(m.Content); ok {
+				ir.System = s
+				continue
+			}
+		}
+		if len(m.Content) > 0 {
+			if parts, err := parseContent(m.Content); err == nil {
+				msg.Content = parts
+			} else {
+				return nil, err
+			}
+		}
+		for _, tc := range m.ToolCalls {
+			msg.ToolCalls = append(msg.ToolCalls, xl.ToolCall{
+				ID:        tc.ID,
+				Name:      tc.Function.Name,
+				Arguments: tc.Function.Arguments,
+			})
+		}
+		if m.Role == "tool" && len(msg.Content) > 0 {
+			// Fold into canonical tool_result part
+			if s, ok := plainText(m.Content); ok {
+				msg.Content = []xl.Part{{
+					Type:      xl.PartToolResult,
+					ToolUseID: m.ToolCallID,
+					Output:    s,
+				}}
+			}
+		}
+		ir.Messages = append(ir.Messages, msg)
+	}
+	return ir, nil
+}
+
+func parseStop(raw json.RawMessage) []string {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return []string{s}
+	}
+	var arr []string
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		return arr
+	}
+	return nil
+}
+
+func plainText(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 {
+		return "", true
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s, true
+	}
+	return "", false
+}
+
+func parseContent(raw json.RawMessage) ([]xl.Part, error) {
+	if s, ok := plainText(raw); ok {
+		if s == "" {
+			return nil, nil
+		}
+		return []xl.Part{{Type: xl.PartText, Text: s}}, nil
+	}
+	var arr []map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return nil, fmt.Errorf("openai: content: %w", err)
+	}
+	var parts []xl.Part
+	for _, item := range arr {
+		var t string
+		_ = json.Unmarshal(item["type"], &t)
+		switch t {
+		case "text":
+			var txt string
+			_ = json.Unmarshal(item["text"], &txt)
+			parts = append(parts, xl.Part{Type: xl.PartText, Text: txt})
+		case "image_url", "input_audio", "image":
+			return nil, fmt.Errorf("openai: images/audio not supported")
+		default:
+			var txt string
+			if _, ok := item["text"]; ok {
+				_ = json.Unmarshal(item["text"], &txt)
+				parts = append(parts, xl.Part{Type: xl.PartText, Text: txt})
+			}
+		}
+	}
+	return parts, nil
+}
+
+// --- Response ---
+
+type oaiResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Created int64  `json:"created"`
+	Model   string `json:"model"`
+	Choices []struct {
+		Index        int        `json:"index"`
+		Message      oaiMessage `json:"message"`
+		FinishReason string     `json:"finish_reason"`
+		Logprobs     any        `json:"logprobs,omitempty"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		TotalTokens      int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+func (Parser) ParseChatResponse(body []byte) (*xl.ChatResponse, error) {
+	var r oaiResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("openai: parse response: %w", err)
+	}
+	if len(r.Choices) == 0 {
+		return nil, fmt.Errorf("openai: response has no choices")
+	}
+	c := r.Choices[0]
+	msg := xl.Message{Role: xl.Role(c.Message.Role)}
+	if parts, err := parseContent(c.Message.Content); err == nil {
+		msg.Content = parts
+	}
+	for _, tc := range c.Message.ToolCalls {
+		msg.ToolCalls = append(msg.ToolCalls, xl.ToolCall{
+			ID:        tc.ID,
+			Name:      tc.Function.Name,
+			Arguments: tc.Function.Arguments,
+		})
+	}
+	return &xl.ChatResponse{
+		ID:           r.ID,
+		Model:        r.Model,
+		Created:      r.Created,
+		Message:      msg,
+		FinishReason: normalizeFinish(c.FinishReason),
+		Usage: xl.Usage{
+			PromptTokens:     r.Usage.PromptTokens,
+			CompletionTokens: r.Usage.CompletionTokens,
+			TotalTokens:      r.Usage.TotalTokens,
+		},
+	}, nil
+}
+
+func normalizeFinish(s string) xl.FinishReason {
+	switch s {
+	case "stop", "":
+		return xl.FinishStop
+	case "length":
+		return xl.FinishLength
+	case "tool_calls", "function_call":
+		return xl.FinishToolCalls
+	}
+	return xl.FinishStop
+}
+
+// --- Emitter ---
+
+func (Emitter) EmitChatRequest(req *xl.ChatRequest, _ xl.EndpointKind) ([]byte, error) {
+	out := map[string]any{
+		"model": req.Model,
+	}
+	var msgs []map[string]any
+	if req.System != "" {
+		msgs = append(msgs, map[string]any{"role": "system", "content": req.System})
+	}
+	for _, m := range req.Messages {
+		om := map[string]any{"role": string(m.Role)}
+		if m.Name != "" {
+			om["name"] = m.Name
+		}
+		// tool-role messages carry tool_call_id and string output
+		if m.Role == xl.RoleTool {
+			var outStr string
+			var toolID string
+			for _, p := range m.Content {
+				if p.Type == xl.PartToolResult {
+					outStr = p.Output
+					toolID = p.ToolUseID
+				}
+			}
+			if m.ToolCallID != "" {
+				toolID = m.ToolCallID
+			}
+			om["tool_call_id"] = toolID
+			om["content"] = outStr
+			msgs = append(msgs, om)
+			continue
+		}
+		// tool_result parts at user-role (Anthropic style) → separate tool messages
+		hasToolResult := false
+		for _, p := range m.Content {
+			if p.Type == xl.PartToolResult {
+				hasToolResult = true
+				break
+			}
+		}
+		if hasToolResult && m.Role == xl.RoleUser {
+			for _, p := range m.Content {
+				if p.Type == xl.PartToolResult {
+					msgs = append(msgs, map[string]any{
+						"role":         "tool",
+						"tool_call_id": p.ToolUseID,
+						"content":      p.Output,
+					})
+				} else if p.Type == xl.PartText && p.Text != "" {
+					msgs = append(msgs, map[string]any{"role": "user", "content": p.Text})
+				}
+			}
+			continue
+		}
+		// Assistant with tool_use parts
+		if m.Role == xl.RoleAssistant {
+			var text strings.Builder
+			var calls []map[string]any
+			for _, p := range m.Content {
+				switch p.Type {
+				case xl.PartText:
+					text.WriteString(p.Text)
+				case xl.PartToolUse:
+					args := p.Input
+					if len(args) == 0 {
+						args = json.RawMessage(`{}`)
+					}
+					argsStr, _ := json.Marshal(string(args))
+					// OpenAI expects arguments as a JSON-encoded string
+					calls = append(calls, map[string]any{
+						"id":   p.ToolUseID,
+						"type": "function",
+						"function": map[string]any{
+							"name":      p.ToolName,
+							"arguments": json.RawMessage(argsStr),
+						},
+					})
+				}
+			}
+			for _, tc := range m.ToolCalls {
+				args := tc.Arguments
+				if len(args) == 0 {
+					args = json.RawMessage(`{}`)
+				}
+				argsStr, _ := json.Marshal(string(args))
+				calls = append(calls, map[string]any{
+					"id":   tc.ID,
+					"type": "function",
+					"function": map[string]any{
+						"name":      tc.Name,
+						"arguments": json.RawMessage(argsStr),
+					},
+				})
+			}
+			if text.Len() > 0 {
+				om["content"] = text.String()
+			} else {
+				om["content"] = nil
+			}
+			if len(calls) > 0 {
+				om["tool_calls"] = calls
+			}
+			msgs = append(msgs, om)
+			continue
+		}
+		// Default: concatenate text parts
+		var text strings.Builder
+		for _, p := range m.Content {
+			if p.Type == xl.PartText {
+				text.WriteString(p.Text)
+			}
+		}
+		om["content"] = text.String()
+		msgs = append(msgs, om)
+	}
+	out["messages"] = msgs
+
+	if req.Stream {
+		out["stream"] = true
+	}
+	if req.Temperature != nil {
+		out["temperature"] = *req.Temperature
+	}
+	if req.TopP != nil {
+		out["top_p"] = *req.TopP
+	}
+	if req.MaxTokens != nil {
+		out["max_tokens"] = *req.MaxTokens
+	}
+	if req.Seed != nil {
+		out["seed"] = *req.Seed
+	}
+	if len(req.Stop) > 0 {
+		if len(req.Stop) == 1 {
+			out["stop"] = req.Stop[0]
+		} else {
+			out["stop"] = req.Stop
+		}
+	}
+	if req.ToolChoice != nil {
+		out["tool_choice"] = req.ToolChoice
+	}
+	if len(req.Tools) > 0 {
+		var tools []map[string]any
+		for _, t := range req.Tools {
+			tools = append(tools, map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name":        t.Name,
+					"description": t.Description,
+					"parameters":  t.Schema,
+				},
+			})
+		}
+		out["tools"] = tools
+	}
+	for k, v := range req.Extra {
+		if _, clash := out[k]; !clash {
+			out[k] = v
+		}
+	}
+	return json.Marshal(out)
+}
+
+func (Emitter) EmitChatResponse(r *xl.ChatResponse) ([]byte, error) {
+	var content any
+	var calls []map[string]any
+	var textBuf strings.Builder
+	for _, p := range r.Message.Content {
+		switch p.Type {
+		case xl.PartText:
+			textBuf.WriteString(p.Text)
+		case xl.PartToolUse:
+			args := p.Input
+			if len(args) == 0 {
+				args = json.RawMessage(`{}`)
+			}
+			argsStr, _ := json.Marshal(string(args))
+			calls = append(calls, map[string]any{
+				"id":   p.ToolUseID,
+				"type": "function",
+				"function": map[string]any{
+					"name":      p.ToolName,
+					"arguments": json.RawMessage(argsStr),
+				},
+			})
+		}
+	}
+	for _, tc := range r.Message.ToolCalls {
+		args := tc.Arguments
+		if len(args) == 0 {
+			args = json.RawMessage(`{}`)
+		}
+		argsStr, _ := json.Marshal(string(args))
+		calls = append(calls, map[string]any{
+			"id":   tc.ID,
+			"type": "function",
+			"function": map[string]any{
+				"name":      tc.Name,
+				"arguments": json.RawMessage(argsStr),
+			},
+		})
+	}
+	if textBuf.Len() > 0 {
+		content = textBuf.String()
+	}
+
+	msg := map[string]any{"role": string(r.Message.Role)}
+	if content != nil {
+		msg["content"] = content
+	} else {
+		msg["content"] = nil
+	}
+	if len(calls) > 0 {
+		msg["tool_calls"] = calls
+	}
+
+	finish := string(r.FinishReason)
+	if finish == "" {
+		finish = "stop"
+	}
+	out := map[string]any{
+		"id":      r.ID,
+		"object":  "chat.completion",
+		"created": r.Created,
+		"model":   r.Model,
+		"choices": []map[string]any{{
+			"index":         0,
+			"message":       msg,
+			"finish_reason": finish,
+		}},
+		"usage": map[string]any{
+			"prompt_tokens":     r.Usage.PromptTokens,
+			"completion_tokens": r.Usage.CompletionTokens,
+			"total_tokens":      r.Usage.TotalTokens,
+		},
+	}
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(out); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// Ensure interface compliance.
+var (
+	_ xl.Parser  = Parser{}
+	_ xl.Emitter = Emitter{}
+)
+
+// compile-time unused import guards
+var _ = io.Discard

--- a/proxy/translate/openai/stream.go
+++ b/proxy/translate/openai/stream.go
@@ -1,0 +1,321 @@
+package openai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	xl "github.com/mostlygeek/llama-swap/proxy/translate"
+)
+
+// --- StreamParser ---
+
+// StreamParser decodes an OpenAI SSE stream. Each frame is a single line
+// starting with `data: ` followed by either `[DONE]` or a chat.completion
+// chunk JSON object. Frames are terminated by a blank line.
+type StreamParser struct {
+	buf      bytes.Buffer
+	sawStart bool
+	// per-tool-call-index argument buffering is not required for OpenAI→IR
+	// (each delta is already a json-string fragment we forward verbatim).
+	modelID string
+	respID  string
+}
+
+func NewStreamParser() xl.StreamParser { return &StreamParser{} }
+
+func (p *StreamParser) Feed(chunk []byte) ([]xl.StreamEvent, error) {
+	p.buf.Write(chunk)
+	var events []xl.StreamEvent
+	for {
+		data := p.buf.Bytes()
+		// SSE frames are delimited by a blank line. Find the next blank line.
+		idx := bytes.Index(data, []byte("\n\n"))
+		if idx < 0 {
+			// also accept \r\n\r\n
+			idx = bytes.Index(data, []byte("\r\n\r\n"))
+			if idx < 0 {
+				return events, nil
+			}
+			frame := data[:idx]
+			p.buf.Next(idx + 4)
+			evs, err := p.parseFrame(frame)
+			if err != nil {
+				return events, err
+			}
+			events = append(events, evs...)
+			continue
+		}
+		frame := data[:idx]
+		p.buf.Next(idx + 2)
+		evs, err := p.parseFrame(frame)
+		if err != nil {
+			return events, err
+		}
+		events = append(events, evs...)
+	}
+}
+
+func (p *StreamParser) Close() ([]xl.StreamEvent, error) {
+	// If we never saw [DONE], synthesize a stop event.
+	if p.buf.Len() > 0 {
+		// best-effort parse remainder
+		evs, _ := p.parseFrame(p.buf.Bytes())
+		p.buf.Reset()
+		return evs, nil
+	}
+	return nil, nil
+}
+
+func (p *StreamParser) parseFrame(frame []byte) ([]xl.StreamEvent, error) {
+	frame = bytes.TrimSpace(frame)
+	if len(frame) == 0 {
+		return nil, nil
+	}
+	// frame may contain multiple lines; we only care about `data:` lines.
+	var dataBuf bytes.Buffer
+	for _, line := range bytes.Split(frame, []byte("\n")) {
+		line = bytes.TrimRight(line, "\r")
+		if bytes.HasPrefix(line, []byte("data:")) {
+			payload := bytes.TrimSpace(line[len("data:"):])
+			dataBuf.Write(payload)
+		}
+	}
+	if dataBuf.Len() == 0 {
+		return nil, nil
+	}
+	payload := dataBuf.Bytes()
+	if bytes.Equal(payload, []byte("[DONE]")) {
+		return []xl.StreamEvent{{Type: xl.StreamStop}}, nil
+	}
+
+	var chunk struct {
+		ID      string `json:"id"`
+		Model   string `json:"model"`
+		Created int64  `json:"created"`
+		Choices []struct {
+			Index int `json:"index"`
+			Delta struct {
+				Role      string `json:"role,omitempty"`
+				Content   string `json:"content,omitempty"`
+				ToolCalls []struct {
+					Index    int    `json:"index"`
+					ID       string `json:"id,omitempty"`
+					Type     string `json:"type,omitempty"`
+					Function struct {
+						Name      string `json:"name,omitempty"`
+						Arguments string `json:"arguments,omitempty"`
+					} `json:"function"`
+				} `json:"tool_calls,omitempty"`
+			} `json:"delta"`
+			FinishReason string `json:"finish_reason,omitempty"`
+		} `json:"choices"`
+		Usage *struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+			TotalTokens      int `json:"total_tokens"`
+		} `json:"usage,omitempty"`
+	}
+	if err := json.Unmarshal(payload, &chunk); err != nil {
+		return nil, fmt.Errorf("openai stream: %w", err)
+	}
+
+	var events []xl.StreamEvent
+	if !p.sawStart {
+		p.sawStart = true
+		p.modelID = chunk.Model
+		p.respID = chunk.ID
+		events = append(events, xl.StreamEvent{Type: xl.StreamStart, Model: chunk.Model, ID: chunk.ID})
+	}
+	for _, ch := range chunk.Choices {
+		if ch.Delta.Content != "" {
+			events = append(events, xl.StreamEvent{Type: xl.StreamTextDelta, Index: ch.Index, Text: ch.Delta.Content})
+		}
+		for _, tc := range ch.Delta.ToolCalls {
+			if tc.ID != "" || tc.Function.Name != "" {
+				events = append(events, xl.StreamEvent{
+					Type:  xl.StreamToolUseStart,
+					Index: tc.Index,
+					ToolCall: &xl.ToolCall{
+						ID:   tc.ID,
+						Name: tc.Function.Name,
+					},
+				})
+			}
+			if tc.Function.Arguments != "" {
+				events = append(events, xl.StreamEvent{
+					Type:      xl.StreamToolArgsDelta,
+					Index:     tc.Index,
+					ArgsDelta: tc.Function.Arguments,
+				})
+			}
+		}
+		if ch.FinishReason != "" {
+			events = append(events, xl.StreamEvent{
+				Type:         xl.StreamStop,
+				FinishReason: normalizeFinish(ch.FinishReason),
+			})
+		}
+	}
+	if chunk.Usage != nil {
+		events = append(events, xl.StreamEvent{
+			Type: xl.StreamUsage,
+			Usage: &xl.Usage{
+				PromptTokens:     chunk.Usage.PromptTokens,
+				CompletionTokens: chunk.Usage.CompletionTokens,
+				TotalTokens:      chunk.Usage.TotalTokens,
+			},
+		})
+	}
+	return events, nil
+}
+
+// --- StreamEmitter ---
+
+// StreamEmitter writes IR events as an OpenAI SSE stream.
+type StreamEmitter struct {
+	model   string
+	id      string
+	started bool
+	done    bool
+	// per-tool-index accumulated state, to emit proper id/name/index on first
+	// fragment and args deltas afterwards.
+	toolStarted map[int]bool
+}
+
+func NewStreamEmitter() xl.StreamEmitter {
+	return &StreamEmitter{toolStarted: map[int]bool{}}
+}
+
+func (e *StreamEmitter) ContentType() string { return "text/event-stream" }
+
+func (e *StreamEmitter) Emit(w io.Writer, ev xl.StreamEvent) error {
+	switch ev.Type {
+	case xl.StreamStart:
+		if ev.Model != "" {
+			e.model = ev.Model
+		}
+		if ev.ID != "" {
+			e.id = ev.ID
+		}
+		e.started = true
+		// OpenAI emits its initial role-only delta as the first chunk.
+		return e.writeChunk(w, map[string]any{
+			"id":      e.id,
+			"object":  "chat.completion.chunk",
+			"created": 0,
+			"model":   e.model,
+			"choices": []map[string]any{{
+				"index": 0,
+				"delta": map[string]any{"role": "assistant"},
+			}},
+		})
+	case xl.StreamTextDelta:
+		return e.writeChunk(w, map[string]any{
+			"id":      e.id,
+			"object":  "chat.completion.chunk",
+			"created": 0,
+			"model":   e.model,
+			"choices": []map[string]any{{
+				"index": 0,
+				"delta": map[string]any{"content": ev.Text},
+			}},
+		})
+	case xl.StreamToolUseStart:
+		if ev.ToolCall == nil {
+			return nil
+		}
+		e.toolStarted[ev.Index] = true
+		tc := map[string]any{
+			"index": ev.Index,
+			"id":    ev.ToolCall.ID,
+			"type":  "function",
+			"function": map[string]any{
+				"name":      ev.ToolCall.Name,
+				"arguments": "",
+			},
+		}
+		return e.writeChunk(w, map[string]any{
+			"id": e.id, "object": "chat.completion.chunk", "model": e.model,
+			"choices": []map[string]any{{
+				"index": 0,
+				"delta": map[string]any{"tool_calls": []map[string]any{tc}},
+			}},
+		})
+	case xl.StreamToolArgsDelta:
+		tc := map[string]any{
+			"index": ev.Index,
+			"function": map[string]any{
+				"arguments": ev.ArgsDelta,
+			},
+		}
+		return e.writeChunk(w, map[string]any{
+			"id": e.id, "object": "chat.completion.chunk", "model": e.model,
+			"choices": []map[string]any{{
+				"index": 0,
+				"delta": map[string]any{"tool_calls": []map[string]any{tc}},
+			}},
+		})
+	case xl.StreamToolUseStop:
+		return nil
+	case xl.StreamUsage:
+		if ev.Usage == nil {
+			return nil
+		}
+		return e.writeChunk(w, map[string]any{
+			"id": e.id, "object": "chat.completion.chunk", "model": e.model,
+			"choices": []map[string]any{},
+			"usage": map[string]any{
+				"prompt_tokens":     ev.Usage.PromptTokens,
+				"completion_tokens": ev.Usage.CompletionTokens,
+				"total_tokens":      ev.Usage.TotalTokens,
+			},
+		})
+	case xl.StreamStop:
+		if e.done {
+			return nil
+		}
+		e.done = true
+		finish := string(ev.FinishReason)
+		if finish == "" {
+			finish = "stop"
+		}
+		if err := e.writeChunk(w, map[string]any{
+			"id": e.id, "object": "chat.completion.chunk", "model": e.model,
+			"choices": []map[string]any{{
+				"index":         0,
+				"delta":         map[string]any{},
+				"finish_reason": finish,
+			}},
+		}); err != nil {
+			return err
+		}
+		_, err := io.WriteString(w, "data: [DONE]\n\n")
+		return err
+	case xl.StreamError:
+		return e.writeChunk(w, map[string]any{
+			"error": map[string]any{"message": ev.Err},
+		})
+	}
+	return nil
+}
+
+func (e *StreamEmitter) writeChunk(w io.Writer, obj map[string]any) error {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	if _, err := io.WriteString(w, "data: "); err != nil {
+		return err
+	}
+	if _, err := w.Write(b); err != nil {
+		return err
+	}
+	_, err = io.WriteString(w, "\n\n")
+	return err
+}
+
+// unused import guard
+var _ = strings.Repeat

--- a/proxy/translate/pipeline.go
+++ b/proxy/translate/pipeline.go
@@ -1,0 +1,151 @@
+package translate
+
+import (
+	"fmt"
+)
+
+// Registry holds the protocol adapter implementations. Tests and handlers
+// register adapters at init time (see pkg openai/anthropic/ollama).
+type Registry struct {
+	parsers       map[Protocol]Parser
+	emitters      map[Protocol]Emitter
+	streamParsers map[Protocol]func() StreamParser
+	streamEmits   map[Protocol]func() StreamEmitter
+}
+
+var defaultRegistry = &Registry{
+	parsers:       map[Protocol]Parser{},
+	emitters:      map[Protocol]Emitter{},
+	streamParsers: map[Protocol]func() StreamParser{},
+	streamEmits:   map[Protocol]func() StreamEmitter{},
+}
+
+// Register registers adapter components for a protocol. Safe to call from
+// adapter package init() functions.
+func Register(p Protocol, parser Parser, emitter Emitter) {
+	defaultRegistry.parsers[p] = parser
+	defaultRegistry.emitters[p] = emitter
+}
+
+// RegisterStream registers streaming factories for a protocol.
+func RegisterStream(p Protocol, parser func() StreamParser, emitter func() StreamEmitter) {
+	defaultRegistry.streamParsers[p] = parser
+	defaultRegistry.streamEmits[p] = emitter
+}
+
+// GetParser returns the registered parser or an error.
+func GetParser(p Protocol) (Parser, error) {
+	if a, ok := defaultRegistry.parsers[p]; ok {
+		return a, nil
+	}
+	return nil, fmt.Errorf("translate: no parser registered for %q", p)
+}
+
+// GetEmitter returns the registered emitter or an error.
+func GetEmitter(p Protocol) (Emitter, error) {
+	if a, ok := defaultRegistry.emitters[p]; ok {
+		return a, nil
+	}
+	return nil, fmt.Errorf("translate: no emitter registered for %q", p)
+}
+
+// NewStreamParser constructs a new StreamParser for p or returns an error.
+func NewStreamParser(p Protocol) (StreamParser, error) {
+	if f, ok := defaultRegistry.streamParsers[p]; ok {
+		return f(), nil
+	}
+	return nil, fmt.Errorf("translate: no stream parser registered for %q", p)
+}
+
+// NewStreamEmitter constructs a new StreamEmitter for p or returns an error.
+func NewStreamEmitter(p Protocol) (StreamEmitter, error) {
+	if f, ok := defaultRegistry.streamEmits[p]; ok {
+		return f(), nil
+	}
+	return nil, fmt.Errorf("translate: no stream emitter registered for %q", p)
+}
+
+// TranslateRequest parses a request body in the inbound protocol, applies
+// any direction-specific rewrites (tool IDs), then emits the target
+// protocol's wire-format body.
+func TranslateRequest(inbound, target Protocol, kind EndpointKind, body []byte) ([]byte, error) {
+	in, err := GetParser(inbound)
+	if err != nil {
+		return nil, err
+	}
+	out, err := GetEmitter(target)
+	if err != nil {
+		return nil, err
+	}
+	ir, err := in.ParseChatRequest(body, kind)
+	if err != nil {
+		return nil, err
+	}
+	rewriteRequestIDs(ir, inbound, target)
+	return out.EmitChatRequest(ir, kind)
+}
+
+// TranslateResponse parses an upstream non-streaming response in target
+// protocol and emits it in the inbound (client) protocol.
+func TranslateResponse(inbound, target Protocol, body []byte) ([]byte, error) {
+	in, err := GetParser(target)
+	if err != nil {
+		return nil, err
+	}
+	out, err := GetEmitter(inbound)
+	if err != nil {
+		return nil, err
+	}
+	ir, err := in.ParseChatResponse(body)
+	if err != nil {
+		return nil, err
+	}
+	rewriteResponseIDs(ir, inbound, target)
+	return out.EmitChatResponse(ir)
+}
+
+// rewriteRequestIDs rewrites assistant tool_call IDs + tool_result IDs so
+// that the target protocol sees an ID in its own namespace while the return
+// path can reverse the transform.
+func rewriteRequestIDs(ir *ChatRequest, inbound, target Protocol) {
+	if inbound == target {
+		return
+	}
+	for mi := range ir.Messages {
+		m := &ir.Messages[mi]
+		for ci := range m.Content {
+			p := &m.Content[ci]
+			switch p.Type {
+			case PartToolUse:
+				p.ToolUseID = MapToolIDOutbound(inbound, target, p.ToolUseID)
+			case PartToolResult:
+				// tool_result inbound IDs were minted in inbound's namespace;
+				// forward to target's namespace so the target recognises them.
+				p.ToolUseID = MapToolIDOutbound(inbound, target, p.ToolUseID)
+			}
+		}
+		for ti := range m.ToolCalls {
+			m.ToolCalls[ti].ID = MapToolIDOutbound(inbound, target, m.ToolCalls[ti].ID)
+		}
+		if m.ToolCallID != "" {
+			m.ToolCallID = MapToolIDOutbound(inbound, target, m.ToolCallID)
+		}
+	}
+}
+
+// rewriteResponseIDs rewrites assistant tool_use IDs in the upstream's
+// namespace back into the inbound client's namespace.
+func rewriteResponseIDs(ir *ChatResponse, inbound, target Protocol) {
+	if inbound == target {
+		return
+	}
+	for ci := range ir.Message.Content {
+		p := &ir.Message.Content[ci]
+		if p.Type == PartToolUse {
+			p.ToolUseID = MapToolIDInbound(inbound, target, p.ToolUseID)
+		}
+	}
+	for ti := range ir.Message.ToolCalls {
+		ir.Message.ToolCalls[ti].ID = MapToolIDInbound(inbound, target, ir.Message.ToolCalls[ti].ID)
+	}
+}

--- a/proxy/translate/pipeline_test.go
+++ b/proxy/translate/pipeline_test.go
@@ -1,0 +1,161 @@
+package translate_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	xl "github.com/mostlygeek/llama-swap/proxy/translate"
+	_ "github.com/mostlygeek/llama-swap/proxy/translate/adapters"
+)
+
+func TestChoose(t *testing.T) {
+	cases := []struct {
+		in     xl.Protocol
+		sup    []xl.Protocol
+		target xl.Protocol
+		needXl bool
+	}{
+		{xl.ProtocolOpenAI, []xl.Protocol{xl.ProtocolOpenAI, xl.ProtocolAnthropic}, xl.ProtocolOpenAI, false},
+		{xl.ProtocolAnthropic, []xl.Protocol{xl.ProtocolOllama}, xl.ProtocolOllama, true},
+		{xl.ProtocolOllama, []xl.Protocol{xl.ProtocolAnthropic, xl.ProtocolOpenAI}, xl.ProtocolOpenAI, true},
+		{xl.ProtocolAnthropic, []xl.Protocol{xl.ProtocolAnthropic}, xl.ProtocolAnthropic, false},
+	}
+	for _, c := range cases {
+		target, needXl := xl.Choose(c.in, c.sup)
+		if target != c.target || needXl != c.needXl {
+			t.Errorf("Choose(%v,%v)=(%v,%v) want (%v,%v)", c.in, c.sup, target, needXl, c.target, c.needXl)
+		}
+	}
+}
+
+func TestTranslateRequest_OpenAIToAnthropic(t *testing.T) {
+	body := []byte(`{
+		"model":"m1",
+		"messages":[
+			{"role":"system","content":"be brief"},
+			{"role":"user","content":"hi"}
+		],
+		"temperature":0.2,
+		"max_tokens":50
+	}`)
+	out, err := xl.TranslateRequest(xl.ProtocolOpenAI, xl.ProtocolAnthropic, xl.KindChat, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["system"] != "be brief" {
+		t.Errorf("system: %v", got["system"])
+	}
+	if got["max_tokens"] == nil {
+		t.Errorf("max_tokens missing")
+	}
+	msgs, _ := got["messages"].([]any)
+	if len(msgs) != 1 {
+		t.Fatalf("messages: %v", msgs)
+	}
+}
+
+func TestTranslateResponse_AnthropicToOpenAI(t *testing.T) {
+	body := []byte(`{
+		"id":"msg_1","type":"message","role":"assistant","model":"m1",
+		"content":[{"type":"text","text":"hello"}],
+		"stop_reason":"end_turn",
+		"usage":{"input_tokens":3,"output_tokens":1}
+	}`)
+	out, err := xl.TranslateResponse(xl.ProtocolOpenAI, xl.ProtocolAnthropic, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	choices := got["choices"].([]any)
+	msg := choices[0].(map[string]any)["message"].(map[string]any)
+	if msg["content"] != "hello" {
+		t.Errorf("content: %v", msg["content"])
+	}
+	if !strings.EqualFold(choices[0].(map[string]any)["finish_reason"].(string), "stop") {
+		t.Errorf("finish_reason: %v", choices[0])
+	}
+}
+
+func TestToolIDRoundTrip_OpenAIThroughAnthropic(t *testing.T) {
+	// Client is OpenAI. Upstream speaks Anthropic.
+	// 1. Client sends assistant tool_call with id=call_abc and then tool role with same id.
+	reqBody := []byte(`{
+		"model":"m","messages":[
+			{"role":"assistant","content":null,"tool_calls":[
+				{"id":"call_abc","type":"function","function":{"name":"ping","arguments":"{}"}}
+			]},
+			{"role":"tool","tool_call_id":"call_abc","content":"pong"}
+		]
+	}`)
+	out, err := xl.TranslateRequest(xl.ProtocolOpenAI, xl.ProtocolAnthropic, xl.KindChat, reqBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(out, &got); err != nil {
+		t.Fatal(err)
+	}
+	// Expect tool_use id to be "toolu_oa_abc" and tool_result id likewise.
+	msgs := got["messages"].([]any)
+	foundUse, foundRes := false, false
+	for _, mi := range msgs {
+		m := mi.(map[string]any)
+		blocks, _ := m["content"].([]any)
+		for _, bi := range blocks {
+			b := bi.(map[string]any)
+			switch b["type"] {
+			case "tool_use":
+				if b["id"] == "toolu_oa_abc" {
+					foundUse = true
+				}
+			case "tool_result":
+				if b["tool_use_id"] == "toolu_oa_abc" {
+					foundRes = true
+				}
+			}
+		}
+	}
+	if !foundUse || !foundRes {
+		t.Fatalf("ID not rewritten in outbound request: %s", out)
+	}
+
+	// 2. Upstream (Anthropic) responds with a tool_use id=toolu_oa_abc. The
+	// client (OpenAI) should see "call_abc" again.
+	respBody := []byte(`{
+		"id":"x","type":"message","role":"assistant","model":"m",
+		"content":[{"type":"tool_use","id":"toolu_oa_abc","name":"ping","input":{}}],
+		"stop_reason":"tool_use","usage":{"input_tokens":1,"output_tokens":1}
+	}`)
+	out2, err := xl.TranslateResponse(xl.ProtocolOpenAI, xl.ProtocolAnthropic, respBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out2), `"id":"call_abc"`) {
+		t.Fatalf("tool id not reversed: %s", out2)
+	}
+}
+
+func TestTranslateRequest_OpenAIToOllama(t *testing.T) {
+	body := []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}],"stream":false,"temperature":0.5}`)
+	out, err := xl.TranslateRequest(xl.ProtocolOpenAI, xl.ProtocolOllama, xl.KindChat, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got map[string]any
+	_ = json.Unmarshal(out, &got)
+	if got["stream"] != false {
+		t.Errorf("stream: %v", got["stream"])
+	}
+	opts := got["options"].(map[string]any)
+	if opts["temperature"] != 0.5 {
+		t.Errorf("temperature: %v", opts["temperature"])
+	}
+}

--- a/proxy/translate/protocol.go
+++ b/proxy/translate/protocol.go
@@ -1,0 +1,124 @@
+package translate
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Protocol names a wire format.
+type Protocol string
+
+const (
+	ProtocolOpenAI    Protocol = "openai"
+	ProtocolAnthropic Protocol = "anthropic"
+	ProtocolOllama    Protocol = "ollama"
+)
+
+// ValidProtocols is the closed set accepted in configuration.
+var ValidProtocols = []Protocol{ProtocolOpenAI, ProtocolAnthropic, ProtocolOllama}
+
+// ParseProtocol parses a string into a Protocol or returns an error.
+func ParseProtocol(s string) (Protocol, error) {
+	switch Protocol(strings.ToLower(strings.TrimSpace(s))) {
+	case ProtocolOpenAI:
+		return ProtocolOpenAI, nil
+	case ProtocolAnthropic:
+		return ProtocolAnthropic, nil
+	case ProtocolOllama:
+		return ProtocolOllama, nil
+	default:
+		return "", fmt.Errorf("unknown protocol %q (valid: openai, anthropic, ollama)", s)
+	}
+}
+
+// EndpointKind classifies an inbound chat-family endpoint. Translation runs
+// only for these; every other route is pass-through.
+type EndpointKind string
+
+const (
+	// KindChat is the rich chat endpoint for a protocol:
+	//   openai    → POST /v1/chat/completions
+	//   anthropic → POST /v1/messages
+	//   ollama    → POST /api/chat
+	KindChat EndpointKind = "chat"
+	// KindGenerate is the single-prompt Ollama legacy endpoint:
+	//   ollama    → POST /api/generate
+	// (OpenAI /v1/completions is intentionally NOT in scope for v1.)
+	KindGenerate EndpointKind = "generate"
+)
+
+// DetectInbound classifies the inbound request path into (protocol, kind)
+// and whether this request is a chat-family request eligible for
+// translation. Paths outside the chat family return (_, _, false) so the
+// caller can skip the entire translation block.
+func DetectInbound(method, path string) (Protocol, EndpointKind, bool) {
+	if method != "POST" {
+		return "", "", false
+	}
+	switch path {
+	case "/v1/chat/completions":
+		return ProtocolOpenAI, KindChat, true
+	case "/v1/messages":
+		return ProtocolAnthropic, KindChat, true
+	case "/api/chat":
+		return ProtocolOllama, KindChat, true
+	case "/api/generate":
+		return ProtocolOllama, KindGenerate, true
+	}
+	return "", "", false
+}
+
+// CanonicalPath returns the upstream path to use when forwarding a
+// translated request to a model that natively speaks target.
+func CanonicalPath(target Protocol, kind EndpointKind) string {
+	switch target {
+	case ProtocolOpenAI:
+		return "/v1/chat/completions"
+	case ProtocolAnthropic:
+		return "/v1/messages"
+	case ProtocolOllama:
+		if kind == KindGenerate {
+			return "/api/generate"
+		}
+		return "/api/chat"
+	}
+	return ""
+}
+
+// Parser turns a protocol's wire bytes into IR.
+type Parser interface {
+	// ParseChatRequest parses a full request body. For KindGenerate
+	// inputs, the parser is expected to fold the legacy prompt into a
+	// single user message.
+	ParseChatRequest(body []byte, kind EndpointKind) (*ChatRequest, error)
+	// ParseChatResponse parses a full non-streaming response body.
+	ParseChatResponse(body []byte) (*ChatResponse, error)
+}
+
+// StreamParser turns upstream stream bytes into StreamEvents.
+type StreamParser interface {
+	// Feed is called with newly-arrived upstream bytes. It returns zero
+	// or more StreamEvents fully decoded from complete frames. Partial
+	// frames are buffered internally until the next Feed.
+	Feed(chunk []byte) ([]StreamEvent, error)
+	// Close is called when the upstream stream ends. It returns any
+	// StreamEvents synthesized from buffered-but-unterminated state
+	// (e.g. a final error event if upstream aborted mid-frame).
+	Close() ([]StreamEvent, error)
+}
+
+// Emitter turns IR into a protocol's wire bytes.
+type Emitter interface {
+	EmitChatRequest(req *ChatRequest, kind EndpointKind) ([]byte, error)
+	EmitChatResponse(resp *ChatResponse) ([]byte, error)
+}
+
+// StreamEmitter writes translated stream frames in the client's protocol.
+type StreamEmitter interface {
+	// ContentType returns the media type for the response Content-Type
+	// header the client expects.
+	ContentType() string
+	// Emit writes one StreamEvent in the target wire format and flushes.
+	Emit(w io.Writer, ev StreamEvent) error
+}

--- a/proxy/translate/protocol_test.go
+++ b/proxy/translate/protocol_test.go
@@ -1,0 +1,60 @@
+package translate
+
+import "testing"
+
+func TestDetectInbound(t *testing.T) {
+	cases := []struct {
+		method, path string
+		wantProto    Protocol
+		wantKind     EndpointKind
+		wantOK       bool
+	}{
+		{"POST", "/v1/chat/completions", ProtocolOpenAI, KindChat, true},
+		{"POST", "/v1/messages", ProtocolAnthropic, KindChat, true},
+		{"POST", "/api/chat", ProtocolOllama, KindChat, true},
+		{"POST", "/api/generate", ProtocolOllama, KindGenerate, true},
+		{"POST", "/v1/responses", "", "", false},
+		{"POST", "/v1/completions", "", "", false},
+		{"POST", "/v1/embeddings", "", "", false},
+		{"GET", "/v1/chat/completions", "", "", false},
+	}
+	for _, tc := range cases {
+		p, k, ok := DetectInbound(tc.method, tc.path)
+		if p != tc.wantProto || k != tc.wantKind || ok != tc.wantOK {
+			t.Errorf("DetectInbound(%q,%q)=(%q,%q,%v) want (%q,%q,%v)",
+				tc.method, tc.path, p, k, ok, tc.wantProto, tc.wantKind, tc.wantOK)
+		}
+	}
+}
+
+func TestCanonicalPath(t *testing.T) {
+	cases := []struct {
+		target Protocol
+		kind   EndpointKind
+		want   string
+	}{
+		{ProtocolOpenAI, KindChat, "/v1/chat/completions"},
+		{ProtocolOpenAI, KindGenerate, "/v1/chat/completions"},
+		{ProtocolAnthropic, KindChat, "/v1/messages"},
+		{ProtocolOllama, KindChat, "/api/chat"},
+		{ProtocolOllama, KindGenerate, "/api/generate"},
+	}
+	for _, tc := range cases {
+		got := CanonicalPath(tc.target, tc.kind)
+		if got != tc.want {
+			t.Errorf("CanonicalPath(%q,%q)=%q want %q", tc.target, tc.kind, got, tc.want)
+		}
+	}
+}
+
+func TestParseProtocol(t *testing.T) {
+	if _, err := ParseProtocol("openai"); err != nil {
+		t.Errorf("openai: %v", err)
+	}
+	if _, err := ParseProtocol(" Anthropic "); err != nil {
+		t.Errorf("anthropic: %v", err)
+	}
+	if _, err := ParseProtocol("gemini"); err == nil {
+		t.Errorf("gemini should fail")
+	}
+}

--- a/proxy/translate/stream_test.go
+++ b/proxy/translate/stream_test.go
@@ -1,0 +1,121 @@
+package translate_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	xl "github.com/mostlygeek/llama-swap/proxy/translate"
+	_ "github.com/mostlygeek/llama-swap/proxy/translate/adapters"
+)
+
+// translateStream is a tiny helper that runs chunks through a parser of
+// upstream then an emitter of client and returns the emitted bytes.
+func translateStream(t *testing.T, upstream, client xl.Protocol, chunks [][]byte) string {
+	t.Helper()
+	sp, err := xl.NewStreamParser(upstream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	se, err := xl.NewStreamEmitter(client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var buf bytes.Buffer
+	for _, c := range chunks {
+		evs, err := sp.Feed(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, ev := range evs {
+			if err := se.Emit(&buf, ev); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	final, _ := sp.Close()
+	for _, ev := range final {
+		_ = se.Emit(&buf, ev)
+	}
+	return buf.String()
+}
+
+func TestStream_OpenAIToAnthropic(t *testing.T) {
+	upstream := [][]byte{
+		[]byte(`data: {"id":"c1","object":"chat.completion.chunk","model":"m","choices":[{"index":0,"delta":{"role":"assistant"}}]}` + "\n\n"),
+		[]byte(`data: {"id":"c1","model":"m","choices":[{"index":0,"delta":{"content":"hi "}}]}` + "\n\n"),
+		[]byte(`data: {"id":"c1","model":"m","choices":[{"index":0,"delta":{"content":"there"}}]}` + "\n\n"),
+		[]byte(`data: {"id":"c1","model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n"),
+		[]byte("data: [DONE]\n\n"),
+	}
+	out := translateStream(t, xl.ProtocolOpenAI, xl.ProtocolAnthropic, upstream)
+	for _, want := range []string{
+		"event: message_start",
+		"event: content_block_start",
+		`"text":"hi "`,
+		`"text":"there"`,
+		"event: content_block_stop",
+		"event: message_delta",
+		"event: message_stop",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestStream_AnthropicToOpenAI(t *testing.T) {
+	upstream := [][]byte{
+		[]byte("event: message_start\ndata: " + `{"type":"message_start","message":{"id":"msg_1","model":"m"}}` + "\n\n"),
+		[]byte("event: content_block_start\ndata: " + `{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n"),
+		[]byte("event: content_block_delta\ndata: " + `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hel"}}` + "\n\n"),
+		[]byte("event: content_block_delta\ndata: " + `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lo"}}` + "\n\n"),
+		[]byte("event: content_block_stop\ndata: " + `{"type":"content_block_stop","index":0}` + "\n\n"),
+		[]byte("event: message_delta\ndata: " + `{"type":"message_delta","delta":{"stop_reason":"end_turn"}}` + "\n\n"),
+		[]byte("event: message_stop\ndata: " + `{"type":"message_stop"}` + "\n\n"),
+	}
+	out := translateStream(t, xl.ProtocolAnthropic, xl.ProtocolOpenAI, upstream)
+	for _, want := range []string{
+		`"delta":{"role":"assistant"}`,
+		`"content":"hel"`,
+		`"content":"lo"`,
+		`"finish_reason":"stop"`,
+		"data: [DONE]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestStream_OllamaToOpenAI(t *testing.T) {
+	upstream := [][]byte{
+		[]byte(`{"model":"m","message":{"role":"assistant","content":"foo"},"done":false}` + "\n"),
+		[]byte(`{"model":"m","message":{"role":"assistant","content":"bar"},"done":false}` + "\n"),
+		[]byte(`{"model":"m","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":3,"eval_count":2}` + "\n"),
+	}
+	out := translateStream(t, xl.ProtocolOllama, xl.ProtocolOpenAI, upstream)
+	for _, want := range []string{
+		`"content":"foo"`,
+		`"content":"bar"`,
+		`"finish_reason":"stop"`,
+		"data: [DONE]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestStream_ChunkedFrames(t *testing.T) {
+	// Split the same OpenAI chunk across two writes — parser must buffer.
+	chunks := [][]byte{
+		[]byte("data: {\"id\":\"c1\",\"model\":\"m\",\"choices\":[{\"index\":0,\"delta\":"),
+		[]byte("{\"content\":\"ok\"}}]}\n\n"),
+		[]byte("data: [DONE]\n\n"),
+	}
+	out := translateStream(t, xl.ProtocolOpenAI, xl.ProtocolAnthropic, chunks)
+	if !strings.Contains(out, `"text":"ok"`) {
+		t.Errorf("chunked frame lost: %s", out)
+	}
+}

--- a/proxy/translation_proxy.go
+++ b/proxy/translation_proxy.go
@@ -1,0 +1,114 @@
+package proxy
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	xl "github.com/mostlygeek/llama-swap/proxy/translate"
+)
+
+// resolveModelProtocols returns the ordered list of protocols the model
+// identified by modelID natively supports. When matrix is in use, it
+// intersects across all candidate physical models.
+func resolveModelProtocols(pm *ProxyManager, modelID string) []xl.Protocol {
+	if pm.matrix != nil {
+		if ps := pm.matrix.ProtocolsFor(modelID); len(ps) > 0 {
+			return toProtocols(ps)
+		}
+	}
+	if m, ok := pm.config.Models[modelID]; ok {
+		return toProtocols(m.Protocols)
+	}
+	return []xl.Protocol{xl.ProtocolOpenAI, xl.ProtocolAnthropic}
+}
+
+func toProtocols(ss []string) []xl.Protocol {
+	out := make([]xl.Protocol, 0, len(ss))
+	for _, s := range ss {
+		out = append(out, xl.Protocol(s))
+	}
+	return out
+}
+
+// responseTranslator buffers the upstream response body, then translates it
+// into the client's protocol before forwarding. Used for non-streaming
+// responses only; streaming is handled by a dedicated writer wrapper
+// installed elsewhere.
+type responseTranslator struct {
+	gin.ResponseWriter
+	inbound xl.Protocol
+	target  xl.Protocol
+	logger  interface {
+		Errorf(string, ...any)
+		Debugf(string, ...any)
+	}
+	buf         bytes.Buffer
+	status      int
+	headersSent bool
+}
+
+// WriteHeader is intentionally captured; we rewrite headers on flushTo.
+func (r *responseTranslator) WriteHeader(code int) {
+	r.status = code
+}
+
+func (r *responseTranslator) Write(p []byte) (int, error) {
+	return r.buf.Write(p)
+}
+
+func (r *responseTranslator) WriteString(s string) (int, error) {
+	return r.buf.WriteString(s)
+}
+
+// Flush is a no-op; we flush once on completion.
+func (r *responseTranslator) Flush() {}
+
+// flushTo translates the buffered body and writes the final response to the
+// original writer.
+func (r *responseTranslator) flushTo(orig gin.ResponseWriter) {
+	body := r.buf.Bytes()
+	status := r.status
+	if status == 0 {
+		status = http.StatusOK
+	}
+
+	// Non-2xx: pass-through in the upstream's body verbatim, but still
+	// rewrite Content-Type to the client's expected media type so the
+	// client isn't confused about where the error came from.
+	if status < 200 || status >= 300 {
+		r.writeOriginal(orig, status, body, upstreamContentType(r.target))
+		return
+	}
+
+	translated, err := xl.TranslateResponse(r.inbound, r.target, body)
+	if err != nil {
+		r.logger.Errorf("translate response %s→%s: %v; forwarding upstream body verbatim", r.target, r.inbound, err)
+		r.writeOriginal(orig, http.StatusBadGateway, []byte(fmt.Sprintf(`{"error":"translate response failed: %s"}`, err.Error())), upstreamContentType(r.inbound))
+		return
+	}
+	r.writeOriginal(orig, status, translated, upstreamContentType(r.inbound))
+}
+
+func (r *responseTranslator) writeOriginal(orig gin.ResponseWriter, status int, body []byte, ct string) {
+	h := orig.Header()
+	h.Del("Content-Length")
+	for k := range h {
+		if strings.EqualFold(k, "Transfer-Encoding") {
+			h.Del(k)
+		}
+	}
+	h.Set("Content-Type", ct)
+	h.Set("Content-Length", strconv.Itoa(len(body)))
+	orig.WriteHeader(status)
+	_, _ = orig.Write(body)
+}
+
+// upstreamContentType returns the JSON media type for a non-streaming body
+// in the given protocol.
+func upstreamContentType(p xl.Protocol) string {
+	return "application/json"
+}

--- a/proxy/translation_stream.go
+++ b/proxy/translation_stream.go
@@ -1,0 +1,141 @@
+package proxy
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	xl "github.com/mostlygeek/llama-swap/proxy/translate"
+)
+
+// streamTranslator wraps gin.ResponseWriter to intercept a streaming upstream
+// response, decode it into IR StreamEvents (parser), and re-encode it into
+// the client's protocol (emitter). It also rewrites Content-Type and strips
+// Content-Length / Transfer-Encoding so clients see the right media type.
+type streamTranslator struct {
+	gin.ResponseWriter
+	parser          xl.StreamParser
+	emitter         xl.StreamEmitter
+	clientProto     xl.Protocol
+	headerRewritten bool
+	parserErr       error
+	// fallback buffer for non-2xx responses where we should pass bytes
+	// through rather than try to parse them as a stream.
+	passThrough bool
+}
+
+func newStreamTranslator(w gin.ResponseWriter, upstream, client xl.Protocol) (*streamTranslator, error) {
+	sp, err := xl.NewStreamParser(upstream)
+	if err != nil {
+		return nil, err
+	}
+	se, err := xl.NewStreamEmitter(client)
+	if err != nil {
+		return nil, err
+	}
+	return &streamTranslator{
+		ResponseWriter: w,
+		parser:         sp,
+		emitter:        se,
+		clientProto:    client,
+	}, nil
+}
+
+func (t *streamTranslator) WriteHeader(code int) {
+	if t.headerRewritten {
+		return
+	}
+	t.headerRewritten = true
+	h := t.ResponseWriter.Header()
+	h.Del("Content-Length")
+	h.Del("Transfer-Encoding")
+	if code >= 200 && code < 300 {
+		h.Set("Content-Type", t.emitter.ContentType())
+		h.Set("X-Accel-Buffering", "no")
+		h.Set("Cache-Control", "no-cache")
+	} else {
+		// error body: forward verbatim, keep JSON as a safe default.
+		t.passThrough = true
+		if h.Get("Content-Type") == "" {
+			h.Set("Content-Type", "application/json")
+		}
+	}
+	t.ResponseWriter.WriteHeader(code)
+}
+
+func (t *streamTranslator) Write(p []byte) (int, error) {
+	if !t.headerRewritten {
+		t.WriteHeader(http.StatusOK)
+	}
+	if t.passThrough {
+		return t.ResponseWriter.Write(p)
+	}
+	if t.parserErr != nil {
+		// once we've started emitting a translated stream, upstream parse
+		// errors turn into an error event and subsequent writes are dropped.
+		return len(p), nil
+	}
+	events, err := t.parser.Feed(p)
+	if err != nil {
+		t.parserErr = err
+		_ = t.emitter.Emit(t.ResponseWriter, xl.StreamEvent{Type: xl.StreamError, Err: err.Error()})
+		t.flush()
+		return len(p), nil
+	}
+	for _, ev := range events {
+		if err := t.emitter.Emit(t.ResponseWriter, ev); err != nil {
+			return len(p), err
+		}
+	}
+	t.flush()
+	return len(p), nil
+}
+
+// WriteString satisfies gin.ResponseWriter; delegate to Write.
+func (t *streamTranslator) WriteString(s string) (int, error) {
+	return t.Write([]byte(s))
+}
+
+// Flush is called by ReverseProxy to push frames to the client.
+func (t *streamTranslator) Flush() {
+	t.flush()
+}
+
+func (t *streamTranslator) flush() {
+	if f, ok := t.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack is forwarded so that things like websocket upgrades (not used here
+// but defensive) still work if the underlying writer supports it.
+func (t *streamTranslator) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := t.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, fmt.Errorf("hijack not supported")
+}
+
+// close drains any buffered state in the parser and emits a terminal frame
+// if upstream aborted before sending one.
+func (t *streamTranslator) close() {
+	if t.passThrough {
+		return
+	}
+	events, err := t.parser.Close()
+	if err != nil && t.parserErr == nil {
+		_ = t.emitter.Emit(t.ResponseWriter, xl.StreamEvent{Type: xl.StreamError, Err: err.Error()})
+	}
+	for _, ev := range events {
+		_ = t.emitter.Emit(t.ResponseWriter, ev)
+	}
+	// ensure a terminal stop is always sent so clients don't hang.
+	_ = t.emitter.Emit(t.ResponseWriter, xl.StreamEvent{Type: xl.StreamStop, FinishReason: xl.FinishStop})
+	t.flush()
+}
+
+// compile-time guard: used by translation_proxy at some point.
+var _ = bytes.Buffer{}


### PR DESCRIPTION
## Summary

- New `proxy/translate` package: canonical OpenAI-shaped IR, with parsers/emitters for OpenAI, Anthropic and Ollama chat endpoints (both non-streaming and streaming).
- `ModelConfig.Protocols` declares which wire formats each model natively supports. Default `[openai, anthropic]` preserves existing behaviour bit-for-bit.
- When a client's protocol is supported: zero-cost pass-through. When it isn't: translate request + response (including SSE/NDJSON streaming and tool-use), with stateless reversible tool-call ID mapping.
- Ollama API surface registered: `/api/chat`, `/api/generate`, `/api/tags` (filtered by `protocols`), `/api/show`.
- Header bridging (`x-api-key` ↔ `Authorization: Bearer`, default `anthropic-version`) and protocol-aware error envelopes from `sendErrorResponse`.
- Peer-routed models return 501 on Ollama mismatch for now; cross-peer translation is a follow-up.

## Status

Draft. Covered by `go test ./proxy/translate/...` (IR, cross-protocol, ID round-trip, stream parsers/emitters) and `make test-dev` is green. End-to-end integration tests against a real upstream and `response_format=json_schema` translation are listed as follow-ups in the plan.