### PR TITLE
.github/workflows: add toggle for pushing unified images to github

### DIFF
--- a/.github/workflows/unified-docker.yml
+++ b/.github/workflows/unified-docker.yml
@@ -97,7 +97,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: ${{ !env.ACT && (github.event_name == "schedule" || inputs.push_to_ghcr == "true") }}
+        if: ${{ !env.ACT && (github.event_name == 'schedule' || inputs.push_to_ghcr == true) }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -121,7 +121,7 @@ jobs:
           docker/unified/build-image.sh --${{ matrix.backend }}
 
       - name: Push to GitHub Container Registry
-        if: ${{ !env.ACT && (github.event_name == "schedule" || inputs.push_to_ghcr == "true") }}
+        if: ${{ !env.ACT && (github.event_name == 'schedule' || inputs.push_to_ghcr == true) }}
         run: |
           BASE_TAG="ghcr.io/mostlygeek/llama-swap:unified-${{ matrix.backend }}"
           DATE_TAG=$(date -u +%Y-%m-%d)

--- a/.github/workflows/unified-docker.yml
+++ b/.github/workflows/unified-docker.yml
@@ -36,6 +36,11 @@ on:
         type: boolean
         required: false
         default: true
+      push_to_ghcr:
+        description: "Push images to ghcr.io"
+        type: boolean
+        required: false
+        default: true
 
 permissions:
   contents: read
@@ -92,7 +97,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: ${{ !env.ACT }}
+        if: ${{ !env.ACT && (github.event_name == "schedule" || inputs.push_to_ghcr == "true") }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -116,7 +121,7 @@ jobs:
           docker/unified/build-image.sh --${{ matrix.backend }}
 
       - name: Push to GitHub Container Registry
-        if: ${{ !env.ACT }}
+        if: ${{ !env.ACT && (github.event_name == "schedule" || inputs.push_to_ghcr == "true") }}
         run: |
           BASE_TAG="ghcr.io/mostlygeek/llama-swap:unified-${{ matrix.backend }}"
           DATE_TAG=$(date -u +%Y-%m-%d)


### PR DESCRIPTION
Add ability to dispatch (manually run) unified container builds in github without push to ghcr.io.