### PR TITLE
proxy: reload on SIGHUP, support running as systemd `Type=notify-reload` service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.1
 
 require (
 	github.com/billziss-gh/golib v0.2.0
+	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/klauspost/compress v1.18.5

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/
 github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=
 github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
+github.com/coreos/go-systemd/v22 v22.7.0 h1:LAEzFkke61DFROc7zNLX/WA2i5J8gYqe0rSj9KI28KA=
+github.com/coreos/go-systemd/v22 v22.7.0/go.mod h1:xNUYtjHu2EDXbsxz1i41wouACIwT7Ybq9o0BQhMwD0w=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/llama-swap.go
+++ b/llama-swap.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -12,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/fsnotify/fsnotify"
 	"github.com/gin-gonic/gin"
 	"github.com/mostlygeek/llama-swap/event"
@@ -77,7 +79,7 @@ func main() {
 	// Setup channels for server management
 	exitChan := make(chan struct{})
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
 	// Create server with initial handler
 	srv := &http.Server{
@@ -85,7 +87,13 @@ func main() {
 	}
 
 	// Support for watching config and reloading when it changes
+	var started bool
 	reloadProxyManager := func() {
+		if started {
+			daemon.SdNotify(false, daemon.SdNotifyReloading+"\n"+daemon.SdNotifyMonotonicUsec())
+			defer daemon.SdNotify(false, daemon.SdNotifyReady)
+		}
+
 		if currentPM, ok := srv.Handler.(*proxy.ProxyManager); ok {
 			conf, err = config.LoadConfig(*configPath)
 			if err != nil {
@@ -120,14 +128,14 @@ func main() {
 
 	// load the initial proxy manager
 	reloadProxyManager()
+	started = true
 	debouncedReload := debounce(time.Second, reloadProxyManager)
+	defer event.On(func(e proxy.ConfigFileChangedEvent) {
+		if e.ReloadingState == proxy.ReloadingStateStart {
+			debouncedReload()
+		}
+	})()
 	if *watchConfig {
-		defer event.On(func(e proxy.ConfigFileChangedEvent) {
-			if e.ReloadingState == proxy.ReloadingStateStart {
-				debouncedReload()
-			}
-		})()
-
 		fmt.Println("Watching Configuration for changes")
 		go func() {
 			absConfigPath, err := filepath.Abs(*configPath)
@@ -172,33 +180,53 @@ func main() {
 
 	// shutdown on signal
 	go func() {
-		sig := <-sigChan
-		fmt.Printf("Received signal %v, shutting down...\n", sig)
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer cancel()
+		for {
+			sig := <-sigChan
+			if sig == syscall.SIGHUP {
+				event.Emit(proxy.ConfigFileChangedEvent{
+					ReloadingState: proxy.ReloadingStateStart,
+				})
+			} else {
+				fmt.Printf("Received signal %v, shutting down...\n", sig)
+				daemon.SdNotify(false, daemon.SdNotifyStopping)
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 
-		if pm, ok := srv.Handler.(*proxy.ProxyManager); ok {
-			pm.Shutdown()
-		} else {
-			fmt.Println("srv.Handler is not of type *proxy.ProxyManager")
-		}
+				if pm, ok := srv.Handler.(*proxy.ProxyManager); ok {
+					pm.Shutdown()
+				} else {
+					fmt.Println("srv.Handler is not of type *proxy.ProxyManager")
+				}
 
-		if err := srv.Shutdown(ctx); err != nil {
-			fmt.Printf("Server shutdown error: %v\n", err)
+				if err := srv.Shutdown(ctx); err != nil {
+					fmt.Printf("Server shutdown error: %v\n", err)
+				}
+				close(exitChan)
+				cancel()
+				return
+			}
 		}
-		close(exitChan)
 	}()
+
+	runServer := func() error {
+		ln, err := net.Listen("tcp", *listenStr)
+		if err != nil {
+			return err
+		}
+
+		daemon.SdNotify(false, daemon.SdNotifyReady)
+
+		if useTLS {
+			fmt.Printf("llama-swap listening with TLS on https://%s\n", *listenStr)
+			return srv.ServeTLS(ln, *certFile, *keyFile)
+		} else {
+			fmt.Printf("llama-swap listening on http://%s\n", *listenStr)
+			return srv.Serve(ln)
+		}
+	}
 
 	// Start server
 	go func() {
-		var err error
-		if useTLS {
-			fmt.Printf("llama-swap listening with TLS on https://%s\n", *listenStr)
-			err = srv.ListenAndServeTLS(*certFile, *keyFile)
-		} else {
-			fmt.Printf("llama-swap listening on http://%s\n", *listenStr)
-			err = srv.ListenAndServe()
-		}
+		err := runServer()
 		if err != nil && err != http.ErrServerClosed {
 			log.Fatalf("Fatal server error: %v\n", err)
 		}


### PR DESCRIPTION
Emit all the necessary messages to integrate with systemd (and especially the `systemd reload` command) when running in a `Type=notify-reload` service, as described in `man 5 systemd.service`. This includes the ability to trigger a reload with SIGHUP (even when not running as a systemd service).

Additionally, this potentially solves #547, since `docker kill -s SIGHUP llama-swap` can be used to send SIGHUP to llama-swap running in docker.