### PR TITLE
proxy: add excludeFromMetrics option to hide models from activity stats

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -412,6 +412,15 @@ models:
     unlisted: true
     cmd: llama-server --port ${PORT} -m Llama-3.2-1B-Instruct-Q4_K_M.gguf -ngl 0
 
+  # Exclude model from metrics example:
+  "qwen-hidden-metrics":
+    # excludeFromMetrics: boolean, true or false
+    # - optional, default: false
+    # - when true, requests to this model will not appear in /ui/#/activity
+    # - useful for hiding test or internal models from usage statistics
+    excludeFromMetrics: true
+    cmd: llama-server --port ${PORT} -m Qwen3-4B-Q4_K_M.gguf -ngl 0
+
   # Docker example:
   # container runtimes like Docker and Podman can be used reliably with
   # a combination of cmd, cmdStop, and ${MODEL_ID}

--- a/proxy/config/model_config.go
+++ b/proxy/config/model_config.go
@@ -21,15 +21,16 @@ type TimeoutsConfig struct {
 }
 
 type ModelConfig struct {
-	Cmd           string   `yaml:"cmd"`
-	CmdStop       string   `yaml:"cmdStop"`
-	Proxy         string   `yaml:"proxy"`
-	Aliases       []string `yaml:"aliases"`
-	Env           []string `yaml:"env"`
-	CheckEndpoint string   `yaml:"checkEndpoint"`
-	UnloadAfter   int      `yaml:"ttl"`
-	Unlisted      bool     `yaml:"unlisted"`
-	UseModelName  string   `yaml:"useModelName"`
+	Cmd                string   `yaml:"cmd"`
+	CmdStop            string   `yaml:"cmdStop"`
+	Proxy              string   `yaml:"proxy"`
+	Aliases            []string `yaml:"aliases"`
+	Env                []string `yaml:"env"`
+	CheckEndpoint      string   `yaml:"checkEndpoint"`
+	UnloadAfter        int      `yaml:"ttl"`
+	Unlisted           bool     `yaml:"unlisted"`
+	ExcludeFromMetrics bool     `yaml:"excludeFromMetrics"`
+	UseModelName       string   `yaml:"useModelName"`
 
 	// #179 for /v1/models
 	Name        string `yaml:"name"`
@@ -59,18 +60,19 @@ type ModelConfig struct {
 func (m *ModelConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type rawModelConfig ModelConfig
 	defaults := rawModelConfig{
-		Cmd:              "",
-		CmdStop:          "",
-		Proxy:            "http://localhost:${PORT}",
-		Aliases:          []string{},
-		Env:              []string{},
-		CheckEndpoint:    "/health",
-		UnloadAfter:      MODEL_CONFIG_DEFAULT_TTL, // use GlobalTTL
-		Unlisted:         false,
-		UseModelName:     "",
-		ConcurrencyLimit: 0,
-		Name:             "",
-		Description:      "",
+		Cmd:                "",
+		CmdStop:            "",
+		Proxy:              "http://localhost:${PORT}",
+		Aliases:            []string{},
+		Env:                []string{},
+		CheckEndpoint:      "/health",
+		UnloadAfter:        MODEL_CONFIG_DEFAULT_TTL, // use GlobalTTL
+		Unlisted:           false,
+		ExcludeFromMetrics: false,
+		UseModelName:       "",
+		ConcurrencyLimit:   0,
+		Name:               "",
+		Description:        "",
 
 		// matches http.DefaultTransport
 		Timeouts: TimeoutsConfig{

--- a/proxy/proxymanager_api.go
+++ b/proxy/proxymanager_api.go
@@ -162,7 +162,11 @@ func (pm *ProxyManager) apiSendEvents(c *gin.Context) {
 	}
 
 	sendMetrics := func(metrics []ActivityLogEntry) {
-		jsonData, err := json.Marshal(metrics)
+		filtered := pm.filterExcludedMetrics(metrics)
+		if len(filtered) == 0 {
+			return
+		}
+		jsonData, err := json.Marshal(filtered)
 		if err == nil {
 			select {
 			case sendBuffer <- messageEnvelope{Type: msgTypeMetrics, Data: string(jsonData)}:
@@ -242,7 +246,9 @@ func (pm *ProxyManager) apiSendEvents(c *gin.Context) {
 }
 
 func (pm *ProxyManager) apiGetMetrics(c *gin.Context) {
-	jsonData, err := pm.metricsMonitor.getMetricsJSON()
+	metrics := pm.metricsMonitor.getMetrics()
+	filtered := pm.filterExcludedMetrics(metrics)
+	jsonData, err := json.Marshal(filtered)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get metrics"})
 		return
@@ -298,6 +304,31 @@ func (pm *ProxyManager) apiGetPerformance(c *gin.Context) {
 		"sys_stats": sysStats,
 		"gpu_stats": gpuStats,
 	})
+}
+
+func (pm *ProxyManager) filterExcludedMetrics(metrics []ActivityLogEntry) []ActivityLogEntry {
+	if len(metrics) == 0 {
+		return metrics
+	}
+
+	excludedModels := make(map[string]bool)
+	for modelID, modelConfig := range pm.config.Models {
+		if modelConfig.ExcludeFromMetrics {
+			excludedModels[modelID] = true
+		}
+	}
+
+	if len(excludedModels) == 0 {
+		return metrics
+	}
+
+	filtered := make([]ActivityLogEntry, 0, len(metrics))
+	for _, m := range metrics {
+		if !excludedModels[m.Model] {
+			filtered = append(filtered, m)
+		}
+	}
+	return filtered
 }
 
 func (pm *ProxyManager) apiUnloadSingleModelHandler(c *gin.Context) {


### PR DESCRIPTION
Add excludeFromMetrics field to ModelConfig that allows excluding a model's requests from appearing in the /ui/#/activity page and metrics API.

- adds excludeFromMetrics boolean config option (default: false)
- filters excluded models in apiGetMetrics endpoint
- filters excluded models in SSE events
- adds documentation in configuration.md

---

Co-authored-by: opencode (minimax-m2.5-free)