### PR TITLE
(682) glm 5.1 configwatcher: replace fsnotify with fstat polling and add SIGHUP support

### DIFF
--- a/configwatcher/watcher.go
+++ b/configwatcher/watcher.go
@@ -1,0 +1,73 @@
+package configwatcher
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+type Watcher struct {
+	path        string
+	interval    time.Duration
+	onChange    func()
+	done        chan struct{}
+	wg          sync.WaitGroup
+	lastModTime time.Time
+	lastSize    int64
+}
+
+func NewWatcher(path string, interval time.Duration, onChange func()) *Watcher {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+	return &Watcher{
+		path:     absPath,
+		interval: interval,
+		onChange: onChange,
+		done:     make(chan struct{}),
+	}
+}
+
+func (w *Watcher) Start() {
+	info, err := os.Stat(w.path)
+	if err == nil {
+		w.lastModTime = info.ModTime()
+		w.lastSize = info.Size()
+	}
+
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		ticker := time.NewTicker(w.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				w.check()
+			case <-w.done:
+				return
+			}
+		}
+	}()
+}
+
+func (w *Watcher) Stop() {
+	close(w.done)
+	w.wg.Wait()
+}
+
+func (w *Watcher) check() {
+	info, err := os.Stat(w.path)
+	if err != nil {
+		return
+	}
+
+	if info.ModTime() != w.lastModTime || info.Size() != w.lastSize {
+		w.lastModTime = info.ModTime()
+		w.lastSize = info.Size()
+		w.onChange()
+	}
+}

--- a/configwatcher/watcher_test.go
+++ b/configwatcher/watcher_test.go
@@ -1,0 +1,141 @@
+package configwatcher
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWatcher_DetectsModification(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("initial"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var called atomic.Int32
+	w := NewWatcher(path, 100*time.Millisecond, func() {
+		called.Add(1)
+	})
+	w.Start()
+	defer w.Stop()
+
+	time.Sleep(200 * time.Millisecond)
+
+	if err := os.WriteFile(path, []byte("updated content here"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for called.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("onChange was not called after file modification")
+		default:
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+}
+
+func TestWatcher_DetectsSizeChange(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("short"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var called atomic.Int32
+	w := NewWatcher(path, 100*time.Millisecond, func() {
+		called.Add(1)
+	})
+	w.Start()
+	defer w.Stop()
+
+	time.Sleep(200 * time.Millisecond)
+
+	if err := os.WriteFile(path, []byte("this is a much longer content string"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for called.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("onChange was not called after file size change")
+		default:
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+}
+
+func TestWatcher_FileDeletedAndRecreated(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("initial"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var called atomic.Int32
+	w := NewWatcher(path, 100*time.Millisecond, func() {
+		called.Add(1)
+	})
+	w.Start()
+	defer w.Stop()
+
+	time.Sleep(200 * time.Millisecond)
+
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(300 * time.Millisecond)
+
+	if err := os.WriteFile(path, []byte("recreated with different content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for called.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("onChange was not called after file recreation")
+		default:
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+}
+
+func TestWatcher_Stop(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("initial"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w := NewWatcher(path, 50*time.Millisecond, func() {})
+	w.Start()
+	w.Stop()
+}
+
+func TestWatcher_NoFalsePositives(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("unchanged"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var called atomic.Int32
+	w := NewWatcher(path, 100*time.Millisecond, func() {
+		called.Add(1)
+	})
+	w.Start()
+	defer w.Stop()
+
+	time.Sleep(500 * time.Millisecond)
+
+	if called.Load() != 0 {
+		t.Fatalf("onChange was called %d times without any file change", called.Load())
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.26.1
 
 require (
 	github.com/billziss-gh/golib v0.2.0
-	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/klauspost/compress v1.18.5
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/llama-swap.go
+++ b/llama-swap.go
@@ -9,11 +9,12 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"syscall"
 	"time"
 
-	"github.com/fsnotify/fsnotify"
 	"github.com/gin-gonic/gin"
+	"github.com/mostlygeek/llama-swap/configwatcher"
 	"github.com/mostlygeek/llama-swap/event"
 	"github.com/mostlygeek/llama-swap/proxy"
 	"github.com/mostlygeek/llama-swap/proxy/config"
@@ -76,8 +77,14 @@ func main() {
 
 	// Setup channels for server management
 	exitChan := make(chan struct{})
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	shutdownChan := make(chan os.Signal, 1)
+	signal.Notify(shutdownChan, syscall.SIGINT, syscall.SIGTERM)
+
+	var reloadChan chan os.Signal
+	if runtime.GOOS != "windows" {
+		reloadChan = make(chan os.Signal, 1)
+		signal.Notify(reloadChan, syscall.SIGHUP)
+	}
 
 	// Create server with initial handler
 	srv := &http.Server{
@@ -129,64 +136,46 @@ func main() {
 		})()
 
 		fmt.Println("Watching Configuration for changes")
-		go func() {
-			absConfigPath, err := filepath.Abs(*configPath)
-			if err != nil {
-				fmt.Printf("Error getting absolute path for watching config file: %v\n", err)
-				return
-			}
-			watcher, err := fsnotify.NewWatcher()
-			if err != nil {
-				fmt.Printf("Error creating file watcher: %v. File watching disabled.\n", err)
-				return
-			}
-
-			configDir := filepath.Dir(absConfigPath)
-			err = watcher.Add(configDir)
-			if err != nil {
-				fmt.Printf("Error adding config path directory (%s) to watcher: %v. File watching disabled.", configDir, err)
-				return
-			}
-
-			defer watcher.Close()
-			for {
-				select {
-				case changeEvent := <-watcher.Events:
-					if changeEvent.Name == absConfigPath && (changeEvent.Has(fsnotify.Write) || changeEvent.Has(fsnotify.Create) || changeEvent.Has(fsnotify.Remove)) {
-						event.Emit(proxy.ConfigFileChangedEvent{
-							ReloadingState: proxy.ReloadingStateStart,
-						})
-					} else if changeEvent.Name == filepath.Join(configDir, "..data") && changeEvent.Has(fsnotify.Create) {
-						// the change for k8s configmap
-						event.Emit(proxy.ConfigFileChangedEvent{
-							ReloadingState: proxy.ReloadingStateStart,
-						})
-					}
-
-				case err := <-watcher.Errors:
-					log.Printf("File watcher error: %v", err)
-				}
-			}
-		}()
+		absConfigPath, err := filepath.Abs(*configPath)
+		if err != nil {
+			fmt.Printf("Error getting absolute path for watching config file: %v\n", err)
+		} else {
+			watcher := configwatcher.NewWatcher(absConfigPath, 2*time.Second, func() {
+				event.Emit(proxy.ConfigFileChangedEvent{
+					ReloadingState: proxy.ReloadingStateStart,
+				})
+			})
+			go watcher.Start()
+			defer watcher.Stop()
+		}
 	}
 
-	// shutdown on signal
+	// handle shutdown and reload signals
 	go func() {
-		sig := <-sigChan
-		fmt.Printf("Received signal %v, shutting down...\n", sig)
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-		defer cancel()
+		for {
+			select {
+			case sig := <-shutdownChan:
+				fmt.Printf("Received signal %v, shutting down...\n", sig)
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+				defer cancel()
 
-		if pm, ok := srv.Handler.(*proxy.ProxyManager); ok {
-			pm.Shutdown()
-		} else {
-			fmt.Println("srv.Handler is not of type *proxy.ProxyManager")
-		}
+				if pm, ok := srv.Handler.(*proxy.ProxyManager); ok {
+					pm.Shutdown()
+				} else {
+					fmt.Println("srv.Handler is not of type *proxy.ProxyManager")
+				}
 
-		if err := srv.Shutdown(ctx); err != nil {
-			fmt.Printf("Server shutdown error: %v\n", err)
+				if err := srv.Shutdown(ctx); err != nil {
+					fmt.Printf("Server shutdown error: %v\n", err)
+				}
+				close(exitChan)
+				return
+
+			case <-reloadChan:
+				fmt.Println("Received SIGHUP, reloading configuration...")
+				reloadProxyManager()
+			}
 		}
-		close(exitChan)
 	}()
 
 	// Start server


### PR DESCRIPTION
…port

fsnotify does not detect changes to Docker volume-mounted files because inotify events don't propagate across the host/container boundary. Replace it with a polling-based configwatcher that uses os.Stat to compare mtime and size at a 2-second interval. Add SIGHUP signal handling for immediate config reload on Unix systems.

- Add configwatcher package with polling-based file change detection
- Add SIGHUP support with runtime GOOS check instead of build tags
- Remove fsnotify dependency

fixes #682