### PR TITLE
(682) qwen3.6 proxy: replace fsnotify with fstat polling and add SIGHUP support

### DIFF
--- a/filewatcher.go
+++ b/filewatcher.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"os"
+	"time"
+)
+
+// FileWatcher polls files for changes using fstat (modification time comparison).
+// It is cross-platform (POSIX and Windows), supports symlinks, and works
+// in Docker containers with volume-mounted files.
+type FileWatcher struct {
+	interval time.Duration
+	paths    map[string]time.Time // path -> last known mtime
+	done     chan struct{}
+	onChange func()
+}
+
+// NewFileWatcher creates a new FileWatcher that polls at the given interval.
+// Call Start() to begin watching.
+func NewFileWatcher(interval time.Duration) *FileWatcher {
+	return &FileWatcher{
+		interval: interval,
+		paths:    make(map[string]time.Time),
+		done:     make(chan struct{}),
+	}
+}
+
+// Add registers a file path to watch. The path can be a regular file or a
+// symlink; os.Stat is used so symlinks are followed (important for k8s configmap
+// ..data swap pattern).
+func (fw *FileWatcher) Add(path string) {
+	fw.paths[path] = time.Time{}
+}
+
+// Start begins the polling loop in a goroutine. The onChange callback is
+// invoked whenever any watched file's modification time changes.
+func (fw *FileWatcher) Start(onChange func()) {
+	fw.onChange = onChange
+
+	go func() {
+		ticker := time.NewTicker(fw.interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-fw.done:
+				return
+			case <-ticker.C:
+				for path, lastMtime := range fw.paths {
+					info, err := os.Stat(path)
+					if err != nil {
+						// File may have been deleted or is temporarily unavailable.
+						// Reset the tracked mtime so re-creation is detected.
+						fw.paths[path] = time.Time{}
+						continue
+					}
+
+					mtime := info.ModTime()
+					if !mtime.Equal(lastMtime) {
+						fw.paths[path] = mtime
+						if fw.onChange != nil {
+							fw.onChange()
+						}
+						break
+					}
+				}
+			}
+		}
+	}()
+}
+
+// Stop signals the polling loop to exit.
+func (fw *FileWatcher) Stop() {
+	close(fw.done)
+}

--- a/filewatcher_test.go
+++ b/filewatcher_test.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestFileWatcher_DetectsChange(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.yaml")
+
+	// Create initial file
+	if err := os.WriteFile(testFile, []byte("initial"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	watcher := NewFileWatcher(100 * time.Millisecond)
+	watcher.Add(testFile)
+
+	changed := make(chan struct{}, 10)
+	watcher.Start(func() {
+		select {
+		case changed <- struct{}{}:
+		default:
+		}
+	})
+	defer watcher.Stop()
+
+	// Wait for initial stat to record mtime
+	time.Sleep(200 * time.Millisecond)
+
+	// Modify the file
+	time.Sleep(50 * time.Millisecond) // Ensure mtime differs
+	if err := os.WriteFile(testFile, []byte("modified"), 0644); err != nil {
+		t.Fatalf("failed to modify test file: %v", err)
+	}
+
+	// Wait for change to be detected
+	select {
+	case <-changed:
+		// Success
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for file change detection")
+	}
+}
+
+func TestFileWatcher_MultiplePaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	file1 := filepath.Join(tmpDir, "file1.yaml")
+	file2 := filepath.Join(tmpDir, "file2.yaml")
+
+	if err := os.WriteFile(file1, []byte("data1"), 0644); err != nil {
+		t.Fatalf("failed to create file1: %v", err)
+	}
+	if err := os.WriteFile(file2, []byte("data2"), 0644); err != nil {
+		t.Fatalf("failed to create file2: %v", err)
+	}
+
+	watcher := NewFileWatcher(100 * time.Millisecond)
+	watcher.Add(file1)
+	watcher.Add(file2)
+
+	var changeCount int64
+	watcher.Start(func() {
+		atomic.AddInt64(&changeCount, 1)
+	})
+	defer watcher.Stop()
+
+	// Wait for initial stat and a couple of ticks
+	time.Sleep(350 * time.Millisecond)
+	initialChanges := atomic.LoadInt64(&changeCount)
+
+	// Modify file1
+	time.Sleep(50 * time.Millisecond)
+	if err := os.WriteFile(file1, []byte("modified1"), 0644); err != nil {
+		t.Fatalf("failed to modify file1: %v", err)
+	}
+
+	// Wait for at least one new change
+	for i := 0; i < 20; i++ {
+		time.Sleep(100 * time.Millisecond)
+		newCount := atomic.LoadInt64(&changeCount)
+		if newCount > initialChanges {
+			break
+		}
+	}
+
+	// Now modify file2
+	time.Sleep(50 * time.Millisecond)
+	beforeFile2 := atomic.LoadInt64(&changeCount)
+	if err := os.WriteFile(file2, []byte("modified2"), 0644); err != nil {
+		t.Fatalf("failed to modify file2: %v", err)
+	}
+
+	// Wait for file2 change
+	for i := 0; i < 20; i++ {
+		time.Sleep(100 * time.Millisecond)
+		newCount := atomic.LoadInt64(&changeCount)
+		if newCount > beforeFile2 {
+			break
+		}
+	}
+
+	finalCount := atomic.LoadInt64(&changeCount)
+	if finalCount <= initialChanges {
+		t.Fatalf("expected more changes after modifying both files, got %d (initial: %d)", finalCount, initialChanges)
+	}
+}
+
+func TestFileWatcher_Symlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	realFile := filepath.Join(tmpDir, "real.yaml")
+	linkFile := filepath.Join(tmpDir, "link.yaml")
+
+	// Create real file
+	if err := os.WriteFile(realFile, []byte("real data"), 0644); err != nil {
+		t.Fatalf("failed to create real file: %v", err)
+	}
+
+	// Create symlink
+	if err := os.Symlink(realFile, linkFile); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	watcher := NewFileWatcher(100 * time.Millisecond)
+	watcher.Add(linkFile)
+
+	changed := make(chan struct{}, 10)
+	watcher.Start(func() {
+		select {
+		case changed <- struct{}{}:
+		default:
+		}
+	})
+	defer watcher.Stop()
+
+	// Wait for initial stat
+	time.Sleep(200 * time.Millisecond)
+
+	// Modify the real file (should be detected via symlink)
+	time.Sleep(50 * time.Millisecond)
+	if err := os.WriteFile(realFile, []byte("modified real data"), 0644); err != nil {
+		t.Fatalf("failed to modify real file: %v", err)
+	}
+
+	select {
+	case <-changed:
+		// Success - symlink detection works
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for symlink target change detection")
+	}
+}
+
+func TestFileWatcher_FileDeleted(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.yaml")
+
+	if err := os.WriteFile(testFile, []byte("data"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	watcher := NewFileWatcher(100 * time.Millisecond)
+	watcher.Add(testFile)
+
+	// Should not panic when file is deleted
+	watcher.Start(func() {})
+	defer watcher.Stop()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Delete the file
+	if err := os.Remove(testFile); err != nil {
+		t.Fatalf("failed to delete test file: %v", err)
+	}
+
+	// Wait a bit to ensure no panic
+	time.Sleep(300 * time.Millisecond)
+}
+
+func TestFileWatcher_FileRecreated(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.yaml")
+
+	if err := os.WriteFile(testFile, []byte("data"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	watcher := NewFileWatcher(100 * time.Millisecond)
+	watcher.Add(testFile)
+
+	changed := make(chan struct{}, 10)
+	watcher.Start(func() {
+		select {
+		case changed <- struct{}{}:
+		default:
+		}
+	})
+	defer watcher.Stop()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// Delete the file
+	if err := os.Remove(testFile); err != nil {
+		t.Fatalf("failed to delete test file: %v", err)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+
+	// Recreate the file (should be detected because mtime goes from zero time to now)
+	if err := os.WriteFile(testFile, []byte("recreated"), 0644); err != nil {
+		t.Fatalf("failed to recreate test file: %v", err)
+	}
+
+	select {
+	case <-changed:
+		// Success - recreation detected
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for file recreation detection")
+	}
+}
+
+func TestFileWatcher_Stop(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.yaml")
+
+	if err := os.WriteFile(testFile, []byte("data"), 0644); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	watcher := NewFileWatcher(50 * time.Millisecond)
+	watcher.Add(testFile)
+
+	changed := make(chan struct{}, 100)
+	watcher.Start(func() {
+		select {
+		case changed <- struct{}{}:
+		default:
+		}
+	})
+
+	// Let it run for a bit
+	time.Sleep(150 * time.Millisecond)
+
+	// Stop the watcher
+	watcher.Stop()
+
+	// Modify the file after stop - should not trigger
+	time.Sleep(50 * time.Millisecond)
+	if err := os.WriteFile(testFile, []byte("modified after stop"), 0644); err != nil {
+		t.Fatalf("failed to modify test file: %v", err)
+	}
+
+	// Wait and ensure no more changes
+	time.Sleep(300 * time.Millisecond)
+
+	close(changed)
+	count := 0
+	for range changed {
+		count++
+	}
+
+	// Should have had some changes before stop, but not after
+	if count < 1 {
+		t.Logf("warning: no changes detected before stop (count: %d)", count)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.26.1
 
 require (
 	github.com/billziss-gh/golib v0.2.0
-	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/klauspost/compress v1.18.5
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/llama-swap.go
+++ b/llama-swap.go
@@ -12,7 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/fsnotify/fsnotify"
 	"github.com/gin-gonic/gin"
 	"github.com/mostlygeek/llama-swap/event"
 	"github.com/mostlygeek/llama-swap/proxy"
@@ -77,7 +76,7 @@ func main() {
 	// Setup channels for server management
 	exitChan := make(chan struct{})
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
 	// Create server with initial handler
 	srv := &http.Server{
@@ -129,50 +128,29 @@ func main() {
 		})()
 
 		fmt.Println("Watching Configuration for changes")
-		go func() {
-			absConfigPath, err := filepath.Abs(*configPath)
-			if err != nil {
-				fmt.Printf("Error getting absolute path for watching config file: %v\n", err)
-				return
-			}
-			watcher, err := fsnotify.NewWatcher()
-			if err != nil {
-				fmt.Printf("Error creating file watcher: %v. File watching disabled.\n", err)
-				return
-			}
-
+		absConfigPath, err := filepath.Abs(*configPath)
+		if err != nil {
+			fmt.Printf("Error getting absolute path for watching config file: %v\n", err)
+		} else {
 			configDir := filepath.Dir(absConfigPath)
-			err = watcher.Add(configDir)
-			if err != nil {
-				fmt.Printf("Error adding config path directory (%s) to watcher: %v. File watching disabled.", configDir, err)
-				return
-			}
-
-			defer watcher.Close()
-			for {
-				select {
-				case changeEvent := <-watcher.Events:
-					if changeEvent.Name == absConfigPath && (changeEvent.Has(fsnotify.Write) || changeEvent.Has(fsnotify.Create) || changeEvent.Has(fsnotify.Remove)) {
-						event.Emit(proxy.ConfigFileChangedEvent{
-							ReloadingState: proxy.ReloadingStateStart,
-						})
-					} else if changeEvent.Name == filepath.Join(configDir, "..data") && changeEvent.Has(fsnotify.Create) {
-						// the change for k8s configmap
-						event.Emit(proxy.ConfigFileChangedEvent{
-							ReloadingState: proxy.ReloadingStateStart,
-						})
-					}
-
-				case err := <-watcher.Errors:
-					log.Printf("File watcher error: %v", err)
-				}
-			}
-		}()
+			watcher := NewFileWatcher(2 * time.Second)
+			watcher.Add(absConfigPath)
+			watcher.Add(filepath.Join(configDir, "..data"))
+			watcher.Start(func() {
+				debouncedReload()
+			})
+			defer watcher.Stop()
+		}
 	}
 
 	// shutdown on signal
 	go func() {
 		sig := <-sigChan
+		if sig == syscall.SIGHUP {
+			fmt.Println("Received SIGHUP, reloading configuration")
+			reloadProxyManager()
+			return
+		}
 		fmt.Printf("Received signal %v, shutting down...\n", sig)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		defer cancel()


### PR DESCRIPTION
Replace fsnotify with a custom fstat-based file watcher that polls at 2-second intervals. This fixes Docker volume mount compatibility and removes an external dependency.

- add filewatcher.go with cross-platform fstat polling
- support symlinks (k8s configmap ..data pattern)
- add SIGHUP signal handler for immediate config reload
- if LoadConfig fails during reload, print error and skip reload
- remove github.com/fsnotify/fsnotify dependency

fixes #682