### PR TITLE
(682) Qwen3.6 proxy: replace fsnotify with fstat polling and add SIGHUP reload

### DIFF
--- a/filewatch/filewatch.go
+++ b/filewatch/filewatch.go
@@ -1,0 +1,104 @@
+// Package filewatch provides a simple file watcher using fstat-based polling.
+// It works with Docker volume mounts, symlinks, and is compatible with POSIX
+// and Windows systems.
+package filewatch
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Watcher polls a file for changes using stat-based comparison.
+type Watcher struct {
+	path     string
+	interval time.Duration
+	done     chan struct{}
+	mu       sync.Mutex
+	stopped  bool
+}
+
+// NewWatcher creates a new file watcher that polls at the given interval.
+func NewWatcher(path string, interval time.Duration) *Watcher {
+	return &Watcher{
+		path:     path,
+		interval: interval,
+		done:     make(chan struct{}),
+	}
+}
+
+// Start begins polling the file and returns a channel that receives a struct{}
+// whenever the file changes. The channel is non-blocking; callers should
+// read from it promptly to avoid missing events.
+func (w *Watcher) Start() <-chan struct{} {
+	changes := make(chan struct{}, 1)
+
+	w.mu.Lock()
+	if w.stopped {
+		w.mu.Unlock()
+		return changes
+	}
+	w.mu.Unlock()
+
+	go w.watch(changes)
+	return changes
+}
+
+// Close stops the watcher.
+func (w *Watcher) Close() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.stopped {
+		w.stopped = true
+		close(w.done)
+	}
+}
+
+func (w *Watcher) watch(changes chan<- struct{}) {
+	var lastMod time.Time
+	var lastModValid bool
+
+	for {
+		select {
+		case <-w.done:
+			return
+		case <-time.After(w.interval):
+		}
+
+		statPath := w.path
+
+		// Resolve symlinks to get the actual file for stat
+		resolved, err := filepath.EvalSymlinks(w.path)
+		if err == nil {
+			statPath = resolved
+		}
+
+		info, err := os.Stat(statPath)
+		if err != nil {
+			// File doesn't exist yet or can't be stat'd; just skip this poll
+			continue
+		}
+
+		modTime := info.ModTime()
+
+		w.mu.Lock()
+		if w.stopped {
+			w.mu.Unlock()
+			return
+		}
+		w.mu.Unlock()
+
+		if lastModValid && !modTime.Equal(lastMod) {
+			select {
+			case changes <- struct{}{}:
+			default:
+			}
+			lastMod = modTime
+			lastModValid = true
+		} else if !lastModValid {
+			lastMod = modTime
+			lastModValid = true
+		}
+	}
+}

--- a/filewatch/filewatch_test.go
+++ b/filewatch/filewatch_test.go
@@ -1,0 +1,153 @@
+package filewatch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWatcher_DetectsFileChange(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.yaml")
+
+	// Create initial file
+	if err := os.WriteFile(testFile, []byte("initial"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w := NewWatcher(testFile, 100*time.Millisecond)
+	changes := w.Start()
+	defer w.Close()
+
+	// Wait for initial stat to register
+	time.Sleep(200 * time.Millisecond)
+
+	// Modify the file
+	if err := os.WriteFile(testFile, []byte("modified"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should detect change within polling interval
+	select {
+	case <-changes:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Fatal("did not detect file change")
+	}
+}
+
+func TestWatcher_Symlink(t *testing.T) {
+	tmpDir := t.TempDir()
+	realFile := filepath.Join(tmpDir, "real.yaml")
+	symlinkFile := filepath.Join(tmpDir, "link.yaml")
+
+	// Create real file and symlink
+	if err := os.WriteFile(realFile, []byte("initial"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realFile, symlinkFile); err != nil {
+		t.Fatal(err)
+	}
+
+	w := NewWatcher(symlinkFile, 100*time.Millisecond)
+	changes := w.Start()
+	defer w.Close()
+
+	// Wait for initial stat
+	time.Sleep(200 * time.Millisecond)
+
+	// Modify through symlink
+	if err := os.WriteFile(symlinkFile, []byte("via symlink"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-changes:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Fatal("did not detect symlink change")
+	}
+}
+
+func TestWatcher_K8sConfigmapSymlinkSwap(t *testing.T) {
+	tmpDir := t.TempDir()
+	realFile1 := filepath.Join(tmpDir, "real1.yaml")
+	realFile2 := filepath.Join(tmpDir, "real2.yaml")
+	symlinkFile := filepath.Join(tmpDir, "config.yaml")
+
+	// Create initial real file and symlink
+	if err := os.WriteFile(realFile1, []byte("v1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realFile1, symlinkFile); err != nil {
+		t.Fatal(err)
+	}
+
+	w := NewWatcher(symlinkFile, 100*time.Millisecond)
+	changes := w.Start()
+	defer w.Close()
+
+	// Wait for initial stat
+	time.Sleep(200 * time.Millisecond)
+
+	// Simulate k8s configmap swap: remove symlink, create new one
+	os.Remove(symlinkFile)
+	if err := os.WriteFile(realFile2, []byte("v2"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(realFile2, symlinkFile); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-changes:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Fatal("did not detect k8s configmap symlink swap")
+	}
+}
+
+func TestWatcher_NoSpuriousChanges(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.yaml")
+
+	if err := os.WriteFile(testFile, []byte("unchanged"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w := NewWatcher(testFile, 100*time.Millisecond)
+	changes := w.Start()
+	defer w.Close()
+
+	// Wait for multiple poll cycles without changes
+	select {
+	case <-changes:
+		t.Fatal("spurious change detected")
+	case <-time.After(500 * time.Millisecond):
+		// Success - no changes
+	}
+}
+
+func TestWatcher_Close(t *testing.T) {
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.yaml")
+
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	w := NewWatcher(testFile, 50*time.Millisecond)
+	changes := w.Start()
+	w.Close()
+
+	// Channel should be closed and not receive anything
+	select {
+	case _, ok := <-changes:
+		if ok {
+			t.Fatal("changes channel should be closed after Close()")
+		}
+	case <-time.After(200 * time.Millisecond):
+		// Channel might not be closed but watcher should stop polling
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.26.1
 
 require (
 	github.com/billziss-gh/golib v0.2.0
-	github.com/fsnotify/fsnotify v1.9.0
 	github.com/gin-gonic/gin v1.10.0
 	github.com/klauspost/compress v1.18.5
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
-github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=

--- a/llama-swap.go
+++ b/llama-swap.go
@@ -12,9 +12,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/fsnotify/fsnotify"
 	"github.com/gin-gonic/gin"
 	"github.com/mostlygeek/llama-swap/event"
+	"github.com/mostlygeek/llama-swap/filewatch"
 	"github.com/mostlygeek/llama-swap/proxy"
 	"github.com/mostlygeek/llama-swap/proxy/config"
 )
@@ -77,7 +77,7 @@ func main() {
 	// Setup channels for server management
 	exitChan := make(chan struct{})
 	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
 	// Create server with initial handler
 	srv := &http.Server{
@@ -87,11 +87,12 @@ func main() {
 	// Support for watching config and reloading when it changes
 	reloadProxyManager := func() {
 		if currentPM, ok := srv.Handler.(*proxy.ProxyManager); ok {
-			conf, err = config.LoadConfig(*configPath)
+			newConf, err := config.LoadConfig(*configPath)
 			if err != nil {
 				fmt.Printf("Warning, unable to reload configuration: %v\n", err)
 				return
 			}
+			conf = newConf
 
 			fmt.Println("Configuration Changed")
 			currentPM.Shutdown()
@@ -107,11 +108,12 @@ func main() {
 				})
 			})
 		} else {
-			conf, err = config.LoadConfig(*configPath)
+			newConf, err := config.LoadConfig(*configPath)
 			if err != nil {
 				fmt.Printf("Error, unable to load configuration: %v\n", err)
 				os.Exit(1)
 			}
+			conf = newConf
 			newPM := proxy.New(conf)
 			newPM.SetVersion(date, commit, version)
 			srv.Handler = newPM
@@ -135,37 +137,14 @@ func main() {
 				fmt.Printf("Error getting absolute path for watching config file: %v\n", err)
 				return
 			}
-			watcher, err := fsnotify.NewWatcher()
-			if err != nil {
-				fmt.Printf("Error creating file watcher: %v. File watching disabled.\n", err)
-				return
-			}
-
-			configDir := filepath.Dir(absConfigPath)
-			err = watcher.Add(configDir)
-			if err != nil {
-				fmt.Printf("Error adding config path directory (%s) to watcher: %v. File watching disabled.", configDir, err)
-				return
-			}
-
+			watcher := filewatch.NewWatcher(absConfigPath, 2*time.Second)
+			changes := watcher.Start()
 			defer watcher.Close()
-			for {
-				select {
-				case changeEvent := <-watcher.Events:
-					if changeEvent.Name == absConfigPath && (changeEvent.Has(fsnotify.Write) || changeEvent.Has(fsnotify.Create) || changeEvent.Has(fsnotify.Remove)) {
-						event.Emit(proxy.ConfigFileChangedEvent{
-							ReloadingState: proxy.ReloadingStateStart,
-						})
-					} else if changeEvent.Name == filepath.Join(configDir, "..data") && changeEvent.Has(fsnotify.Create) {
-						// the change for k8s configmap
-						event.Emit(proxy.ConfigFileChangedEvent{
-							ReloadingState: proxy.ReloadingStateStart,
-						})
-					}
 
-				case err := <-watcher.Errors:
-					log.Printf("File watcher error: %v", err)
-				}
+			for range changes {
+				event.Emit(proxy.ConfigFileChangedEvent{
+					ReloadingState: proxy.ReloadingStateStart,
+				})
 			}
 		}()
 	}
@@ -173,6 +152,11 @@ func main() {
 	// shutdown on signal
 	go func() {
 		sig := <-sigChan
+		if sig == syscall.SIGHUP {
+			fmt.Println("Received SIGHUP, reloading configuration")
+			reloadProxyManager()
+			return
+		}
 		fmt.Printf("Received signal %v, shutting down...\n", sig)
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		defer cancel()


### PR DESCRIPTION
Replace fsnotify with a custom filewatch package that uses os.Stat() polling. This fixes config file watching in Docker when files are volume mounted (fsnotify only works with directory mounts).

- add filewatch package with 2s polling interval, symlink support, and k8s configmap compatibility
- add SIGHUP signal handler for immediate config reload
- if LoadConfig fails during reload, print error and keep old config instead of crashing
- remove fsnotify dependency

fixes #682