### PR TITLE
docs(examples): replace removed profiles with groups in aider guide

### DIFF
--- a/docs/examples/aider-qwq-coder/README.md
+++ b/docs/examples/aider-qwq-coder/README.md
@@ -95,21 +95,23 @@ models:
 
 ## Advanced, Dual GPU Configuration
 
-If you have _dual 24GB GPUs_ you can use llama-swap profiles to avoid swapping between QwQ and Qwen Coder.
+If you have _dual 24GB GPUs_ you can use llama-swap groups to keep QwQ and Qwen Coder resident at the same time.
 
 In llama-swap's configuration file:
 
-1. add a `profiles` section with `aider` as the profile name
-2. using the `env` field to specify the GPU IDs for each model
+1. add a `groups` section with `swap: false` so requests do not evict the other coding model
+2. use the `env` field to pin each model to a GPU
 
 ```yaml
 # config.yaml
 
-# Add a profile for aider
-profiles:
+# Keep both coding models loaded on separate GPUs
+groups:
   aider:
-    - qwen-coder-32B
-    - QwQ
+    swap: false
+    members:
+      - qwen-coder-32B
+      - QwQ
 
 models:
   "qwen-coder-32B":
@@ -127,25 +129,27 @@ models:
     cmd: /path/to/llama-server ...
 ```
 
-Append the profile tag, `aider:`, to the model names in the model settings file
+With groups, the model names in aider stay the same. You can keep using the same model IDs:
 
 ```yaml
 # aider.model.settings.yml
-- name: "openai/aider:QwQ"
-  weak_model_name: "openai/aider:qwen-coder-32B-aider"
-  editor_model_name: "openai/aider:qwen-coder-32B-aider"
+- name: "openai/QwQ"
+  weak_model_name: "openai/qwen-coder-32B"
+  editor_model_name: "openai/qwen-coder-32B"
 
-- name: "openai/aider:qwen-coder-32B"
-  editor_model_name: "openai/aider:qwen-coder-32B-aider"
+- name: "openai/qwen-coder-32B"
+  editor_model_name: "openai/qwen-coder-32B"
 ```
+
+If you also need helper models to stay resident, put them in their own group and add `persistent: true`.
 
 Run aider with:
 
 ```sh
 $ aider --architect \
     --no-show-model-warnings \
-    --model openai/aider:QwQ \
-    --editor-model openai/aider:qwen-coder-32B \
+    --model openai/QwQ \
+    --editor-model openai/qwen-coder-32B \
     --config aider.conf.yml \
     --model-settings-file aider.model.settings.yml
     --openai-api-key "sk-na" \

--- a/docs/examples/aider-qwq-coder/aider.model.settings.dualgpu.yml
+++ b/docs/examples/aider-qwq-coder/aider.model.settings.dualgpu.yml
@@ -1,7 +1,7 @@
-# this makes use of llama-swap's profile feature to
-# keep the architect and editor models in VRAM on different GPUs
+# this keeps the architect and editor models in VRAM on different GPUs
+# using a llama-swap group with swap: false
 
-- name: "openai/aider:QwQ"
+- name: "openai/QwQ"
   edit_format: diff
   extra_params:
     max_tokens: 16384
@@ -12,10 +12,10 @@
     num_ctx: 16384
   use_temperature: 0.6
   reasoning_tag: think
-  weak_model_name: "openai/aider:qwen-coder-32B"
-  editor_model_name: "openai/aider:qwen-coder-32B"
+  weak_model_name: "openai/qwen-coder-32B"
+  editor_model_name: "openai/qwen-coder-32B"
 
-- name: "openai/aider:qwen-coder-32B"
+- name: "openai/qwen-coder-32B"
   edit_format: diff
   extra_params:
     max_tokens: 16384
@@ -25,4 +25,4 @@
   use_temperature: 0.6
   reasoning_tag: think
   editor_edit_format: editor-diff
-  editor_model_name: "openai/aider:qwen-coder-32B"
+  editor_model_name: "openai/qwen-coder-32B"

--- a/docs/examples/aider-qwq-coder/llama-swap.yaml
+++ b/docs/examples/aider-qwq-coder/llama-swap.yaml
@@ -1,8 +1,10 @@
 healthCheckTimeout: 300
 logLevel: debug
 
-profiles:
-    aider:
+groups:
+  aider:
+    swap: false
+    members:
       - qwen-coder-32B
       - QwQ
 


### PR DESCRIPTION
## Summary
- update the dual-GPU aider example to use groups instead of the removed profiles feature
- align the sample llama-swap.yaml with the current swap: false group syntax
- drop the outdated openai/aider: model prefixes from the dual-GPU model settings example

## Testing
- not run (documentation-only change)

Closes #518