### PR TITLE
Push unified docker images on scheduled runs

### DIFF
--- a/.github/workflows/unified-docker.yml
+++ b/.github/workflows/unified-docker.yml
@@ -121,7 +121,7 @@ jobs:
           docker/unified/build-image.sh --${{ matrix.backend }}
 
       - name: Push to GitHub Container Registry
-        if: ${{ !env.ACT && inputs.push_to_ghcr == true }}
+        if: ${{ !env.ACT && (github.event_name == 'schedule' || inputs.push_to_ghcr == true) }}
         run: |
           BASE_TAG="ghcr.io/mostlygeek/llama-swap:unified-${{ matrix.backend }}"
           DATE_TAG=$(date -u +%Y-%m-%d)


### PR DESCRIPTION
Fixes #693

I think removing `github.event_name == 'schedule'` was a mistake? Re-adding it should make it so the image gets pushed again.