### PR TITLE
ui-svelte: support reasoning and reasoning_content

### DIFF
--- a/ui-svelte/src/components/CaptureDialog.svelte
+++ b/ui-svelte/src/components/CaptureDialog.svelte
@@ -106,6 +106,7 @@
         const delta = parsed.choices?.[0]?.delta;
         if (delta?.content) result.content += delta.content;
         if (delta?.reasoning_content) result.reasoning += delta.reasoning_content;
+        if (delta?.reasoning) result.reasoning += delta.reasoning;
       } catch {
         // skip unparseable lines
       }

--- a/ui-svelte/src/lib/chatApi.ts
+++ b/ui-svelte/src/lib/chatApi.ts
@@ -25,7 +25,7 @@ function parseSSELine(line: string): StreamChunk | null {
     const parsed = JSON.parse(data);
     const delta = parsed.choices?.[0]?.delta;
     const content = delta?.content || "";
-    const reasoning_content = delta?.reasoning_content || "";
+    const reasoning_content = delta?.reasoning_content || delta?.reasoning || "";
 
     if (content || reasoning_content) {
       return { content, reasoning_content, done: false };


### PR DESCRIPTION
Support `reasoning` v1/chat/completion delta that vLLM uses. 