### PR TITLE
ui-svelte: default theme to user preferred color scheme

### DIFF
--- a/ui-svelte/src/stores/theme.ts
+++ b/ui-svelte/src/stores/theme.ts
@@ -3,7 +3,8 @@ import { persistentStore } from "./persistent";
 import type { ScreenWidth } from "../lib/types";
 
 // Persistent stores
-export const isDarkMode = persistentStore<boolean>("theme", false);
+const systemDark = typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches;
+export const isDarkMode = persistentStore<boolean>("theme", systemDark);
 export const appTitle = persistentStore<string>("app-title", "llama-swap");
 
 // Non-persistent stores


### PR DESCRIPTION
Simple, if not set is localStorage use whatever the user's preferred color scheme is to start.