### PR TITLE
Allow regular model IDs in Matrix DSL

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -329,13 +329,12 @@
             "type": "object",
             "description": "Solver-based alternative to groups. Declares valid combinations of concurrent models. The solver minimizes eviction cost when swapping. A config must use either groups or matrix, not both.",
             "required": [
-                "vars",
                 "sets"
             ],
             "properties": {
                 "vars": {
                     "type": "object",
-                    "description": "Short names for models. Keys must be alphanumeric, 1-8 characters. All sets and evict_costs must use these IDs.",
+                    "description": "Optional short names for models. Keys must be alphanumeric, 1-8 characters. Sets and evict_costs can use vars or real model IDs.",
                     "minProperties": 1,
                     "additionalProperties": {
                         "type": "string"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -360,10 +360,10 @@ models:
 #
 matrix:
   # vars: short names for models (alphanumeric, 1-8 chars)
-  # - required for sets and evict_costs settings
-  # - each entry is a short name to a real model ID. Do not use an alias
+  # - optional for sets and evict_costs settings
+  # - each entry is a short name to a real model ID
   # - used to keep set DSL logic short and easier to read
-  # - sets and evict_costs only use identifiers defined in vars
+  # - sets and evict_costs can use vars or real model IDs
   vars:
     g: gemma-model
     q: qwen-model

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -451,10 +451,10 @@ models:
 #
 matrix:
   # vars: short names for models (alphanumeric, 1-8 chars)
-  # - required for sets and evict_costs settings
-  # - each entry is a short name to a real model ID. Do not use an alias
+  # - optional for sets and evict_costs settings
+  # - each entry is a short name to a real model ID
   # - used to keep set DSL logic short and easier to read
-  # - sets and evict_costs only use identifiers defined in vars
+  # - sets and evict_costs can use vars or real model IDs
   vars:
     g: gemma-model
     q: qwen-model

--- a/proxy/config/matrix.go
+++ b/proxy/config/matrix.go
@@ -146,6 +146,9 @@ func validateMatrixVars(matrix MatrixConfig, models map[string]ModelConfig) erro
 		if !varKeyPattern.MatchString(id) {
 			return fmt.Errorf("var key %q must be alphanumeric and 1-8 characters", id)
 		}
+		if _, exists := models[id]; exists {
+			return fmt.Errorf("var key %q conflicts with model id %q", id, id)
+		}
 		if _, exists := models[modelName]; !exists {
 			return fmt.Errorf("var key %q references unknown model %q", id, modelName)
 		}

--- a/proxy/config/matrix.go
+++ b/proxy/config/matrix.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"regexp"
-	"sort"
 
 	"gopkg.in/yaml.v3"
 )
@@ -66,32 +65,12 @@ func ValidateMatrix(matrix MatrixConfig, models map[string]ModelConfig) ([]Expan
 		return nil, fmt.Errorf("matrix must define at least one set")
 	}
 
-	if len(matrix.Var) == 0 {
-		return nil, fmt.Errorf("matrix must define at least one var")
+	if err := validateMatrixVars(matrix, models); err != nil {
+		return nil, err
 	}
 
-	// Validate var entries
-	if matrix.Var != nil {
-		for id, modelName := range matrix.Var {
-			if !varKeyPattern.MatchString(id) {
-				return nil, fmt.Errorf("var key %q must be alphanumeric and 1-8 characters", id)
-			}
-			if _, exists := models[modelName]; !exists {
-				return nil, fmt.Errorf("var key %q references unknown model %q", id, modelName)
-			}
-		}
-	}
-
-	// Validate evict_costs
-	if matrix.EvictCosts != nil {
-		for key, cost := range matrix.EvictCosts {
-			if cost <= 0 {
-				return nil, fmt.Errorf("evict_cost for %q must be a positive integer, got %d", key, cost)
-			}
-			if _, ok := matrix.Var[key]; !ok {
-				return nil, fmt.Errorf("evict_costs: unknown var ID %q", key)
-			}
-		}
+	if err := validateEvictCosts(matrix, models); err != nil {
+		return nil, err
 	}
 
 	// Build dependency graph for +ref topological sort
@@ -121,7 +100,7 @@ func ValidateMatrix(matrix MatrixConfig, models map[string]ModelConfig) ([]Expan
 	}
 
 	// Expand sets in topological order
-	resolvedRefs := make(map[string][][]string) // set name -> expanded alias-level combos
+	resolvedRefs := make(map[string][][]string) // set name -> expanded identifier combos
 	var allExpanded []ExpandedSet
 	totalCombinations := 0
 
@@ -140,17 +119,12 @@ func ValidateMatrix(matrix MatrixConfig, models map[string]ModelConfig) ([]Expan
 
 		resolvedRefs[name] = combos
 
-		// Resolve var IDs to real model names
+		// Resolve identifiers to real model names
 		for _, combo := range combos {
-			resolved := make([]string, len(combo))
-			for i, ident := range combo {
-				realName, ok := matrix.Var[ident]
-				if !ok {
-					return nil, fmt.Errorf("set %q: unknown var ID %q", name, ident)
-				}
-				resolved[i] = realName
+			resolved, err := resolveMatrixCombo(matrix, models, combo)
+			if err != nil {
+				return nil, fmt.Errorf("set %q: %w", name, err)
 			}
-			sort.Strings(resolved)
 			allExpanded = append(allExpanded, ExpandedSet{
 				SetName: name,
 				DSL:     dsl,
@@ -165,6 +139,62 @@ func ValidateMatrix(matrix MatrixConfig, models map[string]ModelConfig) ([]Expan
 	}
 
 	return allExpanded, nil
+}
+
+func validateMatrixVars(matrix MatrixConfig, models map[string]ModelConfig) error {
+	for id, modelName := range matrix.Var {
+		if !varKeyPattern.MatchString(id) {
+			return fmt.Errorf("var key %q must be alphanumeric and 1-8 characters", id)
+		}
+		if _, exists := models[modelName]; !exists {
+			return fmt.Errorf("var key %q references unknown model %q", id, modelName)
+		}
+	}
+	return nil
+}
+
+func resolveMatrixCombo(matrix MatrixConfig, models map[string]ModelConfig, combo []string) ([]string, error) {
+	resolved := make([]string, len(combo))
+	for i, ident := range combo {
+		realName, ok := resolveMatrixIdent(matrix, models, ident)
+		if !ok {
+			return nil, fmt.Errorf("unknown model ID %q", ident)
+		}
+		resolved[i] = realName
+	}
+	return dedupAndSort(resolved), nil
+}
+
+func resolveMatrixIdent(matrix MatrixConfig, models map[string]ModelConfig, ident string) (string, bool) {
+	if realName, ok := matrix.Var[ident]; ok {
+		return realName, true
+	}
+	if _, ok := models[ident]; ok {
+		return ident, true
+	}
+	return "", false
+}
+
+func validateEvictCosts(matrix MatrixConfig, models map[string]ModelConfig) error {
+	if matrix.EvictCosts == nil {
+		return nil
+	}
+
+	sources := make(map[string]string, len(matrix.EvictCosts))
+	for key, cost := range matrix.EvictCosts {
+		if cost <= 0 {
+			return fmt.Errorf("evict_cost for %q must be a positive integer, got %d", key, cost)
+		}
+		realName, ok := resolveMatrixIdent(matrix, models, key)
+		if !ok {
+			return fmt.Errorf("evict_costs: unknown model ID %q", key)
+		}
+		if previous, exists := sources[realName]; exists {
+			return fmt.Errorf("evict_costs: %q and %q both resolve to model %q", previous, key, realName)
+		}
+		sources[realName] = key
+	}
+	return nil
 }
 
 // topologicalSort returns set names in dependency order.
@@ -215,7 +245,6 @@ func (m *MatrixConfig) ResolvedEvictCosts() map[string]int {
 		return costs
 	}
 	for key, cost := range m.EvictCosts {
-		// Resolve var ID if present
 		if realName, ok := m.Var[key]; ok {
 			costs[realName] = cost
 		} else {

--- a/proxy/config/matrix_dsl.go
+++ b/proxy/config/matrix_dsl.go
@@ -84,7 +84,7 @@ func tokenize(input string) ([]token, error) {
 }
 
 func isIdentChar(ch rune) bool {
-	return unicode.IsLetter(ch) || unicode.IsDigit(ch) || ch == '_' || ch == '-' || ch == '.'
+	return unicode.IsLetter(ch) || unicode.IsDigit(ch) || strings.ContainsRune("_-./:", ch)
 }
 
 // AST node types

--- a/proxy/config/matrix_dsl_test.go
+++ b/proxy/config/matrix_dsl_test.go
@@ -99,6 +99,14 @@ func TestDSL_Tokenize(t *testing.T) {
 			input:  "a @ b",
 			errMsg: "unexpected character",
 		},
+		{
+			name:  "identifier with slash and colon",
+			input: "author/model:F16",
+			expect: []token{
+				{tokIdent, "author/model:F16"},
+				{tokEOF, ""},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/proxy/config/matrix_test.go
+++ b/proxy/config/matrix_test.go
@@ -89,8 +89,7 @@ func TestValidateMatrix_WithRef(t *testing.T) {
 	assert.Equal(t, []string{"gemma", "reranker", "voxtral"}, megaEntries[0].Models)
 }
 
-func TestValidateMatrix_MapIDRequired(t *testing.T) {
-	// DSL cannot use real model names directly — must use var IDs
+func TestValidateMatrix_DirectModelIDs(t *testing.T) {
 	models := makeModels("gemma", "voxtral")
 
 	matrix := MatrixConfig{
@@ -100,17 +99,49 @@ func TestValidateMatrix_MapIDRequired(t *testing.T) {
 		},
 	}
 
-	_, err := ValidateMatrix(matrix, models)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown var ID")
+	expanded, err := ValidateMatrix(matrix, models)
+	require.NoError(t, err)
+	require.Len(t, expanded, 1)
+	assert.Equal(t, []string{"gemma", "voxtral"}, expanded[0].Models)
 }
 
-func TestValidateMatrix_InvalidAliasKey(t *testing.T) {
+func TestValidateMatrix_DirectModelIDsWithSpecialCharacters(t *testing.T) {
+	models := makeModels("author/model:F16", "openai/gpt-4.1-mini")
+
+	matrix := MatrixConfig{
+		Sets: OrderedSets{
+			{Name: "combo", DSL: "author/model:F16 & openai/gpt-4.1-mini"},
+		},
+	}
+
+	expanded, err := ValidateMatrix(matrix, models)
+	require.NoError(t, err)
+	require.Len(t, expanded, 1)
+	assert.Equal(t, []string{"author/model:F16", "openai/gpt-4.1-mini"}, expanded[0].Models)
+}
+
+func TestValidateMatrix_DedupAfterResolution(t *testing.T) {
+	models := makeModels("gemma")
+
+	matrix := MatrixConfig{
+		Var: map[string]string{"g": "gemma"},
+		Sets: OrderedSets{
+			{Name: "combo", DSL: "g & gemma"},
+		},
+	}
+
+	expanded, err := ValidateMatrix(matrix, models)
+	require.NoError(t, err)
+	require.Len(t, expanded, 1)
+	assert.Equal(t, []string{"gemma"}, expanded[0].Models)
+}
+
+func TestValidateMatrix_InvalidVarKey(t *testing.T) {
 	models := makeModels("gemma")
 
 	tests := []struct {
 		name   string
-		alias  string
+		varID  string
 		errMsg string
 	}{
 		{"too long", "abcdefghi", "alphanumeric and 1-8 characters"},
@@ -121,8 +152,8 @@ func TestValidateMatrix_InvalidAliasKey(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			matrix := MatrixConfig{
-				Var:  map[string]string{tt.alias: "gemma"},
-				Sets: OrderedSets{{Name: "s", DSL: tt.alias}},
+				Var:  map[string]string{tt.varID: "gemma"},
+				Sets: OrderedSets{{Name: "s", DSL: tt.varID}},
 			}
 			_, err := ValidateMatrix(matrix, models)
 			require.Error(t, err)
@@ -131,7 +162,7 @@ func TestValidateMatrix_InvalidAliasKey(t *testing.T) {
 	}
 }
 
-func TestValidateMatrix_AliasReferencesUnknownModel(t *testing.T) {
+func TestValidateMatrix_VarReferencesUnknownModel(t *testing.T) {
 	models := makeModels("gemma")
 
 	matrix := MatrixConfig{
@@ -169,7 +200,7 @@ func TestValidateMatrix_EvictCostInvalid(t *testing.T) {
 		assert.Contains(t, err.Error(), "positive integer")
 	})
 
-	t.Run("unknown var ID in evict_costs", func(t *testing.T) {
+	t.Run("unknown model ID in evict_costs", func(t *testing.T) {
 		matrix := MatrixConfig{
 			Var:        map[string]string{"g": "gemma"},
 			EvictCosts: map[string]int{"unknown": 5},
@@ -177,7 +208,18 @@ func TestValidateMatrix_EvictCostInvalid(t *testing.T) {
 		}
 		_, err := ValidateMatrix(matrix, models)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unknown var ID")
+		assert.Contains(t, err.Error(), "unknown model ID")
+	})
+
+	t.Run("duplicate resolved model in evict_costs", func(t *testing.T) {
+		matrix := MatrixConfig{
+			Var:        map[string]string{"g": "gemma"},
+			EvictCosts: map[string]int{"g": 5, "gemma": 10},
+			Sets:       OrderedSets{{Name: "s", DSL: "g"}},
+		}
+		_, err := ValidateMatrix(matrix, models)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "both resolve to model")
 	})
 }
 
@@ -230,18 +272,58 @@ func TestValidateMatrix_UnknownMapIDInDSL(t *testing.T) {
 
 	_, err := ValidateMatrix(matrix, models)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown var ID")
+	assert.Contains(t, err.Error(), "unknown model ID")
+}
+
+func TestValidateMatrix_ConfigMatrixDoesNotUseAliases(t *testing.T) {
+	t.Run("set DSL", func(t *testing.T) {
+		yaml := `
+models:
+  gemma:
+    cmd: echo gemma
+    proxy: http://localhost:8080
+    aliases:
+      - gpt-4o-mini
+  author/model:F16:
+    cmd: echo model
+    proxy: http://localhost:8081
+matrix:
+  sets:
+    combo: "gpt-4o-mini & author/model:F16"
+`
+		_, err := LoadConfigFromReader(strings.NewReader(yaml))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown model ID")
+	})
+
+	t.Run("evict_costs", func(t *testing.T) {
+		yaml := `
+models:
+  gemma:
+    cmd: echo gemma
+    proxy: http://localhost:8080
+    aliases:
+      - gpt-4o-mini
+matrix:
+  evict_costs:
+    gpt-4o-mini: 5
+  sets:
+    combo: "gemma"
+`
+		_, err := LoadConfigFromReader(strings.NewReader(yaml))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown model ID")
+	})
 }
 
 func TestValidateMatrix_ResolvedEvictCosts(t *testing.T) {
 	mc := &MatrixConfig{
 		Var: map[string]string{
 			"g": "gemma",
-			"L": "llama70B",
 		},
 		EvictCosts: map[string]int{
-			"L": 30,
-			"g": 5,
+			"llama70B": 30,
+			"g":        5,
 		},
 	}
 


### PR DESCRIPTION
While short vars for matrix logic seemed convenient at first, I found that maintaining another set of model ID to be more cumbersome than expected in practice. Especially with long, frequently updated model lists.

This PR makes `vars` optional and lets matrix sets use either `vars` or normal model IDs. Using YAML's multiline syntax, I think this is just as readable as the var-based one-liners:

```yml
matrix:
  sets:
    default: >
      gemma4-4b
      & (gemma4-31 | qwen3.6-27 | qwen3.6-35)
      & (minimax2.7 | qwen3.5-397)
```

Also:

- `evict_costs` works with either `vars` or model IDs.
- Slightly relaxes matrix validation to support common model ID chars like `/` and `:`.

## References

- https://github.com/mostlygeek/llama-swap/issues/643
- Closes https://github.com/mostlygeek/llama-swap/issues/699