### PR TITLE
config: remove hard cap on macro length

### DIFF
--- a/proxy/config/config.go
+++ b/proxy/config/config.go
@@ -646,9 +646,6 @@ func validateMacro(name string, value any) error {
 	// Validate that value is a scalar type
 	switch v := value.(type) {
 	case string:
-		if len(v) >= 1024 {
-			return fmt.Errorf("macro value for '%s' exceeds maximum length of 1024 characters", name)
-		}
 		// Check for self-reference
 		macroSlug := fmt.Sprintf("${%s}", name)
 		if strings.Contains(v, macroSlug) {


### PR DESCRIPTION
This arbitrary limit creates unnecessary friction. 

E.g. when running vLLM with [Genesis patches](https://github.com/Sandermage/genesis-vllm-patches), a number of environment variables are required, which may not fit - forcing the user to create split macros for the sake of it.