### PR TITLE
proxy: add versionless API endpoint

### DIFF
--- a/proxy/helpers_test.go
+++ b/proxy/helpers_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -125,6 +126,22 @@ func injectTestHandlers(pm *ProxyManager, modelResponses map[string]string) {
 // newTestHandler returns an http.Handler that mimics simple-responder's API.
 // It supports the endpoints that routing tests depend on, without launching
 // any subprocess or binding any port.
+func respondJSON(w http.ResponseWriter, respond string, bodyBytes []byte) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"responseMessage":  respond,
+		"h_content_length": strconv.Itoa(len(bodyBytes)),
+		"request_body":     string(bodyBytes),
+		"usage": map[string]any{
+			"completion_tokens": 10, "prompt_tokens": 25, "total_tokens": 35,
+		},
+		"timings": map[string]any{
+			"prompt_n": 25, "prompt_ms": 13, "predicted_n": 10,
+			"predicted_ms": 17, "predicted_per_second": 10,
+		},
+	})
+}
+
 func newTestHandler(respond string) http.Handler {
 	mux := http.NewServeMux()
 
@@ -170,19 +187,7 @@ func newTestHandler(respond string) http.Handler {
 			fmt.Fprintf(w, "event: message\ndata: [DONE]\n\n")
 			flusher.Flush()
 		} else {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{
-				"responseMessage":  respond,
-				"h_content_length": r.Header.Get("Content-Length"),
-				"request_body":     string(bodyBytes),
-				"usage": map[string]any{
-					"completion_tokens": 10, "prompt_tokens": 25, "total_tokens": 35,
-				},
-				"timings": map[string]any{
-					"prompt_n": 25, "prompt_ms": 13, "predicted_n": 10,
-					"predicted_ms": 17, "predicted_per_second": 10,
-				},
-			})
+			respondJSON(w, respond, bodyBytes)
 		}
 	})
 
@@ -198,14 +203,20 @@ func newTestHandler(respond string) http.Handler {
 	})
 
 	mux.HandleFunc("/v1/completions", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
-			"responseMessage": respond,
-			"usage": map[string]any{
-				"completion_tokens": 10, "prompt_tokens": 25, "total_tokens": 35,
-			},
-		})
+		bodyBytes, _ := io.ReadAll(r.Body)
+		respondJSON(w, respond, bodyBytes)
 	})
+
+	for _, path := range []string{
+		"/chat/completions", "/completions",
+		"/responses", "/messages", "/messages/count_tokens",
+		"/embeddings", "/rerank", "/reranking",
+	} {
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			bodyBytes, _ := io.ReadAll(r.Body)
+			respondJSON(w, respond, bodyBytes)
+		})
+	}
 
 	mux.HandleFunc("/completion", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -351,6 +351,16 @@ func (pm *ProxyManager) setupGinEngine() {
 	pm.ginEngine.POST("/v1/rerank", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
 	pm.ginEngine.POST("/v1/reranking", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
 
+	// Unversioned API endpoints, see issue #728
+	pm.ginEngine.POST("/v/chat/completions", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
+	pm.ginEngine.POST("/v/responses", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
+	pm.ginEngine.POST("/v/completions", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
+	pm.ginEngine.POST("/v/messages", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
+	pm.ginEngine.POST("/v/messages/count_tokens", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
+	pm.ginEngine.POST("/v/embeddings", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
+	pm.ginEngine.POST("/v/rerank", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
+	pm.ginEngine.POST("/v/reranking", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
+
 	// llama-server's /infill endpoint for code infilling
 	pm.ginEngine.POST("/infill", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
 
@@ -859,6 +869,11 @@ func (pm *ProxyManager) mkProxyJSONHandler(cf captureFields) func(*gin.Context) 
 		c.Request.Header.Del("transfer-encoding")
 		c.Request.Header.Set("content-length", strconv.Itoa(len(bodyBytes)))
 		c.Request.ContentLength = int64(len(bodyBytes))
+
+		// issue #728 support versionless API requests
+		if strings.HasPrefix(c.Request.URL.Path, "/v/") {
+			c.Request.URL.Path = strings.TrimPrefix(c.Request.URL.Path, "/v")
+		}
 
 		// issue #366 extract values that downstream handlers may need
 		isStreaming := gjson.GetBytes(bodyBytes, "stream").Bool()

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -1779,3 +1779,103 @@ models:
 	assert.Nil(t, capture.ReqBody)
 	assert.NotNil(t, capture.RespBody)
 }
+
+func TestProxyManager_VersionlessEndpoints_LocalModel(t *testing.T) {
+	cfg := testConfigFromYAML(t, `
+healthCheckTimeout: 15
+logLevel: error
+models:
+  model1:
+    cmd: {{RESPONDER}} --port ${PORT} --silent --respond model1
+`)
+
+	proxy := New(cfg)
+	defer proxy.StopProcesses(StopWaitForInflightRequest)
+	injectTestHandlers(proxy, nil)
+
+	endpoints := []string{
+		"/v/chat/completions",
+		"/v/responses",
+		"/v/completions",
+		"/v/embeddings",
+		"/v/rerank",
+		"/v/reranking",
+	}
+
+	for _, endpoint := range endpoints {
+		t.Run(endpoint, func(t *testing.T) {
+			reqBody := `{"model":"model1"}`
+			req := httptest.NewRequest("POST", endpoint, bytes.NewBufferString(reqBody))
+			w := CreateTestResponseRecorder()
+			proxy.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Contains(t, w.Body.String(), "model1")
+		})
+	}
+
+	t.Run("/v/messages", func(t *testing.T) {
+		reqBody := `{"model":"model1","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest("POST", "/v/messages", bytes.NewBufferString(reqBody))
+		w := CreateTestResponseRecorder()
+		proxy.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "model1")
+	})
+}
+
+func TestProxyManager_VersionlessEndpoints_PeerModel(t *testing.T) {
+	peerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{"endpoint":"%s","model":"peer-model"}`, r.URL.Path)
+	}))
+	defer peerServer.Close()
+
+	cfg := testConfigFromYAML(t, fmt.Sprintf(`
+healthCheckTimeout: 15
+logLevel: error
+peers:
+  test-peer:
+    proxy: %s
+    models:
+      - peer-model
+models:
+  local-model:
+    cmd: {{RESPONDER}} --port ${PORT} --silent --respond local-model
+`, peerServer.URL))
+
+	proxy := New(cfg)
+	defer proxy.StopProcesses(StopImmediately)
+
+	endpoints := []struct {
+		path       string
+		wantSuffix string
+	}{
+		{"/v/chat/completions", "/chat/completions"},
+		{"/v/responses", "/responses"},
+		{"/v/completions", "/completions"},
+		{"/v/embeddings", "/embeddings"},
+		{"/v/rerank", "/rerank"},
+		{"/v/reranking", "/reranking"},
+	}
+
+	for _, ep := range endpoints {
+		t.Run(ep.path, func(t *testing.T) {
+			reqBody := `{"model":"peer-model"}`
+			req := httptest.NewRequest("POST", ep.path, bytes.NewBufferString(reqBody))
+			w := CreateTestResponseRecorder()
+			proxy.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Contains(t, w.Body.String(), ep.wantSuffix)
+		})
+	}
+
+	t.Run("/v/messages", func(t *testing.T) {
+		reqBody := `{"model":"peer-model","messages":[{"role":"user","content":"hi"}]}`
+		req := httptest.NewRequest("POST", "/v/messages", bytes.NewBufferString(reqBody))
+		w := CreateTestResponseRecorder()
+		proxy.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "/messages")
+	})
+}


### PR DESCRIPTION
This implements changes proposed in #728.

Note that the versionless endpoint in this implementation does not work with local servers which require the `/v1` in their path.

Tested using Z.ai API and llama.cpp

### Z.ai coding plan:
```
$ curl http://localhost:9292/v/chat/completions   -H "Content-Type: application/json"   -d '{"model":"glm-5.1","messages":
[{"role":"user","content":"What is the capital of Namibia? Answer in a single word only."}]}' | jq
```
```json
{
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "content": "Windhoek",
        "reasoning_content": "1.  Identify the core question: \"What is the capital of Namibia?\"\n2.  Retrieve knowledge about Namibia: The capital city of Namibia is Windhoek.\n3.  Check constraints: \"Answer in a single word only.\"\n4.  Formulate the response: Windhoek.\n5.  Verify constraint: \"Windhoek\" is exactly one word.",
        "role": "assistant"
      }
    }
  ],
  "created": 1777829435,
  "id": "20260504013033ac7383cfd9d24e0a",
  "model": "glm-5.1",
  "object": "chat.completion",
  "request_id": "20260504013033ac7383cfd9d24e0a",
  "usage": {
    "completion_tokens": 84,
    "completion_tokens_details": {
      "reasoning_tokens": 79
    },
    "prompt_tokens": 20,
    "prompt_tokens_details": {
      "cached_tokens": 0
    },
    "total_tokens": 104
  }
}
```

### Llama.cpp:
```
$ curl http://localhost:9292/v/chat/completions   -H "Content-Type: application/json"   -d '{"model":"mistral-small-4:instruct","messages":[{"role":"user","content":"What is the capital of Namibia? Answer in a single word only."}]}' | jq
```
```json
{
  "choices": [
    {
      "finish_reason": "stop",
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "Windhoek"
      }
    }
  ],
  "created": 1777829380,
  "model": "bartowski/mistralai_Mistral-Small-4-119B-2603-GGUF:IQ4_NL",
  "system_fingerprint": "b8994-aab68217b",
  "object": "chat.completion",
  "usage": {
    "completion_tokens": 3,
    "prompt_tokens": 29,
    "total_tokens": 32,
    "prompt_tokens_details": {
      "cached_tokens": 28
    }
  },
  "id": "chatcmpl-gj71evxxS0RVwz98H1hNE7mqtMr8VwXv",
  "timings": {
    "cache_n": 28,
    "prompt_n": 1,
    "prompt_ms": 24.634,
    "prompt_per_token_ms": 24.634,
    "prompt_per_second": 40.59430056020135,
    "predicted_n": 3,
    "predicted_ms": 47.559,
    "predicted_per_token_ms": 15.853,
    "predicted_per_second": 63.07954330410648
  }
}
```