### PR TITLE
proxy: add per-model ackTimeout keep-alive for slow upstream responses

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -224,6 +224,12 @@
                         "pattern": "^/.*$|^none$",
                         "description": "URL path to check if the server is ready. Use 'none' to skip health checking."
                     },
+                    "ackTimeout": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 0,
+                        "description": "Timeout in seconds before sending a keep-alive heartbeat to the client when upstream is unresponsive. Set to 0 to disable."
+                    },
                     "ttl": {
                         "type": "integer",
                         "minimum": -1,

--- a/config-schema.json
+++ b/config-schema.json
@@ -224,6 +224,12 @@
                         "pattern": "^/.*$|^none$",
                         "description": "URL path to check if the server is ready. Use 'none' to skip health checking."
                     },
+                    "heartbeatInterval": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 0,
+                        "description": "Interval in seconds for sending keep-alive HTTP 200 packets to the client during streaming when upstream is unresponsive. Set to 0 to disable. Prevents client timeouts during long prompt processing or generation sessions."
+                    },
                     "ackTimeout": {
                         "type": "integer",
                         "minimum": 0,

--- a/proxy/config/config.go
+++ b/proxy/config/config.go
@@ -276,6 +276,10 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 			return Config{}, fmt.Errorf("model %s: invalid TTL value %d", modelId, modelConfig.UnloadAfter)
 		}
 
+		if modelConfig.AckTimeout < 0 {
+			return Config{}, fmt.Errorf("model %s: ackTimeout must be >= 0", modelId)
+		}
+
 		// Validate model macros
 		for _, macro := range modelConfig.Macros {
 			if err = validateMacro(macro.Name, macro.Value); err != nil {

--- a/proxy/config/config.go
+++ b/proxy/config/config.go
@@ -276,8 +276,11 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 			return Config{}, fmt.Errorf("model %s: invalid TTL value %d", modelId, modelConfig.UnloadAfter)
 		}
 
-		if modelConfig.AckTimeout < 0 {
-			return Config{}, fmt.Errorf("model %s: ackTimeout must be >= 0", modelId)
+		// for #726
+		if modelConfig.HeartbeatInterval < 0 {
+			return Config{}, fmt.Errorf("model %s: heartbeatInterval must be >= 0", modelId)
+		} else if modelConfig.HeartbeatInterval > 0 && modelConfig.HeartbeatInterval < 10 {
+			modelConfig.HeartbeatInterval = 10
 		}
 
 		// Validate model macros

--- a/proxy/config/model_config.go
+++ b/proxy/config/model_config.go
@@ -33,7 +33,7 @@ type ModelConfig struct {
 
 	// see #726
 	// After this seconds, send keep-alive packet back to client,  0 = disable (default)
-	AckTimeout int `yaml:"ackTimeout"`
+	HeartbeatInterval int `yaml:"heartbeatInterval"`
 
 	// #179 for /v1/models
 	Name        string `yaml:"name"`

--- a/proxy/config/model_config.go
+++ b/proxy/config/model_config.go
@@ -31,6 +31,10 @@ type ModelConfig struct {
 	Unlisted      bool     `yaml:"unlisted"`
 	UseModelName  string   `yaml:"useModelName"`
 
+	// see #726
+	// After this seconds, send keep-alive packet back to client,  0 = disable (default)
+	AckTimeout int `yaml:"ackTimeout"`
+
 	// #179 for /v1/models
 	Name        string `yaml:"name"`
 	Description string `yaml:"description"`

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -77,8 +77,8 @@ type Process struct {
 	// used for testing to override the default value
 	gracefulStopTimeout time.Duration
 
-	// ackTimeout to send HTTP 200 to the client when upstream is waiting too long (0 = disabled)
-	ackTimeout time.Duration
+	// keepAliveInterval to send HTTP 200 to the client when upstream is waiting too long (0 = disabled)
+	heartbeatInterval time.Duration
 
 	// used for testing to bypass subprocess and reverse proxy
 	testHandler http.Handler
@@ -147,7 +147,7 @@ func NewProcess(ID string, healthCheckTimeout int, config config.ModelConfig, pr
 		// To be removed when migration over exec.CommandContext is complete
 		// stop timeout
 		gracefulStopTimeout: 10 * time.Second,
-		ackTimeout:          time.Duration(config.AckTimeout) * time.Second,
+		heartbeatInterval:   time.Duration(config.HeartbeatInterval) * time.Second,
 		cmdWaitChan:         make(chan struct{}),
 	}
 }
@@ -567,10 +567,6 @@ func (p *Process) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create a synchronized proxyResponseWriter to prevent concurrent writes
-	// between heartbeat goroutine and reverseProxy.
-	prw := newProxyResponseWriter(w)
-
 	p.inFlightRequests.Add(1)
 	p.inFlightRequestsCount.Add(1)
 	defer func() {
@@ -581,6 +577,8 @@ func (p *Process) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 
 	// for #366
 	// - extract streaming param from request context, should have been set by proxymanager
+	isStreaming, _ := r.Context().Value(proxyCtxKey("streaming")).(bool)
+
 	var srw *statusResponseWriter
 	swapCtx, cancelLoadCtx := context.WithCancel(r.Context())
 	// start the process on demand
@@ -588,12 +586,10 @@ func (p *Process) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		// start a goroutine to stream loading status messages into the response writer
 		// add a sync so the streaming client only runs when the goroutine has exited
 
-		isStreaming, _ := r.Context().Value(proxyCtxKey("streaming")).(bool)
-
 		// PR #417 (no support for anthropic v1/messages yet)
 		isChatCompletions := strings.HasPrefix(r.URL.Path, "/v1/chat/completions")
 		if p.config.SendLoadingState != nil && *p.config.SendLoadingState && isStreaming && isChatCompletions {
-			srw = newStatusResponseWriter(p, prw)
+			srw = newStatusResponseWriter(p, w)
 			go srw.statusUpdates(swapCtx)
 		} else {
 			p.proxyLogger.Debugf("<%s> SendLoadingState is nil or false, not streaming loading state", p.ID)
@@ -640,47 +636,69 @@ func (p *Process) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// #726: ackTimeout goroutine — sends periodic keep-alive heartbeats
-	// when upstream is unresponsive, preventing client timeouts during long
-	// prompt processing or generation sessions.
+	var proxyW http.ResponseWriter
 
-	if p.ackTimeout > 0 {
-		tickInterval := p.ackTimeout / 2
+	if p.heartbeatInterval > 0 && isStreaming {
+		// #726: heartbeatInterval goroutine — sends periodic keep-alive heartbeats
+		// when upstream is unresponsive, preventing client timeouts during long
+		// prompt processing or generation sessions. Only active for streaming requests.
+		tickInterval := p.heartbeatInterval
+
+		var prw *responseSyncer
+
+		if srw != nil {
+			// SendLoadingState=true + streaming: wrap statusResponseWriter (already has headers)
+			prw = newResponseSyncer(srw)
+		} else {
+			// Streaming request with no loading state — pass-through wrapper.
+			// SSE headers ensure the connection remains open as text/event-stream.
+			prw = newResponseSyncer(w)
+
+			prw.Header().Set("Content-Type", "text/event-stream")
+			prw.Header().Set("Cache-Control", "no-cache")
+			prw.Header().Set("Connection", "keep-alive")
+		}
+
 		go func() {
 			ticker := time.NewTicker(tickInterval)
 			defer ticker.Stop()
 
 			for range ticker.C {
 				select {
-				case <-prw.firstWriteCh:
-					p.proxyLogger.Debugf("<%s> - Cancel sent keep-alive for %s after %v",
-						p.ID, r.RequestURI, time.Since(requestBeginTime))
-					return // upstream started writing — stop sending heartbeats
 				case <-r.Context().Done():
-					p.proxyLogger.Debugf("<%s> - Cancel sent keep-alive for %s after %v",
+					p.proxyLogger.Debugf("<%s> - Cancel send keep-alive message for %s after %v",
 						p.ID, r.RequestURI, time.Since(requestBeginTime))
-					return // client cancelled — stop sending heartbeats
+					return
+				case <-prw.closeCh:
+					// upstream started streaming, stop heartbeats to avoid interleaving
+					p.proxyLogger.Debugf("<%s> upstream started streaming, stopping heartbeats for %s",
+						p.ID, r.RequestURI)
+					return
 				default:
-				}
-				p.proxyLogger.Debugf("<%s> - Sent keep-alive heartbeat for %s after %v",
-					p.ID, r.RequestURI, time.Since(requestBeginTime))
+					prw.mu.Lock()
+					shouldSend := !prw.upstreamStarted.Load() // read under lock
+					prw.mu.Unlock()
 
-				prw.Header().Set("Content-Type", "text/event-stream")
-				prw.Header().Set("Cache-Control", "no-cache")
-				prw.Header().Set("Connection", "keep-alive")
-				prw.WriteHeader(http.StatusOK)
-				fmt.Fprintf(prw, ": heart-beat\n\n")
-				prw.Flush()
+					if shouldSend {
+						p.proxyLogger.Debugf("<%s> Send 200-OK keep-alive for %s - start: %v",
+							p.ID, r.RequestURI, time.Since(requestBeginTime))
+						prw.WriteHeartbeat([]byte(": heart-beat\n\n"))
+					}
+				}
 			}
 		}()
+
+		proxyW = prw
+	} else if srw != nil {
+		proxyW = srw
+	} else {
+		proxyW = w
 	}
 
 	if p.testHandler != nil {
-		p.testHandler.ServeHTTP(prw, r)
-	} else if srw != nil {
-		p.reverseProxy.ServeHTTP(srw, r)
+		p.testHandler.ServeHTTP(proxyW, r)
 	} else {
-		p.reverseProxy.ServeHTTP(prw, r)
+		p.reverseProxy.ServeHTTP(proxyW, r)
 	}
 
 	totalTime := time.Since(requestBeginTime)
@@ -771,57 +789,6 @@ func (p *Process) cmdStopUpstreamProcess() error {
 // Logger returns the logger for this process.
 func (p *Process) Logger() *LogMonitor {
 	return p.processLogger
-}
-
-// proxyResponseWriter wraps http.ResponseWriter to synchronize concurrent writes
-// from the reverseProxy and heartbeat goroutine, preventing data races and
-// premature response commits.
-type proxyResponseWriter struct {
-	mu           sync.RWMutex
-	writer       http.ResponseWriter
-	firstWriteCh chan struct{}
-	firstWritten bool
-}
-
-func newProxyResponseWriter(w http.ResponseWriter) *proxyResponseWriter {
-	return &proxyResponseWriter{
-		writer:       w,
-		firstWriteCh: make(chan struct{}),
-	}
-}
-
-func (p *proxyResponseWriter) Header() http.Header {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	return p.writer.Header()
-}
-
-func (p *proxyResponseWriter) WriteHeader(code int) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if !p.firstWritten {
-		p.firstWritten = true
-		close(p.firstWriteCh)
-	}
-	p.writer.WriteHeader(code)
-}
-
-func (p *proxyResponseWriter) Write(data []byte) (int, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	if !p.firstWritten {
-		p.firstWritten = true
-		close(p.firstWriteCh)
-	}
-	return p.writer.Write(data)
-}
-
-func (p *proxyResponseWriter) Flush() {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	if flusher, ok := p.writer.(http.Flusher); ok {
-		flusher.Flush()
-	}
 }
 
 var loadingRemarks = []string{
@@ -1046,4 +1013,67 @@ func (s *statusResponseWriter) Flush() {
 	if flusher, ok := s.writer.(http.Flusher); ok {
 		flusher.Flush()
 	}
+}
+
+// responseSyncer synchronizes concurrent writes from the heartbeat goroutine
+// and the upstream reverse proxy to prevent data races. It does not implement
+// WriteHeader — headers are set before the proxy goroutine starts, so heartbeat
+// only needs to write body data safely through this wrapper.
+type responseSyncer struct {
+	mu              sync.Mutex
+	writer          http.ResponseWriter
+	upstreamStarted atomic.Bool // true once reverseProxy has written
+	closeCh         chan struct{}
+}
+
+func newResponseSyncer(w http.ResponseWriter) *responseSyncer {
+	return &responseSyncer{
+		writer:  w,
+		closeCh: make(chan struct{}),
+	}
+}
+
+func (p *responseSyncer) Header() http.Header {
+	return p.writer.Header()
+}
+
+// WriteHeartbeat check again stream started
+func (p *responseSyncer) WriteHeartbeat(data []byte) {
+	p.mu.Lock()
+	shouldSend := !p.upstreamStarted.Load()
+	p.mu.Unlock()
+
+	if shouldSend {
+		_, _ = p.writer.Write(data) // пишем напрямую, bypass mutex
+		FlushUnlocked(p.writer)     // flush без захвата lock
+	}
+}
+
+func (p *responseSyncer) Write(data []byte) (int, error) {
+	p.mu.Lock()
+	n, err := p.writer.Write(data)
+	if !p.upstreamStarted.Swap(true) {
+		close(p.closeCh)
+	}
+	p.mu.Unlock() // освобождаем lock ПЕРЕД flush
+
+	FlushUnlocked(p.writer) // flush вне mutex
+	return n, err
+}
+
+// FlushUnlocked calls Flush without acquiring the mutex.
+// It must be called by goroutines that do NOT hold p.mu (e.g., after Unlock).
+func FlushUnlocked(w http.ResponseWriter) {
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (p *responseSyncer) WriteHeader(statusCode int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.upstreamStarted.Swap(true) {
+		close(p.closeCh)
+	}
+	p.writer.WriteHeader(statusCode)
 }

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -77,6 +77,10 @@ type Process struct {
 	// used for testing to override the default value
 	gracefulStopTimeout time.Duration
 
+	// ackTimeout to send HTTP 200 to the client when upstream is waiting too long (0 = disabled)
+	ackTimeout  time.Duration
+	ackSentFlag uint32
+
 	// used for testing to bypass subprocess and reverse proxy
 	testHandler http.Handler
 
@@ -144,6 +148,7 @@ func NewProcess(ID string, healthCheckTimeout int, config config.ModelConfig, pr
 		// To be removed when migration over exec.CommandContext is complete
 		// stop timeout
 		gracefulStopTimeout: 10 * time.Second,
+		ackTimeout:          time.Duration(config.AckTimeout) * time.Second,
 		cmdWaitChan:         make(chan struct{}),
 	}
 }
@@ -630,6 +635,32 @@ func (p *Process) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		if !srw.waitForCompletion(completionTimeout) {
 			p.proxyLogger.Warnf("<%s> status updates goroutine did not complete within %v, proceeding with proxy request", p.ID, completionTimeout)
 		}
+	}
+
+	// for #726 ackTimeout - background goroutine sends ACK if upstream is slow.
+	if p.ackTimeout > 0 {
+		go func() {
+			timer := time.NewTimer(p.ackTimeout)
+			defer timer.Stop()
+			select {
+			case <-r.Context().Done():
+				return
+			case <-timer.C:
+				if atomic.CompareAndSwapUint32(&p.ackSentFlag, 0, 1) {
+					totalTimeAfterStart := time.Since(requestBeginTime)
+					p.proxyLogger.Debugf("<%s> - Sent keep-alive heartbeat for request %s - after start: %v", p.ID, r.RequestURI, totalTimeAfterStart)
+					// Set headers and send keep-alive
+					w.Header().Set("Content-Type", "text/event-stream")
+					w.Header().Set("Cache-Control", "no-cache")
+					w.Header().Set("Connection", "keep-alive")
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprintf(w, ": heart-beat\n\n")
+					if f, ok := w.(http.Flusher); ok {
+						f.Flush()
+					}
+				}
+			}
+		}()
 	}
 
 	if p.testHandler != nil {

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -567,6 +567,10 @@ func (p *Process) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Create a synchronized proxyResponseWriter to prevent concurrent writes
+	// between heartbeat goroutine and reverseProxy.
+	prw := newProxyResponseWriter(w)
+
 	p.inFlightRequests.Add(1)
 	p.inFlightRequestsCount.Add(1)
 	defer func() {
@@ -589,7 +593,7 @@ func (p *Process) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		// PR #417 (no support for anthropic v1/messages yet)
 		isChatCompletions := strings.HasPrefix(r.URL.Path, "/v1/chat/completions")
 		if p.config.SendLoadingState != nil && *p.config.SendLoadingState && isStreaming && isChatCompletions {
-			srw = newStatusResponseWriter(p, w)
+			srw = newStatusResponseWriter(p, prw)
 			go srw.statusUpdates(swapCtx)
 		} else {
 			p.proxyLogger.Debugf("<%s> SendLoadingState is nil or false, not streaming loading state", p.ID)
@@ -646,35 +650,37 @@ func (p *Process) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			ticker := time.NewTicker(tickInterval)
 			defer ticker.Stop()
 
-			for range ticker.C {
-				select {
-				case <-r.Context().Done():
-					p.proxyLogger.Debugf("<%s> - Cancel sent keep-alive for %s after %v",
-						p.ID, r.RequestURI, time.Since(requestBeginTime))
-					return // client cancelled — stop sending heartbeats
-				default:
-					p.proxyLogger.Debugf("<%s> - Sent keep-alive heartbeat for %s after %v",
-						p.ID, r.RequestURI, time.Since(requestBeginTime))
+	for range ticker.C {
+			select {
+			case <-prw.firstWriteCh:
+				p.proxyLogger.Debugf("<%s> - Cancel sent keep-alive for %s after %v",
+					p.ID, r.RequestURI, time.Since(requestBeginTime))
+				return // upstream started writing — stop sending heartbeats
+			case <-r.Context().Done():
+				p.proxyLogger.Debugf("<%s> - Cancel sent keep-alive for %s after %v",
+					p.ID, r.RequestURI, time.Since(requestBeginTime))
+				return // client cancelled — stop sending heartbeats
+			default:
+			}
+			p.proxyLogger.Debugf("<%s> - Sent keep-alive heartbeat for %s after %v",
+				p.ID, r.RequestURI, time.Since(requestBeginTime))
 
-					w.Header().Set("Content-Type", "text/event-stream")
-					w.Header().Set("Cache-Control", "no-cache")
-					w.Header().Set("Connection", "keep-alive")
-					w.WriteHeader(http.StatusOK)
-					fmt.Fprintf(w, ": heart-beat\n\n")
-					if f, ok := w.(http.Flusher); ok {
-						f.Flush()
-					}
-				}
+				prw.Header().Set("Content-Type", "text/event-stream")
+				prw.Header().Set("Cache-Control", "no-cache")
+				prw.Header().Set("Connection", "keep-alive")
+				prw.WriteHeader(http.StatusOK)
+				fmt.Fprintf(prw, ": heart-beat\n\n")
+				prw.Flush()
 			}
 		}()
 	}
 
 	if p.testHandler != nil {
-		p.testHandler.ServeHTTP(w, r)
+		p.testHandler.ServeHTTP(prw, r)
 	} else if srw != nil {
 		p.reverseProxy.ServeHTTP(srw, r)
 	} else {
-		p.reverseProxy.ServeHTTP(w, r)
+		p.reverseProxy.ServeHTTP(prw, r)
 	}
 
 	totalTime := time.Since(requestBeginTime)
@@ -765,6 +771,57 @@ func (p *Process) cmdStopUpstreamProcess() error {
 // Logger returns the logger for this process.
 func (p *Process) Logger() *LogMonitor {
 	return p.processLogger
+}
+
+// proxyResponseWriter wraps http.ResponseWriter to synchronize concurrent writes
+// from the reverseProxy and heartbeat goroutine, preventing data races and
+// premature response commits.
+type proxyResponseWriter struct {
+	mu           sync.RWMutex
+	writer       http.ResponseWriter
+	firstWriteCh chan struct{}
+	firstWritten bool
+}
+
+func newProxyResponseWriter(w http.ResponseWriter) *proxyResponseWriter {
+	return &proxyResponseWriter{
+		writer:       w,
+		firstWriteCh: make(chan struct{}),
+	}
+}
+
+func (p *proxyResponseWriter) Header() http.Header {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.writer.Header()
+}
+
+func (p *proxyResponseWriter) WriteHeader(code int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.firstWritten {
+		p.firstWritten = true
+		close(p.firstWriteCh)
+	}
+	p.writer.WriteHeader(code)
+}
+
+func (p *proxyResponseWriter) Write(data []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.firstWritten {
+		p.firstWritten = true
+		close(p.firstWriteCh)
+	}
+	return p.writer.Write(data)
+}
+
+func (p *proxyResponseWriter) Flush() {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if flusher, ok := p.writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
 }
 
 var loadingRemarks = []string{

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -78,8 +78,7 @@ type Process struct {
 	gracefulStopTimeout time.Duration
 
 	// ackTimeout to send HTTP 200 to the client when upstream is waiting too long (0 = disabled)
-	ackTimeout  time.Duration
-	ackSentFlag uint32
+	ackTimeout time.Duration
 
 	// used for testing to bypass subprocess and reverse proxy
 	testHandler http.Handler
@@ -637,19 +636,26 @@ func (p *Process) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// for #726 ackTimeout - background goroutine sends ACK if upstream is slow.
+	// #726: ackTimeout goroutine — sends periodic keep-alive heartbeats
+	// when upstream is unresponsive, preventing client timeouts during long
+	// prompt processing or generation sessions.
+
 	if p.ackTimeout > 0 {
+		tickInterval := p.ackTimeout / 2
 		go func() {
-			timer := time.NewTimer(p.ackTimeout)
-			defer timer.Stop()
-			select {
-			case <-r.Context().Done():
-				return
-			case <-timer.C:
-				if atomic.CompareAndSwapUint32(&p.ackSentFlag, 0, 1) {
-					totalTimeAfterStart := time.Since(requestBeginTime)
-					p.proxyLogger.Debugf("<%s> - Sent keep-alive heartbeat for request %s - after start: %v", p.ID, r.RequestURI, totalTimeAfterStart)
-					// Set headers and send keep-alive
+			ticker := time.NewTicker(tickInterval)
+			defer ticker.Stop()
+
+			for range ticker.C {
+				select {
+				case <-r.Context().Done():
+					p.proxyLogger.Debugf("<%s> - Cancel sent keep-alive for %s after %v",
+						p.ID, r.RequestURI, time.Since(requestBeginTime))
+					return // client cancelled — stop sending heartbeats
+				default:
+					p.proxyLogger.Debugf("<%s> - Sent keep-alive heartbeat for %s after %v",
+						p.ID, r.RequestURI, time.Since(requestBeginTime))
+
 					w.Header().Set("Content-Type", "text/event-stream")
 					w.Header().Set("Cache-Control", "no-cache")
 					w.Header().Set("Connection", "keep-alive")

--- a/proxy/process.go
+++ b/proxy/process.go
@@ -650,20 +650,20 @@ func (p *Process) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			ticker := time.NewTicker(tickInterval)
 			defer ticker.Stop()
 
-	for range ticker.C {
-			select {
-			case <-prw.firstWriteCh:
-				p.proxyLogger.Debugf("<%s> - Cancel sent keep-alive for %s after %v",
+			for range ticker.C {
+				select {
+				case <-prw.firstWriteCh:
+					p.proxyLogger.Debugf("<%s> - Cancel sent keep-alive for %s after %v",
+						p.ID, r.RequestURI, time.Since(requestBeginTime))
+					return // upstream started writing — stop sending heartbeats
+				case <-r.Context().Done():
+					p.proxyLogger.Debugf("<%s> - Cancel sent keep-alive for %s after %v",
+						p.ID, r.RequestURI, time.Since(requestBeginTime))
+					return // client cancelled — stop sending heartbeats
+				default:
+				}
+				p.proxyLogger.Debugf("<%s> - Sent keep-alive heartbeat for %s after %v",
 					p.ID, r.RequestURI, time.Since(requestBeginTime))
-				return // upstream started writing — stop sending heartbeats
-			case <-r.Context().Done():
-				p.proxyLogger.Debugf("<%s> - Cancel sent keep-alive for %s after %v",
-					p.ID, r.RequestURI, time.Since(requestBeginTime))
-				return // client cancelled — stop sending heartbeats
-			default:
-			}
-			p.proxyLogger.Debugf("<%s> - Sent keep-alive heartbeat for %s after %v",
-				p.ID, r.RequestURI, time.Since(requestBeginTime))
 
 				prw.Header().Set("Content-Type", "text/event-stream")
 				prw.Header().Set("Cache-Control", "no-cache")


### PR DESCRIPTION
Add an optional ackTimeout field to model config that sends a keep-alive heartbeat to the client when the upstream inference server takes longer than the configured timeout to respond. This prevents client-side timeouts (e.g. Kilo Code task timeouts) during long generation or startup sessions.

Key changes:
- Add AckTimeout int field to ModelConfig with YAML tag "ackTimeout"
- Validate ackTimeout >= 0 in LoadConfigFromReader
- Background goroutine in Process.ProxyRequest creates a per-model timer
- Uses atomic.CompareAndSwapUint32 to ensure only one heartbeat is sent per model instance, preventing duplicate ACKs across concurrent requests
- Heartbeat is an SSE comment (: heart-beat) which standard clients ignore but keeps the connection alive and prevents proxy/browser timeouts
- Timer goroutine respects r.Context().Done() for graceful cancellation
- Add ackTimeout to JSON schema (minimum: 0, default: 0 = disabled)

Example config:
    models:
      my-slow-model:
        cmd: llama-server --model /path/to/model.gguf
        ackTimeout: 110  # send heartbeat after 110s of upstream silence

## Summary

Add per-model `ackTimeout` configuration to send a keep-alive heartbeat when the upstream inference server takes longer than expected to respond. This prevents client-side timeouts during long generation or model startup sessions.

- Add `AckTimeout` field to `ModelConfig` (YAML: `ackTimeout`)
- Background goroutine in `Process.ProxyRequest` sends SSE heartbeat after timeout elapses
- Atomic CAS ensures only one heartbeat per model instance across concurrent requests
- Config validation: `ackTimeout >= 0`, default `0` (disabled)