### PR TITLE
proxy: fix data race in /running endpoint and typo in error message

### DIFF
--- a/proxy/process.go
+++ b/proxy/process.go
@@ -304,7 +304,7 @@ func (p *Process) start() error {
 					return fmt.Errorf("process was already starting but wound up in state %v", state)
 				}
 			} else {
-				return fmt.Errorf("processes was in state %v when start() was called", curState)
+				return fmt.Errorf("process was in state %v when start() was called", curState)
 			}
 		} else {
 			return fmt.Errorf("failed to set Process state to starting: current state: %v, error: %v", curState, err)

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -1173,7 +1173,7 @@ func (pm *ProxyManager) listRunningProcessesHandler(context *gin.Context) {
 			if process, ok := pm.matrix.GetProcess(modelID); ok {
 				runningProcesses = append(runningProcesses, gin.H{
 					"model":       process.ID,
-					"state":       process.state,
+					"state":       process.CurrentState(),
 					"cmd":         process.config.Cmd,
 					"proxy":       process.config.Proxy,
 					"ttl":         process.config.UnloadAfter,
@@ -1188,7 +1188,7 @@ func (pm *ProxyManager) listRunningProcessesHandler(context *gin.Context) {
 				if process.CurrentState() == StateReady {
 					runningProcesses = append(runningProcesses, gin.H{
 						"model":       process.ID,
-						"state":       process.state,
+						"state":       process.CurrentState(),
 						"cmd":         process.config.Cmd,
 						"proxy":       process.config.Proxy,
 						"ttl":         process.config.UnloadAfter,


### PR DESCRIPTION
## Problem

The `/running` endpoint in `listRunningProcessesHandler` reads `process.state` directly without holding `stateMutex`. Meanwhile, `swapState()` writes to `process.state` while holding the write lock. This is a data race flagged by the Go race detector.

Also fixes a minor typo: "processes was in state" → "process was in state".

## Fix

- `proxymanager.go`: Replace `process.state` with `process.CurrentState()` which acquires `stateMutex.RLock()` before reading.
- `process.go`: Fix typo in error message.

## Verification

- `gofmt -l` — clean
- `go test -run "TestProcessGroup_|TestProxyManager_" ./proxy/` — all pass
- `go test ./proxy/config/... ./proxy/cache/... ./proxy/configwatcher/...` — all pass