### PR TITLE
ci: use manifest-aware cleanup action for multi-arch :cpu

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -70,8 +70,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./docker/build-container.sh ${{ matrix.platform }} ${{ github.event_name != 'push' }}
 
-  # note make sure mostlygeek/llama-swap has admin rights to the llama-swap package
-  # see: https://github.com/actions/delete-package-versions/issues/74
+  # actions/delete-package-versions can't see manifest lists: pushing
+  # a multi-arch image with `docker buildx --push` creates a tagged OCI
+  # index plus one untagged per-platform manifest per arch, and
+  # `delete-only-untagged-versions: true` then nukes the per-platform
+  # children, leaving the index dangling — `docker pull :cpu` 404s on
+  # the referenced digest. dataaxiom/ghcr-cleanup-action walks tagged
+  # manifest lists and excludes their children from deletion.
   delete-untagged-containers:
     needs: build-and-push
     # Skip on forks — the delete API requires package-admin on the
@@ -79,8 +84,8 @@ jobs:
     if: github.repository == 'mostlygeek/llama-swap'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/delete-package-versions@v5
+      - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
-          package-name: 'llama-swap'
-          package-type: 'container'
-          delete-only-untagged-versions: 'true'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          package: llama-swap
+          delete-untagged: true

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -9,6 +9,11 @@ on:
 
   # Allows manual triggering of the workflow
   workflow_dispatch:
+    inputs:
+      dryrun:
+        description: "Run cleanup step in dry-run mode (log what would be deleted, delete nothing)"
+        type: boolean
+        default: false
 
   # Run on workflow file changes (without pushing)
   push:
@@ -89,3 +94,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           package: llama-swap
           delete-untagged: true
+          dry-run: ${{ inputs.dryrun || false }}


### PR DESCRIPTION
Trying the new build shows :cpu is broken for everyone now! 😱 turns out the cleanup action breaks multi-arch. Here's a fix.


actions/delete-package-versions can't see OCI manifest lists. When the cpu build pushes a multi-arch image, the registry gets a tagged index plus one untagged per-platform manifest per arch. The cleanup step with `delete-only-untagged-versions: true` then deletes the per-platform children, leaving the index dangling — `docker pull ghcr.io/mostlygeek/llama-swap:cpu` 404s on the referenced sha.

Swap to dataaxiom/ghcr-cleanup-action, which inspects tagged manifest lists first and excludes their children from deletion. Single-arch backends behave the same as before.