### PR TITLE
perf: ignore LACT devices reporting zero VRAM

### DIFF
--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -106,6 +106,9 @@ func tryLACT(ctx context.Context, every time.Duration, logger *logmon.Monitor) (
 					if err != nil {
 						continue
 					}
+					if stat.MemTotalMB == 0 {
+						continue
+					}
 					stats = append(stats, stat)
 				}
 				conn.Close()


### PR DESCRIPTION
Ignore LACT devices that report zero total VRAM.

Some virtual GPUs on headless VMs report `MemTotalMB == 0` through LACT, which makes them appear in performance monitoring despite not providing useful memory data. Skip those entries so only usable GPU devices are reported.

This makes performance monitoring cleaner on headless VMs with virtual GPUs that report zero VRAM.