### PR TITLE
ci: unified buildx, GHA layer cache, post-push manifest verifier

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -92,7 +92,9 @@ jobs:
       || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
+      # Pinned past v1.0.16 to pick up the node20 → node24 runtime bump
+      # (#105, 2026-05-11). Drop the SHA back to a tag once v1.0.17 cuts.
+      - uses: dataaxiom/ghcr-cleanup-action@aa3ef78ce6e21c2820a185de1c6c59aafc41b2e7 # main, post-v1.0.16
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           package: llama-swap

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -15,11 +15,12 @@ on:
         type: boolean
         default: false
 
-  # Run on workflow file changes (without pushing)
+  # Run on workflow file changes (smoke build, no push)
   push:
     paths:
       - '.github/workflows/containers.yml'
       - 'docker/build-container.sh'
+      - 'docker/verify-pull.sh'
       - 'docker/*.Containerfile'
 
 # grant permissions on GITHUB_TOKEN to publish packages
@@ -30,41 +31,43 @@ permissions:
   id-token: write
 
 jobs:
+  # The matrix below (`&backends`) is the single source of truth for
+  # every backend. verify-pull references the same anchor via
+  # `*backends`. Append a platform to a tag's `platforms` string to
+  # take that backend multi-arch — buildx + QEMU handle the cross-arch
+  # build, the published index covers every listed platform, and
+  # verify-pull asserts every child manifest is reachable post-cleanup.
   build-and-push:
     runs-on: ubuntu-latest
     strategy:
-      matrix:
-        platform: [intel, cuda, cuda13, vulkan, cpu, musa, rocm]
       fail-fast: false
+      matrix:
+        include: &backends
+          - { tag: cpu,    platforms: "linux/amd64,linux/arm64" }
+          - { tag: intel,  platforms: "linux/amd64" }
+          - { tag: cuda,   platforms: "linux/amd64" }
+          - { tag: cuda13, platforms: "linux/amd64" }
+          - { tag: vulkan, platforms: "linux/amd64" }
+          - { tag: musa,   platforms: "linux/amd64" }
+          - { tag: rocm,   platforms: "linux/amd64" }
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
 
       - name: Free up disk space
-        if: matrix.platform == 'rocm'
-        run: |
-          echo "Before cleanup:"
-          df -h
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo docker system prune -af
-          echo "After cleanup:"
-          df -h
+        if: matrix.tag == 'rocm'
+        run: ./docker/free-disk.sh
 
-      # QEMU enables arm64 cross-builds on the amd64 GitHub runner.
-      # Currently only the cpu backend goes multi-arch; the action is a
-      # no-op for amd64-only builds, so leaving it on for every matrix
-      # entry keeps the workflow simple.
+      # QEMU enables cross-arch builds (linux/arm64 on amd64 runners).
+      # No-op for amd64-only matrix entries.
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a #v4.0.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -73,20 +76,20 @@ jobs:
       - name: Run build-container
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./docker/build-container.sh ${{ matrix.platform }} ${{ github.event_name != 'push' }}
+          PLATFORMS: ${{ matrix.platforms }}
+        run: ./docker/build-container.sh ${{ matrix.tag }} ${{ github.event_name != 'push' }}
 
-  # actions/delete-package-versions can't see manifest lists: pushing
-  # a multi-arch image with `docker buildx --push` creates a tagged OCI
-  # index plus one untagged per-platform manifest per arch, and
-  # `delete-only-untagged-versions: true` then nukes the per-platform
-  # children, leaving the index dangling — `docker pull :cpu` 404s on
-  # the referenced digest. dataaxiom/ghcr-cleanup-action walks tagged
-  # manifest lists and excludes their children from deletion.
+  # dataaxiom action walks tagged manifest lists and excludes their
+  # per-platform children from deletion, so pruning untagged versions
+  # leaves multi-arch indexes intact.
   delete-untagged-containers:
     needs: build-and-push
-    # Skip on forks — the delete API requires package-admin on the
-    # upstream account and would otherwise red-x every fork CI run.
-    if: github.repository == 'mostlygeek/llama-swap'
+    # Runs on upstream cron/dispatch and on workflow_dispatch from forks
+    # (so a fork can validate cleanup end-to-end via `dryrun=true`).
+    # Skipped on fork `schedule` to avoid surprise pruning.
+    if: |
+      github.repository == 'mostlygeek/llama-swap'
+      || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
@@ -95,3 +98,40 @@ jobs:
           package: llama-swap
           delete-untagged: true
           dry-run: ${{ inputs.dryrun || false }}
+
+  # Walks each tag's manifest after cleanup and confirms every declared
+  # platform child is reachable. Regression guard against cleanup
+  # deleting manifest list children.
+  verify-pull:
+    needs: [build-and-push, delete-untagged-containers]
+    if: |
+      always()
+      && needs.build-and-push.result == 'success'
+      && (needs.delete-untagged-containers.result == 'success'
+          || needs.delete-untagged-containers.result == 'skipped')
+      && github.event_name != 'push'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: *backends
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify ${{ matrix.tag }} manifest on ${{ matrix.platforms }}
+        env:
+          REPO: ghcr.io/${{ github.repository }}
+          TAG: ${{ matrix.tag }}
+          PLATFORMS: ${{ matrix.platforms }}
+        run: ./docker/verify-pull.sh

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -77,7 +77,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PLATFORMS: ${{ matrix.platforms }}
+          # Recorded only when actually pushing; verify-pull consumes
+          # these to assert the registry still serves the digest this
+          # run produced.
+          DIGEST_DIR: ${{ runner.temp }}/digests
         run: ./docker/build-container.sh ${{ matrix.tag }} ${{ github.event_name != 'push' }}
+
+      # Smoke (push event) doesn't push → no digests → no upload.
+      - name: Upload pushed-digest manifest
+        if: github.event_name != 'push'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ matrix.tag }}
+          path: ${{ runner.temp }}/digests/
+          if-no-files-found: error
+          retention-days: 1
 
   # dataaxiom action walks tagged manifest lists and excludes their
   # per-platform children from deletion, so pruning untagged versions
@@ -131,9 +145,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download expected digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: digests-${{ matrix.tag }}
+          path: ${{ runner.temp }}/digests/
+
       - name: Verify ${{ matrix.tag }} manifest on ${{ matrix.platforms }}
         env:
           REPO: ghcr.io/${{ github.repository }}
           TAG: ${{ matrix.tag }}
           PLATFORMS: ${{ matrix.platforms }}
+          EXPECTED_DIR: ${{ runner.temp }}/digests
         run: ./docker/verify-pull.sh

--- a/docker/build-container.sh
+++ b/docker/build-container.sh
@@ -26,43 +26,34 @@ log_info() {
 ARCH=$1
 PUSH_IMAGES=${2:-false}
 
-# List of allowed architectures
 ALLOWED_ARCHS=("intel" "vulkan" "musa" "cuda" "cuda13" "cpu" "rocm")
-
-# Check if ARCH is in the allowed list
 if [[ ! " ${ALLOWED_ARCHS[@]} " =~ " ${ARCH} " ]]; then
   log_info "Error: ARCH must be one of the following: ${ALLOWED_ARCHS[@]}"
   exit 1
 fi
 
-# Check if GITHUB_TOKEN is set and not empty
 if [[ -z "${GITHUB_TOKEN:-}" ]]; then
   log_info "Error: GITHUB_TOKEN is not set or is empty."
   exit 1
 fi
 
-# Set llama.cpp base image, customizable using the BASE_LLAMACPP_IMAGE environment
-# variable, this permits testing with forked llama.cpp repositories
+# llama.cpp + stable-diffusion.cpp upstream base images. Override via
+# BASE_LLAMACPP_IMAGE / BASE_SDCPP_IMAGE to test against forks.
 BASE_IMAGE=${BASE_LLAMACPP_IMAGE:-ghcr.io/ggml-org/llama.cpp}
 SD_IMAGE=${BASE_SDCPP_IMAGE:-ghcr.io/leejet/stable-diffusion.cpp}
 
-# LS_REPO is the destination of the built container image — defaults to the
-# current GitHub repository so forked CI builds publish to the fork's own
-# ghcr.io namespace without code changes.
+# Destination namespace — defaults to the current GitHub repo so fork
+# CI publishes to its own ghcr.io.
 LS_REPO=${GITHUB_REPOSITORY:-mostlygeek/llama-swap}
 
-# LS_BINARY_REPO is where the llama-swap release tarball is downloaded
-# from. Decoupled from LS_REPO so forks (which usually have no releases of
-# their own) can still build a container by pulling the canonical binary
-# from upstream. Override via the LS_BINARY_REPO env var when you maintain
-# fork-side releases.
+# Where to pull the llama-swap release tarball from. Decoupled from
+# LS_REPO so forks (which usually have no releases) still build against
+# the upstream binary unless they override this.
 LS_BINARY_REPO=${LS_BINARY_REPO:-mostlygeek/llama-swap}
 
-# the most recent llama-swap tag
-# have to strip out the 'v' due to .tar.gz file naming.
-# Authenticated request — unauth'd github.com API is 60/hr per IP and GHA
-# runners share IPs, so the call regularly returns rate-limit JSON and
-# `.tag_name` then resolves to "null", producing a bogus `vnull` URL below.
+# Authenticated request — unauth'd github.com API is 60/hr per IP and
+# GHA runners share IPs, so the call regularly returns rate-limit JSON
+# and `.tag_name` then resolves to "null", producing a bogus `vnull`.
 LS_VER=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
     "https://api.github.com/repos/${LS_BINARY_REPO}/releases/latest" \
     | jq -r .tag_name | sed 's/v//')
@@ -72,10 +63,8 @@ if [[ -z "$LS_VER" || "$LS_VER" == "null" ]]; then
     exit 1
 fi
 
-# Fetches the most recent llama.cpp tag matching the given prefix
-# Handles pagination to search beyond the first 100 results
-# $1 - tag_prefix (e.g., "server" or "server-vulkan")
-# Returns: the version number extracted from the tag
+# Walks llama.cpp package versions paginated to find the newest tag
+# matching a prefix (e.g. "server" for cpu, "server-cuda" for cuda).
 fetch_llama_tag() {
     local tag_prefix=$1
     local page=1
@@ -87,20 +76,17 @@ fetch_llama_tag() {
         local response=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
             "https://api.github.com/users/ggml-org/packages/container/llama.cpp/versions?per_page=${per_page}&page=${page}")
 
-        # Check for API errors
         if echo "$response" | jq -e '.message' > /dev/null 2>&1; then
             local error_msg=$(echo "$response" | jq -r '.message')
             log_info "GitHub API error: $error_msg"
             return 1
         fi
 
-        # Check if response is empty array (no more pages)
         if [ "$(echo "$response" | jq 'length')" -eq 0 ]; then
             log_debug "No more pages (empty response)"
             return 1
         fi
 
-        # Extract matching tag from this page
         local found_tag=$(echo "$response" | jq -r \
             ".[] | select(.metadata.container.tags[]? | startswith(\"$tag_prefix\")) | .metadata.container.tags[] | select(startswith(\"$tag_prefix\"))" \
             | sort -r | head -n1)
@@ -112,8 +98,6 @@ fetch_llama_tag() {
         fi
 
         page=$((page + 1))
-
-        # Safety limit to prevent infinite loops
         if [ $page -gt 50 ]; then
             log_info "Reached pagination safety limit (50 pages)"
             return 1
@@ -131,84 +115,95 @@ fi
 
 SD_TAG=master-${ARCH}
 
-# Abort if LCPP_TAG is empty.
 if [[ -z "$LCPP_TAG" ]]; then
     log_info "Abort: Could not find llama-server container for arch: $ARCH"
     exit 1
-else
-    log_info "LCPP_TAG: $LCPP_TAG"
 fi
+log_info "LCPP_TAG: $LCPP_TAG"
 
 if [[ ! -z "$DEBUG_ABORT_BUILD" ]]; then
     log_info "Abort: DEBUG_ABORT_BUILD set"
     exit 0
 fi
 
-# cpu is the only backend with a multi-arch upstream base
-# (ghcr.io/ggml-org/llama.cpp:server-bXXXX ships amd64+arm64); GPU backends
-# are amd64-only and stay on the original `docker build` path so the
-# sd-server layer can still FROM the just-built image via the local
-# dockerd image store (buildx's container driver has a separate store
-# that doesn't share with dockerd, which breaks the sd build).
-if [ "$ARCH" == "cpu" ]; then
-    if [ "$PUSH_IMAGES" == "true" ]; then
-        BUILDX_FLAGS="--push --platform linux/amd64,linux/arm64"
-    else
-        # Smoke build: validate both platforms but emit no output. buildx
-        # on the docker-container driver defaults to cacheonly when
-        # neither --push nor --load is given, so each arch fully builds
-        # and a regression in either fails CI — without materializing the
-        # image or needing to --load (which is multi-arch-incompatible).
-        BUILDX_FLAGS="--platform linux/amd64,linux/arm64"
-    fi
+# Platforms to build for. Driven by the workflow's per-backend matrix
+# entry (e.g. `linux/amd64,linux/arm64` for cpu). Default keeps a bare
+# `./build-container.sh <arch>` invocation working locally.
+PLATFORMS=${PLATFORMS:-linux/amd64}
+MULTI_ARCH=0
+case ",${PLATFORMS}," in
+    *,*,*) MULTI_ARCH=1 ;;
+esac
+
+# buildx output mode:
+#   --push    publish a tagged manifest list directly.
+#   --load    smoke, single arch — into local dockerd so sd-server can FROM.
+#   (none)    smoke, multi-arch — cacheonly; buildx can't --load an index.
+if [ "$PUSH_IMAGES" == "true" ]; then
+    BUILDX_OUTPUT="--push"
+elif [ "$MULTI_ARCH" -eq 1 ]; then
+    BUILDX_OUTPUT=""
+else
+    BUILDX_OUTPUT="--load"
 fi
 
+# GHA layer cache, scoped per backend+arch+container-type to keep
+# amd64/arm64 caches disjoint. Skipped outside GHA — `type=gha` needs
+# ACTIONS_RUNTIME_TOKEN.
+buildx_cache_flags() {
+    local scope=$1
+    if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+        echo "--cache-from type=gha,scope=${scope} --cache-to type=gha,mode=max,scope=${scope}"
+    fi
+}
+
+PLATFORM_SLUG=$(echo "$PLATFORMS" | tr ',/' '--')
+
 for CONTAINER_TYPE in non-root root; do
-  CONTAINER_TAG="ghcr.io/${LS_REPO}:v${LS_VER}-${ARCH}-${LCPP_TAG}"
-  CONTAINER_LATEST="ghcr.io/${LS_REPO}:${ARCH}"
-  USER_UID=0
-  USER_GID=0
-  USER_HOME=/root
+    CONTAINER_TAG="ghcr.io/${LS_REPO}:v${LS_VER}-${ARCH}-${LCPP_TAG}"
+    CONTAINER_LATEST="ghcr.io/${LS_REPO}:${ARCH}"
+    USER_UID=0
+    USER_GID=0
+    USER_HOME=/root
 
-  if [ "$CONTAINER_TYPE" == "non-root" ]; then
-    CONTAINER_TAG="${CONTAINER_TAG}-non-root"
-    CONTAINER_LATEST="${CONTAINER_LATEST}-non-root"
-    USER_UID=10001
-    USER_GID=10001
-    USER_HOME=/app
-  fi
+    if [ "$CONTAINER_TYPE" == "non-root" ]; then
+        CONTAINER_TAG="${CONTAINER_TAG}-non-root"
+        CONTAINER_LATEST="${CONTAINER_LATEST}-non-root"
+        USER_UID=10001
+        USER_GID=10001
+        USER_HOME=/app
+    fi
 
-  log_info "Building $CONTAINER_TYPE $CONTAINER_TAG $LS_VER"
-  if [ "$ARCH" == "cpu" ]; then
-    docker buildx build $BUILDX_FLAGS --provenance=false \
-      -f llama-swap.Containerfile \
-      --build-arg BASE_TAG=${BASE_TAG} --build-arg LS_VER=${LS_VER} --build-arg UID=${USER_UID} \
-      --build-arg LS_REPO=${LS_BINARY_REPO} --build-arg GID=${USER_GID} --build-arg USER_HOME=${USER_HOME} \
-      --build-arg BASE_IMAGE=${BASE_IMAGE} \
-      -t ${CONTAINER_TAG} -t ${CONTAINER_LATEST} .
-  else
-    docker build --provenance=false -f llama-swap.Containerfile \
-      --build-arg BASE_TAG=${BASE_TAG} --build-arg LS_VER=${LS_VER} --build-arg UID=${USER_UID} \
-      --build-arg LS_REPO=${LS_BINARY_REPO} --build-arg GID=${USER_GID} --build-arg USER_HOME=${USER_HOME} \
-      -t ${CONTAINER_TAG} -t ${CONTAINER_LATEST} \
-      --build-arg BASE_IMAGE=${BASE_IMAGE} .
-  fi
+    CACHE_FLAGS=$(buildx_cache_flags "${ARCH}-${PLATFORM_SLUG}-${CONTAINER_TYPE}")
 
-  # For architectures with stable-diffusion.cpp support, layer sd-server on top.
-  # Stays on `docker build` so the base resolves from local dockerd.
-  case "$ARCH" in
-    "musa" | "vulkan")
-      log_info "Adding sd-server to $CONTAINER_TAG"
-      docker build --provenance=false -f llama-swap-sd.Containerfile \
-        --build-arg BASE=${CONTAINER_TAG} \
-        --build-arg SD_IMAGE=${SD_IMAGE} --build-arg SD_TAG=${SD_TAG} \
-        --build-arg UID=${USER_UID} --build-arg GID=${USER_GID} \
-        -t ${CONTAINER_TAG} -t ${CONTAINER_LATEST} . ;;
-  esac
+    log_info "Building $CONTAINER_TYPE $CONTAINER_TAG $LS_VER on $PLATFORMS"
+    docker buildx build $BUILDX_OUTPUT $CACHE_FLAGS --provenance=false \
+        --platform "$PLATFORMS" \
+        -f llama-swap.Containerfile \
+        --build-arg BASE_IMAGE=${BASE_IMAGE} --build-arg BASE_TAG=${BASE_TAG} \
+        --build-arg LS_VER=${LS_VER} --build-arg LS_REPO=${LS_BINARY_REPO} \
+        --build-arg UID=${USER_UID} --build-arg GID=${USER_GID} --build-arg USER_HOME=${USER_HOME} \
+        -t ${CONTAINER_TAG} -t ${CONTAINER_LATEST} .
 
-  # cpu builds push inline via buildx --push; all other archs push here.
-  if [ "$ARCH" != "cpu" ] && [ "$PUSH_IMAGES" == "true" ]; then
-    docker push ${CONTAINER_TAG}
-    docker push ${CONTAINER_LATEST}
-  fi
+    # sd-server layer for backends that bundle stable-diffusion.cpp.
+    # Only run on the push path: buildx then pulls FROM the just-pushed
+    # base via the registry. The docker-container buildx driver has its
+    # own image store separate from dockerd, so a `--load`'d base from
+    # the smoke path isn't visible here — skipped to avoid 404 on FROM.
+    case "$ARCH" in
+        "musa" | "vulkan")
+            if [ "$PUSH_IMAGES" != "true" ]; then
+                log_info "Skipping sd-server layer for $ARCH (smoke build, base not in registry)"
+            else
+                log_info "Adding sd-server to $CONTAINER_TAG"
+                SD_CACHE=$(buildx_cache_flags "${ARCH}-${PLATFORM_SLUG}-${CONTAINER_TYPE}-sd")
+                docker buildx build $BUILDX_OUTPUT $SD_CACHE --provenance=false \
+                    --platform "$PLATFORMS" \
+                    -f llama-swap-sd.Containerfile \
+                    --build-arg BASE=${CONTAINER_TAG} \
+                    --build-arg SD_IMAGE=${SD_IMAGE} --build-arg SD_TAG=${SD_TAG} \
+                    --build-arg UID=${USER_UID} --build-arg GID=${USER_GID} \
+                    -t ${CONTAINER_TAG} -t ${CONTAINER_LATEST} .
+            fi ;;
+    esac
 done

--- a/docker/build-container.sh
+++ b/docker/build-container.sh
@@ -26,6 +26,13 @@ log_info() {
 ARCH=$1
 PUSH_IMAGES=${2:-false}
 
+# When set, each pushed tag's manifest/index digest is written to
+# $DIGEST_DIR/<tag>.digest. verify-pull.sh reads these to assert the
+# registry still serves the digest this run pushed (catches cleanup
+# replacing or pruning a tag's index after the build). No-op unless we
+# actually push — non-push builds wouldn't be on the registry to verify.
+DIGEST_DIR=${DIGEST_DIR:-}
+
 ALLOWED_ARCHS=("intel" "vulkan" "musa" "cuda" "cuda13" "cpu" "rocm")
 if [[ ! " ${ALLOWED_ARCHS[@]} " =~ " ${ARCH} " ]]; then
   log_info "Error: ARCH must be one of the following: ${ALLOWED_ARCHS[@]}"
@@ -159,6 +166,33 @@ buildx_cache_flags() {
 
 PLATFORM_SLUG=$(echo "$PLATFORMS" | tr ',/' '--')
 
+# Wraps `docker buildx build` and, when DIGEST_DIR is set on a push
+# build, extracts the pushed manifest digest from the buildx metadata
+# file into $DIGEST_DIR/<digest_name>.digest. For backends that re-tag
+# in a second buildx pass (sd-server layer for musa/vulkan), passing
+# the same digest_name overwrites the base build's digest — which is
+# correct, since the second push is what the tag resolves to.
+buildx_run() {
+    local digest_name="$1"; shift
+    if [ -n "$DIGEST_DIR" ] && [ "$PUSH_IMAGES" = "true" ]; then
+        mkdir -p "$DIGEST_DIR"
+        local meta
+        meta=$(mktemp)
+        docker buildx build --metadata-file "$meta" "$@"
+        local digest
+        digest=$(jq -r '."containerimage.digest" // empty' "$meta")
+        rm -f "$meta"
+        if [ -z "$digest" ]; then
+            log_info "Error: no containerimage.digest in buildx metadata for ${digest_name}"
+            return 1
+        fi
+        echo "$digest" > "$DIGEST_DIR/${digest_name}.digest"
+        log_info "Recorded digest ${digest} -> ${DIGEST_DIR}/${digest_name}.digest"
+    else
+        docker buildx build "$@"
+    fi
+}
+
 for CONTAINER_TYPE in non-root root; do
     CONTAINER_TAG="ghcr.io/${LS_REPO}:v${LS_VER}-${ARCH}-${LCPP_TAG}"
     CONTAINER_LATEST="ghcr.io/${LS_REPO}:${ARCH}"
@@ -176,8 +210,13 @@ for CONTAINER_TYPE in non-root root; do
 
     CACHE_FLAGS=$(buildx_cache_flags "${ARCH}-${PLATFORM_SLUG}-${CONTAINER_TYPE}")
 
+    # Digest filename mirrors verify-pull.sh's tag-suffix loop:
+    # `<arch>` for root, `<arch>-non-root` for non-root.
+    DIGEST_NAME="${ARCH}"
+    [ "$CONTAINER_TYPE" = "non-root" ] && DIGEST_NAME="${ARCH}-non-root"
+
     log_info "Building $CONTAINER_TYPE $CONTAINER_TAG $LS_VER on $PLATFORMS"
-    docker buildx build $BUILDX_OUTPUT $CACHE_FLAGS --provenance=false \
+    buildx_run "$DIGEST_NAME" $BUILDX_OUTPUT $CACHE_FLAGS --provenance=false \
         --platform "$PLATFORMS" \
         -f llama-swap.Containerfile \
         --build-arg BASE_IMAGE=${BASE_IMAGE} --build-arg BASE_TAG=${BASE_TAG} \
@@ -197,7 +236,7 @@ for CONTAINER_TYPE in non-root root; do
             else
                 log_info "Adding sd-server to $CONTAINER_TAG"
                 SD_CACHE=$(buildx_cache_flags "${ARCH}-${PLATFORM_SLUG}-${CONTAINER_TYPE}-sd")
-                docker buildx build $BUILDX_OUTPUT $SD_CACHE --provenance=false \
+                buildx_run "$DIGEST_NAME" $BUILDX_OUTPUT $SD_CACHE --provenance=false \
                     --platform "$PLATFORMS" \
                     -f llama-swap-sd.Containerfile \
                     --build-arg BASE=${CONTAINER_TAG} \

--- a/docker/free-disk.sh
+++ b/docker/free-disk.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Reclaim ~30GB on the GitHub-hosted ubuntu-latest runner so large GPU
+# image builds (rocm/cuda) don't ENOSPC partway through. Only invoked
+# from the build workflow for backends known to need it.
+#
+# Destructive: rm -rf's /usr/share/dotnet, /opt/ghc, /opt/hostedtoolcache,
+# /usr/local/lib/android. On a dev laptop those are real installs, not
+# disposable runner state. Refuses to run unless GITHUB_ACTIONS=true.
+
+set -euo pipefail
+
+if [ "${GITHUB_ACTIONS:-}" != "true" ]; then
+    echo "free-disk.sh refuses to run outside GitHub Actions." >&2
+    echo "It deletes /usr/share/dotnet, /opt/ghc, /opt/hostedtoolcache, and" >&2
+    echo "/usr/local/lib/android — only safe on a disposable runner." >&2
+    exit 1
+fi
+
+echo "Before cleanup:"
+df -h
+sudo rm -rf /usr/share/dotnet
+sudo rm -rf /usr/local/lib/android
+sudo rm -rf /opt/ghc
+sudo rm -rf /opt/hostedtoolcache/CodeQL
+sudo docker system prune -af
+echo "After cleanup:"
+df -h

--- a/docker/verify-pull.sh
+++ b/docker/verify-pull.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Walk the OCI index of every non-versioned tag for one backend and
+# confirm each declared platform's child manifest is reachable. Uses
+# `docker buildx imagetools inspect --raw` so each invocation finishes
+# in seconds without pulling layers.
+#
+# Catches the failure mode where cleanup deletes a tagged manifest
+# list's per-platform children, leaving a dangling index — `docker pull`
+# then 404s on the referenced digest even though the tag still exists.
+#
+# Inputs (env):
+#   REPO       — ghcr.io/<owner>/<repo>
+#   TAG        — backend tag (cpu, intel, cuda, ...)
+#   PLATFORMS  — comma-separated list of platforms the index must serve
+#                (e.g. linux/amd64,linux/arm64)
+#
+# Exits non-zero on any missing platform or unreachable child manifest.
+
+set -uo pipefail
+
+: "${REPO:?REPO is required}"
+: "${TAG:?TAG is required}"
+: "${PLATFORMS:?PLATFORMS is required}"
+
+IFS=',' read -ra want_archs <<< "${PLATFORMS}"
+rc=0
+
+for suffix in "" "-non-root"; do
+    full="${REPO}:${TAG}${suffix}"
+    echo "::group::${full}"
+
+    if ! raw=$(docker buildx imagetools inspect --raw "${full}" 2>&1); then
+        echo "FAIL: top-level manifest unreachable"
+        echo "${raw}"
+        rc=1
+        echo "::endgroup::"
+        continue
+    fi
+
+    if echo "${raw}" | jq -e '.manifests' >/dev/null 2>&1; then
+        # OCI index / Docker manifest list — extract real platform children
+        # (excludes `unknown/unknown` attestation manifests).
+        present=$(echo "${raw}" | jq -r '
+            .manifests[]
+            | select(.platform.architecture != "unknown")
+            | "\(.platform.os)/\(.platform.architecture)"
+        ' | sort -u)
+        digests=$(echo "${raw}" | jq -r '
+            .manifests[]
+            | select(.platform.architecture != "unknown")
+            | .digest
+        ')
+    else
+        # Single manifest. build-container.sh only emits amd64 here.
+        present="linux/amd64"
+        digests=""
+    fi
+
+    echo "Present: $(echo "${present}" | tr '\n' ' ')"
+
+    for want in "${want_archs[@]}"; do
+        if ! grep -qx -- "${want}" <<< "${present}"; then
+            echo "FAIL: missing expected platform ${want}"
+            rc=1
+        fi
+    done
+
+    # Walk each child digest. If cleanup ever deletes a per-platform
+    # child of a tagged index, this fetch 404s — the exact symptom
+    # users hit with `docker pull :cpu`.
+    base="${full%:*}"
+    for d in ${digests}; do
+        if ! docker buildx imagetools inspect --raw "${base}@${d}" >/dev/null 2>&1; then
+            echo "FAIL: child manifest ${d} unreachable (dangling index)"
+            rc=1
+        fi
+    done
+
+    echo "::endgroup::"
+done
+
+exit $rc

--- a/docker/verify-pull.sh
+++ b/docker/verify-pull.sh
@@ -10,24 +10,35 @@
 # then 404s on the referenced digest even though the tag still exists.
 #
 # Inputs (env):
-#   REPO       — ghcr.io/<owner>/<repo>
-#   TAG        — backend tag (cpu, intel, cuda, ...)
-#   PLATFORMS  — comma-separated list of platforms the index must serve
-#                (e.g. linux/amd64,linux/arm64)
+#   REPO          — ghcr.io/<owner>/<repo>
+#   TAG           — backend tag (cpu, intel, cuda, ...)
+#   PLATFORMS     — comma-separated list of platforms the index must serve
+#                   (e.g. linux/amd64,linux/arm64)
+#   EXPECTED_DIR  — optional. Directory containing <tag>.digest files
+#                   produced by build-container.sh on the push build.
+#                   When set, asserts the tag still resolves to the
+#                   digest we pushed this run — catches cleanup
+#                   replacing the index, not just pruning its children.
 #
-# Exits non-zero on any missing platform or unreachable child manifest.
+# Exits non-zero on:
+#   - top-level manifest unreachable
+#   - identity mismatch (registry digest != EXPECTED_DIR/<tag>.digest)
+#   - declared platform missing
+#   - any child manifest unreachable
 
 set -uo pipefail
 
 : "${REPO:?REPO is required}"
 : "${TAG:?TAG is required}"
 : "${PLATFORMS:?PLATFORMS is required}"
+EXPECTED_DIR=${EXPECTED_DIR:-}
 
 IFS=',' read -ra want_archs <<< "${PLATFORMS}"
 rc=0
 
 for suffix in "" "-non-root"; do
     full="${REPO}:${TAG}${suffix}"
+    name="${TAG}${suffix}"
     echo "::group::${full}"
 
     if ! raw=$(docker buildx imagetools inspect --raw "${full}" 2>&1); then
@@ -36,6 +47,27 @@ for suffix in "" "-non-root"; do
         rc=1
         echo "::endgroup::"
         continue
+    fi
+
+    # Identity check: tag's current index digest must equal the digest
+    # build-container.sh recorded when it pushed. Catches cleanup
+    # replacing or repointing the tag between push and verify.
+    if [ -n "${EXPECTED_DIR}" ] && [ -f "${EXPECTED_DIR}/${name}.digest" ]; then
+        expected=$(cat "${EXPECTED_DIR}/${name}.digest")
+        if ! actual=$(docker buildx imagetools inspect "${full}" \
+                --format '{{.Manifest.Digest}}' 2>&1); then
+            echo "FAIL: could not resolve current digest"
+            echo "${actual}"
+            rc=1
+        elif [ "${actual}" != "${expected}" ]; then
+            echo "FAIL: digest drift — expected ${expected}, got ${actual}"
+            rc=1
+        else
+            echo "Identity: ${actual} matches expected"
+        fi
+    elif [ -n "${EXPECTED_DIR}" ]; then
+        echo "FAIL: no expected digest at ${EXPECTED_DIR}/${name}.digest"
+        rc=1
     fi
 
     if echo "${raw}" | jq -e '.manifests' >/dev/null 2>&1; then


### PR DESCRIPTION
After the last change in #751  I realized it was still too complicated, so decided to simplify, prepare for multi-arch for all targets, and do proper verification.

This one uses buildx for all builds. When ready for it, you just add a platform in the matrix and it'll build for that as well.

Also it verifies at the end if after the cleanup, what was built is still available.

Ran it e2e in my own fork, and all steps worked well and as expected.

Full list of changes:

Collapse the split docker build / docker buildx paths into one buildx pipeline driven by a single backend matrix anchor, layer in GHA-scoped buildx cache, and add a post-cleanup verifier that asserts every tag still resolves to the digest this run pushed.

- single &backends YAML anchor { tag, platforms }; build-and-push and verify-pull both consume it via *backends. Adding a platform to a tag's list is the only edit needed to expand multi-arch coverage to a new backend.
- buildx for every backend (cpu and GPUs). GPU backends move off the dockerd docker build path; sd-server layer for musa/vulkan now FROMs the just-pushed base via the registry instead of local dockerd, so it only runs on the push path.
- GHA layer cache scoped per backend / arch / container-type, so amd64 and arm64 caches stay disjoint and a typo in one backend's Containerfile doesn't blow away another's cache.
- verify-pull job + docker/verify-pull.sh script. After cleanup, asserts three things per tag: identity (imagetools inspect digest == digest captured from buildx --metadata-file on the push), shape (declared platform set ⊇ expected), reachability (each child manifest fetchable). Identity catches index drift, reachability catches the dangling-index failure mode users hit when cleanup prunes a tagged multi-arch image's per-platform children.
- delete-untagged-containers now also runs on workflow_dispatch from forks, so fork CI can validate the cleanup path end-to-end via dryrun=true. schedule trigger still upstream-only.
- bump dataaxiom/ghcr-cleanup-action past v1.0.16 to pick up the node20 → node24 runtime bump ahead of the 2026-06-02 deprecation.
- extract docker/free-disk.sh and docker/verify-pull.sh from inline workflow blocks; free-disk.sh refuses to run outside GHA.