### PR TITLE
fix: use --loop instead of -loop for nvidia-smi (driver 540+ compat)

### DIFF
--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -139,7 +139,7 @@ func tryNvidiaSmi(ctx context.Context, every time.Duration, logger *logmon.Monit
 	cmd := exec.CommandContext(ctx, "nvidia-smi",
 		"--query-gpu=index,name,uuid,temperature.gpu,utilization.gpu,memory.used,memory.total,fan.speed,power.draw",
 		"--format=csv,noheader,nounits",
-		"-loop", fmt.Sprintf("%d", sec),
+		"--loop", fmt.Sprintf("%d", sec),
 	)
 
 	stdout, err := cmd.StdoutPipe()


### PR DESCRIPTION
Fixes #756.

The GPU monitor goroutine calls nvidia-smi with single-dash `-loop N` ([`internal/perf/monitor_unix.go:142`](https://github.com/mostlygeek/llama-swap/blob/v213/internal/perf/monitor_unix.go#L142)). That form was removed from nvidia-smi in newer driver releases; confirmed broken on **driver 595.58.03** (RTX PRO 6000 Blackwell Max-Q, CUDA 13.2):

```
$ nvidia-smi --query-gpu=... --format=csv,noheader,nounits -loop 5
ERROR: Option -loop is not recognized. Please run 'nvidia-smi -h' for help.
```

`nvidia-smi --help` on driver 595 documents only:
```
    -l,   --loop=               Probe until Ctrl+C at specified second interval.
    -lms, --loop-ms=            Probe until Ctrl+C at specified millisecond interval.
```

nvidia-smi exits with non-zero immediately, the stdout pipe closes, the read goroutine gets `!ok`, and the user sees the `failed reading from gpuCh - stopping read goroutine` error.

## Fix

One-character change: `-loop` → `--loop`. Both `--loop N` and `--loop=N` work on every driver version I can find back to 470.

## Verification

- Cloned v213, applied the patch, rebuilt locally with stubbed `ui_dist`
- Deployed on the affected system; `[ERROR] failed reading from gpuCh` no longer appears
- Routing, swap, idle-eviction TTL, concurrencyLimit all continue to work

## Compatibility risk

Low. `--loop` is the canonical long-form documented in every nvidia-smi version I can find. `-l` would also work but `--loop` matches the surrounding style of using `--`-prefixed flags (`--query-gpu`, `--format`).

cc the OP from #756 — your LACT setup may still have a separate issue (LACT-path returning a stale channel before nvidia-smi-path is tried), but this fix removes the nvidia-smi-path failure on newer drivers regardless.
