### PR TITLE
proxy,ui: split provider API surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,21 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
 - ✅ On-demand model switching
 - ✅ Use any local OpenAI compatible server (llama.cpp, vllm, tabbyAPI, stable-diffusion.cpp, etc.)
   - future proof, upgrade your inference servers at any time.
-- ✅ OpenAI API supported endpoints:
-  - `v1/completions`
-  - `v1/chat/completions`
-  - `v1/responses`
-  - `v1/embeddings`
-  - `v1/models` - list available models
-  - `v1/audio/speech` ([#36](https://github.com/mostlygeek/llama-swap/issues/36))
-  - `v1/audio/transcriptions` ([docs](https://github.com/mostlygeek/llama-swap/issues/41#issuecomment-2722637867))
-  - `v1/audio/voices`
-  - `v1/images/generations`
-  - `v1/images/edits`
-- ✅ Anthropic API supported endpoints:
-  - `v1/messages`
-  - `v1/messages/count_tokens`
+- ✅ OpenAI API supported endpoints under canonical base path `/openai/v1`:
+  - `/completions`
+  - `/chat/completions`
+  - `/responses`
+  - `/embeddings`
+  - `/models` - list available models
+  - `/audio/speech` ([#36](https://github.com/mostlygeek/llama-swap/issues/36))
+  - `/audio/transcriptions` ([docs](https://github.com/mostlygeek/llama-swap/issues/41#issuecomment-2722637867))
+  - `/audio/voices`
+  - `/images/generations`
+  - `/images/edits`
+- ✅ Anthropic API supported endpoints under canonical base path `/anthropic/v1`:
+  - `/messages`
+  - `/messages/count_tokens`
+  - Shared `/v1/...` paths remain available for existing clients.
 - ✅ llama-server (llama.cpp) supported endpoints
   - `v1/rerank`, `v1/reranking`, `/rerank`
   - `/infill` - for code infilling
@@ -215,7 +216,7 @@ See the [configuration documentation](docs/configuration.md) for all options.
 
 ## How does llama-swap work?
 
-When a request is made to an OpenAI compatible endpoint, llama-swap will extract the `model` value and load the appropriate server configuration to serve it. If the wrong upstream server is running, it will be replaced with the correct one. This is where the "swap" part comes in. The upstream server is automatically swapped to handle the request correctly.
+When a request is made to an OpenAI-compatible endpoint such as `/openai/v1/chat/completions`, or an Anthropic-compatible endpoint such as `/anthropic/v1/messages`, llama-swap will extract the `model` value and load the appropriate server configuration to serve it. If the wrong upstream server is running, it will be replaced with the correct one. This is where the "swap" part comes in. The upstream server is automatically swapped to handle the request correctly. Older shared `/v1/...` routes still work for existing clients.
 
 In the most basic configuration llama-swap handles one model at a time. For more advanced use cases, using a `matrix` allows multiple models to be loaded at the same time. You have complete control over how your system resources are used.
 
@@ -234,7 +235,7 @@ location /api/events {
 }
 
 # Streaming chat completions (stream=true)
-location /v1/chat/completions {
+location /openai/v1/chat/completions {
     proxy_pass http://your-llama-swap-backend;
     proxy_buffering off;
     proxy_cache off;

--- a/docs/2026-05-16-split-api-surfaces/PRD.md
+++ b/docs/2026-05-16-split-api-surfaces/PRD.md
@@ -1,0 +1,93 @@
+# PRD: Split API Surfaces
+
+## Status
+
+Draft — 2026-05-16
+**Stakeholders:** llama-swap maintainers, API client users [assumed]
+
+## Problem Statement
+
+llama-swap supports both OpenAI-compatible and Anthropic-compatible endpoints. This compatibility is powerful, but users configuring tools can be confused when both API families share similar base URLs or when a client expects an explicit provider-specific base path.
+
+Providing clearer split API surfaces would make llama-swap easier to integrate with CLI agents and reduce ambiguity between OpenAI and Anthropic modes. Existing routes must continue to work to avoid breaking current users, but they should be documented as obsolete shared paths so new integrations prefer the provider-specific surfaces.
+
+## Goals
+
+- Make OpenAI-compatible and Anthropic-compatible endpoints explicit in docs, UI, and routing.
+- Preserve existing endpoint compatibility while marking shared `/v1` routes obsolete for new integrations.
+- Allow integrations to generate less ambiguous config.
+- Keep model selection and swapping behavior consistent across API families.
+
+## Target Users / Personas
+
+CLI agent user [assumed]: configures tools that distinguish between OpenAI and Anthropic providers.
+
+API client developer [assumed]: writes local scripts against llama-swap and wants stable, obvious base URLs.
+
+Operator [assumed]: exposes llama-swap to a small local network and wants to document correct endpoints for users.
+
+## Scope
+
+### In Scope
+
+- Display explicit OpenAI and Anthropic base URLs in the UI.
+- Document both API surfaces with examples.
+- Add canonical provider-specific routes under `/openai/v1` and `/anthropic/v1`.
+- Preserve existing `/v1/...` behavior as obsolete compatibility routes.
+- Ensure request routing extracts model names correctly from both surfaces.
+- Ensure canonical provider routes only expose endpoints that match that provider schema.
+
+### Out of Scope
+
+- Removing existing `/v1` endpoints.
+- Adding cross-provider aliases such as `/openai/v1/messages` or `/anthropic/v1/chat/completions`.
+- Translating every OpenAI feature to Anthropic or every Anthropic feature to OpenAI.
+- Changing upstream server protocol behavior.
+- Introducing provider-specific authentication in the first version.
+
+## Functional Requirements
+
+1. **Explicit API Surface Display**
+   1.1 Users can see OpenAI-compatible and Anthropic-compatible base URLs in the dashboard.
+   1.2 Users can copy base URLs and minimal curl examples.
+
+2. **Route Compatibility**
+   2.1 Existing OpenAI-compatible routes continue to work.
+   2.2 Existing Anthropic-compatible routes continue to work.
+   2.3 Existing shared `/v1` routes are marked obsolete in docs and UI copy for new integrations.
+   2.4 Canonical split routes map to the same internal handlers as existing compatible routes.
+   2.5 Canonical split routes are provider-specific: OpenAI routes only expose OpenAI-compatible endpoints, and Anthropic routes only expose Anthropic-compatible endpoints.
+
+3. **Configuration**
+   3.1 Generated integration snippets prefer canonical provider paths.
+   3.2 Shared `/v1` paths remain available for existing configurations but are not the preferred generated output.
+
+4. **Documentation**
+   4.1 Documentation includes endpoint tables for both API families.
+   4.2 Documentation explains compatibility between obsolete shared paths and canonical provider paths.
+
+## Non-Functional Requirements (summary)
+
+The change must be backward compatible. Route aliases should add negligible overhead and must not duplicate business logic. Provider-prefixed paths outside the canonical route table should use the server's default behavior for unimplemented endpoints.
+
+## User Journeys / Key Flows
+
+1. User opens Integrations, selects Anthropic mode, and copies `http://localhost:8080/anthropic/v1` as the base URL.
+2. Existing user continues using obsolete-compatible `http://localhost:8080/v1/chat/completions` without changes.
+3. API developer checks the dashboard and sees the canonical base URL for each endpoint family.
+4. User attempts `http://localhost:8080/anthropic/v1/chat/completions`; because chat completions belongs to the OpenAI-compatible surface, llama-swap does not register that route and the server returns its default unimplemented endpoint response.
+
+## Assumptions & Dependencies
+
+| Item                   | Type       | Detail                                                                      |
+| ---------------------- | ---------- | --------------------------------------------------------------------------- |
+| Backward compatibility | Dependency | Existing `/v1` routes cannot break.                                         |
+| Integration page       | Dependency | Split surfaces are most valuable when used by generated snippets.           |
+| Route aliases          | Dependency | Provider-specific routes are canonical and must not duplicate handlers.      |
+
+## Decisions
+
+- Canonical OpenAI-compatible base path: `/openai/v1`.
+- Canonical Anthropic-compatible base path: `/anthropic/v1`.
+- Shared `/v1` routes remain available for compatibility but are obsolete for new integrations.
+- Canonical provider routes only expose endpoints that match their provider schema.

--- a/docs/2026-05-16-split-api-surfaces/SPEC.md
+++ b/docs/2026-05-16-split-api-surfaces/SPEC.md
@@ -1,0 +1,259 @@
+# Technical Specification: Split API Surfaces
+
+## Document Info
+
+**Status:** Draft
+**Version:** 1.0
+**Date:** 2026-05-16
+**Target release:** TBD
+
+## 1. Overview
+
+### 1.1 Purpose
+
+This spec defines explicit OpenAI-compatible and Anthropic-compatible API surfaces for llama-swap while preserving existing shared routes as obsolete compatibility paths.
+
+### 1.2 Background
+
+llama-swap supports many OpenAI-compatible endpoints and Anthropic-compatible `/v1/messages` endpoints. Some clients configure providers by base URL, and shared `/v1` paths can be confusing even when technically correct. New integrations should use canonical provider-specific base paths while existing `/v1` integrations continue to work.
+
+### 1.3 Goals
+
+| Goal | Success Metric | Target |
+| ---- | -------------- | ------ |
+| Backward compatibility | Existing route tests pass unchanged | 100% |
+| Clarity | UI displays canonical provider base URLs | Both API families |
+| Low risk | Split paths reuse existing handlers | No duplicate handler logic |
+| Schema correctness | Provider-prefixed routes expose only matching schemas | No cross-provider aliases |
+
+### 1.4 Non-Goals
+
+- Remove obsolete shared `/v1` routes.
+- Implement cross-provider request translation.
+- Add provider-specific auth policy.
+- Add cross-provider aliases such as `/openai/v1/messages` or `/anthropic/v1/chat/completions`.
+
+## 2. Functional Requirements
+
+### 2.1 Actors
+
+| Actor | Description |
+| ----- | ----------- |
+| API client user | Configures a client with provider-specific base URLs. |
+| Maintainer | Maintains route compatibility and documentation. |
+
+### 2.2 User Flows
+
+**Flow: Configure Anthropic Client**
+
+1. User opens UI or docs.
+2. User copies Anthropic-compatible base URL.
+3. Client sends request to split Anthropic route.
+4. llama-swap routes the request through existing Anthropic-compatible handling.
+
+### 2.3 Functional Requirements
+
+#### FR-001: OpenAI Canonical Route Surface
+
+**Priority:** Should-have
+**Actor:** API client user
+**Description:** The system should support `/openai/v1/...` as the canonical base path for OpenAI-compatible endpoints.
+**Acceptance criteria:**
+
+- [x] `/openai/v1/chat/completions` behaves like `/v1/chat/completions`.
+- [x] `/openai/v1/models` behaves like `/v1/models`.
+- [x] `/openai/v1/messages` is not registered and uses default server behavior for unimplemented endpoints.
+- [x] Existing auth behavior is unchanged.
+
+#### FR-002: Anthropic Canonical Route Surface
+
+**Priority:** Should-have
+**Actor:** API client user
+**Description:** The system should support `/anthropic/v1/...` as the canonical base path for Anthropic-compatible endpoints.
+**Acceptance criteria:**
+
+- [x] `/anthropic/v1/messages` behaves like `/v1/messages`.
+- [x] `/anthropic/v1/messages/count_tokens` behaves like `/v1/messages/count_tokens`.
+- [x] `/anthropic/v1/chat/completions` is not registered and uses default server behavior for unimplemented endpoints.
+- [x] Existing auth behavior is unchanged.
+
+#### FR-003: Existing Route Preservation
+
+**Priority:** Must-have
+**Actor:** Existing user
+**Description:** The system shall preserve all existing shared `/v1` route behavior as obsolete-compatible behavior.
+**Acceptance criteria:**
+
+- [x] Existing endpoint tests pass without changing expected paths.
+- [x] Existing docs examples remain valid or are marked obsolete-compatible.
+- [x] New docs and generated snippets prefer canonical provider paths.
+
+## 3. Non-Functional Requirements
+
+| Category | Requirement | Target | Priority |
+| -------- | ----------- | ------ | -------- |
+| Compatibility | No existing route regressions | 100% | High |
+| Performance | Route alias overhead | Negligible | Medium |
+| Maintainability | Handler duplication | None | High |
+| Documentation | Provider route tables | Complete for supported endpoints and obsolete shared paths | High |
+
+## 4. System Architecture
+
+### 4.1 Architecture Overview
+
+Canonical provider routes should be implemented as aliases that normalize provider-prefixed paths to existing internal routing. The proxy manager should not need separate business logic per prefix beyond endpoint-family identification.
+
+```mermaid
+flowchart LR
+    Client --> Router
+    Router -->|/v1/* obsolete-compatible| ExistingHandlers
+    Router -->|/openai/v1/* OpenAI schema only| ExistingHandlers
+    Router -->|/anthropic/v1/* Anthropic schema only| ExistingHandlers
+    ExistingHandlers --> ProxyManager
+```
+
+### 4.2 Component Responsibilities
+
+| Component | Technology | Responsibility |
+| --------- | ---------- | -------------- |
+| HTTP router | Go | Register obsolete shared paths and canonical provider paths |
+| UI/integrations | Svelte | Display/copy static provider-specific URLs |
+| Docs | Markdown | Explain canonical and obsolete-compatible paths |
+
+### 4.3 Key Design Decisions
+
+**Decision: Alias, not fork**
+
+- Chosen: Canonical provider routes reuse existing handlers.
+- Rationale: Avoids behavior drift and duplicate tests.
+- Trade-off: Some route internals may need path normalization.
+
+**Decision: Provider schema boundaries**
+
+- Chosen: Canonical provider routes only expose endpoints that match that provider's request and response schema.
+- Rationale: A provider-prefixed base URL should be safe to give to clients that expect that provider schema.
+- Trade-off: A user cannot use `/anthropic/v1/chat/completions` as a cosmetic alias for an OpenAI-compatible request.
+
+**Decision: Obsolete shared routes**
+
+- Chosen: Existing shared `/v1` routes remain available but are documented as obsolete for new integrations.
+- Rationale: Current users should not break, but docs should guide new setups to less ambiguous base URLs.
+- Trade-off: The server continues carrying both route families.
+
+## 5. API Design
+
+### 5.1 New Endpoints
+
+No new admin or metadata endpoints are required. The canonical surfaces are static proxy routes.
+
+### 5.2 Canonical OpenAI-Compatible Endpoints
+
+Register canonical aliases for:
+
+- `/openai/v1/completions`
+- `/openai/v1/chat/completions`
+- `/openai/v1/responses`
+- `/openai/v1/embeddings`
+- `/openai/v1/models`
+- `/openai/v1/audio/speech`
+- `/openai/v1/audio/transcriptions`
+- `/openai/v1/audio/voices`
+- `/openai/v1/images/generations`
+- `/openai/v1/images/edits`
+
+Do not register OpenAI-prefixed aliases for Anthropic-compatible endpoints.
+
+### 5.3 Canonical Anthropic-Compatible Endpoints
+
+Register canonical aliases for:
+
+- `/anthropic/v1/messages`
+- `/anthropic/v1/messages/count_tokens`
+
+Do not register Anthropic-prefixed aliases for OpenAI-compatible endpoints.
+
+### 5.4 Obsolete-Compatible Shared Endpoints
+
+Preserve existing shared routes for current users:
+
+- `/v1/completions`
+- `/v1/chat/completions`
+- `/v1/responses`
+- `/v1/embeddings`
+- `/v1/models`
+- `/v1/audio/speech`
+- `/v1/audio/transcriptions`
+- `/v1/audio/voices`
+- `/v1/images/generations`
+- `/v1/images/edits`
+- `/v1/messages`
+- `/v1/messages/count_tokens`
+
+These routes should be described as obsolete-compatible in docs and UI copy. They are not removed or behaviorally changed in this work.
+
+### 5.5 Path Normalization
+
+Before proxying to an upstream model server, provider-prefixed canonical paths must be normalized to the existing upstream path. For example:
+
+| Incoming path | Upstream path |
+| ------------- | ------------- |
+| `/openai/v1/chat/completions` | `/v1/chat/completions` |
+| `/openai/v1/models` | `/v1/models` |
+| `/anthropic/v1/messages` | `/v1/messages` |
+| `/anthropic/v1/messages/count_tokens` | `/v1/messages/count_tokens` |
+
+The request body, auth behavior, CORS behavior, metrics capture, and model selection behavior should otherwise match the obsolete-compatible `/v1` route.
+
+## 6. Data Model
+
+No persistent data model changes are required.
+
+## 7. Security Considerations
+
+- Canonical provider routes must use the same authentication and CORS behavior as obsolete-compatible shared routes.
+- Error responses should not expose more path or config detail than existing handlers.
+- Provider-prefixed paths outside the canonical route table should use the server's default behavior for unimplemented endpoints rather than translating between schemas.
+
+## 8. Observability
+
+| Signal | What to instrument | Tooling |
+| ------ | ------------------ | ------- |
+| Metrics | Requests by provider surface [assumed] | Existing metrics if available |
+| Logs | Route normalization errors | Existing logger |
+
+## 9. Testing Strategy
+
+| Level | Scope | Tools | Coverage Target |
+| ----- | ----- | ----- | --------------- |
+| Unit | Path normalization | Go test | All canonical aliases |
+| Integration | Obsolete-compatible and canonical route behavior | Go test | Main endpoint families |
+| Integration | Unimplemented provider-prefixed routes | Go test | OpenAI and Anthropic mismatch examples |
+| Docs | Endpoint examples | Manual review | All documented paths |
+
+## 10. Implementation Plan
+
+### Phase 1: Docs
+
+- [x] Update docs with explicit base URLs.
+- [x] Update integration snippets to use canonical static base URLs.
+
+### Phase 2: Route Aliases
+
+- [x] Register OpenAI-compatible canonical routes.
+- [x] Register Anthropic-compatible canonical routes.
+- [x] Add tests proving obsolete-compatible and canonical paths use equivalent behavior.
+- [x] Add tests proving wrong-schema provider-prefixed routes are not registered and use default unimplemented endpoint behavior.
+
+### Phase 3: UI
+
+- [x] Display provider base URLs on dashboard.
+- [x] Add copyable curl examples.
+
+## 11. Decisions
+
+| # | Decision | Status |
+| - | -------- | ------ |
+| 1 | Canonical OpenAI-compatible base path is `/openai/v1`. | Decided |
+| 2 | Canonical Anthropic-compatible base path is `/anthropic/v1`. | Decided |
+| 3 | Existing `/v1` routes remain enabled and are marked obsolete-compatible. | Decided |
+| 4 | Canonical provider routes only expose endpoints matching that provider schema. | Decided |

--- a/proxy/helpers_test.go
+++ b/proxy/helpers_test.go
@@ -127,11 +127,12 @@ func injectTestHandlers(pm *ProxyManager, modelResponses map[string]string) {
 // newTestHandler returns an http.Handler that mimics simple-responder's API.
 // It supports the endpoints that routing tests depend on, without launching
 // any subprocess or binding any port.
-func respondJSON(w http.ResponseWriter, respond string, bodyBytes []byte) {
+func respondJSON(w http.ResponseWriter, r *http.Request, respond string, bodyBytes []byte) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
 		"responseMessage":  respond,
 		"h_content_length": strconv.Itoa(len(bodyBytes)),
+		"h_path":           r.URL.Path,
 		"request_body":     string(bodyBytes),
 		"usage": map[string]any{
 			"completion_tokens": 10, "prompt_tokens": 25, "total_tokens": 35,
@@ -188,7 +189,7 @@ func newTestHandler(respond string) http.Handler {
 			fmt.Fprintf(w, "event: message\ndata: [DONE]\n\n")
 			flusher.Flush()
 		} else {
-			respondJSON(w, respond, bodyBytes)
+			respondJSON(w, r, respond, bodyBytes)
 		}
 	})
 
@@ -205,17 +206,19 @@ func newTestHandler(respond string) http.Handler {
 
 	mux.HandleFunc("/v1/completions", func(w http.ResponseWriter, r *http.Request) {
 		bodyBytes, _ := io.ReadAll(r.Body)
-		respondJSON(w, respond, bodyBytes)
+		respondJSON(w, r, respond, bodyBytes)
 	})
 
 	for _, path := range []string{
 		"/chat/completions", "/completions",
 		"/responses", "/messages", "/messages/count_tokens",
 		"/embeddings", "/rerank", "/reranking",
+		"/v1/responses", "/v1/messages", "/v1/messages/count_tokens",
+		"/v1/embeddings", "/v1/images/generations", "/v1/images/edits",
 	} {
 		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
 			bodyBytes, _ := io.ReadAll(r.Body)
-			respondJSON(w, respond, bodyBytes)
+			respondJSON(w, r, respond, bodyBytes)
 		})
 	}
 
@@ -229,38 +232,43 @@ func newTestHandler(respond string) http.Handler {
 		})
 	})
 
-	mux.HandleFunc("/v1/audio/transcriptions", func(w http.ResponseWriter, r *http.Request) {
-		if err := r.ParseMultipartForm(10 << 20); err != nil {
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("Error parsing multipart form: %s", err)})
-			return
-		}
-		model := r.FormValue("model")
-		if model == "" {
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]string{"error": "Missing model parameter"})
-			return
-		}
-		file, _, err := r.FormFile("file")
-		if err != nil {
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("Error getting file: %s", err)})
-			return
-		}
-		fileBytes, _ := io.ReadAll(file)
-		file.Close()
-		json.NewEncoder(w).Encode(map[string]any{
-			"text":             fmt.Sprintf("The length of the file is %d bytes", len(fileBytes)),
-			"model":            model,
-			"h_content_type":   r.Header.Get("Content-Type"),
-			"h_content_length": r.Header.Get("Content-Length"),
+	for _, path := range []string{
+		"/v1/audio/transcriptions",
+	} {
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseMultipartForm(10 << 20); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("Error parsing multipart form: %s", err)})
+				return
+			}
+			model := r.FormValue("model")
+			if model == "" {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(map[string]string{"error": "Missing model parameter"})
+				return
+			}
+			file, _, err := r.FormFile("file")
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(map[string]string{"error": fmt.Sprintf("Error getting file: %s", err)})
+				return
+			}
+			fileBytes, _ := io.ReadAll(file)
+			file.Close()
+			json.NewEncoder(w).Encode(map[string]any{
+				"text":             fmt.Sprintf("The length of the file is %d bytes", len(fileBytes)),
+				"model":            model,
+				"h_content_type":   r.Header.Get("Content-Type"),
+				"h_content_length": r.Header.Get("Content-Length"),
+				"h_path":           r.URL.Path,
+			})
 		})
-	})
+	}
 
 	mux.HandleFunc("/v1/audio/voices", func(w http.ResponseWriter, r *http.Request) {
 		model := r.URL.Query().Get("model")
 		json.NewEncoder(w).Encode(map[string]any{
-			"voices": []string{"voice1"}, "model": model,
+			"voices": []string{"voice1"}, "model": model, "h_path": r.URL.Path,
 		})
 	})
 

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -338,16 +338,22 @@ func (pm *ProxyManager) setupGinEngine() {
 	// Protected routes use pm.apiKeyAuth() middleware
 	llmHandler := pm.mkProxyJSONHandler(captureAll)
 	pm.ginEngine.POST("/v1/chat/completions", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
+	pm.ginEngine.POST("/openai/v1/chat/completions", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
 	pm.ginEngine.POST("/v1/responses", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
+	pm.ginEngine.POST("/openai/v1/responses", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
 	// Support legacy /v1/completions api, see issue #12
 	pm.ginEngine.POST("/v1/completions", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
+	pm.ginEngine.POST("/openai/v1/completions", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
 	// Support anthropic /v1/messages (added https://github.com/ggml-org/llama.cpp/pull/17570)
 	pm.ginEngine.POST("/v1/messages", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
+	pm.ginEngine.POST("/anthropic/v1/messages", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
 	// Support anthropic count_tokens API (Also added in the above PR)
 	pm.ginEngine.POST("/v1/messages/count_tokens", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
+	pm.ginEngine.POST("/anthropic/v1/messages/count_tokens", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
 
 	// Support embeddings and reranking
 	pm.ginEngine.POST("/v1/embeddings", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
+	pm.ginEngine.POST("/openai/v1/embeddings", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
 
 	// llama-server's /reranking endpoint + aliases
 	pm.ginEngine.POST("/reranking", pm.apiKeyAuth(), pm.trackInflight(), llmHandler)
@@ -379,15 +385,34 @@ func (pm *ProxyManager) setupGinEngine() {
 		pm.mkProxyJSONHandler(captureReqAll|captureRespHeaders),
 	)
 	pm.ginEngine.POST(
+		"/openai/v1/audio/speech",
+		pm.apiKeyAuth(),
+		pm.trackInflight(),
+		pm.mkProxyJSONHandler(captureReqAll|captureRespHeaders),
+	)
+	pm.ginEngine.POST(
 		"/v1/audio/voices",
 		pm.apiKeyAuth(),
 		pm.trackInflight(),
 		pm.mkProxyJSONHandler(captureReqHeaders|captureRespAll),
 	)
+	pm.ginEngine.POST(
+		"/openai/v1/audio/voices",
+		pm.apiKeyAuth(),
+		pm.trackInflight(),
+		pm.mkProxyJSONHandler(captureReqHeaders|captureRespAll),
+	)
 	pm.ginEngine.GET("/v1/audio/voices", pm.apiKeyAuth(), pm.trackInflight(), pm.proxyGETModelHandler)
+	pm.ginEngine.GET("/openai/v1/audio/voices", pm.apiKeyAuth(), pm.trackInflight(), pm.proxyGETModelHandler)
 
 	pm.ginEngine.POST(
 		"/v1/audio/transcriptions",
+		pm.apiKeyAuth(),
+		pm.trackInflight(),
+		pm.mkPostFormHandler(captureReqHeaders|captureRespHeaders|captureRespBody),
+	)
+	pm.ginEngine.POST(
+		"/openai/v1/audio/transcriptions",
 		pm.apiKeyAuth(),
 		pm.trackInflight(),
 		pm.mkPostFormHandler(captureReqHeaders|captureRespHeaders|captureRespBody),
@@ -398,9 +423,21 @@ func (pm *ProxyManager) setupGinEngine() {
 		pm.trackInflight(),
 		pm.mkProxyJSONHandler(captureReqAll|captureRespHeaders),
 	)
+	pm.ginEngine.POST(
+		"/openai/v1/images/generations",
+		pm.apiKeyAuth(),
+		pm.trackInflight(),
+		pm.mkProxyJSONHandler(captureReqAll|captureRespHeaders),
+	)
 
 	pm.ginEngine.POST(
 		"/v1/images/edits",
+		pm.apiKeyAuth(),
+		pm.trackInflight(),
+		pm.mkPostFormHandler(captureReqHeaders|captureRespHeaders),
+	)
+	pm.ginEngine.POST(
+		"/openai/v1/images/edits",
 		pm.apiKeyAuth(),
 		pm.trackInflight(),
 		pm.mkPostFormHandler(captureReqHeaders|captureRespHeaders),
@@ -420,6 +457,7 @@ func (pm *ProxyManager) setupGinEngine() {
 	pm.ginEngine.GET("/sdapi/v1/loras", pm.apiKeyAuth(), pm.trackInflight(), pm.proxyGETModelHandler)
 
 	pm.ginEngine.GET("/v1/models", pm.apiKeyAuth(), pm.listModelsHandler)
+	pm.ginEngine.GET("/openai/v1/models", pm.apiKeyAuth(), pm.listModelsHandler)
 
 	// in proxymanager_loghandlers.go
 	pm.ginEngine.GET("/logs", pm.apiKeyAuth(), pm.sendLogsHandlers)
@@ -513,6 +551,17 @@ func (pm *ProxyManager) trackInflight() gin.HandlerFunc {
 // ServeHTTP implements http.Handler interface
 func (pm *ProxyManager) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	pm.ginEngine.ServeHTTP(w, r)
+}
+
+func normalizeProviderPrefixedPath(path string) string {
+	switch {
+	case strings.HasPrefix(path, "/openai/v1/"):
+		return strings.TrimPrefix(path, "/openai")
+	case strings.HasPrefix(path, "/anthropic/v1/"):
+		return strings.TrimPrefix(path, "/anthropic")
+	default:
+		return path
+	}
 }
 
 // StopProcesses acquires a lock and stops all running upstream processes.
@@ -880,6 +929,7 @@ func (pm *ProxyManager) mkProxyJSONHandler(cf captureFields) func(*gin.Context) 
 		if strings.HasPrefix(c.Request.URL.Path, "/v/") {
 			c.Request.URL.Path = strings.TrimPrefix(c.Request.URL.Path, "/v")
 		}
+		c.Request.URL.Path = normalizeProviderPrefixedPath(c.Request.URL.Path)
 
 		// issue #366 extract values that downstream handlers may need
 		isStreaming := gjson.GetBytes(bodyBytes, "stream").Bool()
@@ -1029,6 +1079,7 @@ func (pm *ProxyManager) mkPostFormHandler(cf captureFields) func(*gin.Context) {
 		// set the content length of the body
 		modifiedReq.Header.Set("Content-Length", strconv.Itoa(requestBuffer.Len()))
 		modifiedReq.ContentLength = int64(requestBuffer.Len())
+		modifiedReq.URL.Path = normalizeProviderPrefixedPath(modifiedReq.URL.Path)
 
 		// Use the modified request for proxying
 		if pm.metricsMonitor != nil {
@@ -1080,6 +1131,8 @@ func (pm *ProxyManager) proxyGETModelHandler(c *gin.Context) {
 		pm.sendErrorResponse(c, http.StatusBadRequest, fmt.Sprintf("could not find suitable handler for %s", requestedModel))
 		return
 	}
+
+	c.Request.URL.Path = normalizeProviderPrefixedPath(c.Request.URL.Path)
 
 	if err := nextHandler(modelID, c.Writer, c.Request); err != nil {
 		pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error proxying request: %s", err.Error()))

--- a/proxy/proxymanager_test.go
+++ b/proxy/proxymanager_test.go
@@ -68,6 +68,198 @@ models:
 		assert.Contains(t, w.Body.String(), modelName)
 	}
 }
+
+func TestProxyManager_OpenAIProviderPrefixedRoutesNormalizeUpstreamPath(t *testing.T) {
+	cfg := testConfigFromYAML(t, `
+healthCheckTimeout: 15
+logLevel: error
+models:
+  model1:
+    cmd: test --port ${PORT}
+`)
+
+	proxy := New(cfg)
+	injectTestHandlers(proxy, nil)
+	defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+	tests := []struct {
+		name         string
+		method       string
+		path         string
+		body         string
+		expectedPath string
+	}{
+		{
+			name:         "chat completions",
+			method:       http.MethodPost,
+			path:         "/openai/v1/chat/completions",
+			body:         `{"model":"model1"}`,
+			expectedPath: "/v1/chat/completions",
+		},
+		{
+			name:         "responses",
+			method:       http.MethodPost,
+			path:         "/openai/v1/responses",
+			body:         `{"model":"model1"}`,
+			expectedPath: "/v1/responses",
+		},
+		{
+			name:         "embeddings",
+			method:       http.MethodPost,
+			path:         "/openai/v1/embeddings",
+			body:         `{"model":"model1"}`,
+			expectedPath: "/v1/embeddings",
+		},
+		{
+			name:         "audio voices get",
+			method:       http.MethodGet,
+			path:         "/openai/v1/audio/voices?model=model1",
+			expectedPath: "/v1/audio/voices",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body))
+			w := CreateTestResponseRecorder()
+
+			proxy.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, tt.expectedPath, gjson.Get(w.Body.String(), "h_path").String())
+		})
+	}
+}
+
+func TestProxyManager_OpenAIProviderPrefixedFormRoutesNormalizeUpstreamPath(t *testing.T) {
+	cfg := testConfigFromYAML(t, `
+healthCheckTimeout: 15
+logLevel: error
+models:
+  model1:
+    cmd: test --port ${PORT}
+`)
+
+	proxy := New(cfg)
+	injectTestHandlers(proxy, nil)
+	defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+	tests := []struct {
+		name         string
+		path         string
+		expectedPath string
+	}{
+		{
+			name:         "audio transcriptions",
+			path:         "/openai/v1/audio/transcriptions",
+			expectedPath: "/v1/audio/transcriptions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b bytes.Buffer
+			form := multipart.NewWriter(&b)
+			fw, err := form.CreateFormField("model")
+			assert.NoError(t, err)
+			_, err = fw.Write([]byte("model1"))
+			assert.NoError(t, err)
+			fw, err = form.CreateFormFile("file", "test.dat")
+			assert.NoError(t, err)
+			_, err = fw.Write([]byte("test"))
+			assert.NoError(t, err)
+			assert.NoError(t, form.Close())
+
+			req := httptest.NewRequest(http.MethodPost, tt.path, &b)
+			req.Header.Set("Content-Type", form.FormDataContentType())
+			w := CreateTestResponseRecorder()
+
+			proxy.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, tt.expectedPath, gjson.Get(w.Body.String(), "h_path").String())
+		})
+	}
+}
+
+func TestProxyManager_AnthropicProviderPrefixedRoutesNormalizeUpstreamPath(t *testing.T) {
+	cfg := testConfigFromYAML(t, `
+healthCheckTimeout: 15
+logLevel: error
+models:
+  model1:
+    cmd: test --port ${PORT}
+`)
+
+	proxy := New(cfg)
+	injectTestHandlers(proxy, nil)
+	defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+	tests := []struct {
+		name         string
+		path         string
+		expectedPath string
+	}{
+		{
+			name:         "messages",
+			path:         "/anthropic/v1/messages",
+			expectedPath: "/v1/messages",
+		},
+		{
+			name:         "count tokens",
+			path:         "/anthropic/v1/messages/count_tokens",
+			expectedPath: "/v1/messages/count_tokens",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(`{"model":"model1"}`))
+			w := CreateTestResponseRecorder()
+
+			proxy.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusOK, w.Code)
+			assert.Equal(t, tt.expectedPath, gjson.Get(w.Body.String(), "h_path").String())
+		})
+	}
+}
+
+func TestProxyManager_ProviderPrefixedRoutesDoNotCrossRegisterSchemas(t *testing.T) {
+	cfg := testConfigFromYAML(t, `
+healthCheckTimeout: 15
+logLevel: error
+models:
+  model1:
+    cmd: test --port ${PORT}
+`)
+
+	proxy := New(cfg)
+	injectTestHandlers(proxy, nil)
+	defer proxy.StopProcesses(StopWaitForInflightRequest)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{name: "openai messages is not registered", path: "/openai/v1/messages"},
+		{name: "openai audio translations is not registered", path: "/openai/v1/audio/translations"},
+		{name: "openai image variations is not registered", path: "/openai/v1/images/variations"},
+		{name: "anthropic chat completions is not registered", path: "/anthropic/v1/chat/completions"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(`{"model":"model1"}`))
+			w := CreateTestResponseRecorder()
+
+			proxy.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusNotFound, w.Code)
+		})
+	}
+}
+
 func TestProxyManager_SwapMultiProcess(t *testing.T) {
 	cfg := testConfigFromYAML(t, `
 healthCheckTimeout: 15

--- a/ui-svelte/src/components/ModelsPanel.svelte
+++ b/ui-svelte/src/components/ModelsPanel.svelte
@@ -53,6 +53,14 @@
   function getModelDisplay(model: Model): string {
     return $showIdorNameStore === "id" ? model.id : (model.name || model.id);
   }
+
+  function apiBase(path: string): string {
+    return `${window.location.origin}${path}`;
+  }
+
+  async function copyText(value: string): Promise<void> {
+    await navigator.clipboard?.writeText(value);
+  }
 </script>
 
 <div class="card h-full flex flex-col">
@@ -147,6 +155,26 @@
   </div>
 
   <div class="flex-1 overflow-y-auto">
+    <div class="my-4 grid grid-cols-1 gap-2 text-sm xl:grid-cols-2">
+      <div class="rounded border border-gray-200 dark:border-white/10 bg-surface p-3">
+        <div class="flex items-center justify-between gap-2">
+          <span class="font-semibold">OpenAI-compatible</span>
+          <button class="btn btn--sm" onclick={() => copyText(apiBase("/openai/v1"))}>Copy</button>
+        </div>
+        <code class="mt-2 block break-all text-xs">{apiBase("/openai/v1")}</code>
+        <code class="mt-1 block break-all text-xs text-txtsecondary">curl {apiBase("/openai/v1")}/models</code>
+      </div>
+      <div class="rounded border border-gray-200 dark:border-white/10 bg-surface p-3">
+        <div class="flex items-center justify-between gap-2">
+          <span class="font-semibold">Anthropic-compatible</span>
+          <button class="btn btn--sm" onclick={() => copyText(apiBase("/anthropic/v1"))}>Copy</button>
+        </div>
+        <code class="mt-2 block break-all text-xs">{apiBase("/anthropic/v1")}</code>
+        <code class="mt-1 block break-all text-xs text-txtsecondary">curl {apiBase("/anthropic/v1")}/messages</code>
+      </div>
+      <p class="text-xs text-txtsecondary xl:col-span-2">Shared /v1 paths remain available for existing clients.</p>
+    </div>
+
     <table class="w-full">
       <thead class="sticky top-0 bg-card z-10">
         <tr class="text-left border-b border-gray-200 dark:border-white/10 bg-surface">

--- a/ui-svelte/src/components/playground/ChatInterface.svelte
+++ b/ui-svelte/src/components/playground/ChatInterface.svelte
@@ -11,7 +11,7 @@
   const selectedModelStore = persistentStore<string>("playground-selected-model", "");
   const systemPromptStore = persistentStore<string>("playground-system-prompt", "");
   const temperatureStore = persistentStore<number>("playground-temperature", 0.7);
-  const endpointStore = persistentStore<Endpoint>("playground-endpoint", "v1/chat/completions");
+  const endpointStore = persistentStore<Endpoint>("playground-endpoint", "openai/v1/chat/completions");
   const maxTokensStore = persistentStore<number>("playground-max-tokens", 4096);
 
   function loadMessages(): ChatMessage[] {
@@ -37,6 +37,16 @@
 
   let hasModels = $derived($models.some((m) => !m.unlisted));
   let userScrolledUp = $state(false);
+
+  $effect(() => {
+    const obsoleteEndpoints: Record<string, Endpoint> = {
+      "v1/chat/completions": "openai/v1/chat/completions",
+      "v1/messages": "anthropic/v1/messages",
+      "v1/responses": "openai/v1/responses",
+    };
+    const canonicalEndpoint = obsoleteEndpoints[$endpointStore as string];
+    if (canonicalEndpoint) endpointStore.set(canonicalEndpoint);
+  });
 
   $effect(() => {
     playgroundStores.chatStreaming.set(isStreaming);
@@ -329,9 +339,9 @@
           bind:value={$endpointStore}
           disabled={isStreaming}
         >
-          <option value="v1/chat/completions">/v1/chat/completions</option>
-          <option value="v1/messages">/v1/messages</option>
-          <option value="v1/responses">/v1/responses</option>
+          <option value="openai/v1/chat/completions">/openai/v1/chat/completions</option>
+          <option value="anthropic/v1/messages">/anthropic/v1/messages</option>
+          <option value="openai/v1/responses">/openai/v1/responses</option>
         </select>
       </div>
       <div class="mb-4">
@@ -374,7 +384,7 @@
           bind:value={$maxTokensStore}
           disabled={isStreaming}
         />
-        <p class="text-xs text-txtsecondary mt-1">Required for /v1/messages.</p>
+        <p class="text-xs text-txtsecondary mt-1">Required for /anthropic/v1/messages.</p>
       </div>
     </div>
   {/if}

--- a/ui-svelte/src/lib/chatApi.ts
+++ b/ui-svelte/src/lib/chatApi.ts
@@ -1,6 +1,6 @@
 import type { ChatMessage, ContentPart } from "./types";
 
-export type Endpoint = "v1/chat/completions" | "v1/messages" | "v1/responses";
+export type Endpoint = "openai/v1/chat/completions" | "anthropic/v1/messages" | "openai/v1/responses";
 
 export interface StreamChunk {
   content: string;
@@ -119,11 +119,11 @@ function buildRequest(
 ): { url: string; body: object } {
   const url = "/" + endpoint;
   switch (endpoint) {
-    case "v1/messages":
+    case "anthropic/v1/messages":
       return { url, body: buildMessagesBody(model, messages, options) };
-    case "v1/responses":
+    case "openai/v1/responses":
       return { url, body: buildResponsesBody(model, messages, options) };
-    case "v1/chat/completions":
+    case "openai/v1/chat/completions":
     default:
       return { url, body: buildChatCompletionsBody(model, messages, options) };
   }
@@ -282,11 +282,11 @@ function parseStream(
   reader: ReadableStreamDefaultReader<Uint8Array>
 ): AsyncGenerator<StreamChunk> {
   switch (endpoint) {
-    case "v1/messages":
+    case "anthropic/v1/messages":
       return parseMessagesStream(reader);
-    case "v1/responses":
+    case "openai/v1/responses":
       return parseResponsesStream(reader);
-    case "v1/chat/completions":
+    case "openai/v1/chat/completions":
     default:
       return parseChatCompletionsStream(reader);
   }
@@ -298,7 +298,7 @@ export async function* streamChatCompletion(
   signal?: AbortSignal,
   options?: ChatOptions
 ): AsyncGenerator<StreamChunk> {
-  const endpoint = options?.endpoint ?? "v1/chat/completions";
+  const endpoint = options?.endpoint ?? "openai/v1/chat/completions";
   const { url, body } = buildRequest(endpoint, model, messages, options);
 
   const response = await fetch(url, {


### PR DESCRIPTION
Add canonical provider-prefixed API paths for OpenAI and Anthropic clients while keeping the existing shared `/v1` routes available.

  - add `/openai/v1` routes for OpenAI-compatible endpoints
  - add `/anthropic/v1` routes for Anthropic-compatible endpoints
  - normalize provider-prefixed paths before proxying upstream
  - update the playground endpoint defaults and model panel API hints
  - document the new API surfaces

<img width="1614" height="504" alt="image" src="https://github.com/user-attachments/assets/b4f49ba6-78a3-49d9-81d9-db6a237bd9e5" />
