### PR TITLE
Add ROCm stats via rocm-smi

### DIFF
--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -227,6 +227,7 @@ func tryRocmSmi(ctx context.Context, every time.Duration, logger *logmon.Monitor
 	if every < time.Second {
 		every = time.Second
 	}
+	const pollTimeout = 5 * time.Second
 
 	ch := make(chan []GpuStat, 1)
 
@@ -240,9 +241,15 @@ func tryRocmSmi(ctx context.Context, every time.Duration, logger *logmon.Monitor
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				cmd := exec.CommandContext(ctx, "rocm-smi", "-i", "-P", "-t", "-f", "-u", "--showmemuse", "--showmeminfo", "vram", "--showproductname", "--csv")
+				pollCtx, cancel := context.WithTimeout(ctx, pollTimeout)
+				cmd := exec.CommandContext(pollCtx, "rocm-smi", "-i", "-P", "-t", "-f", "-u", "--showmemuse", "--showmeminfo", "vram", "--showproductname", "--csv")
 				out, err := cmd.Output()
+				timedOut := pollCtx.Err() == context.DeadlineExceeded
+				cancel()
 				if err != nil {
+					if timedOut {
+						logger.Debug("rocm-smi timed out")
+					}
 					continue
 				}
 

--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -303,9 +303,9 @@ func parseRocmSmiLine(line string) *GpuStat {
 	memUsed, _ := strconv.ParseUint(strings.TrimSpace(fields[18]), 10, 64)
 	cardSeries := strings.TrimSpace(fields[19])
 	name := device
-	if cardSeries != "" {
+	if cardSeries != "" && cardSeries != "N/A" {
 		name = cardSeries + " " + device
-	} else if deviceName != "" {
+	} else if deviceName != "" && deviceName != "N/A" {
 		name = deviceName + " " + device
 	}
 

--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -275,7 +275,7 @@ func tryRocmSmi(ctx context.Context, every time.Duration, logger *logmon.Monitor
 
 func parseRocmSmiLine(line string) *GpuStat {
 	fields := strings.Split(line, ",")
-	if len(fields) < 16 {
+	if len(fields) < 20 {
 		return nil
 	}
 
@@ -284,19 +284,22 @@ func parseRocmSmiLine(line string) *GpuStat {
 	if err != nil {
 		return nil
 	}
-	uuid := strings.TrimSpace(fields[1])
-	tempC, _ := strconv.ParseFloat(strings.TrimSpace(fields[2]), 64)
-	vramTempC, _ := strconv.ParseFloat(strings.TrimSpace(fields[4]), 64)
-	fanSpeed, _ := strconv.ParseFloat(strings.TrimSpace(fields[6]), 64)
-	powerDraw, _ := strconv.ParseFloat(strings.TrimSpace(fields[8]), 64)
-	gpuUtil, _ := strconv.ParseFloat(strings.TrimSpace(fields[9]), 64)
-	memUtil, _ := strconv.ParseFloat(strings.TrimSpace(fields[10]), 64)
-	memTotal, _ := strconv.ParseUint(strings.TrimSpace(fields[13]), 10, 64)
-	memUsed, _ := strconv.ParseUint(strings.TrimSpace(fields[14]), 10, 64)
-	cardSeries := strings.TrimSpace(fields[15])
+	deviceName := strings.TrimSpace(fields[1])
+	uuid := strings.TrimSpace(fields[5])
+	tempC, _ := strconv.ParseFloat(strings.TrimSpace(fields[6]), 64)
+	vramTempC, _ := strconv.ParseFloat(strings.TrimSpace(fields[8]), 64)
+	fanSpeed, _ := strconv.ParseFloat(strings.TrimSpace(fields[10]), 64)
+	powerDraw, _ := strconv.ParseFloat(strings.TrimSpace(fields[12]), 64)
+	gpuUtil, _ := strconv.ParseFloat(strings.TrimSpace(fields[13]), 64)
+	memUtil, _ := strconv.ParseFloat(strings.TrimSpace(fields[14]), 64)
+	memTotal, _ := strconv.ParseUint(strings.TrimSpace(fields[17]), 10, 64)
+	memUsed, _ := strconv.ParseUint(strings.TrimSpace(fields[18]), 10, 64)
+	cardSeries := strings.TrimSpace(fields[19])
 	name := device
 	if cardSeries != "" {
 		name = cardSeries + " " + device
+	} else if deviceName != "" {
+		name = deviceName + " " + device
 	}
 
 	const toMB = 1024 * 1024

--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -38,6 +38,13 @@ func getGpuStats(ctx context.Context, every time.Duration, logger *logmon.Monito
 		logger.Debugf("nvidia-smi: %s", err.Error())
 	}
 
+	if ch, err := tryRocmSmi(ctx, every, logger); err == nil {
+		logger.Info("using rocm-smi for GPU monitoring")
+		return ch, nil
+	} else {
+		logger.Debugf("rocm-smi: %s", err.Error())
+	}
+
 	if ch, err := trySysfs(ctx, every, logger); err == nil {
 		logger.Info("using sysfs for GPU monitoring")
 		return ch, nil
@@ -210,6 +217,85 @@ func parseNvidiaSmiLine(line string) *GpuStat {
 		MemTotalMB:  memTotal,
 		FanSpeedPct: fanSpeed,
 		PowerDrawW:  powerDraw,
+	}
+}
+
+func tryRocmSmi(ctx context.Context, every time.Duration, logger *logmon.Monitor) (chan []GpuStat, error) {
+	if _, err := exec.LookPath("rocm-smi"); err != nil {
+		return nil, ErrNoGpuTool
+	}
+	if every < time.Second {
+		every = time.Second
+	}
+
+	ch := make(chan []GpuStat, 1)
+
+	go func() {
+		defer close(ch)
+		ticker := time.NewTicker(every)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				cmd := exec.CommandContext(ctx, "rocm-smi", "-P", "-t", "-u", "--showmemuse", "--csv")
+				out, err := cmd.Output()
+				if err != nil {
+					continue
+				}
+
+				stats := make([]GpuStat, 0)
+				scanner := bufio.NewScanner(strings.NewReader(string(out)))
+				for scanner.Scan() {
+					line := strings.TrimSpace(scanner.Text())
+					if line == "" || strings.HasPrefix(line, "device,") {
+						continue
+					}
+
+					stat := parseRocmSmiLine(line)
+					if stat != nil {
+						stats = append(stats, *stat)
+					}
+				}
+
+				if len(stats) > 0 {
+					select {
+					case ch <- stats:
+					default:
+					}
+				}
+			}
+		}
+	}()
+
+	return ch, nil
+}
+
+func parseRocmSmiLine(line string) *GpuStat {
+	fields := strings.Split(line, ",")
+	if len(fields) < 9 {
+		return nil
+	}
+
+	device := strings.TrimSpace(fields[0])
+	id, _ := strconv.Atoi(strings.TrimPrefix(device, "card"))
+	tempC, _ := strconv.ParseFloat(strings.TrimSpace(fields[1]), 64)
+	vramTempC, _ := strconv.ParseFloat(strings.TrimSpace(fields[3]), 64)
+	powerDraw, _ := strconv.ParseFloat(strings.TrimSpace(fields[4]), 64)
+	gpuUtil, _ := strconv.ParseFloat(strings.TrimSpace(fields[5]), 64)
+	memUtil, _ := strconv.ParseFloat(strings.TrimSpace(fields[6]), 64)
+
+	return &GpuStat{
+		Timestamp:  time.Now(),
+		ID:         id,
+		Name:       device,
+		TempC:      int(tempC),
+		VramTempC:  int(vramTempC),
+		GpuUtilPct: gpuUtil,
+		MemUtilPct: memUtil,
+		PowerDrawW: powerDraw,
 	}
 }
 

--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -240,7 +240,7 @@ func tryRocmSmi(ctx context.Context, every time.Duration, logger *logmon.Monitor
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				cmd := exec.CommandContext(ctx, "rocm-smi", "-P", "-t", "-u", "--showmemuse", "--csv")
+				cmd := exec.CommandContext(ctx, "rocm-smi", "-i", "-P", "-t", "-f", "-u", "--showmemuse", "--showmeminfo", "vram", "--showproductname", "--csv")
 				out, err := cmd.Output()
 				if err != nil {
 					continue
@@ -275,27 +275,45 @@ func tryRocmSmi(ctx context.Context, every time.Duration, logger *logmon.Monitor
 
 func parseRocmSmiLine(line string) *GpuStat {
 	fields := strings.Split(line, ",")
-	if len(fields) < 9 {
+	if len(fields) < 16 {
 		return nil
 	}
 
 	device := strings.TrimSpace(fields[0])
-	id, _ := strconv.Atoi(strings.TrimPrefix(device, "card"))
-	tempC, _ := strconv.ParseFloat(strings.TrimSpace(fields[1]), 64)
-	vramTempC, _ := strconv.ParseFloat(strings.TrimSpace(fields[3]), 64)
-	powerDraw, _ := strconv.ParseFloat(strings.TrimSpace(fields[4]), 64)
-	gpuUtil, _ := strconv.ParseFloat(strings.TrimSpace(fields[5]), 64)
-	memUtil, _ := strconv.ParseFloat(strings.TrimSpace(fields[6]), 64)
+	id, err := strconv.Atoi(strings.TrimPrefix(device, "card"))
+	if err != nil {
+		return nil
+	}
+	uuid := strings.TrimSpace(fields[1])
+	tempC, _ := strconv.ParseFloat(strings.TrimSpace(fields[2]), 64)
+	vramTempC, _ := strconv.ParseFloat(strings.TrimSpace(fields[4]), 64)
+	fanSpeed, _ := strconv.ParseFloat(strings.TrimSpace(fields[6]), 64)
+	powerDraw, _ := strconv.ParseFloat(strings.TrimSpace(fields[8]), 64)
+	gpuUtil, _ := strconv.ParseFloat(strings.TrimSpace(fields[9]), 64)
+	memUtil, _ := strconv.ParseFloat(strings.TrimSpace(fields[10]), 64)
+	memTotal, _ := strconv.ParseUint(strings.TrimSpace(fields[13]), 10, 64)
+	memUsed, _ := strconv.ParseUint(strings.TrimSpace(fields[14]), 10, 64)
+	cardSeries := strings.TrimSpace(fields[15])
+	name := device
+	if cardSeries != "" {
+		name = cardSeries + " " + device
+	}
+
+	const toMB = 1024 * 1024
 
 	return &GpuStat{
-		Timestamp:  time.Now(),
-		ID:         id,
-		Name:       device,
-		TempC:      int(tempC),
-		VramTempC:  int(vramTempC),
-		GpuUtilPct: gpuUtil,
-		MemUtilPct: memUtil,
-		PowerDrawW: powerDraw,
+		Timestamp:   time.Now(),
+		ID:          id,
+		Name:        name,
+		UUID:        uuid,
+		TempC:       int(tempC),
+		VramTempC:   int(vramTempC),
+		GpuUtilPct:  gpuUtil,
+		MemUtilPct:  memUtil,
+		MemUsedMB:   int(memUsed / toMB),
+		MemTotalMB:  int(memTotal / toMB),
+		FanSpeedPct: fanSpeed,
+		PowerDrawW:  powerDraw,
 	}
 }
 


### PR DESCRIPTION
## Summary

Add ROCm GPU stats support using `rocm-smi`.

The existing GPU backends are LACT, `nvidia-smi`, and a placeholder sysfs backend. LACT works well on hosts where its daemon/socket is available, but it is not always straightforward to expose into Docker containers. This adds a ROCm path for AMD GPUs by querying `rocm-smi` inside the running environment, mimicking the implementation used for `nvidia-smi`.

## Details

Two functions were added for this implementation: `tryRocmSmi` and `parseRocmSmiLine`

### `tryRocmSmi`
Runs the following command once per polling interval:
`rocm-smi -i -P -t -f -u --showmemuse --showmeminfo vram --showproductname --csv`

Since `rocm-smi` doesn't have a `-loop` flag, this command is just executed every poll instead of having a stdout pipe. 

Polling is clamped to at least 1 second to avoid excessive process spawning.

Expected Output Example:
```
device,Device Name,Device ID,Device Rev,Subsystem ID,GUID,Temperature (Sensor edge) (C),Temperature (Sensor junction) (C),Temperature (Sensor memory) (C),Fan speed (level),Fan speed (%),Fan RPM,Current Socket Graphics Package Power (W),GPU use (%),GPU Memory Allocated (VRAM%),GPU Memory Read/Write Activity (%),Memory Activity,VRAM Total Memory (B),VRAM Total Used Memory (B),Card Series,Card Model,Card Vendor,Card SKU,Node ID,GFX Version
card0,AMD Instinct MI60 / MI50,0x66a1,0x02,0x0834,34810,33.0,34.0,38.0,37,15,0,19.0,0,20,0,N/A,34342961152,7097057280,AMD Instinct MI60 / MI50,0x66a1,Advanced Micro Devices Inc. [AMD/ATI],D1631700,4,gfx906
```

### `parseRocmSmiLine`
This parses the output very similar to the `nvidia-smi` implementation.


rocm-smi column | GpuStat field | Notes
-- | -- | --
device | ID | Parses card0 -> 0; malformed IDs are skipped
Card Series + device | Name | Example: AMD Instinct MI60 / MI50 card0; falls back to Device Name + device, then device
GUID | UUID | Used as stable GPU identifier from -i output
Temperature (Sensor edge) (C) | TempC | Float converted to int
Temperature (Sensor memory) (C) | VramTempC | Float converted to int
Fan speed (%) | FanSpeedPct | Float
Current Socket Graphics Package Power (W) | PowerDrawW | Float
GPU use (%) | GpuUtilPct | Float
GPU Memory Allocated (VRAM%) | MemUtilPct | Float
VRAM Total Memory (B) | MemTotalMB | Bytes converted to MB
VRAM Total Used Memory (B) | MemUsedMB | Bytes converted to MB


There are some extraneous columns, which are ignored:


Column | Reason
-- | --
Temperature (Sensor junction) (C) | Not currently represented separately in GpuStat
Fan speed (level) | Percent is preferred
Fan RPM | No matching GpuStat field
GPU Memory Read/Write Activity (%) | No matching GpuStat field
Memory Activity | No matching GpuStat field
Remaining product/hardware fields | Not used by UI/API/Prometheus metrics


## Validation

Querying the data from llama-swap inside the container:

```
root@044c4ce08f4a:/app# curl -s http://localhost:8080/api/performance | python3 -c 'import sys,json; g=json.load(sys.stdin).get("gpu_stats", []); print(json.dumps(g[-1] if g else {}, indent=2))'
{
  "timestamp": "2026-05-16T20:06:35.556888025-05:00",
  "id": 2,
  "name": "AMD Instinct MI60 / MI50 card2",
  "uuid": "19447",
  "temp_c": 29,
  "vram_temp_c": 32,
  "gpu_util_pct": 0,
  "mem_util_pct": 0,
  "mem_used_mb": 10,
  "mem_total_mb": 32752,
  "fan_speed_pct": 15,
  "power_draw_w": 16
}
```
<img width="1512" height="796" alt="Screenshot 2026-05-16 at 8 08 34 PM" src="https://github.com/user-attachments/assets/975f6a88-b080-4e6b-a883-ad12e0d75df1" />


## Additional Notes

- `amd-smi` is the recommended tool to use for querying stats instead of `rocm-smi`, which is "deprecated and will no longer get updates". However, `amd-smi` returns `N/A` for a good chunk of values on my machine (gfx906 cards), and seems like it is also not correctly reporting data on newer systems based on a brief check online. I highly doubt `rocm-smi` is going anywhere anytime soon, so this, I feel, is fine for implementation now. `amd-smi` is very similar to `rocm-smi` in terms of flags, and also has a `-w`/`--watch` flag akin to `--loop`, so it shouldn't be too hard to swap over if/when `rocm-smi` stops working.
- AI was used to write the code, as I primarily use Python and am not deeply familiar with Go. However, I did review the code manually for what it's worth. Also, in addition to having the existing implementation to reference, the planning and testing was done by me; the AI had plenty of guidance to implement this.