### PR TITLE
config,server: add runtime-switchable alias profiles

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -494,6 +494,38 @@
         "matrix": {
             "$ref": "#/definitions/matrixConfig"
         },
+        "profiles": {
+            "type": "object",
+            "description": "Runtime-switchable alias overlays. When a profile is active, its alias map overrides default alias resolution. Switch via the UI dropdown or POST /api/profiles/activate/<name>. Selection does not persist across restarts.",
+            "propertyNames": {
+                "minLength": 1
+            },
+            "additionalProperties": {
+                "type": "object",
+                "required": [
+                    "aliases"
+                ],
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "aliases": {
+                        "type": "object",
+                        "minProperties": 1,
+                        "propertyNames": {
+                            "minLength": 1
+                        },
+                        "additionalProperties": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "description": "Map of alias name to target. The target may be any model ID, static alias, or setParamsByID variant key; unknown targets are rejected at load time. An empty string or YAML null (~) disables the local alias while this profile is active."
+                    }
+                }
+            }
+        },
         "hooks": {
             "type": "object",
             "properties": {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -416,6 +416,23 @@ models:
     # - processes have 5 seconds to shutdown until forceful termination is attempted
     cmdStop: docker stop ${MODEL_ID}
 
+# profiles: runtime-switchable alias overlays
+# - optional, default: empty
+# - remap aliases to different model IDs at runtime, switched via the UI
+#   dropdown or POST /api/profiles/activate/<name>
+# - the active profile is runtime state and does not persist across restarts
+# - target must resolve in a single step: a model ID, a static model
+#   alias, or a setParamsByID variant key. Profile aliases never chain
+#   to other profile aliases (including within the same profile) and
+#   cannot shadow a model ID; both are rejected at load time.
+# - use null (~) to disable an alias while the profile is active
+# profiles:
+#   plan-smarter:
+#     description: "Use the smarter model for planning; disable image gen"
+#     aliases:
+#       llm-plan: "glm-5.1"
+#       image-gen: ~
+
 # hooks: a dictionary of event triggers and actions
 # - optional, default: empty dictionary
 # - the only supported hook is on_startup

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -72,16 +72,17 @@ models:
 
 llama-swap supports many more features to customize how you want to manage your environment.
 
-| Feature   | Description                                    |
-| --------- | ---------------------------------------------- |
-| `ttl`     | automatic unloading of models after a timeout  |
-| `macros`  | reusable snippets to use in configurations     |
-| `matrix`  | run multiple models at a time                  |
-| `hooks`   | event driven functionality                     |
-| `env`     | define environment variables per model         |
-| `aliases` | serve a model with different names             |
-| `filters` | modify requests before sending to the upstream |
-| `...`     | And many more tweaks                           |
+| Feature    | Description                                    |
+| ---------- | ---------------------------------------------- |
+| `ttl`      | automatic unloading of models after a timeout  |
+| `macros`   | reusable snippets to use in configurations     |
+| `matrix`   | run multiple models at a time                  |
+| `hooks`    | event driven functionality                     |
+| `env`      | define environment variables per model         |
+| `aliases`  | serve a model with different names             |
+| `profiles` | switch alias mappings at runtime               |
+| `filters`  | modify requests before sending to the upstream |
+| `...`      | And many more tweaks                           |
 
 ## Full Configuration Example
 
@@ -461,6 +462,23 @@ models:
     # - on Windows, calls taskkill to stop the process
     # - processes have 5 seconds to shutdown until forceful termination is attempted
     cmdStop: docker stop ${MODEL_ID}
+
+# profiles: runtime-switchable alias overlays
+# - optional, default: empty
+# - remap aliases to different model IDs at runtime, switched via the UI
+#   dropdown or POST /api/profiles/activate/<name>
+# - the active profile is runtime state and does not persist across restarts
+# - target must resolve in a single step: a model ID, a static model
+#   alias, or a setParamsByID variant key. Profile aliases never chain
+#   to other profile aliases (including within the same profile) and
+#   cannot shadow a model ID; both are rejected at load time.
+# - use null (~) to disable an alias while the profile is active
+# profiles:
+#   plan-smarter:
+#     description: "Use the smarter model for planning; disable image gen"
+#     aliases:
+#       llm-plan: "glm-5.1"
+#       image-gen: ~
 
 # =============================================================================
 # matrix: run concurrent models with a solver-based swap DSL

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,32 @@ func (c *GroupConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// ProfileConfig is a named runtime overlay that remaps aliases to different
+// targets without a config reload. See fork README and issue discussion for
+// PR #774. Note: upstream removed its list-based `profiles:` feature; this fork
+// repurposes the key for runtime alias overlays.
+type ProfileConfig struct {
+	Description string            `yaml:"description"`
+	Aliases     map[string]string `yaml:"aliases"`
+}
+
+// UnmarshalYAML provides a targeted error for the removed legacy profiles shape
+// (a bare list of model IDs), guiding users to the alias-map form or to groups.
+func (p *ProfileConfig) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.SequenceNode {
+		return fmt.Errorf("legacy profiles format removed: use profiles.<name>.aliases map; see docs/configuration.md and use groups for concurrent model loading")
+	}
+
+	type rawProfileConfig ProfileConfig
+	var raw rawProfileConfig
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+
+	*p = ProfileConfig(raw)
+	return nil
+}
+
 type HooksConfig struct {
 	OnStartup HookOnStartup `yaml:"on_startup"`
 }
@@ -118,20 +144,20 @@ type UIActivityConfig struct {
 }
 
 type Config struct {
-	HealthCheckTimeout int                    `yaml:"healthCheckTimeout"`
-	LogRequests        bool                   `yaml:"logRequests"`
-	LogLevel           string                 `yaml:"logLevel"`
-	LogTimeFormat      string                 `yaml:"logTimeFormat"`
-	LogToStdout        string                 `yaml:"logToStdout"`
-	MetricsMaxInMemory int                    `yaml:"metricsMaxInMemory"`
-	CaptureBuffer      int                    `yaml:"captureBuffer"`
-	Store              *Store                 `yaml:"store"`
-	UI                 UIConfig               `yaml:"ui"`
-	Performance        PerformanceConfig      `yaml:"performance"`
-	GlobalTTL          int                    `yaml:"globalTTL"`
-	UnloadTimeout      int                    `yaml:"unloadTimeout"`
-	Models             map[string]ModelConfig `yaml:"models"` /* key is model ID */
-	Profiles           map[string][]string    `yaml:"profiles"`
+	HealthCheckTimeout int                      `yaml:"healthCheckTimeout"`
+	LogRequests        bool                     `yaml:"logRequests"`
+	LogLevel           string                   `yaml:"logLevel"`
+	LogTimeFormat      string                   `yaml:"logTimeFormat"`
+	LogToStdout        string                   `yaml:"logToStdout"`
+	MetricsMaxInMemory int                      `yaml:"metricsMaxInMemory"`
+	CaptureBuffer      int                      `yaml:"captureBuffer"`
+	Store              *Store                   `yaml:"store"`
+	UI                 UIConfig                 `yaml:"ui"`
+	Performance        PerformanceConfig        `yaml:"performance"`
+	GlobalTTL          int                      `yaml:"globalTTL"`
+	UnloadTimeout      int                      `yaml:"unloadTimeout"`
+	Models             map[string]ModelConfig   `yaml:"models"` /* key is model ID */
+	Profiles           map[string]ProfileConfig `yaml:"profiles"`
 
 	// routing is the canonical source for swap/scheduling configuration.
 	// New code must read Routing, never the backwards-compat fields below.
@@ -201,13 +227,74 @@ type RouterSettings struct {
 }
 
 func (c *Config) RealModelName(search string) (string, bool) {
+	return c.RealModelNameWithProfile(search, nil)
+}
+
+// EffectiveRequestName applies active profile aliases without shadowing model IDs.
+func (c *Config) EffectiveRequestName(search string, profileAliases map[string]string) string {
 	if _, found := c.Models[search]; found {
-		return search, true
-	} else if name, found := c.aliases[search]; found {
-		return name, found
-	} else {
+		return search
+	}
+	if target, ok := profileAliases[search]; ok {
+		return target
+	}
+	return search
+}
+
+// RealModelNameWithProfile resolves search to a model ID with profile aliases applied.
+func (c *Config) RealModelNameWithProfile(search string, profileAliases map[string]string) (string, bool) {
+	effective := c.EffectiveRequestName(search, profileAliases)
+	if effective == "" {
 		return "", false
 	}
+	if _, found := c.Models[effective]; found {
+		return effective, true
+	}
+	name, found := c.aliases[effective]
+	return name, found
+}
+
+// EffectiveAliasesFor returns aliases that resolve to modelID under the profile overlay.
+func (c *Config) EffectiveAliasesFor(modelID string, profileAliases map[string]string) []string {
+	static := c.Models[modelID].Aliases
+	if len(profileAliases) == 0 {
+		return static
+	}
+
+	seen := make(map[string]struct{}, len(static))
+	out := make([]string, 0, len(static))
+	for _, alias := range static {
+		if target, overridden := profileAliases[alias]; overridden {
+			resolved, _ := c.RealModelName(target)
+			if resolved != modelID {
+				continue
+			}
+		}
+		if _, found := seen[alias]; found {
+			continue
+		}
+		seen[alias] = struct{}{}
+		out = append(out, alias)
+	}
+
+	added := make([]string, 0)
+	for alias, target := range profileAliases {
+		if _, found := c.Models[alias]; found {
+			continue
+		}
+		resolved, _ := c.RealModelName(target)
+		if resolved != modelID {
+			continue
+		}
+		if _, found := seen[alias]; found {
+			continue
+		}
+		seen[alias] = struct{}{}
+		added = append(added, alias)
+	}
+	sort.Strings(added)
+	out = append(out, added...)
+	return out
 }
 
 func (c *Config) FindConfig(modelName string) (ModelConfig, string, bool) {

--- a/internal/config/config_posix_test.go
+++ b/internal/config/config_posix_test.go
@@ -140,8 +140,9 @@ models:
 healthCheckTimeout: 15
 profiles:
   test:
-    - model1
-    - model2
+    description: "remap m1 to model2"
+    aliases:
+      m1: model2
 groups:
   group1:
     swap: true
@@ -267,8 +268,11 @@ groups:
 		Performance: PerformanceConfig{
 			Every: 5 * time.Second,
 		},
-		Profiles: map[string][]string{
-			"test": {"model1", "model2"},
+		Profiles: map[string]ProfileConfig{
+			"test": {
+				Description: "remap m1 to model2",
+				Aliases:     map[string]string{"m1": "model2"},
+			},
 		},
 		aliases: map[string]string{
 			"m1":        "model1",

--- a/internal/config/config_windows_test.go
+++ b/internal/config/config_windows_test.go
@@ -132,8 +132,9 @@ models:
 healthCheckTimeout: 15
 profiles:
   test:
-    - model1
-    - model2
+    description: "remap m1 to model2"
+    aliases:
+      m1: model2
 groups:
   group1:
     swap: true
@@ -256,8 +257,11 @@ groups:
 		Performance: PerformanceConfig{
 			Every: 5 * time.Second,
 		},
-		Profiles: map[string][]string{
-			"test": {"model1", "model2"},
+		Profiles: map[string]ProfileConfig{
+			"test": {
+				Description: "remap m1 to model2",
+				Aliases:     map[string]string{"m1": "model2"},
+			},
 		},
 		aliases: map[string]string{
 			"m1":        "model1",

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -103,6 +103,25 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		}
 	}
 
+	// Validate profile names and alias names (targets are validated after all
+	// aliases, including setParamsByID keys, are registered below).
+	for profileName, profile := range config.Profiles {
+		if profileName == "" {
+			return Config{}, fmt.Errorf("profile name cannot be empty")
+		}
+		if len(profile.Aliases) == 0 {
+			return Config{}, fmt.Errorf("profile %s: aliases map cannot be empty", profileName)
+		}
+		for alias := range profile.Aliases {
+			if alias == "" {
+				return Config{}, fmt.Errorf("profile %s: alias name cannot be empty", profileName)
+			}
+			if _, found := config.Models[alias]; found {
+				return Config{}, fmt.Errorf("profile %s: alias %q conflicts with model ID", profileName, alias)
+			}
+		}
+	}
+
 	// Validate global macros
 	for _, macro := range config.Macros {
 		if err = validateMacro(macro.Name, macro.Value); err != nil {
@@ -315,6 +334,22 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		}
 
 		config.Models[modelId] = modelConfig
+	}
+
+	// Validate profile alias targets after all aliases are registered.
+	for profileName, profile := range config.Profiles {
+		for alias, target := range profile.Aliases {
+			if target == "" {
+				continue
+			}
+			if _, ok := config.Models[target]; ok {
+				continue
+			}
+			if _, ok := config.aliases[target]; ok {
+				continue
+			}
+			return Config{}, fmt.Errorf("profile %s: alias %q target %q is not a known model or alias", profileName, alias, target)
+		}
 	}
 
 	// Normalize routing config. The legacy top-level `matrix`/`groups` keys and

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -123,6 +123,27 @@ func TestLoadConfigSources_DuplicatePeer(t *testing.T) {
 	assert.Contains(t, err.Error(), `duplicate peers "remote"`)
 }
 
+func TestLoadConfigSources_ProfilesMerge(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, "a.yaml", "models:\n"+modelCfg("m1", "echo m1")+"profiles:\n  first:\n    aliases: {a1: m1}\n")
+	writeYAML(t, dir, "b.yaml", "models:\n"+modelCfg("m2", "echo m2")+"profiles:\n  second:\n    aliases: {a2: m2}\n")
+
+	cfg, err := LoadConfigSources("", dir)
+	require.NoError(t, err)
+	assert.Contains(t, cfg.Profiles, "first")
+	assert.Contains(t, cfg.Profiles, "second")
+}
+
+func TestLoadConfigSources_DuplicateProfile(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, "a.yaml", "models:\n"+modelCfg("m1", "echo m1")+"profiles:\n  shared:\n    aliases: {a1: m1}\n")
+	writeYAML(t, dir, "b.yaml", "models:\n"+modelCfg("m2", "echo m2")+"profiles:\n  shared:\n    aliases: {a2: m2}\n")
+
+	_, err := LoadConfigSources("", dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate profiles "shared"`)
+}
+
 func TestLoadConfigSources_ScalarConflict(t *testing.T) {
 	dir := t.TempDir()
 	writeYAML(t, dir, "a.yaml", "models:\n"+modelCfg("m1", "echo m1")+"\nglobalTTL: 100\n")

--- a/internal/config/profiles_test.go
+++ b/internal/config/profiles_test.go
@@ -1,0 +1,188 @@
+package config
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const profilesBaseModels = `
+models:
+  glm-5.1:
+    cmd: path/to/cmd
+    proxy: "http://localhost:8080"
+    aliases:
+      - llm-plan
+    filters:
+      setParamsByID:
+        glm-thinking:
+          reasoning: true
+  qwen-3:
+    cmd: path/to/cmd
+    proxy: "http://localhost:8081"
+  image-model:
+    cmd: path/to/cmd
+    proxy: "http://localhost:8082"
+    aliases:
+      - image-gen
+`
+
+func loadProfilesConfig(t *testing.T, extra string) (Config, error) {
+	t.Helper()
+	return LoadConfigFromReader(strings.NewReader(profilesBaseModels + extra))
+}
+
+func TestConfig_ProfileResolution(t *testing.T) {
+	cfg, err := loadProfilesConfig(t, `
+profiles:
+  plan-smarter:
+    description: "smarter planning"
+    aliases:
+      llm-plan: qwen-3
+      image-gen: ~
+`)
+	require.NoError(t, err)
+
+	overlay := cfg.Profiles["plan-smarter"].Aliases
+
+	// Without a profile the static alias resolves to its own model.
+	got, found := cfg.RealModelName("llm-plan")
+	require.True(t, found)
+	assert.Equal(t, "glm-5.1", got)
+
+	// With the profile overlay it is remapped to qwen-3.
+	got, found = cfg.RealModelNameWithProfile("llm-plan", overlay)
+	require.True(t, found)
+	assert.Equal(t, "qwen-3", got)
+
+	// A disabled alias (~) is not found while the profile is active.
+	_, found = cfg.RealModelNameWithProfile("image-gen", overlay)
+	assert.False(t, found)
+
+	// Model IDs always win over a profile alias of the same name is impossible
+	// (load-time rejected), but unrelated model IDs still resolve.
+	got, found = cfg.RealModelNameWithProfile("qwen-3", overlay)
+	require.True(t, found)
+	assert.Equal(t, "qwen-3", got)
+}
+
+func TestConfig_EffectiveRequestName(t *testing.T) {
+	cfg, err := loadProfilesConfig(t, `
+profiles:
+  variant:
+    aliases:
+      llm-plan: glm-thinking
+`)
+	require.NoError(t, err)
+	overlay := cfg.Profiles["variant"].Aliases
+
+	// The effective request name is the profile target, so setParamsByID keys
+	// match the variant.
+	assert.Equal(t, "glm-thinking", cfg.EffectiveRequestName("llm-plan", overlay))
+	// The variant key still resolves to the base model.
+	got, found := cfg.RealModelNameWithProfile("llm-plan", overlay)
+	require.True(t, found)
+	assert.Equal(t, "glm-5.1", got)
+	// Non-overridden names pass through unchanged.
+	assert.Equal(t, "qwen-3", cfg.EffectiveRequestName("qwen-3", overlay))
+}
+
+func TestConfig_EffectiveAliasesFor(t *testing.T) {
+	cfg, err := loadProfilesConfig(t, `
+profiles:
+  plan-smarter:
+    aliases:
+      llm-plan: qwen-3
+`)
+	require.NoError(t, err)
+	overlay := cfg.Profiles["plan-smarter"].Aliases
+
+	// llm-plan no longer resolves to glm-5.1 under the overlay.
+	glmAliases := cfg.EffectiveAliasesFor("glm-5.1", overlay)
+	assert.False(t, slices.Contains(glmAliases, "llm-plan"))
+
+	// qwen-3 now gains llm-plan.
+	qwenAliases := cfg.EffectiveAliasesFor("qwen-3", overlay)
+	assert.True(t, slices.Contains(qwenAliases, "llm-plan"))
+
+	// With no overlay the static aliases are returned unchanged.
+	assert.Equal(t, cfg.Models["glm-5.1"].Aliases, cfg.EffectiveAliasesFor("glm-5.1", nil))
+}
+
+func TestConfig_ProfileValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		extra   string
+		wantErr string
+	}{
+		{
+			name: "empty aliases map",
+			extra: `
+profiles:
+  bad:
+    description: "no aliases"
+`,
+			wantErr: "aliases map cannot be empty",
+		},
+		{
+			name: "alias shadows model id",
+			extra: `
+profiles:
+  bad:
+    aliases:
+      qwen-3: glm-5.1
+`,
+			wantErr: "conflicts with model ID",
+		},
+		{
+			name: "unknown target",
+			extra: `
+profiles:
+  bad:
+    aliases:
+      llm-plan: does-not-exist
+`,
+			wantErr: "is not a known model or alias",
+		},
+		{
+			name: "legacy sequence shape rejected",
+			extra: `
+profiles:
+  bad:
+    - glm-5.1
+`,
+			wantErr: "legacy profiles format removed",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := loadProfilesConfig(t, tc.extra)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestConfig_ProfileTargetCanBeAliasOrVariant(t *testing.T) {
+	// Targets may be a model ID, a static alias, or a setParamsByID variant key.
+	cfg, err := loadProfilesConfig(t, `
+profiles:
+  mixed:
+    aliases:
+      a: glm-5.1
+      b: llm-plan
+      c: glm-thinking
+`)
+	require.NoError(t, err)
+	overlay := cfg.Profiles["mixed"].Aliases
+
+	for _, alias := range []string{"a", "b", "c"} {
+		got, found := cfg.RealModelNameWithProfile(alias, overlay)
+		require.Truef(t, found, "alias %q should resolve", alias)
+		assert.Equalf(t, "glm-5.1", got, "alias %q resolves to glm-5.1", alias)
+	}
+}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -137,6 +137,7 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 	created := time.Now().Unix()
 	data := make([]modelRecord, 0, len(s.cfg.Models))
 	running := s.local.RunningModels()
+	_, profileAliases := s.ActiveProfile()
 
 	modelStatus := func(id string) string {
 		if _, ok := running[id]; ok {
@@ -173,7 +174,7 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 		data = append(data, newRecord(id, mc.Name, mc.Description, mc.Metadata, mc.Capabilities, status))
 
 		if s.cfg.IncludeAliasesInList {
-			for _, alias := range mc.Aliases {
+			for _, alias := range s.cfg.EffectiveAliasesFor(id, profileAliases) {
 				if alias := strings.TrimSpace(alias); alias != "" {
 					data = append(data, newRecord(alias, mc.Name, mc.Description, mc.Metadata, mc.Capabilities, status))
 				}

--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -32,6 +32,7 @@ type apiModel struct {
 // state (defaulting to "stopped"), followed by peer models.
 func (s *Server) modelStatus() []apiModel {
 	running := s.local.RunningModels()
+	_, profileAliases := s.ActiveProfile()
 
 	ids := make([]string, 0, len(s.cfg.Models))
 	for id := range s.cfg.Models {
@@ -53,7 +54,7 @@ func (s *Server) modelStatus() []apiModel {
 			Description:  mc.Description,
 			State:        state,
 			Unlisted:     mc.Unlisted,
-			Aliases:      mc.Aliases,
+			Aliases:      s.cfg.EffectiveAliasesFor(id, profileAliases),
 			Capabilities: capsMap,
 		})
 	}
@@ -77,7 +78,8 @@ func (s *Server) handleAPIUnloadAll(w http.ResponseWriter, r *http.Request) {
 // handleAPIUnloadModel stops a single named local process.
 func (s *Server) handleAPIUnloadModel(w http.ResponseWriter, r *http.Request) {
 	requested := strings.TrimPrefix(r.PathValue("model"), "/")
-	realName, found := s.cfg.RealModelName(requested)
+	_, profileAliases := s.ActiveProfile()
+	realName, found := s.cfg.RealModelNameWithProfile(requested, profileAliases)
 	if !found {
 		shared.SendResponse(w, r, http.StatusNotFound, "model not found")
 		return
@@ -272,6 +274,7 @@ const (
 	msgTypeActivity    messageType = "activity"
 	msgTypeInFlight    messageType = "inflight"
 	msgTypeUIConfig    messageType = "uiConfig"
+	msgTypeProfile     messageType = "profileChanged"
 )
 
 type messageEnvelope struct {
@@ -338,6 +341,11 @@ func (s *Server) handleAPIEvents(w http.ResponseWriter, r *http.Request) {
 			send(messageEnvelope{Type: msgTypeUIConfig, Data: string(j)})
 		}
 	}
+	sendActiveProfile := func(name string) {
+		if j, err := json.Marshal(map[string]string{"activeProfile": name}); err == nil {
+			send(messageEnvelope{Type: msgTypeProfile, Data: string(j)})
+		}
+	}
 
 	defer event.On(func(e shared.ProcessStateChangeEvent) { sendModels() })()
 	defer event.On(func(e shared.ConfigFileChangedEvent) { sendModels() })()
@@ -345,6 +353,12 @@ func (s *Server) handleAPIEvents(w http.ResponseWriter, r *http.Request) {
 	defer s.upstreamlog.OnLogData(func(data []byte) { sendLogData("upstream", data) })()
 	defer event.On(func(e ActivityLogEvent) { sendActivity(e.Metrics.ID) })()
 	defer event.On(func(e shared.InFlightRequestsEvent) { sendInFlight(e) })()
+	defer event.On(func(e shared.ProfileChangedEvent) {
+		sendActiveProfile(e.ActiveProfileName)
+		// The active profile changes which aliases resolve where, so refresh
+		// the model listing too.
+		sendModels()
+	})()
 
 	// initial payload
 	sendLogData("proxy", s.proxylog.GetHistory())
@@ -352,6 +366,8 @@ func (s *Server) handleAPIEvents(w http.ResponseWriter, r *http.Request) {
 	sendModels()
 	sendUIConfig()
 	sendInFlight(s.inflight.Current())
+	activeProfile, _ := s.ActiveProfile()
+	sendActiveProfile(activeProfile)
 
 	for {
 		select {

--- a/internal/server/profiles.go
+++ b/internal/server/profiles.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/mostlygeek/llama-swap/internal/chain"
+	"github.com/mostlygeek/llama-swap/internal/event"
+	"github.com/mostlygeek/llama-swap/internal/shared"
+)
+
+// ActiveProfile returns the active profile name and a copy of its alias overlay.
+// When no profile is active (or the active name is unknown) it returns an empty
+// name and a nil overlay, which all profile-aware resolution treats as "no
+// remapping".
+func (s *Server) ActiveProfile() (string, map[string]string) {
+	s.activeProfileMu.RLock()
+	defer s.activeProfileMu.RUnlock()
+	if s.activeProfileName == "" {
+		return "", nil
+	}
+	profile, found := s.cfg.Profiles[s.activeProfileName]
+	if !found {
+		return "", nil
+	}
+	return s.activeProfileName, maps.Clone(profile.Aliases)
+}
+
+// SetActiveProfile selects the active profile by name. An empty name clears the
+// active profile. Unknown names are rejected. A ProfileChangedEvent is emitted
+// only when the active name actually changes.
+func (s *Server) SetActiveProfile(name string) error {
+	s.activeProfileMu.Lock()
+	if name != "" {
+		if _, found := s.cfg.Profiles[name]; !found {
+			s.activeProfileMu.Unlock()
+			return fmt.Errorf("profile not found: %s", name)
+		}
+	}
+	changed := s.activeProfileName != name
+	s.activeProfileName = name
+	s.activeProfileMu.Unlock()
+
+	if changed {
+		event.Emit(shared.ProfileChangedEvent{ActiveProfileName: name})
+	}
+	return nil
+}
+
+// CreateProfileMiddleware returns middleware that applies the active profile's
+// alias overlay before body filtering and model dispatch. It runs after
+// CreateRequestContextMiddleware has populated the request context, then
+// rewrites the resolved model in the context so every downstream consumer (body
+// filters, in-flight tracking, metrics, dispatch) sees the profile-resolved
+// model. When no profile is active it is a complete pass through with zero
+// overhead.
+//
+// Only aliases explicitly overridden by the active profile are remapped: model
+// IDs always win, static aliases and peer models resolve normally downstream,
+// and an alias whose profile target is empty (YAML ~) is reported as not found
+// while the profile is active.
+func (s *Server) CreateProfileMiddleware() chain.Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, overlay := s.ActiveProfile()
+			if len(overlay) == 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			data, ok := shared.ReadContext(r.Context())
+			if !ok {
+				// Context not populated yet; let the downstream resolver report
+				// the missing-model error.
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			requested := data.Model
+			target, overridden := overlay[requested]
+			if !overridden {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if _, isModel := s.cfg.Models[requested]; isModel {
+				// Model IDs always win over profile alias overrides.
+				next.ServeHTTP(w, r)
+				return
+			}
+			if target == "" {
+				// Alias disabled while this profile is active.
+				shared.SendError(w, r, shared.ErrNoLocalModelFound)
+				return
+			}
+
+			modelID, found := s.cfg.RealModelNameWithProfile(requested, overlay)
+			if !found {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			data.Model = s.cfg.EffectiveRequestName(requested, overlay)
+			data.ModelID = modelID
+			if mc, ok := s.cfg.Models[modelID]; ok {
+				data.SendLoadingState = mc.SendLoadingState != nil && *mc.SendLoadingState
+			}
+			*r = *r.WithContext(shared.SetContext(r.Context(), data))
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// apiProfile is one entry in the GET /api/profiles payload.
+type apiProfile struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	Aliases     map[string]string `json:"aliases"`
+}
+
+// handleAPIListProfiles serves the configured profiles plus the active one.
+func (s *Server) handleAPIListProfiles(w http.ResponseWriter, r *http.Request) {
+	names := make([]string, 0, len(s.cfg.Profiles))
+	for name := range s.cfg.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	profiles := make([]apiProfile, 0, len(names))
+	for _, name := range names {
+		profile := s.cfg.Profiles[name]
+		profiles = append(profiles, apiProfile{
+			Name:        name,
+			Description: profile.Description,
+			Aliases:     profile.Aliases,
+		})
+	}
+
+	active, _ := s.ActiveProfile()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"active":   active,
+		"profiles": profiles,
+	})
+}
+
+// handleAPIActivateProfile selects the active profile named in the path. An
+// empty name clears the active profile.
+func (s *Server) handleAPIActivateProfile(w http.ResponseWriter, r *http.Request) {
+	name := strings.TrimPrefix(r.PathValue("name"), "/")
+	if err := s.SetActiveProfile(name); err != nil {
+		shared.SendResponse(w, r, http.StatusNotFound, "profile not found")
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+}

--- a/internal/server/profiles_test.go
+++ b/internal/server/profiles_test.go
@@ -1,0 +1,303 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/router"
+	"github.com/mostlygeek/llama-swap/internal/shared"
+	"github.com/mostlygeek/llama-swap/internal/store"
+)
+
+const profileServerConfig = `
+models:
+  glm-5.1:
+    cmd: path/to/cmd
+    proxy: "http://localhost:8080"
+    aliases:
+      - llm-plan
+  qwen-3:
+    cmd: path/to/cmd
+    proxy: "http://localhost:8081"
+  image-model:
+    cmd: path/to/cmd
+    proxy: "http://localhost:8082"
+    aliases:
+      - image-gen
+includeAliasesInList: true
+profiles:
+  plan-smarter:
+    description: "smarter planning; no image gen"
+    aliases:
+      llm-plan: qwen-3
+      image-gen: ~
+`
+
+// profileServerMatrixConfig declares the same models and profiles but routes
+// through a matrix instead of groups, to prove the profile overlay is a layer
+// in front of routing and behaves identically regardless of the backend.
+const profileServerMatrixConfig = `
+models:
+  glm-5.1:
+    cmd: path/to/cmd
+    proxy: "http://localhost:8080"
+    aliases:
+      - llm-plan
+  qwen-3:
+    cmd: path/to/cmd
+    proxy: "http://localhost:8081"
+  image-model:
+    cmd: path/to/cmd
+    proxy: "http://localhost:8082"
+    aliases:
+      - image-gen
+includeAliasesInList: true
+matrix:
+  vars:
+    a: glm-5.1
+    b: qwen-3
+    c: image-model
+  sets:
+    s: "a | b | c"
+profiles:
+  plan-smarter:
+    description: "smarter planning; no image gen"
+    aliases:
+      llm-plan: qwen-3
+      image-gen: ~
+`
+
+// echoModelIDRouter returns a stub local router that echoes the resolved model
+// ID from the request context, so tests can assert which model a request was
+// routed to after the profile overlay runs.
+func echoModelIDRouter(models ...string) *stubRouter {
+	stub := newStubRouter(models, "")
+	stub.serveHTTP = func(w http.ResponseWriter, r *http.Request) {
+		data, _ := shared.ReadContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(data.ModelID))
+	}
+	return stub
+}
+
+func newProfileServer(t *testing.T, local router.LocalRouter) *Server {
+	t.Helper()
+	return newProfileServerFrom(t, profileServerConfig, local)
+}
+
+func newProfileServerFrom(t *testing.T, configYAML string, local router.LocalRouter) *Server {
+	t.Helper()
+	cfg, err := config.LoadConfigFromReader(strings.NewReader(configYAML))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	proxylog := logmon.NewWriter(io.Discard)
+	st, err := store.New("")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	s := &Server{
+		cfg:         cfg,
+		muxlog:      logmon.NewWriter(io.Discard),
+		proxylog:    proxylog,
+		upstreamlog: logmon.NewWriter(io.Discard),
+		inflight:    newInflightTracker(),
+		metrics:     newMetricsMonitor(proxylog, 0, 0, st),
+		store:       st,
+		local:       local,
+		peer:        newStubRouter(nil, ""),
+		shutdownCtx: ctx,
+		shutdownFn:  cancel,
+	}
+	s.routes()
+	return s
+}
+
+func TestServer_ProfileRewritesModelBeforeDispatch(t *testing.T) {
+	s := newProfileServer(t, echoModelIDRouter("glm-5.1", "qwen-3", "image-model"))
+
+	// Without a profile, the static alias dispatches to glm-5.1.
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, chatRequest("llm-plan"))
+	if w.Code != http.StatusOK || w.Body.String() != "glm-5.1" {
+		t.Fatalf("no profile: status=%d body=%q want glm-5.1", w.Code, w.Body.String())
+	}
+
+	// Activate the profile: the same alias now dispatches to qwen-3.
+	if err := s.SetActiveProfile("plan-smarter"); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	w = httptest.NewRecorder()
+	s.ServeHTTP(w, chatRequest("llm-plan"))
+	if w.Code != http.StatusOK || w.Body.String() != "qwen-3" {
+		t.Fatalf("profile active: status=%d body=%q want qwen-3", w.Code, w.Body.String())
+	}
+
+	// A disabled alias (~) is not found while the profile is active.
+	w = httptest.NewRecorder()
+	s.ServeHTTP(w, chatRequest("image-gen"))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("disabled alias: status=%d want 404", w.Code)
+	}
+
+	// Clearing the profile restores default resolution.
+	if err := s.SetActiveProfile(""); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	w = httptest.NewRecorder()
+	s.ServeHTTP(w, chatRequest("image-gen"))
+	if w.Code != http.StatusOK || w.Body.String() != "image-model" {
+		t.Fatalf("after clear: status=%d body=%q want image-model", w.Code, w.Body.String())
+	}
+}
+
+func TestServer_ProfileListEndpoint(t *testing.T) {
+	s := newProfileServer(t, echoModelIDRouter("glm-5.1", "qwen-3", "image-model"))
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/profiles", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d", w.Code)
+	}
+	var body struct {
+		Active   string       `json:"active"`
+		Profiles []apiProfile `json:"profiles"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.Active != "" {
+		t.Errorf("active=%q want empty", body.Active)
+	}
+	if len(body.Profiles) != 1 || body.Profiles[0].Name != "plan-smarter" {
+		t.Fatalf("profiles=%+v", body.Profiles)
+	}
+	if body.Profiles[0].Description != "smarter planning; no image gen" {
+		t.Errorf("description=%q", body.Profiles[0].Description)
+	}
+}
+
+func TestServer_ProfileActivateEndpoint(t *testing.T) {
+	s := newProfileServer(t, echoModelIDRouter("glm-5.1", "qwen-3", "image-model"))
+
+	// Activate a known profile.
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/profiles/activate/plan-smarter", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("activate status=%d", w.Code)
+	}
+	if name, _ := s.ActiveProfile(); name != "plan-smarter" {
+		t.Errorf("active=%q want plan-smarter", name)
+	}
+
+	// Unknown profile returns 404.
+	w = httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/profiles/activate/nope", nil))
+	if w.Code != http.StatusNotFound {
+		t.Errorf("unknown activate status=%d want 404", w.Code)
+	}
+
+	// Empty name clears the active profile.
+	w = httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/profiles/activate/", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("clear status=%d", w.Code)
+	}
+	if name, _ := s.ActiveProfile(); name != "" {
+		t.Errorf("active=%q want empty", name)
+	}
+}
+
+func TestServer_ProfileAffectsModelListing(t *testing.T) {
+	s := newProfileServer(t, echoModelIDRouter("glm-5.1", "qwen-3", "image-model"))
+
+	listing := func() map[string]bool {
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+		if w.Code != http.StatusOK {
+			t.Fatalf("/v1/models status=%d", w.Code)
+		}
+		var resp struct {
+			Data []struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		ids := make(map[string]bool, len(resp.Data))
+		for _, d := range resp.Data {
+			ids[d.ID] = true
+		}
+		return ids
+	}
+
+	// Without a profile, llm-plan lists under glm-5.1.
+	ids := listing()
+	if !ids["llm-plan"] {
+		t.Errorf("expected llm-plan in default listing: %v", ids)
+	}
+
+	// With the profile, llm-plan resolves to qwen-3 so it no longer lists as a
+	// glm-5.1 alias, and image-gen is disabled.
+	if err := s.SetActiveProfile("plan-smarter"); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	ids = listing()
+	if ids["image-gen"] {
+		t.Errorf("disabled alias image-gen should not be listed: %v", ids)
+	}
+}
+
+// TestServer_ProfileParityGroupsAndMatrix asserts the profile overlay rewrites
+// the requested model to the same target whether the backend is groups or
+// matrix, confirming it is a routing-agnostic front layer.
+func TestServer_ProfileParityGroupsAndMatrix(t *testing.T) {
+	cases := []struct {
+		name   string
+		config string
+	}{
+		{"groups", profileServerConfig},
+		{"matrix", profileServerMatrixConfig},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newProfileServerFrom(t, tc.config, echoModelIDRouter("glm-5.1", "qwen-3", "image-model"))
+
+			// Default resolution.
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, chatRequest("llm-plan"))
+			if w.Code != http.StatusOK || w.Body.String() != "glm-5.1" {
+				t.Fatalf("%s default: status=%d body=%q want glm-5.1", tc.name, w.Code, w.Body.String())
+			}
+
+			// Overlay rewrites to qwen-3.
+			if err := s.SetActiveProfile("plan-smarter"); err != nil {
+				t.Fatalf("activate: %v", err)
+			}
+			w = httptest.NewRecorder()
+			s.ServeHTTP(w, chatRequest("llm-plan"))
+			if w.Code != http.StatusOK || w.Body.String() != "qwen-3" {
+				t.Fatalf("%s profile: status=%d body=%q want qwen-3", tc.name, w.Code, w.Body.String())
+			}
+
+			// Disabled alias is not found.
+			w = httptest.NewRecorder()
+			s.ServeHTTP(w, chatRequest("image-gen"))
+			if w.Code != http.StatusNotFound {
+				t.Fatalf("%s disabled: status=%d want 404", tc.name, w.Code)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -41,6 +41,9 @@ type Server struct {
 	mux     *http.ServeMux
 	handler http.Handler
 
+	activeProfileMu   sync.RWMutex
+	activeProfileName string
+
 	shutdownCtx  context.Context
 	shutdownFn   context.CancelFunc
 	shuttingDown atomic.Bool
@@ -206,6 +209,7 @@ func (s *Server) routes() {
 	modelChain := chain.New(
 		authMW,
 		CreateRequestContextMiddleware(s.cfg),
+		s.CreateProfileMiddleware(),
 		CreateInflightMiddleware(s.inflight),
 		CreateFilterMiddleware(s.cfg),
 		CreateFormFilterMiddleware(s.cfg),
@@ -260,6 +264,8 @@ func (s *Server) routes() {
 	// API group (API-key protected) consumed by the UI.
 	mux.Handle("POST /api/models/unload", apiChain.ThenFunc(s.handleAPIUnloadAll))
 	mux.Handle("POST /api/models/unload/{model...}", apiChain.ThenFunc(s.handleAPIUnloadModel))
+	mux.Handle("GET /api/profiles", apiChain.ThenFunc(s.handleAPIListProfiles))
+	mux.Handle("POST /api/profiles/activate/{name...}", apiChain.ThenFunc(s.handleAPIActivateProfile))
 	mux.Handle("POST /api/inflight/{id}/cancel", apiChain.ThenFunc(s.handleAPICancelInflight))
 	mux.Handle("GET /api/events", apiChain.ThenFunc(s.handleAPIEvents))
 	mux.Handle("GET /api/metrics/activity", apiChain.ThenFunc(s.handleAPIActivity))

--- a/internal/shared/events.go
+++ b/internal/shared/events.go
@@ -7,6 +7,7 @@ const ConfigFileChangedEventID = 0x03
 const ActivityLogEventID = 0x05
 const ModelPreloadedEventID = 0x06
 const InFlightRequestsEventID = 0x07
+const ProfileChangedEventID = 0x08
 
 // ProcessStateChangeEvent is emitted whenever a process transitions between
 // lifecycle states. States are carried as strings so this package stays a leaf
@@ -68,4 +69,12 @@ type InflightRequestEntry struct {
 	RespBytes   int64             `json:"resp_bytes"`
 	ElapsedMs   int64             `json:"elapsed_ms"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+type ProfileChangedEvent struct {
+	ActiveProfileName string
+}
+
+func (e ProfileChangedEvent) Type() uint32 {
+	return ProfileChangedEventID
 }

--- a/llama-swap.go
+++ b/llama-swap.go
@@ -108,10 +108,6 @@ func main() {
 	// so a LogToStdout change requires a restart to take effect.
 	muxLog, proxyLog, upstreamLog := server.NewLoggers(cfg.LogToStdout)
 
-	if len(cfg.Profiles) > 0 {
-		proxyLog.Warn("Profile functionality has been removed in favor of Groups. See the README for more information.")
-	}
-
 	applyLogSettings := func(cfg config.Config) {
 		level := logmon.LevelInfo
 		switch strings.ToLower(strings.TrimSpace(cfg.LogLevel)) {
@@ -209,10 +205,6 @@ func main() {
 		if err != nil {
 			proxyLog.Warnf("failed to reload config: %v", err)
 			return
-		}
-
-		if len(newCfg.Profiles) > 0 {
-			proxyLog.Warn("Profile functionality has been removed in favor of Groups. See the README for more information.")
 		}
 
 		if perfMon != nil {

--- a/ui-svelte/src/components/AppSidebar.svelte
+++ b/ui-svelte/src/components/AppSidebar.svelte
@@ -7,7 +7,7 @@
   import { toggleTheme, themeMode, appTitle } from "../stores/theme";
   import { currentRoute } from "../stores/route";
   import { playgroundActivity } from "../stores/playgroundActivity";
-  import { performanceEnabled, models } from "../stores/api";
+  import { performanceEnabled, models, profiles, activeProfile, fetchProfiles, setActiveProfile } from "../stores/api";
   import { showUnlistedModels } from "../stores/modelDisplay";
   import { modelsMenuOpen } from "../stores/sidebar";
   import type { Model } from "../lib/types";
@@ -52,6 +52,15 @@
     yellow: "bg-warning",
     green: "bg-success",
   };
+
+  async function handleProfileChange(e: Event): Promise<void> {
+    const target = e.currentTarget as HTMLSelectElement;
+    try {
+      await setActiveProfile(target.value);
+    } catch {
+      void fetchProfiles();
+    }
+  }
 </script>
 
 <Sidebar.Root collapsible="icon">
@@ -181,6 +190,25 @@
         </Sidebar.Menu>
       </Sidebar.GroupContent>
     </Sidebar.Group>
+
+    {#if $profiles.length > 0}
+      <Sidebar.Group class="group-data-[collapsible=icon]:hidden">
+        <Sidebar.GroupLabel>Profile</Sidebar.GroupLabel>
+        <Sidebar.GroupContent>
+          <select
+            value={$activeProfile}
+            onchange={handleProfileChange}
+            aria-label="Active profile"
+            class="w-full rounded-md border border-sidebar-border bg-sidebar-accent px-2 py-1.5 text-sm text-sidebar-foreground focus:outline-none focus:ring-2 focus:ring-sidebar-ring"
+          >
+            <option value="">(no profile)</option>
+            {#each $profiles as profile}
+              <option value={profile.name} title={profile.description ?? ""}>{profile.name}</option>
+            {/each}
+          </select>
+        </Sidebar.GroupContent>
+      </Sidebar.Group>
+    {/if}
   </Sidebar.Content>
 
   <Sidebar.Footer>

--- a/ui-svelte/src/lib/types.ts
+++ b/ui-svelte/src/lib/types.ts
@@ -138,8 +138,14 @@ export interface PerformanceResponse {
 }
 
 export interface APIEventEnvelope {
-  type: "modelStatus" | "logData" | "activity" | "inflight" | "uiConfig" | "perfsys" | "perfgpu";
+  type: "modelStatus" | "logData" | "activity" | "inflight" | "uiConfig" | "perfsys" | "perfgpu" | "profileChanged";
   data: string;
+}
+
+export interface Profile {
+  name: string;
+  description?: string;
+  aliases: Record<string, string>;
 }
 
 export interface HistogramData {

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -10,6 +10,7 @@ import type {
   InFlightStats,
   InflightRequestEntry,
   PerformanceResponse,
+  Profile,
   UIConfig,
 } from "../lib/types";
 import { connectionState } from "./theme";
@@ -31,6 +32,8 @@ const defaultUIConfig = (): UIConfig => ({
 });
 export const uiConfig = writable<UIConfig>(defaultUIConfig());
 export const performanceEnabled = writable<boolean>(false);
+export const profiles = writable<Profile[]>([]);
+export const activeProfile = writable<string>("");
 export const versionInfo = writable<VersionInfo>({
   build_date: "unknown",
   commit: "unknown",
@@ -54,6 +57,8 @@ export function enableAPIEvents(enabled: boolean): void {
     inFlightRequests.set(0);
     inflightRequestEntries.set([]);
     uiConfig.set(defaultUIConfig());
+    profiles.set([]);
+    activeProfile.set("");
     return;
   }
 
@@ -75,6 +80,7 @@ export function enableAPIEvents(enabled: boolean): void {
       inflightRequestEntries.set([]);
       uiConfig.set(defaultUIConfig());
       models.set([]);
+      activeProfile.set("");
       retryCount = 0;
       connectionState.set("connected");
     };
@@ -169,6 +175,12 @@ export function handleAPIEventMessage(data: string): void {
       uiConfig.set(JSON.parse(message.data) as UIConfig);
       break;
     }
+
+    case "profileChanged": {
+      const data = JSON.parse(message.data) as { activeProfile: string };
+      activeProfile.set(data.activeProfile ?? "");
+      break;
+    }
   }
 }
 
@@ -185,8 +197,33 @@ connectionState.subscribe(async (status) => {
     } catch (error) {
       console.error(error);
     }
+    void fetchProfiles();
   }
 });
+
+export async function fetchProfiles(): Promise<void> {
+  try {
+    const response = await fetch("/api/profiles");
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const data = (await response.json()) as { active: string; profiles: Profile[] };
+    profiles.set(data.profiles || []);
+    activeProfile.set(data.active || "");
+  } catch (error) {
+    console.error("Failed to fetch profiles:", error);
+  }
+}
+
+export async function setActiveProfile(name: string): Promise<void> {
+  const response = await fetch(`/api/profiles/activate/${encodeURIComponent(name)}`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  activeProfile.set(name);
+}
 
 export async function listModels(): Promise<Model[]> {
   try {


### PR DESCRIPTION
### Motivation

llama-swap already supports aliases, which makes it possible to give models **semantic, intent-based names** - `llm-plan`, `llm-code`, `llm-image`, `llm-assistant-smart` - and let clients address those instead of concrete model IDs like `qwen3.6-27b` or `glm-5.1`. Agents and harnesses keep these names in client configuration, which is inconvenient to change and not meant to be edited mid-session.

`profiles:` makes it possible to reroute aliases to different models using the UI profile-selector dropdown (or via API), without restarting llama-swap or reconfiguring any client.

### Example

```yaml
models:
  qwen3.6-27b: { cmd: ..., aliases: [llm-plan, llm-code] }
  glm-5.1:     { cmd: ... }
  flux:        { cmd: ..., aliases: [image-gen] }

profiles:
  plan-smarter:
    description: "Use the smarter model for planning; disable image gen"
    aliases:
      llm-plan: "glm-5.1"
      image-gen: ~
```

With `plan-smarter` active, `llm-plan` resolves to `glm-5.1` instead of the default `qwen3.6-27b`, and `image-gen` is disabled to keep the focused session free of stray load cycles. No restart, no client changes.

### Compatibility

- Additive. If `profiles:` is absent, behaviour is unchanged and the UI dropdown does not appear.
- No changes to existing alias resolution, `groups`, `matrix`, or `setParamsByID` semantics for non-profile requests.
- Schema additions live entirely under the new `profiles:` block.
- A profile can introduce new aliases, retarget static ones, or disable them with `~` - all scoped to the active profile.

### What it touches

- **Config validation:** load-time checks that profile alias targets resolve to a model or registered alias, that names don't shadow model IDs, and that cross-profile chains are rejected.
- **Request routing:** `Config.RealModelNameWithProfile` overlays the active profile's aliases on top of static aliases.
- **`setParamsByID`** lookup uses the profile-rewritten request name, so a profile alias can target a variant key (e.g. `llm-task → some-model:nothink`) and trigger that variant's params.
- **API:** new REST endpoints to list and activate profiles, plus an SSE event so the UI updates without polling.
- **UI:** a header dropdown that only renders when profiles are configured; switching profile triggers an SSE refresh and the standard `/v1/models` listing reflects the active profile's alias reassignments automatically.

### Notes for review

@mostlygeek, happy to change anything you'd prefer different - naming, UI, scope.

We use llama-swap in a small team with a growing number of client apps running both on the server and on users' machines. Profiles let us experiment and switch between focused configurations without restarts and worrying that one stray request triggers a long unload/load cycle. We keep profiles like `coding-smarter`, `coding-faster`, `general-chat`, each routing aliases to different set of models. All clients continue to work without fighting for a specific model.

A couple of design choices worth mentioning:

- **Naming.** If this stays purely about aliases, a more specific name (`aliasProfiles`?) might fit better than `profiles`. I chose `profiles` because the same config might carry other runtime-switchable overrides later. Not sure about this.
- **Resolution depth.** One-step resolution only: a profile alias can chain through one statically-registered alias (including auto-registered `setParamsByID` variant keys), but profile-to-profile chains are rejected at load time. To keep it simple.