### PR TITLE
docker: fix container build tag selection lag

### DIFF
--- a/docker/build-container.sh
+++ b/docker/build-container.sh
@@ -101,9 +101,10 @@ fetch_llama_tag() {
         fi
 
         # Extract matching tag from this page
-        local found_tag=$(echo "$response" | jq -r --arg prefix "$tag_prefix" \
+        local found_tag
+        found_tag=$(echo "$response" | jq -r --arg prefix "$tag_prefix" \
             '.[] | .metadata.container.tags[]? | select(test("^" + $prefix + "-b[0-9]+$"))' \
-            | sort -V | tail -n1)
+            | sort -V | tail -n1) || return 1
 
         if [ -n "$found_tag" ]; then
             log_debug "Found tag: $found_tag on page $page"

--- a/docker/build-container.sh
+++ b/docker/build-container.sh
@@ -101,9 +101,9 @@ fetch_llama_tag() {
         fi
 
         # Extract matching tag from this page
-        local found_tag=$(echo "$response" | jq -r \
-            ".[] | select(.metadata.container.tags[]? | startswith(\"$tag_prefix\")) | .metadata.container.tags[] | select(startswith(\"$tag_prefix\"))" \
-            | sort -r | head -n1)
+        local found_tag=$(echo "$response" | jq -r --arg prefix "$tag_prefix" \
+            '.[] | .metadata.container.tags[]? | select(test("^" + $prefix + "-b[0-9]+$"))' \
+            | sort -V | tail -n1)
 
         if [ -n "$found_tag" ]; then
             log_debug "Found tag: $found_tag on page $page"


### PR DESCRIPTION
Ensure fetch_llama_tag matches build tags precisely and sorts them numerically to select the newest bNNNN build.

- Restrict tag matches to ^$prefix-b[0-9]+$ to avoid matching static tags and other backend architectures.
- Sort matching tags numerically using version sort (sort -V) instead of lexicographical sort to correctly prioritize newer builds.

fixes #777