### PR TITLE
docker: Add optional FFmpeg support for whisper.cpp

### DIFF
--- a/docker/unified/Dockerfile
+++ b/docker/unified/Dockerfile
@@ -25,6 +25,7 @@ ENV PATH="/usr/lib/ccache:${PATH}"
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential cmake git python3 python3-pip libssl-dev \
     curl ca-certificates ccache make wget \
+    pkg-config libavcodec-dev libavformat-dev libavutil-dev libswresample-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
@@ -42,6 +43,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential cmake git python3 python3-pip libssl-dev \
     curl ca-certificates ccache make wget software-properties-common \
     libvulkan-dev glslang-tools spirv-tools vulkan-validationlayers glslc \
+    pkg-config libavcodec-dev libavformat-dev libavutil-dev libswresample-dev \
     spirv-headers \
     && rm -rf /var/lib/apt/lists/*
 
@@ -55,11 +57,13 @@ FROM builder-base-${BACKEND} AS builder-base
 
 FROM builder-base AS whisper-build
 ARG BACKEND=cuda
+ARG WHISPER_FFMPEG=yes
 ARG WHISPER_COMMIT_HASH=master
 COPY install-whisper.sh /build/
 RUN --mount=type=cache,id=ccache-${BACKEND},target=/ccache \
     --mount=type=cache,id=whisper-${BACKEND},target=/src/whisper.cpp/build \
-    BACKEND=${BACKEND} bash /build/install-whisper.sh "${WHISPER_COMMIT_HASH}"
+    BACKEND=${BACKEND} WHISPER_FFMPEG=${WHISPER_FFMPEG} \
+    bash /build/install-whisper.sh "${WHISPER_COMMIT_HASH}"
 
 # ── Build stable-diffusion.cpp ────────────────────────────────────────
 
@@ -119,6 +123,7 @@ ENV PATH="/usr/local/bin:${PATH}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgomp1 python3 curl ca-certificates \
+    libavcodec60 libavformat60 libavutil58 libswresample4 \
     && rm -rf /var/lib/apt/lists/*
 
 # CUDA stub drivers for container compatibility
@@ -135,6 +140,7 @@ ENV PATH="/usr/local/bin:${PATH}"
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgomp1 libvulkan1 mesa-vulkan-drivers \
     python3 curl ca-certificates \
+    libavcodec60 libavformat60 libavutil58 libswresample4 \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Select runtime base by BACKEND ────────────────────────────────────

--- a/docker/unified/build-image.sh
+++ b/docker/unified/build-image.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 BACKEND=""
 NO_CACHE=false
+WHISPER_FFMPEG="${WHISPER_FFMPEG:-yes}"
 
 for arg in "$@"; do
     case $arg in
@@ -46,6 +47,7 @@ for arg in "$@"; do
             echo "  SD_REF               Pin stable-diffusion.cpp to a commit, tag, or branch"
             echo "  IK_LLAMA_REF         Pin ik_llama.cpp to a commit, tag, or branch (CUDA only)"
             echo "  LS_VERSION           Override llama-swap version (e.g., '170' or 'latest')"
+            echo "  WHISPER_FFMPEG       Enable whisper.cpp FFmpeg support (default: yes)"
             exit 0
             ;;
     esac
@@ -201,6 +203,7 @@ BUILD_ARGS=(
     --build-arg "SD_COMMIT_HASH=${SD_HASH}"
     --build-arg "IK_LLAMA_COMMIT_HASH=${IK_LLAMA_HASH}"
     --build-arg "LS_VERSION=${LS_HASH}"
+    --build-arg "WHISPER_FFMPEG=${WHISPER_FFMPEG}"
     -t "${DOCKER_IMAGE_TAG}"
     -f "${SCRIPT_DIR}/Dockerfile"
 )

--- a/docker/unified/install-whisper.sh
+++ b/docker/unified/install-whisper.sh
@@ -5,8 +5,15 @@ set -e
 
 COMMIT_HASH="${1:-master}"
 BACKEND="${BACKEND:-cuda}"
+WHISPER_FFMPEG="${WHISPER_FFMPEG:-yes}"
 
 mkdir -p /install/bin /install/lib
+
+if [[ "${WHISPER_FFMPEG,,}" == "yes" || "${WHISPER_FFMPEG,,}" == "true" ]]; then
+    WHISPER_FFMPEG_ENABLED=1
+else
+    WHISPER_FFMPEG_ENABLED=0
+fi
 
 # Clone and checkout (init-based so cache-mounted /src/whisper.cpp/build dir doesn't break clone)
 echo "=== Cloning whisper.cpp at ${COMMIT_HASH} ==="
@@ -41,6 +48,10 @@ elif [ "$BACKEND" = "vulkan" ]; then
         -DGGML_CUDA=OFF
         -DGGML_VULKAN=ON
     )
+fi
+
+if [ "$WHISPER_FFMPEG_ENABLED" -eq 1 ]; then
+    CMAKE_FLAGS+=(-DWHISPER_FFMPEG=ON)
 fi
 
 TARGETS=(whisper-cli whisper-server)


### PR DESCRIPTION
### Summary

Solves [#783](https://github.com/mostlygeek/llama-swap/issues/783)
Adds optional FFmpeg support for whisper.cpp builds as described [here](https://github.com/ggml-org/whisper.cpp/tree/master#ffmpeg-support-linux-only)

Currently ffmpeg needs to be installed manually and it is launched as a sub-process when using it with whisper-server and `--convert`. Setting WHISPER_FFMPEG=yes at build time enables linking the ffmpeg libraries into the whisper binary at compile time.

The result is that the binary can natively decode audio formats like Opus, AAC, MP3, etc. without spawning any external process.

Changes:
- Adds the build arg/env toggle
- Installs required FFmpeg dev/runtime libraries in build and runtime images. 
- Adds `-DWHISPER_FFMPEG=ON` to CMAKE_FLAGS in install-whisper.sh if enabled.
- Separates Docker build cache for FFmpeg/non-FFmpeg builds

WHISPER_FFMPEG Behavior:

- yes / true => enabled (default)
- no / false => disabled

Libraries are not installed conditionally, but image size difference is minimal:
Build: pkg-config libavcodec-dev libavformat-dev libavutil-dev libswresample-dev ~31.5 MB
Runtime: libavcodec60 libavformat60 libavutil58 libswresample4 ~20.4 MB

`pkg-config not mentioned in whisper.cpp readme, but added to build image as whisper uses it to detect them. `libswresample-dev/libswresample4` also not in readme, but is checked for at build time so added for consistency: [src](https://github.com/ggml-org/whisper.cpp/blob/master/cmake/FindFFmpeg.cmake)