### PR TITLE
Add new power draw column header for rocm-smi monitoring

### DIFF
--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -281,51 +281,40 @@ func parseRocmSmiLine(header string, line string) *GpuStat {
 				return nil
 			}
 			result.ID = id
-			break
 		case "Device Name":
 			deviceName = val
-			break
 		case "GUID":
 			result.UUID = val
-			break
 		case "Temperature (Sensor edge) (C)":
 			tempC, _ := strconv.ParseFloat(val, 64)
 			result.TempC = int(tempC)
-			break
 		case "Temperature (Sensor memory) (C)":
 			vramTempC, _ := strconv.ParseFloat(val, 64)
 			result.VramTempC = int(vramTempC)
-			break
 		case "Fan speed (%)":
 			fanSpeed, _ := strconv.ParseFloat(val, 64)
 			result.FanSpeedPct = fanSpeed
-			break
 		case "Current Socket Graphics Package Power (W)":
+			fallthrough
+		case "Average Graphics Package Power (W)":
 			powerDraw, _ := strconv.ParseFloat(val, 64)
 			result.PowerDrawW = powerDraw
-			break
 		case "GPU use (%)":
 			gpuUtil, _ := strconv.ParseFloat(val, 64)
 			result.GpuUtilPct = gpuUtil
-			break
 		case "GPU Memory Allocated (VRAM%)":
 			memUtil, _ := strconv.ParseFloat(val, 64)
 			result.MemUtilPct = memUtil
-			break
 		case "VRAM Total Memory (B)":
 			memTotal, _ := strconv.ParseUint(val, 10, 64)
 			result.MemTotalMB = int(memTotal / toMB)
-			break
 		case "VRAM Total Used Memory (B)":
 			memUsed, _ := strconv.ParseUint(val, 10, 64)
 			result.MemUsedMB = int(memUsed / toMB)
-			break
 		case "Card Series":
 			cardSeries = val
-			break
 		case "GFX Version":
 			gfxVersion = val
-			break
 		}
 	}
 


### PR DESCRIPTION
# Overview
This patch fixes https://github.com/mostlygeek/llama-swap/pull/775#issuecomment-4535303706 and removes some unnecessary `break` statements.

## The third variant now also works with power draw:
`
device,Device Name,Device ID,Device Rev,Subsystem ID,GUID,Temperature (Sensor edge) (C),Temperature (Sensor junction) (C),Temperature (Sensor memory) (C),Average Graphics Package Power (W),GPU use (%),GPU Memory Allocated (VRAM%),GPU Memory Read/Write Activity (%),Memory Activity,Avg. Memory Bandwidth,VRAM Total Memory (B),VRAM Total Used Memory (B),Card Series,Card Model,Card Vendor,Card SKU,Node ID,GFX Version
`
<img width="1121" height="315" alt="image" src="https://github.com/user-attachments/assets/4b908c4d-2401-4dfe-9bac-e7aa770cfb42" />

## Old variants:
`
device,Device Name,Device ID,Device Rev,Subsystem ID,GUID,Temperature (Sensor edge) (C),Temperature (Sensor junction) (C),Temperature (Sensor memory) (C),Fan speed (level),Fan speed (%),Fan RPM,Current Socket Graphics Package Power (W),GPU use (%),GPU Memory Allocated (VRAM%),GPU Memory Read/Write Activity (%),Memory Activity,VRAM Total Memory (B),VRAM Total Used Memory (B),Card Series,Card Model,Card Vendor,Card SKU,Node ID,GFX Version
`
<img width="1118" height="308" alt="image" src="https://github.com/user-attachments/assets/b236e0cd-4505-42e5-b497-cff62c720e3d" />

`
device,Device Name,Device ID,Device Rev,Subsystem ID,GUID,Temperature (Sensor edge) (C),Current Socket Graphics Package Power (W),GPU use (%),GPU Memory Allocated (VRAM%),Memory Activity,VRAM Total Memory (B),VRAM Total Used Memory (B),Card Series,Card Model,Card Vendor,Card SKU,Node ID,GFX Version
`
<img width="1120" height="312" alt="image" src="https://github.com/user-attachments/assets/1adde1c3-5f35-4db4-ba13-65751ac076e8" />