### PR TITLE
fix: update the concurrency middleware to respond with a JSON payload

### DIFF
--- a/internal/server/concurrency.go
+++ b/internal/server/concurrency.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"golang.org/x/sync/semaphore"
@@ -48,9 +47,7 @@ func CreateConcurrencyMiddleware(cfg config.Config) chain.Middleware {
 			if !sem.TryAcquire(1) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusTooManyRequests)
-				json.NewEncoder(w).Encode(map[string]string{
-					"error": "Too many requests",
-				})
+				w.Write([]byte(`{"error":"Too many requests"}`))
 				return
 			}
 			defer sem.Release(1)

--- a/internal/server/concurrency.go
+++ b/internal/server/concurrency.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 
 	"golang.org/x/sync/semaphore"
@@ -45,7 +46,11 @@ func CreateConcurrencyMiddleware(cfg config.Config) chain.Middleware {
 				return
 			}
 			if !sem.TryAcquire(1) {
-				http.Error(w, "Too many requests", http.StatusTooManyRequests)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusTooManyRequests)
+				json.NewEncoder(w).Encode(map[string]string{
+					"error": "Too many requests",
+				})
 				return
 			}
 			defer sem.Release(1)


### PR DESCRIPTION
update the concurrency middleware to respond with a JSON payload instead of plain text when the request limit is reached to be compatible with openai api standard