### PR TITLE
Add priority-aware fair scheduling

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -517,6 +517,18 @@
             "type": "object",
             "description": "Optional priority-aware fair admission in front of per-model concurrency limits. When omitted, llama-swap rejects over-limit requests with a bare 429. When present, over-limit requests are queued and admitted by caller priority, and rejected with 429 + Retry-After only when the queue is full or the estimated wait exceeds maxWait. The caller id is the API key presented on the request.",
             "properties": {
+                "mode": {
+                    "type": "string",
+                    "enum": ["absolute", "proportion"],
+                    "default": "absolute",
+                    "description": "How the priority number is interpreted under contention. 'absolute': highest priority served first (FIFO within a priority). 'proportion': priority is a weight and callers are admitted in proportion to their weights (weighted fair queuing)."
+                },
+                "priorityIncreasePerSecondWaiting": {
+                    "type": "number",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Amount added to a waiter's effective priority for every second it has waited, composing with either mode. 0 disables aging. In absolute mode it prevents starvation (a long-waiting low priority eventually overtakes); in proportion mode it grows a long-waiter's share."
+                },
                 "priorities": {
                     "type": "object",
                     "additionalProperties": {

--- a/config-schema.json
+++ b/config-schema.json
@@ -525,10 +525,18 @@
                     "default": {},
                     "description": "Map of caller id (API key) to priority. Higher priority is served first under contention."
                 },
+                "modelPriorities": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    },
+                    "default": {},
+                    "description": "Map of model id to the default priority for that model. Applies to callers not listed in priorities (e.g. a single client that can't be told apart by API key), so priority can be driven by which model is requested. Models absent here use defaultPriority."
+                },
                 "defaultPriority": {
                     "type": "integer",
                     "default": 1,
-                    "description": "Priority assigned to callers not listed in priorities."
+                    "description": "Priority assigned to callers not listed in priorities and models not listed in modelPriorities."
                 },
                 "maxWait": {
                     "type": "string",

--- a/config-schema.json
+++ b/config-schema.json
@@ -512,6 +512,37 @@
             },
             "default": {},
             "description": "A dictionary of remote peers and models they provide. Peers can be another llama-swap or any server that provides the /v1/ generative API endpoints supported by llama-swap."
+        },
+        "scheduling": {
+            "type": "object",
+            "description": "Optional priority-aware fair admission in front of per-model concurrency limits. When omitted, llama-swap rejects over-limit requests with a bare 429. When present, over-limit requests are queued and admitted by caller priority, and rejected with 429 + Retry-After only when the queue is full or the estimated wait exceeds maxWait. The caller id is the API key presented on the request.",
+            "properties": {
+                "priorities": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "integer"
+                    },
+                    "default": {},
+                    "description": "Map of caller id (API key) to priority. Higher priority is served first under contention."
+                },
+                "defaultPriority": {
+                    "type": "integer",
+                    "default": 1,
+                    "description": "Priority assigned to callers not listed in priorities."
+                },
+                "maxWait": {
+                    "type": "string",
+                    "default": "30s",
+                    "description": "How long a queued request may wait for a slot before it is rejected with 429 + Retry-After. Accepts Go durations (e.g. \"500ms\", \"10s\", \"1m\")."
+                },
+                "maxQueueDepth": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "default": 0,
+                    "description": "Maximum number of waiters per model before arrivals are rejected with 429 + Retry-After. 0 means unlimited (only maxWait bounds the queue)."
+                }
+            },
+            "additionalProperties": false
         }
     },
     "allOf": [

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -533,7 +533,17 @@ scheduling:
     sk-interactive-frontend: 10
     sk-bulk-indexer: 1
 
-  # defaultPriority: priority for callers not listed in `priorities`
+  # modelPriorities: map of model id to that model's default priority. Applies to
+  # callers not listed in `priorities` — useful for a single client (e.g. Open
+  # WebUI) that can't be told apart by API key, so priority follows the model
+  # being requested. An explicitly listed caller in `priorities` still wins.
+  # - optional, default: empty (models fall back to defaultPriority)
+  modelPriorities:
+    chat-model: 10      # latency-sensitive, served first
+    bulk-embeddings: 1  # batch work, yields under load
+
+  # defaultPriority: priority for callers not listed in `priorities` and models
+  # not listed in `modelPriorities`
   # - optional, default: 1
   defaultPriority: 5
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -509,3 +509,42 @@ peers:
         provider:
           data_collection: "deny"
           zdr: true
+
+# scheduling: optional priority-aware fair admission in front of per-model
+# concurrency limits.
+# - optional, default: disabled (omit this section)
+# - When ABSENT, llama-swap keeps its original behavior: a request that cannot
+#   immediately acquire a model's concurrency slot is rejected with a bare 429.
+# - When PRESENT, requests that cannot immediately acquire a slot are held in a
+#   per-model queue and admitted by caller priority (highest first; FIFO within
+#   a priority) as slots free. A request is rejected with 429 + Retry-After only
+#   when the queue is full (maxQueueDepth) or its estimated wait exceeds maxWait.
+#   The Retry-After value is derived from a measured EWMA of the model's service
+#   time, so clients get an accurate backoff hint under real load.
+# - The caller id is the API key presented on the request (Authorization Bearer,
+#   Authorization Basic password field, or x-api-key). Callers not listed in
+#   `priorities` use `defaultPriority`.
+scheduling:
+  # priorities: map of caller id (API key) to priority. Higher is served first
+  # under contention.
+  # - optional, default: empty (every caller uses defaultPriority)
+  priorities:
+    # an interactive front-end key gets served ahead of a bulk indexer
+    sk-interactive-frontend: 10
+    sk-bulk-indexer: 1
+
+  # defaultPriority: priority for callers not listed in `priorities`
+  # - optional, default: 1
+  defaultPriority: 5
+
+  # maxWait: how long a queued request may wait for a slot before it is rejected
+  # with 429 + Retry-After. A request whose estimated wait already exceeds this
+  # at arrival is rejected immediately.
+  # - optional, default: 30s
+  # - accepts Go durations: "500ms", "10s", "1m"
+  maxWait: 30s
+
+  # maxQueueDepth: maximum number of waiters per model before arrivals are
+  # rejected with 429 + Retry-After.
+  # - optional, default: 0 (unlimited; only maxWait bounds the queue)
+  maxQueueDepth: 16

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -525,6 +525,23 @@ peers:
 #   Authorization Basic password field, or x-api-key). Callers not listed in
 #   `priorities` use `defaultPriority`.
 scheduling:
+  # mode: how the priority number is interpreted under contention.
+  # - "absolute" (default): highest priority served first, FIFO within a priority.
+  # - "proportion": priority is a weight; callers are admitted in proportion to
+  #   their weights (weighted fair queuing). A weight-10 caller gets ~10x the
+  #   throughput of a weight-1 caller under load; an idle caller never holds back
+  #   a busy one.
+  # - optional, default: absolute
+  mode: absolute
+
+  # priorityIncreasePerSecondWaiting: aging. Adds to a waiter's effective
+  # priority for every second it waits, composing with either mode.
+  # - in absolute mode: prevents starvation — a long-waiting low priority
+  #   eventually overtakes freshly arriving higher-priority requests.
+  # - in proportion mode: grows a long-waiter's share.
+  # - optional, default: 0 (no aging)
+  priorityIncreasePerSecondWaiting: 0
+
   # priorities: map of caller id (API key) to priority. Higher is served first
   # under contention.
   # - optional, default: empty (every caller uses defaultPriority)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,6 +160,10 @@ type Config struct {
 
 	// support remote peers, see issue #433, #296
 	Peers PeerDictionaryConfig `yaml:"peers"`
+
+	// optional priority-aware fair scheduling in front of per-model concurrency
+	// limits. Opt-in: absent section preserves legacy instant-429 behavior.
+	Scheduling SchedulingConfig `yaml:"scheduling"`
 }
 
 func (c *Config) RealModelName(search string) (string, bool) {
@@ -228,6 +232,10 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 	}
 	if err = config.Performance.Validate(); err != nil {
 		return Config{}, fmt.Errorf("performance: %w", err)
+	}
+
+	if err = config.Scheduling.Validate(); err != nil {
+		return Config{}, fmt.Errorf("scheduling: %w", err)
 	}
 
 	if config.StartPort < 1 {

--- a/internal/config/scheduling.go
+++ b/internal/config/scheduling.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"fmt"
+	"time"
+)
+
+// SchedulingConfig enables priority-aware fair admission in front of each
+// model's concurrency limit. It is opt-in: when the top-level `scheduling`
+// section is absent, llama-swap keeps its original behavior (a request that
+// cannot immediately acquire a concurrency slot is rejected with a bare 429).
+//
+// When enabled, a request that cannot immediately acquire a slot is held in a
+// per-model queue and admitted by caller priority (highest first, FIFO within a
+// priority) as slots free. A request is rejected with 429 + Retry-After only
+// when the queue is full or its estimated wait would exceed MaxWait. The
+// Retry-After value is derived from a measured EWMA of the model's service time.
+type SchedulingConfig struct {
+	// Priorities maps a caller id to a priority. The caller id is the API key
+	// presented on the request (Authorization Bearer/Basic password, or
+	// x-api-key). Higher priority is admitted first under contention.
+	Priorities map[string]int `yaml:"priorities"`
+
+	// DefaultPriority is assigned to callers absent from Priorities (including
+	// unauthenticated callers when no API keys are configured).
+	DefaultPriority int `yaml:"defaultPriority"`
+
+	// MaxWait bounds how long a queued request may wait for a slot before it is
+	// rejected with 429 + Retry-After. A request whose estimated wait already
+	// exceeds MaxWait at arrival is rejected immediately.
+	MaxWait time.Duration `yaml:"maxWait"`
+
+	// MaxQueueDepth bounds the number of waiters per model. Arrivals beyond this
+	// are rejected with 429 + Retry-After. 0 means unlimited depth (only MaxWait
+	// bounds the queue).
+	MaxQueueDepth int `yaml:"maxQueueDepth"`
+
+	// enabled records whether the section was present in the YAML, so the
+	// middleware can preserve legacy behavior when it was not.
+	enabled bool
+}
+
+// Defaults applied when the scheduling section is present but leaves a field unset.
+const (
+	defaultSchedulingPriority = 1
+	defaultSchedulingMaxWait  = 30 * time.Second
+)
+
+func (s *SchedulingConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type rawSchedulingConfig SchedulingConfig
+	raw := rawSchedulingConfig{
+		DefaultPriority: defaultSchedulingPriority,
+		MaxWait:         defaultSchedulingMaxWait,
+	}
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+	*s = SchedulingConfig(raw)
+	s.enabled = true
+	return nil
+}
+
+// Enabled reports whether the scheduling section was configured.
+func (s *SchedulingConfig) Enabled() bool {
+	return s != nil && s.enabled
+}
+
+// PriorityFor returns the configured priority for a caller id, or
+// DefaultPriority when the caller is not listed.
+func (s *SchedulingConfig) PriorityFor(callerID string) int {
+	if p, ok := s.Priorities[callerID]; ok {
+		return p
+	}
+	return s.DefaultPriority
+}
+
+// Validate checks the scheduling values and returns an error if invalid.
+func (s *SchedulingConfig) Validate() error {
+	if !s.Enabled() {
+		return nil
+	}
+	if s.MaxWait < 0 {
+		return fmt.Errorf("maxWait must be >= 0, got %v", s.MaxWait)
+	}
+	if s.MaxQueueDepth < 0 {
+		return fmt.Errorf("maxQueueDepth must be >= 0, got %d", s.MaxQueueDepth)
+	}
+	return nil
+}

--- a/internal/config/scheduling.go
+++ b/internal/config/scheduling.go
@@ -21,8 +21,16 @@ type SchedulingConfig struct {
 	// x-api-key). Higher priority is admitted first under contention.
 	Priorities map[string]int `yaml:"priorities"`
 
-	// DefaultPriority is assigned to callers absent from Priorities (including
-	// unauthenticated callers when no API keys are configured).
+	// ModelPriorities maps a model id to the default priority for that model.
+	// It applies to callers absent from Priorities (e.g. a single client like
+	// Open WebUI that can't be distinguished by API key), letting priority be
+	// driven by which model is requested. Models absent here fall back to
+	// DefaultPriority.
+	ModelPriorities map[string]int `yaml:"modelPriorities"`
+
+	// DefaultPriority is assigned to callers absent from both Priorities and
+	// ModelPriorities (including unauthenticated callers when no API keys are
+	// configured).
 	DefaultPriority int `yaml:"defaultPriority"`
 
 	// MaxWait bounds how long a queued request may wait for a slot before it is
@@ -65,10 +73,13 @@ func (s *SchedulingConfig) Enabled() bool {
 	return s != nil && s.enabled
 }
 
-// PriorityFor returns the configured priority for a caller id, or
-// DefaultPriority when the caller is not listed.
-func (s *SchedulingConfig) PriorityFor(callerID string) int {
+// PriorityFor returns the priority for a request. An explicitly listed caller
+// wins (operator intent), then the model's default, then DefaultPriority.
+func (s *SchedulingConfig) PriorityFor(callerID, modelID string) int {
 	if p, ok := s.Priorities[callerID]; ok {
+		return p
+	}
+	if p, ok := s.ModelPriorities[modelID]; ok {
 		return p
 	}
 	return s.DefaultPriority

--- a/internal/config/scheduling.go
+++ b/internal/config/scheduling.go
@@ -11,11 +11,41 @@ import (
 // cannot immediately acquire a concurrency slot is rejected with a bare 429).
 //
 // When enabled, a request that cannot immediately acquire a slot is held in a
-// per-model queue and admitted by caller priority (highest first, FIFO within a
-// priority) as slots free. A request is rejected with 429 + Retry-After only
-// when the queue is full or its estimated wait would exceed MaxWait. The
-// Retry-After value is derived from a measured EWMA of the model's service time.
+// per-model queue and admitted as slots free according to Mode: "absolute"
+// (highest priority first, FIFO within a priority) or "proportion" (priority as
+// a weight, weighted fair queuing). PriorityIncreasePerSecondWaiting optionally
+// ages a waiter's effective priority up over time in either mode. A request is
+// rejected with 429 + Retry-After only when the queue is full or its estimated
+// wait would exceed MaxWait; the Retry-After is a measured EWMA of service time.
+// SchedulingMode selects how the priority number is interpreted under
+// contention.
+type SchedulingMode string
+
+const (
+	// ModeAbsolute serves the highest-priority waiter first (FIFO within a
+	// priority). This is the default and matches the original behavior. With
+	// PriorityIncreasePerSecondWaiting > 0 it becomes starvation-free: a
+	// waiter's effective priority climbs the longer it waits.
+	ModeAbsolute SchedulingMode = "absolute"
+
+	// ModeProportion treats the priority number as a weight and admits callers
+	// in proportion to their weights (weighted fair queuing). A weight-10 caller
+	// gets ~10x the throughput of a weight-1 caller under contention; an idle
+	// class never holds back a busy one (work-conserving).
+	ModeProportion SchedulingMode = "proportion"
+)
+
 type SchedulingConfig struct {
+	// Mode selects how the priority number is interpreted: "absolute" (highest
+	// first) or "proportion" (weighted shares). Defaults to "absolute".
+	Mode SchedulingMode `yaml:"mode"`
+
+	// PriorityIncreasePerSecondWaiting adds to a waiter's effective priority for
+	// every second it has waited, composing with either mode. 0 (default)
+	// disables aging. In absolute mode it prevents starvation (low priority
+	// eventually overtakes); in proportion mode it grows a long-waiter's share.
+	PriorityIncreasePerSecondWaiting float64 `yaml:"priorityIncreasePerSecondWaiting"`
+
 	// Priorities maps a caller id to a priority. The caller id is the API key
 	// presented on the request (Authorization Bearer/Basic password, or
 	// x-api-key). Higher priority is admitted first under contention.
@@ -73,6 +103,14 @@ func (s *SchedulingConfig) Enabled() bool {
 	return s != nil && s.enabled
 }
 
+// ResolvedMode returns the configured mode, defaulting to ModeAbsolute.
+func (s *SchedulingConfig) ResolvedMode() SchedulingMode {
+	if s.Mode == ModeProportion {
+		return ModeProportion
+	}
+	return ModeAbsolute
+}
+
 // PriorityFor returns the priority for a request. An explicitly listed caller
 // wins (operator intent), then the model's default, then DefaultPriority.
 func (s *SchedulingConfig) PriorityFor(callerID, modelID string) int {
@@ -95,6 +133,12 @@ func (s *SchedulingConfig) Validate() error {
 	}
 	if s.MaxQueueDepth < 0 {
 		return fmt.Errorf("maxQueueDepth must be >= 0, got %d", s.MaxQueueDepth)
+	}
+	if s.Mode != "" && s.Mode != ModeAbsolute && s.Mode != ModeProportion {
+		return fmt.Errorf("mode must be %q or %q, got %q", ModeAbsolute, ModeProportion, s.Mode)
+	}
+	if s.PriorityIncreasePerSecondWaiting < 0 {
+		return fmt.Errorf("priorityIncreasePerSecondWaiting must be >= 0, got %v", s.PriorityIncreasePerSecondWaiting)
 	}
 	return nil
 }

--- a/internal/config/scheduling_test.go
+++ b/internal/config/scheduling_test.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestScheduling_DisabledWhenAbsent(t *testing.T) {
+	cfg, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  m1:
+    cmd: echo ${PORT}
+`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Scheduling.Enabled() {
+		t.Fatal("scheduling should be disabled when section is absent")
+	}
+}
+
+func TestScheduling_EnabledWithDefaults(t *testing.T) {
+	cfg, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  m1:
+    cmd: echo ${PORT}
+scheduling:
+  priorities:
+    bulk: 1
+    interactive: 10
+`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !cfg.Scheduling.Enabled() {
+		t.Fatal("scheduling should be enabled when section is present")
+	}
+	if got := cfg.Scheduling.MaxWait; got != 30*time.Second {
+		t.Fatalf("default maxWait = %v, want 30s", got)
+	}
+	if got := cfg.Scheduling.PriorityFor("interactive"); got != 10 {
+		t.Fatalf("PriorityFor(interactive) = %d, want 10", got)
+	}
+	if got := cfg.Scheduling.PriorityFor("unknown"); got != defaultSchedulingPriority {
+		t.Fatalf("PriorityFor(unknown) = %d, want default %d", got, defaultSchedulingPriority)
+	}
+}
+
+func TestScheduling_CustomValues(t *testing.T) {
+	cfg, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  m1:
+    cmd: echo ${PORT}
+scheduling:
+  defaultPriority: 7
+  maxWait: 5s
+  maxQueueDepth: 4
+`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Scheduling.DefaultPriority != 7 {
+		t.Fatalf("defaultPriority = %d, want 7", cfg.Scheduling.DefaultPriority)
+	}
+	if cfg.Scheduling.MaxWait != 5*time.Second {
+		t.Fatalf("maxWait = %v, want 5s", cfg.Scheduling.MaxWait)
+	}
+	if cfg.Scheduling.MaxQueueDepth != 4 {
+		t.Fatalf("maxQueueDepth = %d, want 4", cfg.Scheduling.MaxQueueDepth)
+	}
+}
+
+func TestScheduling_RejectsNegativeMaxQueueDepth(t *testing.T) {
+	_, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  m1:
+    cmd: echo ${PORT}
+scheduling:
+  maxQueueDepth: -1
+`))
+	if err == nil || !strings.Contains(err.Error(), "maxQueueDepth") {
+		t.Fatalf("expected maxQueueDepth validation error, got %v", err)
+	}
+}

--- a/internal/config/scheduling_test.go
+++ b/internal/config/scheduling_test.go
@@ -39,11 +39,46 @@ scheduling:
 	if got := cfg.Scheduling.MaxWait; got != 30*time.Second {
 		t.Fatalf("default maxWait = %v, want 30s", got)
 	}
-	if got := cfg.Scheduling.PriorityFor("interactive"); got != 10 {
+	if got := cfg.Scheduling.PriorityFor("interactive", "m1"); got != 10 {
 		t.Fatalf("PriorityFor(interactive) = %d, want 10", got)
 	}
-	if got := cfg.Scheduling.PriorityFor("unknown"); got != defaultSchedulingPriority {
+	if got := cfg.Scheduling.PriorityFor("unknown", "m1"); got != defaultSchedulingPriority {
 		t.Fatalf("PriorityFor(unknown) = %d, want default %d", got, defaultSchedulingPriority)
+	}
+}
+
+func TestScheduling_ModelPriorities(t *testing.T) {
+	cfg, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  chat:
+    cmd: echo ${PORT}
+  embeddings:
+    cmd: echo ${PORT}
+scheduling:
+  defaultPriority: 5
+  priorities:
+    bulk: 1
+  modelPriorities:
+    chat: 10
+    embeddings: 2
+`))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	// Unlisted caller falls to the per-model default.
+	if got := cfg.Scheduling.PriorityFor("", "chat"); got != 10 {
+		t.Fatalf("PriorityFor(anon, chat) = %d, want 10", got)
+	}
+	if got := cfg.Scheduling.PriorityFor("", "embeddings"); got != 2 {
+		t.Fatalf("PriorityFor(anon, embeddings) = %d, want 2", got)
+	}
+	// A model without a per-model entry falls to defaultPriority.
+	if got := cfg.Scheduling.PriorityFor("", "other"); got != 5 {
+		t.Fatalf("PriorityFor(anon, other) = %d, want 5", got)
+	}
+	// An explicitly listed caller wins over the per-model default.
+	if got := cfg.Scheduling.PriorityFor("bulk", "chat"); got != 1 {
+		t.Fatalf("PriorityFor(bulk, chat) = %d, want 1 (caller wins)", got)
 	}
 }
 

--- a/internal/router/loading.go
+++ b/internal/router/loading.go
@@ -26,6 +26,11 @@ func isLoadingPath(path string) bool {
 	return false
 }
 
+// IsLoadingPath reports whether path is one the loading/thinking stream applies
+// to. Exported for the scheduler admission layer, which streams queue position
+// on the same paths while a request waits for a slot.
+func IsLoadingPath(path string) bool { return isLoadingPath(path) }
+
 type loadingWriter struct {
 	hasWritten bool
 	writer     http.ResponseWriter
@@ -56,7 +61,9 @@ type loadingWriter struct {
 	charPerSecond float64
 }
 
-func newLoadingWriter(logger *logmon.Monitor, modelName string, w http.ResponseWriter, req *http.Request) *loadingWriter {
+// newStreamWriter sets up the SSE response and returns a loadingWriter with no
+// banner emitted. Callers add their own headline (loading vs queued).
+func newStreamWriter(logger *logmon.Monitor, modelName string, w http.ResponseWriter, req *http.Request) *loadingWriter {
 	s := &loadingWriter{
 		writer:        w,
 		req:           req,
@@ -72,9 +79,60 @@ func newLoadingWriter(logger *logmon.Monitor, modelName string, w http.ResponseW
 	s.Header().Set("Cache-Control", "no-cache")
 	s.Header().Set("Connection", "keep-alive")
 	s.WriteHeader(http.StatusOK)
+	return s
+}
+
+func newLoadingWriter(logger *logmon.Monitor, modelName string, w http.ResponseWriter, req *http.Request) *loadingWriter {
+	s := newStreamWriter(logger, modelName, w, req)
 	s.sendLine("━━━━━")
 	s.sendLine(fmt.Sprintf("llama-swap loading model: %s", modelName))
 	return s
+}
+
+func newWaitWriter(logger *logmon.Monitor, modelName string, w http.ResponseWriter, req *http.Request) *loadingWriter {
+	s := newStreamWriter(logger, modelName, w, req)
+	s.sendLine("━━━━━")
+	s.sendLine(fmt.Sprintf("llama-swap queued: %s", modelName))
+	return s
+}
+
+// StreamQueueWait streams a "queued" thinking block to a streaming client while
+// it waits for a scheduler slot, updating it with the live queue position read
+// from positions. The stream is created lazily on the first position received —
+// so a request admitted immediately (no position ever sent) emits nothing and
+// the caller's normal response or 429 path is preserved. The returned stop func
+// ends the stream and fences the writer off the ResponseWriter; call it once the
+// wait resolves, before the real handler reclaims the writer.
+func StreamQueueWait(logger *logmon.Monitor, modelName string, w http.ResponseWriter, req *http.Request, positions <-chan int) (stop func()) {
+	ctx, cancel := context.WithCancel(req.Context())
+	done := make(chan struct{})
+	var lw *loadingWriter
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case pos, ok := <-positions:
+				if !ok {
+					return
+				}
+				if lw == nil {
+					lw = newWaitWriter(logger, modelName, w, req)
+					go lw.start(ctx)
+				}
+				lw.setUpdate(fmt.Sprintf("Queue position: #%d", pos))
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return func() {
+		cancel()
+		<-done // pump goroutine has exited; lw is now safe to read
+		if lw != nil {
+			lw.waitForCompletion(1 * time.Second)
+			lw.release()
+		}
+	}
 }
 
 func (s *loadingWriter) setUpdate(msg string) {

--- a/internal/server/activity_caller_test.go
+++ b/internal/server/activity_caller_test.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"gopkg.in/yaml.v3"
+)
+
+func TestMaskCaller(t *testing.T) {
+	cases := map[string]string{
+		"":          "anonymous",
+		"sk-ragtag": "sk-ra…9",
+		"sk-aw3":    "sk-aw…6",
+		"abc":       "abc", // too short to be a usable secret; passthrough
+	}
+	for in, want := range cases {
+		if got := maskCaller(in); got != want {
+			t.Errorf("maskCaller(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestRecordRejection_AppearsInActivity verifies a scheduler 429 lands in the
+// activity log (masked caller, 429 status) so it shows in the trace view.
+// With captures disabled (buffer 0), no capture is stored.
+func TestRecordRejection_AppearsInActivity(t *testing.T) {
+	mm := newMetricsMonitor(logmon.NewWriter(io.Discard), 10, 0)
+	hdrs := map[string]string{"X-RateLimit-Limit": "1"}
+	body := []byte(`{"reason":"queue_full","hint":{"max_concurrency":1}}`)
+	mm.recordRejection("nomic-embed-text", "sk-ragtag", "/v1/embeddings", 429, hdrs, body)
+
+	got := mm.getMetrics()
+	if len(got) != 1 {
+		t.Fatalf("want 1 activity entry, got %d", len(got))
+	}
+	e := got[0]
+	if e.RespStatusCode != 429 {
+		t.Errorf("status = %d, want 429", e.RespStatusCode)
+	}
+	if e.Model != "nomic-embed-text" || e.ReqPath != "/v1/embeddings" {
+		t.Errorf("model/path = %q/%q", e.Model, e.ReqPath)
+	}
+	if e.Caller != "sk-ra…9" {
+		t.Errorf("caller = %q, want masked sk-ra…9", e.Caller)
+	}
+	if e.HasCapture {
+		t.Error("captures disabled (buffer 0): HasCapture should be false")
+	}
+}
+
+// With captures enabled, a 429 stores a hint-only capture (response side only,
+// no request body) retrievable by ID.
+func TestRecordRejection_CapturesHint(t *testing.T) {
+	mm := newMetricsMonitor(logmon.NewWriter(io.Discard), 10, 1) // 1 MB capture buffer
+	hdrs := map[string]string{"X-RateLimit-Limit": "1", "Retry-After": "5"}
+	body := []byte(`{"reason":"queue_full","hint":{"max_concurrency":1}}`)
+	mm.recordRejection("m1", "sk-ragtag", "/v1/embeddings", 429, hdrs, body)
+
+	got := mm.getMetrics()
+	if len(got) != 1 || !got[0].HasCapture {
+		t.Fatalf("expected one entry with HasCapture=true, got %+v", got)
+	}
+	capture := mm.getCaptureByID(got[0].ID)
+	if capture == nil {
+		t.Fatal("capture not retrievable by ID")
+	}
+	if string(capture.RespBody) != string(body) {
+		t.Errorf("capture resp body = %q, want %q", capture.RespBody, body)
+	}
+	if capture.RespHeaders["X-RateLimit-Limit"] != "1" {
+		t.Errorf("capture resp headers missing the hint: %v", capture.RespHeaders)
+	}
+	if len(capture.ReqBody) != 0 {
+		t.Errorf("hint-only capture must omit the request body, got %d bytes", len(capture.ReqBody))
+	}
+}
+
+// nil metricsMonitor must not panic (Server built without New()).
+func TestRecordRejection_NilSafe(t *testing.T) {
+	var mm *metricsMonitor
+	mm.recordRejection("m", "c", "/p", 429, nil, nil) // must not panic
+}
+
+// TestCallerMiddleware_ResolvesPriorityFromBearer closes the seam between the
+// caller middleware and the scheduler: a Bearer key on the request must surface
+// as the caller id in context, which the scheduling config then maps to the
+// caller's configured priority.
+func TestCallerMiddleware_ResolvesPriorityFromBearer(t *testing.T) {
+	cfg := config.Config{}
+	if err := yaml.Unmarshal([]byte("priorities:\n  sk-vip: 9\ndefaultPriority: 3\n"), &cfg.Scheduling); err != nil {
+		t.Fatalf("unmarshal scheduling: %v", err)
+	}
+
+	var gotPriority int
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPriority = cfg.Scheduling.PriorityFor(callerFromContext(r.Context()))
+	})
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer sk-vip")
+	CreateCallerMiddleware()(inner).ServeHTTP(httptest.NewRecorder(), req)
+
+	if gotPriority != 9 {
+		t.Fatalf("Bearer sk-vip resolved to priority %d, want 9", gotPriority)
+	}
+}

--- a/internal/server/activity_caller_test.go
+++ b/internal/server/activity_caller_test.go
@@ -98,7 +98,7 @@ func TestCallerMiddleware_ResolvesPriorityFromBearer(t *testing.T) {
 
 	var gotPriority int
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		gotPriority = cfg.Scheduling.PriorityFor(callerFromContext(r.Context()))
+		gotPriority = cfg.Scheduling.PriorityFor(callerFromContext(r.Context()), "")
 	})
 
 	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)

--- a/internal/server/concurrency.go
+++ b/internal/server/concurrency.go
@@ -119,7 +119,25 @@ func createSchedulingMiddleware(cfg config.Config, sched *scheduler, logger *log
 
 			callerID := callerFromContext(r.Context())
 			priority := cfg.Scheduling.PriorityFor(callerID)
-			a := sched.enqueue(r.Context(), data.ModelID, priority)
+
+			// For streaming chat requests with loading-state enabled, surface the
+			// live queue position in the reasoning ("thinking") stream while the
+			// request waits for a slot — the admission-queue analog of the swap
+			// queue's position display. The stream is created lazily on the first
+			// position, so a request admitted immediately (or rejected at entry,
+			// before it parks) emits nothing and the normal response / 429 path is
+			// preserved.
+			var posCh chan int
+			var stopWait func()
+			if data.Streaming && data.SendLoadingState && router.IsLoadingPath(r.URL.Path) {
+				posCh = make(chan int, 1)
+				stopWait = router.StreamQueueWait(logger, data.ModelID, w, r, posCh)
+			}
+
+			a := sched.enqueue(r.Context(), data.ModelID, priority, posCh)
+			if stopWait != nil {
+				stopWait()
+			}
 			if !a.admitted {
 				if logger != nil {
 					who := callerID

--- a/internal/server/concurrency.go
+++ b/internal/server/concurrency.go
@@ -1,12 +1,17 @@
 package server
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"strconv"
+	"time"
 
 	"golang.org/x/sync/semaphore"
 
 	"github.com/mostlygeek/llama-swap/internal/chain"
 	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/logmon"
 	"github.com/mostlygeek/llama-swap/internal/router"
 )
 
@@ -15,12 +20,52 @@ import (
 // proxy.Process default.
 const defaultConcurrencyLimit = 10
 
+type callerCtxKey struct{}
+
+// CreateCallerMiddleware captures the caller id (the presented API key) into the
+// request context before the auth middleware strips the auth headers. The
+// scheduler uses it to look up the caller's priority. It is a no-op for behavior
+// when scheduling is disabled; it only annotates the context.
+func CreateCallerMiddleware() chain.Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// extractAPIKey (from auth.go) is read-only; auth strips the headers
+			// downstream. Same key the auth middleware validates against.
+			if id := extractAPIKey(r); id != "" {
+				r = r.WithContext(contextWithCaller(r.Context(), id))
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func contextWithCaller(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, callerCtxKey{}, id)
+}
+
+func callerFromContext(ctx context.Context) string {
+	id, _ := ctx.Value(callerCtxKey{}).(string)
+	return id
+}
+
 // CreateConcurrencyMiddleware returns middleware that limits simultaneous
-// model-dispatched requests per model. Each model gets a semaphore sized to
-// its concurrencyLimit (or defaultConcurrencyLimit). A request that cannot
-// immediately acquire a slot is rejected with 429. Models without a local
-// config entry (e.g. peer-routed models) are not limited.
-func CreateConcurrencyMiddleware(cfg config.Config) chain.Middleware {
+// model-dispatched requests per model.
+//
+// When config.Scheduling is enabled it uses the supplied priority scheduler:
+// requests that cannot immediately acquire a slot are queued and admitted by
+// caller priority, and rejected with 429 + Retry-After only when the queue is
+// full or the wait would exceed maxWait.
+//
+// When scheduling is disabled it preserves the legacy behavior: each model gets
+// a semaphore sized to its concurrencyLimit (or defaultConcurrencyLimit) and a
+// request that cannot immediately acquire a slot is rejected with a bare 429.
+//
+// Models without a local config entry (e.g. peer-routed models) are not limited.
+func CreateConcurrencyMiddleware(cfg config.Config, sched *scheduler, logger *logmon.Monitor) chain.Middleware {
+	if cfg.Scheduling.Enabled() && sched != nil {
+		return createSchedulingMiddleware(cfg, sched, logger)
+	}
+
 	semaphores := make(map[string]*semaphore.Weighted, len(cfg.Models))
 	for id, mc := range cfg.Models {
 		limit := defaultConcurrencyLimit
@@ -54,4 +99,92 @@ func CreateConcurrencyMiddleware(cfg config.Config) chain.Middleware {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// createSchedulingMiddleware is the priority-aware admission path.
+func createSchedulingMiddleware(cfg config.Config, sched *scheduler, logger *logmon.Monitor) chain.Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			data, err := router.FetchContext(r, cfg)
+			if err != nil {
+				router.SendError(w, r, router.ErrNoModelInContext)
+				return
+			}
+
+			q := sched.queueFor(data.ModelID)
+			if q == nil {
+				next.ServeHTTP(w, r) // unmanaged (peer) model
+				return
+			}
+
+			callerID := callerFromContext(r.Context())
+			priority := cfg.Scheduling.PriorityFor(callerID)
+			a := sched.enqueue(r.Context(), data.ModelID, priority)
+			if !a.admitted {
+				if logger != nil {
+					who := callerID
+					if who == "" {
+						who = "(anonymous)"
+					}
+					// A caller that fans out wider than a model's concurrency
+					// queues behind itself; once the queue/wait cap trips it
+					// 429s on its own traffic. Surface the numbers so the
+					// "self-interference" pattern is visible in the log.
+					logger.Warnf("scheduler 429 model=%s caller=%s reason=%s concurrency=%d inflight=%d waiting=%d retry_after=%ds",
+						data.ModelID, who, a.reason, a.concurrency, a.inflight, a.waiting, retryAfterSecs(a.retryAfter))
+				}
+				headers, body := backpressureResponse(data.ModelID, a)
+				writeBackpressure(w, headers, body)
+				return
+			}
+
+			start := time.Now()
+			defer func() {
+				a.release()
+				q.observe(time.Since(start))
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// retryAfterSecs renders a duration as whole seconds (RFC 7231 delta-seconds),
+// floored at 1.
+func retryAfterSecs(d time.Duration) int {
+	secs := int(d.Round(time.Second) / time.Second)
+	if secs < 1 {
+		secs = 1
+	}
+	return secs
+}
+
+// backpressureResponse builds the 429's hint headers and JSON body once, so the
+// same content can be both written to the client and stored as a capture.
+//
+// hint.max_concurrency is the actionable number: cap your client's parallelism
+// (or batch) at this and you stop competing with yourself. The X-RateLimit-*
+// headers carry the same numbers for header-only clients.
+func backpressureResponse(model string, a admission) (headers map[string]string, body []byte) {
+	secs := retryAfterSecs(a.retryAfter)
+	headers = map[string]string{
+		"Content-Type":         "application/json",
+		"Retry-After":          strconv.Itoa(secs),
+		"X-RateLimit-Limit":    strconv.Itoa(a.concurrency), // model's hard slot count
+		"X-RateLimit-Inflight": strconv.Itoa(a.inflight),    // slots in use
+		"X-RateLimit-Waiting":  strconv.Itoa(a.waiting),     // already queued
+	}
+	body = []byte(fmt.Sprintf(
+		`{"error":"Too many requests","reason":%q,"retry_after":%d,"model":%q,"hint":{"max_concurrency":%d,"inflight":%d,"waiting":%d}}`,
+		a.reason, secs, model, a.concurrency, a.inflight, a.waiting))
+	return headers, body
+}
+
+// writeBackpressure emits a 429 carrying the model's concurrency so a client
+// can right-size its executor.
+func writeBackpressure(w http.ResponseWriter, headers map[string]string, body []byte) {
+	for k, v := range headers {
+		w.Header().Set(k, v)
+	}
+	w.WriteHeader(http.StatusTooManyRequests)
+	w.Write(body)
 }

--- a/internal/server/concurrency.go
+++ b/internal/server/concurrency.go
@@ -61,9 +61,9 @@ func callerFromContext(ctx context.Context) string {
 // request that cannot immediately acquire a slot is rejected with a bare 429.
 //
 // Models without a local config entry (e.g. peer-routed models) are not limited.
-func CreateConcurrencyMiddleware(cfg config.Config, sched *scheduler, logger *logmon.Monitor) chain.Middleware {
+func CreateConcurrencyMiddleware(cfg config.Config, sched *scheduler, logger *logmon.Monitor, mm *metricsMonitor) chain.Middleware {
 	if cfg.Scheduling.Enabled() && sched != nil {
-		return createSchedulingMiddleware(cfg, sched, logger)
+		return createSchedulingMiddleware(cfg, sched, logger, mm)
 	}
 
 	semaphores := make(map[string]*semaphore.Weighted, len(cfg.Models))
@@ -102,7 +102,7 @@ func CreateConcurrencyMiddleware(cfg config.Config, sched *scheduler, logger *lo
 }
 
 // createSchedulingMiddleware is the priority-aware admission path.
-func createSchedulingMiddleware(cfg config.Config, sched *scheduler, logger *logmon.Monitor) chain.Middleware {
+func createSchedulingMiddleware(cfg config.Config, sched *scheduler, logger *logmon.Monitor, mm *metricsMonitor) chain.Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			data, err := router.FetchContext(r, cfg)
@@ -133,7 +133,12 @@ func createSchedulingMiddleware(cfg config.Config, sched *scheduler, logger *log
 					logger.Warnf("scheduler 429 model=%s caller=%s reason=%s concurrency=%d inflight=%d waiting=%d retry_after=%ds",
 						data.ModelID, who, a.reason, a.concurrency, a.inflight, a.waiting, retryAfterSecs(a.retryAfter))
 				}
+				// Surface the rejection in the activity/trace stream too — a
+				// scheduler 429 never reaches the metrics middleware, so this is
+				// the only point it can be recorded (no double-count). The hint
+				// headers+body double as the capture's response side.
 				headers, body := backpressureResponse(data.ModelID, a)
+				mm.recordRejection(data.ModelID, callerID, r.URL.Path, http.StatusTooManyRequests, headers, body)
 				writeBackpressure(w, headers, body)
 				return
 			}

--- a/internal/server/concurrency.go
+++ b/internal/server/concurrency.go
@@ -134,7 +134,7 @@ func createSchedulingMiddleware(cfg config.Config, sched *scheduler, logger *log
 				stopWait = router.StreamQueueWait(logger, data.ModelID, w, r, posCh)
 			}
 
-			a := sched.enqueue(r.Context(), data.ModelID, priority, posCh)
+			a := sched.enqueue(r.Context(), data.ModelID, callerID, priority, posCh)
 			if stopWait != nil {
 				stopWait()
 			}

--- a/internal/server/concurrency.go
+++ b/internal/server/concurrency.go
@@ -118,7 +118,7 @@ func createSchedulingMiddleware(cfg config.Config, sched *scheduler, logger *log
 			}
 
 			callerID := callerFromContext(r.Context())
-			priority := cfg.Scheduling.PriorityFor(callerID)
+			priority := cfg.Scheduling.PriorityFor(callerID, data.ModelID)
 
 			// For streaming chat requests with loading-state enabled, surface the
 			// live queue position in the reasoning ("thinking") stream while the

--- a/internal/server/concurrency_test.go
+++ b/internal/server/concurrency_test.go
@@ -3,8 +3,10 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/router"
@@ -30,7 +32,7 @@ func TestServer_ConcurrencyMiddleware_RejectsOverLimit(t *testing.T) {
 		<-release
 		w.WriteHeader(http.StatusOK)
 	})
-	h := CreateConcurrencyMiddleware(cfg)(final)
+	h := CreateConcurrencyMiddleware(cfg, nil, nil)(final)
 
 	// First request occupies the only slot.
 	done := make(chan struct{})
@@ -65,11 +67,45 @@ func TestServer_ConcurrencyMiddleware_UnconfiguredModelPassesThrough(t *testing.
 		called++
 		w.WriteHeader(http.StatusOK)
 	})
-	h := CreateConcurrencyMiddleware(cfg)(final)
+	h := CreateConcurrencyMiddleware(cfg, nil, nil)(final)
 
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, concurrencyTestReq("peer-model"))
 	if w.Code != http.StatusOK || called != 1 {
 		t.Fatalf("unconfigured model: status=%d called=%d, want 200/1", w.Code, called)
+	}
+}
+
+// TestWriteBackpressure_EmitsConcurrencyHint verifies the 429 carries the
+// model's concurrency on both the body and X-RateLimit-* headers so a client
+// can size its executor.
+func TestWriteBackpressure_EmitsConcurrencyHint(t *testing.T) {
+	rec := httptest.NewRecorder()
+	headers, body := backpressureResponse("embed-model", admission{
+		retryAfter:  2 * time.Second,
+		reason:      "queue_full",
+		concurrency: 1,
+		inflight:    1,
+		waiting:     8,
+	})
+	writeBackpressure(rec, headers, body)
+
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", rec.Code)
+	}
+	if got := rec.Header().Get("X-RateLimit-Limit"); got != "1" {
+		t.Errorf("X-RateLimit-Limit = %q, want 1", got)
+	}
+	if got := rec.Header().Get("X-RateLimit-Waiting"); got != "8" {
+		t.Errorf("X-RateLimit-Waiting = %q, want 8", got)
+	}
+	if got := rec.Header().Get("Retry-After"); got != "2" {
+		t.Errorf("Retry-After = %q, want 2", got)
+	}
+	gotBody := rec.Body.String()
+	for _, want := range []string{`"max_concurrency":1`, `"reason":"queue_full"`, `"model":"embed-model"`, `"waiting":8`} {
+		if !strings.Contains(gotBody, want) {
+			t.Errorf("body missing %q; got %s", want, gotBody)
+		}
 	}
 }

--- a/internal/server/concurrency_test.go
+++ b/internal/server/concurrency_test.go
@@ -32,7 +32,7 @@ func TestServer_ConcurrencyMiddleware_RejectsOverLimit(t *testing.T) {
 		<-release
 		w.WriteHeader(http.StatusOK)
 	})
-	h := CreateConcurrencyMiddleware(cfg, nil, nil)(final)
+	h := CreateConcurrencyMiddleware(cfg, nil, nil, nil)(final)
 
 	// First request occupies the only slot.
 	done := make(chan struct{})
@@ -67,7 +67,7 @@ func TestServer_ConcurrencyMiddleware_UnconfiguredModelPassesThrough(t *testing.
 		called++
 		w.WriteHeader(http.StatusOK)
 	})
-	h := CreateConcurrencyMiddleware(cfg, nil, nil)(final)
+	h := CreateConcurrencyMiddleware(cfg, nil, nil, nil)(final)
 
 	w := httptest.NewRecorder()
 	h.ServeHTTP(w, concurrencyTestReq("peer-model"))

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -31,9 +31,12 @@ type TokenMetrics struct {
 
 // ActivityLogEntry represents parsed token statistics from llama-server logs.
 type ActivityLogEntry struct {
-	ID              int          `json:"id"`
-	Timestamp       time.Time    `json:"timestamp"`
-	Model           string       `json:"model"`
+	ID        int       `json:"id"`
+	Timestamp time.Time `json:"timestamp"`
+	Model     string    `json:"model"`
+	// Caller is the masked API key that made the request ("anonymous"
+	// for unkeyed traffic). Masked, never the raw secret — see maskCaller.
+	Caller          string       `json:"caller"`
 	ReqPath         string       `json:"req_path"`
 	RespContentType string       `json:"resp_content_type"`
 	RespStatusCode  int          `json:"resp_status_code"`
@@ -119,14 +122,65 @@ func (mp *metricsMonitor) getMetricsJSON() ([]byte, error) {
 	return json.Marshal(mp.getMetrics())
 }
 
+// maskCaller renders an API key for display without exposing the secret:
+// "anonymous" for unkeyed traffic, otherwise a readable prefix plus the
+// key's length (e.g. "sk-ra…9") so distinct callers stay distinguishable
+// while the full key never reaches the UI or the in-memory log ring.
+func maskCaller(caller string) string {
+	if caller == "" {
+		return "anonymous"
+	}
+	const prefix = 5
+	if len(caller) <= prefix {
+		return caller // already short enough to not be a usable secret
+	}
+	return fmt.Sprintf("%s…%d", caller[:prefix], len(caller))
+}
+
+// recordRejection stores/emits an activity entry for a request the scheduler
+// rejected (429) before it could reach the normal record path. Keeps rejected
+// traffic visible in the activity/trace stream rather than silently dropped.
+//
+// When captures are enabled it also stores a hint-only capture: the rejection's
+// response headers + JSON body (the X-RateLimit-* / max_concurrency hint), so
+// clicking the 429 row in the activity pane shows WHY it was shed. The request
+// body is intentionally omitted — under a 429 storm, buffering every shed
+// prompt would amplify memory exactly when load is highest.
+func (mp *metricsMonitor) recordRejection(modelID, caller, reqPath string, status int, respHeaders map[string]string, respBody []byte) {
+	if mp == nil {
+		return
+	}
+	tm := ActivityLogEntry{
+		Timestamp:      time.Now(),
+		Model:          modelID,
+		Caller:         maskCaller(caller),
+		ReqPath:        reqPath,
+		RespStatusCode: status,
+	}
+	tm.ID = mp.queueMetrics(tm)
+	if mp.enableCaptures {
+		capture := ReqRespCapture{
+			ID:          tm.ID,
+			ReqPath:     reqPath,
+			RespHeaders: respHeaders,
+			RespBody:    respBody,
+		}
+		if mp.addCapture(capture) {
+			tm.HasCapture = true
+		}
+	}
+	mp.emitMetric(tm)
+}
+
 // record parses a completed response body and stores/emits an activity entry.
 // When captures are enabled, a zstd+CBOR capture is stored for successful
 // requests, with cf controlling which request/response parts are retained.
 // reqBody and reqHeaders are the request data buffered before dispatch.
-func (mp *metricsMonitor) record(modelID string, r *http.Request, recorder *responseBodyCopier, cf captureFields, reqBody []byte, reqHeaders map[string]string) {
+func (mp *metricsMonitor) record(modelID, caller string, r *http.Request, recorder *responseBodyCopier, cf captureFields, reqBody []byte, reqHeaders map[string]string) {
 	tm := ActivityLogEntry{
 		Timestamp:       time.Now(),
 		Model:           modelID,
+		Caller:          maskCaller(caller),
 		ReqPath:         r.URL.Path,
 		RespContentType: recorder.Header().Get("Content-Type"),
 		RespStatusCode:  recorder.Status(),

--- a/internal/server/metrics_middleware.go
+++ b/internal/server/metrics_middleware.go
@@ -56,7 +56,7 @@ func CreateMetricsMiddleware(mm *metricsMonitor, cfg config.Config) chain.Middle
 
 			recorder := newBodyCopier(w)
 			next.ServeHTTP(recorder, r)
-			mm.record(data.ModelID, r, recorder, cf, reqBody, reqHeaders)
+			mm.record(data.ModelID, callerFromContext(r.Context()), r, recorder, cf, reqBody, reqHeaders)
 		})
 	}
 }

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"container/heap"
 	"context"
 	"sort"
 	"sync"
@@ -10,10 +9,17 @@ import (
 	"github.com/mostlygeek/llama-swap/internal/config"
 )
 
-// scheduler provides priority-aware fair admission in front of each model's
+// scheduler provides configurable admission in front of each model's
 // concurrency limit. One modelQueue per model bounds in-flight requests to the
-// model's concurrencyLimit and, under contention, admits the highest-priority
-// waiter when a slot frees. A request is rejected (429 + Retry-After) only when
+// model's concurrencyLimit and, under contention, admits a waiter when a slot
+// frees according to the configured mode:
+//
+//   - absolute:   highest effective priority first (FIFO within a priority)
+//   - proportion: weighted fair queuing — callers admitted in proportion to
+//     their priority used as a weight
+//
+// In either mode, PriorityIncreasePerSecondWaiting ages a waiter's effective
+// priority up over time. A request is rejected (429 + Retry-After) only when
 // the queue is full or its estimated wait exceeds maxWait.
 //
 // The scheduler is only constructed when config.Scheduling is enabled; the
@@ -39,7 +45,10 @@ func newScheduler(cfg config.Config) *scheduler {
 		if mc.ConcurrencyLimit > 0 {
 			limit = mc.ConcurrencyLimit
 		}
-		queues[id] = newModelQueue(limit)
+		q := newModelQueue(limit)
+		q.mode = cfg.Scheduling.ResolvedMode()
+		q.agingRate = cfg.Scheduling.PriorityIncreasePerSecondWaiting
+		queues[id] = q
 	}
 	return &scheduler{cfg: cfg.Scheduling, queues: queues}
 }
@@ -67,8 +76,8 @@ type admission struct {
 }
 
 // enqueue admits the request immediately, blocks until a slot frees, or rejects
-// it with a Retry-After estimate. priority is the caller's configured priority
-// (higher served first).
+// it with a Retry-After estimate. caller identifies the weighting class
+// (proportion mode); priority is the request's base priority/weight.
 //
 // posCh, when non-nil, receives the request's live 1-indexed queue position
 // while it waits — the scheduler's analog of the swap queue's position display.
@@ -77,46 +86,58 @@ type admission struct {
 // waits until admitted or the client disconnects rather than being 429'd
 // mid-stream. The entry-time rejections (queue full, hopeless estimate) still
 // apply, before any position is sent.
-func (s *scheduler) enqueue(ctx context.Context, modelID string, priority int, posCh chan int) admission {
+func (s *scheduler) enqueue(ctx context.Context, modelID, caller string, priority int, posCh chan int) admission {
 	q := s.queues[modelID]
 	if q == nil {
 		// Unmanaged model: admit without limiting, matching the legacy
 		// middleware's pass-through for peer models.
 		return admission{admitted: true, release: func() {}}
 	}
-	return q.acquire(ctx, priority, s.cfg.MaxWait, s.cfg.MaxQueueDepth, posCh)
+	return q.acquire(ctx, caller, priority, s.cfg.MaxWait, s.cfg.MaxQueueDepth, posCh)
 }
 
-// modelQueue is a bounded priority admission queue for a single model.
+// modelQueue is a bounded admission queue for a single model.
 type modelQueue struct {
 	concurrency int
+	mode        config.SchedulingMode
+	agingRate   float64          // effective priority gained per second waited
+	now         func() time.Time // injectable clock (tests)
 
 	mu       sync.Mutex
 	inflight int
-	waiters  waiterHeap
+	waiters  []*waiter
 	seq      uint64        // tie-breaker: FIFO within equal priority
 	ewma     time.Duration // measured service time, exponentially weighted
+
+	// proportion mode (weighted fair queuing) virtual-time state:
+	vtime       float64            // global virtual time = start of last admit
+	classFinish map[string]float64 // per-caller virtual finish time
 }
 
 func newModelQueue(concurrency int) *modelQueue {
-	return &modelQueue{concurrency: concurrency}
+	return &modelQueue{
+		concurrency: concurrency,
+		mode:        config.ModeAbsolute,
+		now:         time.Now,
+		classFinish: map[string]float64{},
+	}
 }
 
 // waiter is one request parked awaiting a slot.
 type waiter struct {
-	priority int
-	seq      uint64
-	ready    chan struct{} // closed when admitted
-	index    int           // heap index, -1 once removed
-	canceled bool
-	posCh    chan int // non-nil to receive live position updates; nil otherwise
+	caller     string
+	priority   int
+	seq        uint64
+	enqueuedAt time.Time
+	ready      chan struct{} // closed when admitted
+	posCh      chan int      // non-nil to receive live position updates
 }
 
-func (q *modelQueue) acquire(ctx context.Context, priority int, maxWait time.Duration, maxDepth int, posCh chan int) admission {
+func (q *modelQueue) acquire(ctx context.Context, caller string, priority int, maxWait time.Duration, maxDepth int, posCh chan int) admission {
 	q.mu.Lock()
 
 	// Fast path: a slot is free and nobody is waiting.
-	if q.inflight < q.concurrency && q.waiters.Len() == 0 {
+	if q.inflight < q.concurrency && len(q.waiters) == 0 {
 		q.inflight++
 		q.mu.Unlock()
 		return admission{admitted: true, release: q.release}
@@ -124,28 +145,28 @@ func (q *modelQueue) acquire(ctx context.Context, priority int, maxWait time.Dur
 
 	// Estimate the wait: requests ahead (queued + the overflow beyond capacity)
 	// divided by how many drain per service interval.
-	ahead := q.waiters.Len() + (q.inflight - q.concurrency) + 1
+	ahead := len(q.waiters) + (q.inflight - q.concurrency) + 1
 	if ahead < 1 {
 		ahead = 1
 	}
 	est := q.estimateWait(ahead)
 
-	if maxDepth > 0 && q.waiters.Len() >= maxDepth {
+	if maxDepth > 0 && len(q.waiters) >= maxDepth {
 		rej := admission{retryAfter: est, reason: "queue_full",
-			concurrency: q.concurrency, inflight: q.inflight, waiting: q.waiters.Len()}
+			concurrency: q.concurrency, inflight: q.inflight, waiting: len(q.waiters)}
 		q.mu.Unlock()
 		return rej
 	}
 	if maxWait > 0 && est > maxWait {
 		rej := admission{retryAfter: est, reason: "max_wait",
-			concurrency: q.concurrency, inflight: q.inflight, waiting: q.waiters.Len()}
+			concurrency: q.concurrency, inflight: q.inflight, waiting: len(q.waiters)}
 		q.mu.Unlock()
 		return rej
 	}
 
-	w := &waiter{priority: priority, seq: q.seq, ready: make(chan struct{}), posCh: posCh}
+	w := &waiter{caller: caller, priority: priority, seq: q.seq, enqueuedAt: q.now(), ready: make(chan struct{}), posCh: posCh}
 	q.seq++
-	heap.Push(&q.waiters, w)
+	q.waiters = append(q.waiters, w)
 	q.broadcastPositionsLocked()
 	q.mu.Unlock()
 
@@ -174,7 +195,7 @@ func (q *modelQueue) acquire(ctx context.Context, priority int, maxWait time.Dur
 			a.reason = "max_wait"
 			a.concurrency = q.concurrency
 			a.inflight = q.inflight
-			a.waiting = q.waiters.Len()
+			a.waiting = len(q.waiters)
 			q.mu.Unlock()
 		}
 		return a
@@ -182,69 +203,200 @@ func (q *modelQueue) acquire(ctx context.Context, priority int, maxWait time.Dur
 }
 
 // abandon removes a waiter that gave up (context canceled or timed out). If it
-// was admitted in the race between firing and locking, it returns an admitted
-// admission so the caller still releases the slot.
+// was already admitted by tryAdmit (so no longer in the queue), it returns an
+// admitted admission so the caller still releases the slot.
 func (q *modelQueue) abandon(w *waiter) admission {
 	q.mu.Lock()
 	defer q.mu.Unlock()
-	if w.index >= 0 {
-		heap.Remove(&q.waiters, w.index)
+	if q.removeWaiterLocked(w) {
 		q.broadcastPositionsLocked()
+		q.resetIfIdleLocked()
 		return admission{retryAfter: q.estimateWait(1)}
 	}
-	// Already admitted (ready closed) but we lost the select race; honor the slot.
+	// Not in the queue: tryAdmit already pulled it (ready is closed). Honor the
+	// slot so inflight stays balanced.
 	select {
 	case <-w.ready:
 		return admission{admitted: true, release: q.release}
 	default:
-		w.canceled = true
 		return admission{retryAfter: q.estimateWait(1)}
 	}
 }
 
-// release returns a slot, then admits the next highest-priority waiter if any.
+// removeWaiterLocked drops w from the queue by identity, returning whether it
+// was present.
+func (q *modelQueue) removeWaiterLocked(w *waiter) bool {
+	for i, x := range q.waiters {
+		if x == w {
+			q.waiters = append(q.waiters[:i], q.waiters[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+// release returns a slot, then admits the next waiter(s) if any.
 func (q *modelQueue) release() {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.inflight--
 	q.tryAdmitLocked()
+	q.resetIfIdleLocked()
 }
 
 func (q *modelQueue) tryAdmitLocked() {
 	admitted := false
-	for q.inflight < q.concurrency && q.waiters.Len() > 0 {
-		w := heap.Pop(&q.waiters).(*waiter)
-		if w.canceled {
-			continue
-		}
+	for q.inflight < q.concurrency && len(q.waiters) > 0 {
+		order := q.admissionOrderLocked(q.now())
+		w := order[0]
+		q.commitLocked(w, q.now())
+		q.removeWaiterLocked(w)
 		q.inflight++
 		close(w.ready)
 		admitted = true
 	}
 	if admitted {
-		// Front of the queue moved up; refresh everyone still waiting.
+		// The front of the queue moved; refresh everyone still waiting.
 		q.broadcastPositionsLocked()
 	}
 }
 
-// broadcastPositionsLocked sends every waiter that asked for live updates its
-// current 1-indexed position in service order (priority desc, then FIFO).
-// Callers hold q.mu. Sends are non-blocking and latest-wins so a slow consumer
-// never stalls the scheduler.
-func (q *modelQueue) broadcastPositionsLocked() {
-	n := q.waiters.Len()
-	if n == 0 {
-		return
+// resetIfIdleLocked clears the weighted-fair-queuing virtual clock once the
+// model is fully idle, so shares are accounted within a contention episode and
+// the float counters can't drift without bound.
+func (q *modelQueue) resetIfIdleLocked() {
+	if q.inflight == 0 && len(q.waiters) == 0 {
+		q.vtime = 0
+		if len(q.classFinish) > 0 {
+			q.classFinish = map[string]float64{}
+		}
 	}
-	ordered := make([]*waiter, n)
+}
+
+// effective returns a waiter's priority/weight with aging applied.
+func (q *modelQueue) effective(w *waiter, now time.Time) float64 {
+	p := float64(w.priority)
+	if q.agingRate > 0 {
+		p += q.agingRate * now.Sub(w.enqueuedAt).Seconds()
+	}
+	return p
+}
+
+// admissionOrderLocked returns the current waiters in the order they would be
+// admitted. It does not mutate scheduler state, so it drives both the next-admit
+// decision and the position display (keeping them consistent).
+func (q *modelQueue) admissionOrderLocked(now time.Time) []*waiter {
+	ordered := make([]*waiter, len(q.waiters))
 	copy(ordered, q.waiters)
-	sort.Slice(ordered, func(i, j int) bool {
-		if ordered[i].priority != ordered[j].priority {
-			return ordered[i].priority > ordered[j].priority
+	if q.mode == config.ModeProportion {
+		return q.proportionOrder(ordered, now)
+	}
+	// absolute: highest effective priority first, FIFO within a priority.
+	sort.SliceStable(ordered, func(i, j int) bool {
+		ei, ej := q.effective(ordered[i], now), q.effective(ordered[j], now)
+		if ei != ej {
+			return ei > ej
 		}
 		return ordered[i].seq < ordered[j].seq
 	})
-	for i, w := range ordered {
+	return ordered
+}
+
+// proportionOrder simulates weighted-fair-queuing admission over the given
+// waiters on a clone of the virtual clock, returning admission order. Each
+// caller's next request gets a virtual start of max(its finish, global vtime);
+// the smallest start is served next and the caller's finish advances by
+// 1/weight, so higher-weight callers are served proportionally more often.
+func (q *modelQueue) proportionOrder(ws []*waiter, now time.Time) []*waiter {
+	// Stable per-caller FIFO order.
+	sort.SliceStable(ws, func(i, j int) bool { return ws[i].seq < ws[j].seq })
+
+	finish := make(map[string]float64, len(q.classFinish))
+	for k, v := range q.classFinish {
+		finish[k] = v
+	}
+	vtime := q.vtime
+
+	heads := map[string]int{} // caller -> index of next unserved request in ws
+	remaining := len(ws)
+	order := make([]*waiter, 0, len(ws))
+	for remaining > 0 {
+		var pick *waiter
+		var pickStart float64
+		for i, w := range ws {
+			if w == nil {
+				continue
+			}
+			if idx, seen := heads[w.caller]; seen && idx != i {
+				continue // not this caller's current head
+			}
+			start := finish[w.caller]
+			if start < vtime {
+				start = vtime
+			}
+			if pick == nil || start < pickStart || (start == pickStart && w.seq < pick.seq) {
+				pick, pickStart = w, start
+			}
+		}
+		// Serve pick: advance its caller's virtual finish and the global clock.
+		weight := q.effective(pick, now)
+		if weight < 1 {
+			weight = 1
+		}
+		vtime = pickStart
+		finish[pick.caller] = pickStart + 1.0/weight
+		order = append(order, pick)
+		// Remove pick from ws and advance the caller's head.
+		for i := range ws {
+			if ws[i] == pick {
+				ws[i] = nil
+				break
+			}
+		}
+		next := -1
+		for i, w := range ws {
+			if w != nil && w.caller == pick.caller {
+				next = i
+				break
+			}
+		}
+		if next >= 0 {
+			heads[pick.caller] = next
+		} else {
+			delete(heads, pick.caller)
+		}
+		remaining--
+	}
+	return order
+}
+
+// commitLocked applies the real virtual-clock side effect of admitting w in
+// proportion mode (no-op in absolute mode). It mirrors the first step of
+// proportionOrder so the display and the actual admission agree.
+func (q *modelQueue) commitLocked(w *waiter, now time.Time) {
+	if q.mode != config.ModeProportion {
+		return
+	}
+	start := q.classFinish[w.caller]
+	if start < q.vtime {
+		start = q.vtime
+	}
+	weight := q.effective(w, now)
+	if weight < 1 {
+		weight = 1
+	}
+	q.vtime = start
+	q.classFinish[w.caller] = start + 1.0/weight
+}
+
+// broadcastPositionsLocked sends every waiter that asked for live updates its
+// current 1-indexed position in admission order. Callers hold q.mu. Sends are
+// non-blocking and latest-wins so a slow consumer never stalls the scheduler.
+func (q *modelQueue) broadcastPositionsLocked() {
+	if len(q.waiters) == 0 {
+		return
+	}
+	for i, w := range q.admissionOrderLocked(q.now()) {
 		if w.posCh != nil {
 			sendPosition(w.posCh, i+1)
 		}
@@ -294,34 +446,4 @@ func (q *modelQueue) estimateWait(ahead int) time.Duration {
 		batches = 1
 	}
 	return ewma * time.Duration(batches)
-}
-
-// waiterHeap orders waiters by priority (higher first), then seq (FIFO).
-type waiterHeap []*waiter
-
-func (h waiterHeap) Len() int { return len(h) }
-func (h waiterHeap) Less(i, j int) bool {
-	if h[i].priority != h[j].priority {
-		return h[i].priority > h[j].priority
-	}
-	return h[i].seq < h[j].seq
-}
-func (h waiterHeap) Swap(i, j int) {
-	h[i], h[j] = h[j], h[i]
-	h[i].index = i
-	h[j].index = j
-}
-func (h *waiterHeap) Push(x any) {
-	w := x.(*waiter)
-	w.index = len(*h)
-	*h = append(*h, w)
-}
-func (h *waiterHeap) Pop() any {
-	old := *h
-	n := len(old)
-	w := old[n-1]
-	old[n-1] = nil
-	w.index = -1
-	*h = old[:n-1]
-	return w
 }

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -1,0 +1,264 @@
+package server
+
+import (
+	"container/heap"
+	"context"
+	"sync"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+)
+
+// scheduler provides priority-aware fair admission in front of each model's
+// concurrency limit. One modelQueue per model bounds in-flight requests to the
+// model's concurrencyLimit and, under contention, admits the highest-priority
+// waiter when a slot frees. A request is rejected (429 + Retry-After) only when
+// the queue is full or its estimated wait exceeds maxWait.
+//
+// The scheduler is only constructed when config.Scheduling is enabled; the
+// middleware falls back to the legacy semaphore otherwise.
+type scheduler struct {
+	cfg    config.SchedulingConfig
+	queues map[string]*modelQueue
+}
+
+// newSchedulerIfEnabled builds a scheduler only when config.Scheduling is
+// enabled; otherwise it returns nil and the middleware uses the legacy path.
+func newSchedulerIfEnabled(cfg config.Config) *scheduler {
+	if !cfg.Scheduling.Enabled() {
+		return nil
+	}
+	return newScheduler(cfg)
+}
+
+func newScheduler(cfg config.Config) *scheduler {
+	queues := make(map[string]*modelQueue, len(cfg.Models))
+	for id, mc := range cfg.Models {
+		limit := defaultConcurrencyLimit
+		if mc.ConcurrencyLimit > 0 {
+			limit = mc.ConcurrencyLimit
+		}
+		queues[id] = newModelQueue(limit)
+	}
+	return &scheduler{cfg: cfg.Scheduling, queues: queues}
+}
+
+// queueFor returns the queue for a model, or nil for models the scheduler does
+// not manage (e.g. peer-routed models without a local config entry).
+func (s *scheduler) queueFor(modelID string) *modelQueue {
+	return s.queues[modelID]
+}
+
+// admission is returned by enqueue. When admitted is true the caller holds a
+// slot and MUST call release. When admitted is false the request was rejected
+// and retryAfter carries the suggested backoff; the hint fields describe the
+// model's capacity so the client can right-size its own executor.
+type admission struct {
+	admitted   bool
+	retryAfter time.Duration
+	release    func()
+
+	// Populated on rejection (admitted == false):
+	reason      string // "queue_full" or "max_wait"
+	concurrency int    // the model's hard slot count — the client's parallelism ceiling
+	inflight    int    // slots in use at reject time
+	waiting     int    // requests already queued at reject time
+}
+
+// enqueue admits the request immediately, blocks until a slot frees, or rejects
+// it with a Retry-After estimate. priority is the caller's configured priority
+// (higher served first).
+func (s *scheduler) enqueue(ctx context.Context, modelID string, priority int) admission {
+	q := s.queues[modelID]
+	if q == nil {
+		// Unmanaged model: admit without limiting, matching the legacy
+		// middleware's pass-through for peer models.
+		return admission{admitted: true, release: func() {}}
+	}
+	return q.acquire(ctx, priority, s.cfg.MaxWait, s.cfg.MaxQueueDepth)
+}
+
+// modelQueue is a bounded priority admission queue for a single model.
+type modelQueue struct {
+	concurrency int
+
+	mu       sync.Mutex
+	inflight int
+	waiters  waiterHeap
+	seq      uint64        // tie-breaker: FIFO within equal priority
+	ewma     time.Duration // measured service time, exponentially weighted
+}
+
+func newModelQueue(concurrency int) *modelQueue {
+	return &modelQueue{concurrency: concurrency}
+}
+
+// waiter is one request parked awaiting a slot.
+type waiter struct {
+	priority int
+	seq      uint64
+	ready    chan struct{} // closed when admitted
+	index    int           // heap index, -1 once removed
+	canceled bool
+}
+
+func (q *modelQueue) acquire(ctx context.Context, priority int, maxWait time.Duration, maxDepth int) admission {
+	q.mu.Lock()
+
+	// Fast path: a slot is free and nobody is waiting.
+	if q.inflight < q.concurrency && q.waiters.Len() == 0 {
+		q.inflight++
+		q.mu.Unlock()
+		return admission{admitted: true, release: q.release}
+	}
+
+	// Estimate the wait: requests ahead (queued + the overflow beyond capacity)
+	// divided by how many drain per service interval.
+	ahead := q.waiters.Len() + (q.inflight - q.concurrency) + 1
+	if ahead < 1 {
+		ahead = 1
+	}
+	est := q.estimateWait(ahead)
+
+	if maxDepth > 0 && q.waiters.Len() >= maxDepth {
+		rej := admission{retryAfter: est, reason: "queue_full",
+			concurrency: q.concurrency, inflight: q.inflight, waiting: q.waiters.Len()}
+		q.mu.Unlock()
+		return rej
+	}
+	if maxWait > 0 && est > maxWait {
+		rej := admission{retryAfter: est, reason: "max_wait",
+			concurrency: q.concurrency, inflight: q.inflight, waiting: q.waiters.Len()}
+		q.mu.Unlock()
+		return rej
+	}
+
+	w := &waiter{priority: priority, seq: q.seq, ready: make(chan struct{})}
+	q.seq++
+	heap.Push(&q.waiters, w)
+	q.mu.Unlock()
+
+	var timer *time.Timer
+	var timeout <-chan time.Time
+	if maxWait > 0 {
+		timer = time.NewTimer(maxWait)
+		timeout = timer.C
+		defer timer.Stop()
+	}
+
+	select {
+	case <-w.ready:
+		// Admitted after waiting: tryAdmit already incremented inflight.
+		return admission{admitted: true, release: q.release}
+	case <-ctx.Done():
+		return q.abandon(w)
+	case <-timeout:
+		a := q.abandon(w)
+		if !a.admitted {
+			q.mu.Lock()
+			a.reason = "max_wait"
+			a.concurrency = q.concurrency
+			a.inflight = q.inflight
+			a.waiting = q.waiters.Len()
+			q.mu.Unlock()
+		}
+		return a
+	}
+}
+
+// abandon removes a waiter that gave up (context canceled or timed out). If it
+// was admitted in the race between firing and locking, it returns an admitted
+// admission so the caller still releases the slot.
+func (q *modelQueue) abandon(w *waiter) admission {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if w.index >= 0 {
+		heap.Remove(&q.waiters, w.index)
+		return admission{retryAfter: q.estimateWait(1)}
+	}
+	// Already admitted (ready closed) but we lost the select race; honor the slot.
+	select {
+	case <-w.ready:
+		return admission{admitted: true, release: q.release}
+	default:
+		w.canceled = true
+		return admission{retryAfter: q.estimateWait(1)}
+	}
+}
+
+// release returns a slot, then admits the next highest-priority waiter if any.
+func (q *modelQueue) release() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.inflight--
+	q.tryAdmitLocked()
+}
+
+func (q *modelQueue) tryAdmitLocked() {
+	for q.inflight < q.concurrency && q.waiters.Len() > 0 {
+		w := heap.Pop(&q.waiters).(*waiter)
+		if w.canceled {
+			continue
+		}
+		q.inflight++
+		close(w.ready)
+	}
+}
+
+// observe folds a measured service time into the model's EWMA (alpha = 0.25).
+func (q *modelQueue) observe(d time.Duration) {
+	if d <= 0 {
+		return
+	}
+	q.mu.Lock()
+	if q.ewma <= 0 {
+		q.ewma = d
+	} else {
+		q.ewma = (d + 3*q.ewma) / 4
+	}
+	q.mu.Unlock()
+}
+
+// estimateWait computes ahead/concurrency service intervals at the current
+// EWMA. Callers hold q.mu. Falls back to a small seed before any observation.
+func (q *modelQueue) estimateWait(ahead int) time.Duration {
+	ewma := q.ewma
+	if ewma <= 0 {
+		ewma = time.Second // pre-observation seed
+	}
+	batches := (ahead + q.concurrency - 1) / q.concurrency
+	if batches < 1 {
+		batches = 1
+	}
+	return ewma * time.Duration(batches)
+}
+
+// waiterHeap orders waiters by priority (higher first), then seq (FIFO).
+type waiterHeap []*waiter
+
+func (h waiterHeap) Len() int { return len(h) }
+func (h waiterHeap) Less(i, j int) bool {
+	if h[i].priority != h[j].priority {
+		return h[i].priority > h[j].priority
+	}
+	return h[i].seq < h[j].seq
+}
+func (h waiterHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
+func (h *waiterHeap) Push(x any) {
+	w := x.(*waiter)
+	w.index = len(*h)
+	*h = append(*h, w)
+}
+func (h *waiterHeap) Pop() any {
+	old := *h
+	n := len(old)
+	w := old[n-1]
+	old[n-1] = nil
+	w.index = -1
+	*h = old[:n-1]
+	return w
+}

--- a/internal/server/scheduler.go
+++ b/internal/server/scheduler.go
@@ -3,6 +3,7 @@ package server
 import (
 	"container/heap"
 	"context"
+	"sort"
 	"sync"
 	"time"
 
@@ -68,14 +69,22 @@ type admission struct {
 // enqueue admits the request immediately, blocks until a slot frees, or rejects
 // it with a Retry-After estimate. priority is the caller's configured priority
 // (higher served first).
-func (s *scheduler) enqueue(ctx context.Context, modelID string, priority int) admission {
+//
+// posCh, when non-nil, receives the request's live 1-indexed queue position
+// while it waits — the scheduler's analog of the swap queue's position display.
+// Supplying it also opts the request out of the late maxWait timer: once a
+// streaming caller is shown a position it is committed to a 200 response, so it
+// waits until admitted or the client disconnects rather than being 429'd
+// mid-stream. The entry-time rejections (queue full, hopeless estimate) still
+// apply, before any position is sent.
+func (s *scheduler) enqueue(ctx context.Context, modelID string, priority int, posCh chan int) admission {
 	q := s.queues[modelID]
 	if q == nil {
 		// Unmanaged model: admit without limiting, matching the legacy
 		// middleware's pass-through for peer models.
 		return admission{admitted: true, release: func() {}}
 	}
-	return q.acquire(ctx, priority, s.cfg.MaxWait, s.cfg.MaxQueueDepth)
+	return q.acquire(ctx, priority, s.cfg.MaxWait, s.cfg.MaxQueueDepth, posCh)
 }
 
 // modelQueue is a bounded priority admission queue for a single model.
@@ -100,9 +109,10 @@ type waiter struct {
 	ready    chan struct{} // closed when admitted
 	index    int           // heap index, -1 once removed
 	canceled bool
+	posCh    chan int // non-nil to receive live position updates; nil otherwise
 }
 
-func (q *modelQueue) acquire(ctx context.Context, priority int, maxWait time.Duration, maxDepth int) admission {
+func (q *modelQueue) acquire(ctx context.Context, priority int, maxWait time.Duration, maxDepth int, posCh chan int) admission {
 	q.mu.Lock()
 
 	// Fast path: a slot is free and nobody is waiting.
@@ -133,14 +143,19 @@ func (q *modelQueue) acquire(ctx context.Context, priority int, maxWait time.Dur
 		return rej
 	}
 
-	w := &waiter{priority: priority, seq: q.seq, ready: make(chan struct{})}
+	w := &waiter{priority: priority, seq: q.seq, ready: make(chan struct{}), posCh: posCh}
 	q.seq++
 	heap.Push(&q.waiters, w)
+	q.broadcastPositionsLocked()
 	q.mu.Unlock()
 
 	var timer *time.Timer
 	var timeout <-chan time.Time
-	if maxWait > 0 {
+	// A position-streaming waiter has committed to a 200 response and cannot be
+	// 429'd mid-stream, so it skips the late maxWait timer and waits until
+	// admitted or the client disconnects. The entry estimate gate above still
+	// rejected it earlier if the wait looked hopeless.
+	if posCh == nil && maxWait > 0 {
 		timer = time.NewTimer(maxWait)
 		timeout = timer.C
 		defer timer.Stop()
@@ -174,6 +189,7 @@ func (q *modelQueue) abandon(w *waiter) admission {
 	defer q.mu.Unlock()
 	if w.index >= 0 {
 		heap.Remove(&q.waiters, w.index)
+		q.broadcastPositionsLocked()
 		return admission{retryAfter: q.estimateWait(1)}
 	}
 	// Already admitted (ready closed) but we lost the select race; honor the slot.
@@ -195,6 +211,7 @@ func (q *modelQueue) release() {
 }
 
 func (q *modelQueue) tryAdmitLocked() {
+	admitted := false
 	for q.inflight < q.concurrency && q.waiters.Len() > 0 {
 		w := heap.Pop(&q.waiters).(*waiter)
 		if w.canceled {
@@ -202,6 +219,52 @@ func (q *modelQueue) tryAdmitLocked() {
 		}
 		q.inflight++
 		close(w.ready)
+		admitted = true
+	}
+	if admitted {
+		// Front of the queue moved up; refresh everyone still waiting.
+		q.broadcastPositionsLocked()
+	}
+}
+
+// broadcastPositionsLocked sends every waiter that asked for live updates its
+// current 1-indexed position in service order (priority desc, then FIFO).
+// Callers hold q.mu. Sends are non-blocking and latest-wins so a slow consumer
+// never stalls the scheduler.
+func (q *modelQueue) broadcastPositionsLocked() {
+	n := q.waiters.Len()
+	if n == 0 {
+		return
+	}
+	ordered := make([]*waiter, n)
+	copy(ordered, q.waiters)
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].priority != ordered[j].priority {
+			return ordered[i].priority > ordered[j].priority
+		}
+		return ordered[i].seq < ordered[j].seq
+	})
+	for i, w := range ordered {
+		if w.posCh != nil {
+			sendPosition(w.posCh, i+1)
+		}
+	}
+}
+
+// sendPosition does a non-blocking latest-wins send: a full channel is drained
+// and the newest value queued, so the scheduler never blocks on a consumer.
+func sendPosition(ch chan int, pos int) {
+	select {
+	case ch <- pos:
+	default:
+		select {
+		case <-ch:
+		default:
+		}
+		select {
+		case ch <- pos:
+		default:
+		}
 	}
 }
 

--- a/internal/server/scheduler_test.go
+++ b/internal/server/scheduler_test.go
@@ -1,0 +1,159 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestScheduler_AdmitHighestFirst verifies that under contention the
+// highest-priority waiter is admitted first, regardless of arrival order.
+func TestScheduler_AdmitHighestFirst(t *testing.T) {
+	q := newModelQueue(1)
+	ctx := context.Background()
+
+	busy := q.acquire(ctx, 0, 0, 0) // hold the slot
+
+	results := make(chan int, 3)
+	var wg sync.WaitGroup
+	for _, p := range []int{1, 9, 5} {
+		wg.Add(1)
+		pr := p
+		go func() {
+			defer wg.Done()
+			r := q.acquire(ctx, pr, 0, 0)
+			results <- pr
+			r.release()
+		}()
+		time.Sleep(15 * time.Millisecond) // deterministic enqueue order 1,9,5
+	}
+
+	// Wait for all three to be queued.
+	deadline := time.Now().Add(time.Second)
+	for {
+		q.mu.Lock()
+		n := q.waiters.Len()
+		q.mu.Unlock()
+		if n == 3 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	busy.release() // release one slot at a time by draining
+	first := <-results
+	if first != 9 {
+		t.Fatalf("highest priority (9) should be admitted first, got %d", first)
+	}
+	wg.Wait()
+}
+
+// TestScheduler_RejectMaxQueueDepth verifies a 429 with Retry-After once the
+// queue is full.
+func TestScheduler_RejectMaxQueueDepth(t *testing.T) {
+	q := newModelQueue(1)
+	ctx := context.Background()
+
+	busy := q.acquire(ctx, 1, 0, 0) // slot taken
+	defer busy.release()
+
+	// First waiter fits (depth 1). Use a goroutine since it blocks.
+	go q.acquire(ctx, 1, time.Minute, 1)
+	deadline := time.Now().Add(time.Second)
+	for {
+		q.mu.Lock()
+		n := q.waiters.Len()
+		q.mu.Unlock()
+		if n == 1 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Second waiter exceeds maxQueueDepth=1 -> immediate reject.
+	a := q.acquire(ctx, 1, time.Minute, 1)
+	if a.admitted {
+		t.Fatal("request beyond maxQueueDepth should be rejected")
+	}
+	if a.retryAfter <= 0 {
+		t.Fatal("rejection must carry a positive Retry-After estimate")
+	}
+	// Rejection must carry the capacity hint so the client can right-size.
+	if a.reason != "queue_full" {
+		t.Fatalf("reason = %q, want queue_full", a.reason)
+	}
+	if a.concurrency != 1 {
+		t.Fatalf("hint concurrency = %d, want 1", a.concurrency)
+	}
+}
+
+// TestScheduler_RejectMaxWait verifies rejection when the estimated wait exceeds
+// maxWait at arrival.
+func TestScheduler_RejectMaxWait(t *testing.T) {
+	q := newModelQueue(1)
+	q.observe(10 * time.Second) // seed EWMA high
+	ctx := context.Background()
+
+	busy := q.acquire(ctx, 1, 0, 0)
+	defer busy.release()
+
+	a := q.acquire(ctx, 1, 2*time.Second, 0) // est ~10s > 2s maxWait
+	if a.admitted {
+		t.Fatal("should reject when estimated wait exceeds maxWait")
+	}
+	if a.retryAfter < 2*time.Second {
+		t.Fatalf("Retry-After %v should reflect the estimate", a.retryAfter)
+	}
+}
+
+// TestScheduler_ContextCancelDuringWait ensures a canceled request frees its
+// queue slot and does not leak the reserved concurrency slot.
+func TestScheduler_ContextCancelDuringWait(t *testing.T) {
+	q := newModelQueue(1)
+	busy := q.acquire(context.Background(), 1, 0, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan admission, 1)
+	go func() { done <- q.acquire(ctx, 1, time.Minute, 0) }()
+
+	// Wait until queued, then cancel.
+	deadline := time.Now().Add(time.Second)
+	for {
+		q.mu.Lock()
+		n := q.waiters.Len()
+		q.mu.Unlock()
+		if n == 1 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	cancel()
+
+	a := <-done
+	if a.admitted {
+		t.Fatal("canceled request should not be admitted")
+	}
+	// Slot should still be held only by busy; releasing busy must leave inflight 0.
+	busy.release()
+	q.mu.Lock()
+	inflight := q.inflight
+	q.mu.Unlock()
+	if inflight != 0 {
+		t.Fatalf("inflight should be 0 after release, got %d", inflight)
+	}
+}
+
+// TestScheduler_FastPathNoContention confirms requests within the concurrency
+// limit are all admitted immediately, without queueing.
+func TestScheduler_FastPathNoContention(t *testing.T) {
+	q := newModelQueue(2)
+	ctx := context.Background()
+	a1 := q.acquire(ctx, 1, 0, 0)
+	a2 := q.acquire(ctx, 1, 0, 0)
+	if !a1.admitted || !a2.admitted {
+		t.Fatal("two requests within concurrency 2 should both be admitted")
+	}
+	a1.release()
+	a2.release()
+}

--- a/internal/server/scheduler_test.go
+++ b/internal/server/scheduler_test.go
@@ -13,7 +13,7 @@ func TestScheduler_AdmitHighestFirst(t *testing.T) {
 	q := newModelQueue(1)
 	ctx := context.Background()
 
-	busy := q.acquire(ctx, 0, 0, 0) // hold the slot
+	busy := q.acquire(ctx, 0, 0, 0, nil) // hold the slot
 
 	results := make(chan int, 3)
 	var wg sync.WaitGroup
@@ -22,7 +22,7 @@ func TestScheduler_AdmitHighestFirst(t *testing.T) {
 		pr := p
 		go func() {
 			defer wg.Done()
-			r := q.acquire(ctx, pr, 0, 0)
+			r := q.acquire(ctx, pr, 0, 0, nil)
 			results <- pr
 			r.release()
 		}()
@@ -55,11 +55,11 @@ func TestScheduler_RejectMaxQueueDepth(t *testing.T) {
 	q := newModelQueue(1)
 	ctx := context.Background()
 
-	busy := q.acquire(ctx, 1, 0, 0) // slot taken
+	busy := q.acquire(ctx, 1, 0, 0, nil) // slot taken
 	defer busy.release()
 
 	// First waiter fits (depth 1). Use a goroutine since it blocks.
-	go q.acquire(ctx, 1, time.Minute, 1)
+	go q.acquire(ctx, 1, time.Minute, 1, nil)
 	deadline := time.Now().Add(time.Second)
 	for {
 		q.mu.Lock()
@@ -72,7 +72,7 @@ func TestScheduler_RejectMaxQueueDepth(t *testing.T) {
 	}
 
 	// Second waiter exceeds maxQueueDepth=1 -> immediate reject.
-	a := q.acquire(ctx, 1, time.Minute, 1)
+	a := q.acquire(ctx, 1, time.Minute, 1, nil)
 	if a.admitted {
 		t.Fatal("request beyond maxQueueDepth should be rejected")
 	}
@@ -95,10 +95,10 @@ func TestScheduler_RejectMaxWait(t *testing.T) {
 	q.observe(10 * time.Second) // seed EWMA high
 	ctx := context.Background()
 
-	busy := q.acquire(ctx, 1, 0, 0)
+	busy := q.acquire(ctx, 1, 0, 0, nil)
 	defer busy.release()
 
-	a := q.acquire(ctx, 1, 2*time.Second, 0) // est ~10s > 2s maxWait
+	a := q.acquire(ctx, 1, 2*time.Second, 0, nil) // est ~10s > 2s maxWait
 	if a.admitted {
 		t.Fatal("should reject when estimated wait exceeds maxWait")
 	}
@@ -111,11 +111,11 @@ func TestScheduler_RejectMaxWait(t *testing.T) {
 // queue slot and does not leak the reserved concurrency slot.
 func TestScheduler_ContextCancelDuringWait(t *testing.T) {
 	q := newModelQueue(1)
-	busy := q.acquire(context.Background(), 1, 0, 0)
+	busy := q.acquire(context.Background(), 1, 0, 0, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan admission, 1)
-	go func() { done <- q.acquire(ctx, 1, time.Minute, 0) }()
+	go func() { done <- q.acquire(ctx, 1, time.Minute, 0, nil) }()
 
 	// Wait until queued, then cancel.
 	deadline := time.Now().Add(time.Second)
@@ -149,11 +149,102 @@ func TestScheduler_ContextCancelDuringWait(t *testing.T) {
 func TestScheduler_FastPathNoContention(t *testing.T) {
 	q := newModelQueue(2)
 	ctx := context.Background()
-	a1 := q.acquire(ctx, 1, 0, 0)
-	a2 := q.acquire(ctx, 1, 0, 0)
+	a1 := q.acquire(ctx, 1, 0, 0, nil)
+	a2 := q.acquire(ctx, 1, 0, 0, nil)
 	if !a1.admitted || !a2.admitted {
 		t.Fatal("two requests within concurrency 2 should both be admitted")
 	}
 	a1.release()
 	a2.release()
+}
+
+// TestScheduler_BroadcastsPosition verifies a position-streaming waiter receives
+// its 1-indexed queue position, and that the position moves up as waiters ahead
+// of it are admitted.
+func TestScheduler_BroadcastsPosition(t *testing.T) {
+	q := newModelQueue(1)
+	ctx := context.Background()
+
+	busy := q.acquire(ctx, 1, 0, 0, nil) // hold the only slot
+
+	// A high-priority waiter sits ahead of our tracked one.
+	go q.acquire(ctx, 9, time.Minute, 0, nil)
+	deadline := time.Now().Add(time.Second)
+	for {
+		q.mu.Lock()
+		n := q.waiters.Len()
+		q.mu.Unlock()
+		if n == 1 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	posCh := make(chan int, 1)
+	admitted := make(chan struct{})
+	go func() {
+		a := q.acquire(ctx, 1, time.Minute, 0, posCh)
+		close(admitted)
+		_ = a
+	}()
+
+	// First broadcast: behind the priority-9 waiter -> position #2.
+	if got := waitPosition(t, posCh); got != 2 {
+		t.Fatalf("initial position = %d, want 2", got)
+	}
+
+	// Free a slot: the priority-9 waiter is admitted, ours moves to #1.
+	busy.release()
+	if got := waitPosition(t, posCh); got != 1 {
+		t.Fatalf("position after release = %d, want 1", got)
+	}
+}
+
+// waitPosition reads the next position broadcast, failing on timeout.
+func waitPosition(t *testing.T, ch <-chan int) int {
+	t.Helper()
+	select {
+	case p := <-ch:
+		return p
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for position broadcast")
+		return 0
+	}
+}
+
+// TestScheduler_StreamingSkipsMaxWaitTimer verifies that a position-streaming
+// waiter (posCh != nil) is not rejected by the late maxWait timer: once it is
+// shown a position it is committed to a 200 and must wait until admitted. The
+// entry-time estimate gate still applies and is exercised separately.
+func TestScheduler_StreamingSkipsMaxWaitTimer(t *testing.T) {
+	q := newModelQueue(1)
+	ctx := context.Background()
+
+	busy := q.acquire(ctx, 1, 0, 0, nil) // hold the slot
+
+	posCh := make(chan int, 1)
+	done := make(chan admission, 1)
+	// Tiny maxWait that passes the entry estimate gate (seed EWMA is 1s, est for
+	// one-ahead is 1s which is <= maxWait) but would fire the late timer quickly
+	// for a non-streaming waiter. The streaming waiter must ignore it.
+	go func() { done <- q.acquire(ctx, 1, 1500*time.Millisecond, 0, posCh) }()
+
+	// It should still be waiting well past maxWait, not 429'd.
+	select {
+	case a := <-done:
+		t.Fatalf("streaming waiter resolved early (admitted=%v); late maxWait timer should be disabled", a.admitted)
+	case <-time.After(2 * time.Second):
+	}
+
+	// Releasing the slot admits it.
+	busy.release()
+	select {
+	case a := <-done:
+		if !a.admitted {
+			t.Fatal("streaming waiter should be admitted once a slot frees")
+		}
+		a.release()
+	case <-time.After(time.Second):
+		t.Fatal("streaming waiter not admitted after slot freed")
+	}
 }

--- a/internal/server/scheduler_test.go
+++ b/internal/server/scheduler_test.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
 )
 
 // TestScheduler_AdmitHighestFirst verifies that under contention the
@@ -13,7 +15,7 @@ func TestScheduler_AdmitHighestFirst(t *testing.T) {
 	q := newModelQueue(1)
 	ctx := context.Background()
 
-	busy := q.acquire(ctx, 0, 0, 0, nil) // hold the slot
+	busy := q.acquire(ctx, "", 0, 0, 0, nil) // hold the slot
 
 	results := make(chan int, 3)
 	var wg sync.WaitGroup
@@ -22,7 +24,7 @@ func TestScheduler_AdmitHighestFirst(t *testing.T) {
 		pr := p
 		go func() {
 			defer wg.Done()
-			r := q.acquire(ctx, pr, 0, 0, nil)
+			r := q.acquire(ctx, "", pr, 0, 0, nil)
 			results <- pr
 			r.release()
 		}()
@@ -33,7 +35,7 @@ func TestScheduler_AdmitHighestFirst(t *testing.T) {
 	deadline := time.Now().Add(time.Second)
 	for {
 		q.mu.Lock()
-		n := q.waiters.Len()
+		n := len(q.waiters)
 		q.mu.Unlock()
 		if n == 3 || time.Now().After(deadline) {
 			break
@@ -55,15 +57,15 @@ func TestScheduler_RejectMaxQueueDepth(t *testing.T) {
 	q := newModelQueue(1)
 	ctx := context.Background()
 
-	busy := q.acquire(ctx, 1, 0, 0, nil) // slot taken
+	busy := q.acquire(ctx, "", 1, 0, 0, nil) // slot taken
 	defer busy.release()
 
 	// First waiter fits (depth 1). Use a goroutine since it blocks.
-	go q.acquire(ctx, 1, time.Minute, 1, nil)
+	go q.acquire(ctx, "", 1, time.Minute, 1, nil)
 	deadline := time.Now().Add(time.Second)
 	for {
 		q.mu.Lock()
-		n := q.waiters.Len()
+		n := len(q.waiters)
 		q.mu.Unlock()
 		if n == 1 || time.Now().After(deadline) {
 			break
@@ -72,7 +74,7 @@ func TestScheduler_RejectMaxQueueDepth(t *testing.T) {
 	}
 
 	// Second waiter exceeds maxQueueDepth=1 -> immediate reject.
-	a := q.acquire(ctx, 1, time.Minute, 1, nil)
+	a := q.acquire(ctx, "", 1, time.Minute, 1, nil)
 	if a.admitted {
 		t.Fatal("request beyond maxQueueDepth should be rejected")
 	}
@@ -95,10 +97,10 @@ func TestScheduler_RejectMaxWait(t *testing.T) {
 	q.observe(10 * time.Second) // seed EWMA high
 	ctx := context.Background()
 
-	busy := q.acquire(ctx, 1, 0, 0, nil)
+	busy := q.acquire(ctx, "", 1, 0, 0, nil)
 	defer busy.release()
 
-	a := q.acquire(ctx, 1, 2*time.Second, 0, nil) // est ~10s > 2s maxWait
+	a := q.acquire(ctx, "", 1, 2*time.Second, 0, nil) // est ~10s > 2s maxWait
 	if a.admitted {
 		t.Fatal("should reject when estimated wait exceeds maxWait")
 	}
@@ -111,17 +113,17 @@ func TestScheduler_RejectMaxWait(t *testing.T) {
 // queue slot and does not leak the reserved concurrency slot.
 func TestScheduler_ContextCancelDuringWait(t *testing.T) {
 	q := newModelQueue(1)
-	busy := q.acquire(context.Background(), 1, 0, 0, nil)
+	busy := q.acquire(context.Background(), "", 1, 0, 0, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan admission, 1)
-	go func() { done <- q.acquire(ctx, 1, time.Minute, 0, nil) }()
+	go func() { done <- q.acquire(ctx, "", 1, time.Minute, 0, nil) }()
 
 	// Wait until queued, then cancel.
 	deadline := time.Now().Add(time.Second)
 	for {
 		q.mu.Lock()
-		n := q.waiters.Len()
+		n := len(q.waiters)
 		q.mu.Unlock()
 		if n == 1 || time.Now().After(deadline) {
 			break
@@ -149,8 +151,8 @@ func TestScheduler_ContextCancelDuringWait(t *testing.T) {
 func TestScheduler_FastPathNoContention(t *testing.T) {
 	q := newModelQueue(2)
 	ctx := context.Background()
-	a1 := q.acquire(ctx, 1, 0, 0, nil)
-	a2 := q.acquire(ctx, 1, 0, 0, nil)
+	a1 := q.acquire(ctx, "", 1, 0, 0, nil)
+	a2 := q.acquire(ctx, "", 1, 0, 0, nil)
 	if !a1.admitted || !a2.admitted {
 		t.Fatal("two requests within concurrency 2 should both be admitted")
 	}
@@ -165,14 +167,14 @@ func TestScheduler_BroadcastsPosition(t *testing.T) {
 	q := newModelQueue(1)
 	ctx := context.Background()
 
-	busy := q.acquire(ctx, 1, 0, 0, nil) // hold the only slot
+	busy := q.acquire(ctx, "", 1, 0, 0, nil) // hold the only slot
 
 	// A high-priority waiter sits ahead of our tracked one.
-	go q.acquire(ctx, 9, time.Minute, 0, nil)
+	go q.acquire(ctx, "", 9, time.Minute, 0, nil)
 	deadline := time.Now().Add(time.Second)
 	for {
 		q.mu.Lock()
-		n := q.waiters.Len()
+		n := len(q.waiters)
 		q.mu.Unlock()
 		if n == 1 || time.Now().After(deadline) {
 			break
@@ -183,7 +185,7 @@ func TestScheduler_BroadcastsPosition(t *testing.T) {
 	posCh := make(chan int, 1)
 	admitted := make(chan struct{})
 	go func() {
-		a := q.acquire(ctx, 1, time.Minute, 0, posCh)
+		a := q.acquire(ctx, "", 1, time.Minute, 0, posCh)
 		close(admitted)
 		_ = a
 	}()
@@ -220,14 +222,14 @@ func TestScheduler_StreamingSkipsMaxWaitTimer(t *testing.T) {
 	q := newModelQueue(1)
 	ctx := context.Background()
 
-	busy := q.acquire(ctx, 1, 0, 0, nil) // hold the slot
+	busy := q.acquire(ctx, "", 1, 0, 0, nil) // hold the slot
 
 	posCh := make(chan int, 1)
 	done := make(chan admission, 1)
 	// Tiny maxWait that passes the entry estimate gate (seed EWMA is 1s, est for
 	// one-ahead is 1s which is <= maxWait) but would fire the late timer quickly
 	// for a non-streaming waiter. The streaming waiter must ignore it.
-	go func() { done <- q.acquire(ctx, 1, 1500*time.Millisecond, 0, posCh) }()
+	go func() { done <- q.acquire(ctx, "", 1, 1500*time.Millisecond, 0, posCh) }()
 
 	// It should still be waiting well past maxWait, not 429'd.
 	select {
@@ -246,5 +248,88 @@ func TestScheduler_StreamingSkipsMaxWaitTimer(t *testing.T) {
 		a.release()
 	case <-time.After(time.Second):
 		t.Fatal("streaming waiter not admitted after slot freed")
+	}
+}
+
+// waitForWaiters blocks until the queue has exactly n parked waiters.
+func waitForWaiters(t *testing.T, q *modelQueue, n int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		q.mu.Lock()
+		got := len(q.waiters)
+		q.mu.Unlock()
+		if got == n {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %d waiters (have %d)", n, got)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// TestScheduler_AgingOvertakesFreshHigher verifies that with aging on, a
+// low-priority request that has waited long enough overtakes a freshly arriving
+// higher-priority one (anti-starvation). Without aging the higher base priority
+// would win.
+func TestScheduler_AgingOvertakesFreshHigher(t *testing.T) {
+	q := newModelQueue(1)
+	q.agingRate = 1.0 // +1 effective priority per second waited
+	base := time.Now()
+	var clkMu sync.Mutex
+	clk := base
+	q.now = func() time.Time { clkMu.Lock(); defer clkMu.Unlock(); return clk }
+	setClk := func(d time.Duration) { clkMu.Lock(); clk = base.Add(d); clkMu.Unlock() }
+
+	ctx := context.Background()
+	busy := q.acquire(ctx, "", 0, 0, 0, nil) // hold the slot
+
+	results := make(chan string, 2)
+	go func() { a := q.acquire(ctx, "low", 1, 0, 0, nil); results <- "low"; a.release() }()
+	waitForWaiters(t, q, 1)
+
+	setClk(10 * time.Second) // "low" has now waited 10s -> effective 11
+	go func() { a := q.acquire(ctx, "high", 5, 0, 0, nil); results <- "high"; a.release() }()
+	waitForWaiters(t, q, 2)
+
+	busy.release()
+	if first := <-results; first != "low" {
+		t.Fatalf("aged low (eff 11) should beat fresh high (eff 5); got %q first", first)
+	}
+	<-results
+}
+
+// TestScheduler_ProportionWeightedShares verifies that proportion mode admits
+// callers in proportion to their weight: a weight-3 caller gets ~3x the
+// admissions of a weight-1 caller under sustained contention.
+func TestScheduler_ProportionWeightedShares(t *testing.T) {
+	q := newModelQueue(1)
+	q.mode = config.ModeProportion
+	now := time.Now()
+	q.now = func() time.Time { return now }
+
+	seq := uint64(0)
+	add := func(caller string, weight, n int) {
+		for i := 0; i < n; i++ {
+			q.waiters = append(q.waiters, &waiter{caller: caller, priority: weight, seq: seq, enqueuedAt: now})
+			seq++
+		}
+	}
+	add("A", 3, 40)
+	add("B", 1, 40)
+
+	order := q.admissionOrderLocked(now)
+	a, b := 0, 0
+	for _, w := range order[:16] {
+		if w.caller == "A" {
+			a++
+		} else {
+			b++
+		}
+	}
+	// Expect ~12:4 (3:1). Allow slack for boundary effects.
+	if a < 10 || a > 14 {
+		t.Fatalf("weighted shares off: A=%d B=%d in first 16, want ~12:4", a, b)
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -183,11 +183,12 @@ func (s *Server) routes() {
 	// other's Content-Type. Both run before the metrics middleware so it buffers
 	// the rewritten body.
 	// callerMW captures the caller id (API key) into the context before authMW
-	// strips the auth headers, so the scheduler can resolve caller priority.
+	// strips the auth headers, so the scheduler can resolve caller priority and
+	// the activity log can attribute the request.
 	modelChain := chain.New(
 		CreateCallerMiddleware(),
 		authMW,
-		CreateConcurrencyMiddleware(s.cfg, s.sched, s.proxylog),
+		CreateConcurrencyMiddleware(s.cfg, s.sched, s.proxylog, s.metrics),
 		filterMW,
 		formFilterMW,
 		CreateInflightMiddleware(s.inflight),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,6 +30,7 @@ type Server struct {
 	perf     *perf.Monitor
 	inflight *inflightCounter
 	metrics  *metricsMonitor
+	sched    *scheduler
 	build    BuildInfo
 
 	local router.LocalRouter
@@ -125,6 +126,7 @@ func New(cfg config.Config, muxlog *logmon.Monitor, proxylog *logmon.Monitor, up
 		perf:        perfMon,
 		inflight:    &inflightCounter{},
 		metrics:     newMetricsMonitor(proxylog, cfg.MetricsMaxInMemory, cfg.CaptureBuffer),
+		sched:       newSchedulerIfEnabled(cfg),
 		build:       build,
 		local:       local,
 		peer:        peer,
@@ -180,9 +182,12 @@ func (s *Server) routes() {
 	// bodies and formFilterMW rewrites multipart bodies; each is a no-op for the
 	// other's Content-Type. Both run before the metrics middleware so it buffers
 	// the rewritten body.
+	// callerMW captures the caller id (API key) into the context before authMW
+	// strips the auth headers, so the scheduler can resolve caller priority.
 	modelChain := chain.New(
+		CreateCallerMiddleware(),
 		authMW,
-		CreateConcurrencyMiddleware(s.cfg),
+		CreateConcurrencyMiddleware(s.cfg, s.sched, s.proxylog),
 		filterMW,
 		formFilterMW,
 		CreateInflightMiddleware(s.inflight),

--- a/proxy/helpers_test.go
+++ b/proxy/helpers_test.go
@@ -75,11 +75,36 @@ func getTestPort() int {
 	return port
 }
 
+// testStartPortBlock reserves a contiguous range of ports per config so that
+// auto-assigned model ports (startPort, startPort+1, ...) never overlap between
+// concurrently running test configs. 100 is far above any test's model count.
+const testStartPortBlock = 100
+
+// getTestStartPort reserves a fresh block of ports from the shared monotonic
+// allocator. It draws from the same nextTestPort counter as getTestPort, so
+// single-port and block allocations never collide.
+func getTestStartPort() int {
+	portMutex.Lock()
+	defer portMutex.Unlock()
+
+	port := nextTestPort
+	nextTestPort += testStartPortBlock
+
+	return port
+}
+
 // testConfigFromYAML substitutes {{RESPONDER}} with the simple-responder path and
-// loads through the real config pipeline (env vars, macros, port assignment, etc.)
+// loads through the real config pipeline (env vars, macros, port assignment, etc.).
+//
+// Unless the YAML sets startPort explicitly, an ephemeral high startPort is
+// injected so auto-assigned ${PORT} values (which otherwise default to 5800) do
+// not collide with the well-known default port range or with other tests.
 func testConfigFromYAML(t *testing.T, yamlTmpl string) config.Config {
 	t.Helper()
 	yamlStr := strings.ReplaceAll(yamlTmpl, "{{RESPONDER}}", filepath.ToSlash(simpleResponderPath))
+	if !strings.Contains(yamlStr, "startPort") {
+		yamlStr = fmt.Sprintf("startPort: %d\n%s", getTestStartPort(), yamlStr)
+	}
 	cfg, err := config.LoadConfigFromReader(strings.NewReader(yamlStr))
 	require.NoError(t, err)
 	return cfg

--- a/ui-svelte/src/lib/types.ts
+++ b/ui-svelte/src/lib/types.ts
@@ -24,6 +24,7 @@ export interface ActivityLogEntry {
   id: number;
   timestamp: string;
   model: string;
+  caller: string;
   req_path: string;
   resp_content_type: string;
   resp_status_code: number;

--- a/ui-svelte/src/routes/Activity.svelte
+++ b/ui-svelte/src/routes/Activity.svelte
@@ -11,6 +11,7 @@
     | "id"
     | "time"
     | "model"
+    | "caller"
     | "req_path"
     | "resp_status_code"
     | "resp_content_type"
@@ -32,6 +33,7 @@
     { key: "id", label: "ID", defaultVisible: true },
     { key: "time", label: "Time", defaultVisible: true },
     { key: "model", label: "Model", defaultVisible: true },
+    { key: "caller", label: "Caller", defaultVisible: true },
     { key: "req_path", label: "Path", defaultVisible: false },
     { key: "resp_status_code", label: "Status", defaultVisible: false },
     { key: "resp_content_type", label: "Content-Type", defaultVisible: false },
@@ -191,6 +193,9 @@
           {#if $visibleColumns.includes("model")}
             <th class="px-6 py-3">Model</th>
           {/if}
+          {#if $visibleColumns.includes("caller")}
+            <th class="px-6 py-3">Caller</th>
+          {/if}
           {#if $visibleColumns.includes("req_path")}
             <th class="px-6 py-3">Path</th>
           {/if}
@@ -245,6 +250,9 @@
               {/if}
               {#if $visibleColumns.includes("model")}
                 <td class="px-6 py-4">{metric.model}</td>
+              {/if}
+              {#if $visibleColumns.includes("caller")}
+                <td class="px-6 py-4">{metric.caller || "-"}</td>
               {/if}
               {#if $visibleColumns.includes("req_path")}
                 <td class="px-6 py-4">{metric.req_path || "-"}</td>

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -13,6 +13,12 @@ import { connectionState } from "./theme";
 
 const LOG_LENGTH_LIMIT = 1024 * 100; /* 100KB of log data */
 
+// ACTIVITY_LIMIT bounds the in-memory activity list so the pane can't grow
+// without limit (newest are prepended on every metrics event). Mirrors the
+// server's default metricsMaxInMemory ring so the UI retains the same window
+// the server keeps; older entries drop off the tail.
+const ACTIVITY_LIMIT = 1000;
+
 // Stores
 export const models = writable<Model[]>([]);
 export const proxyLogs = writable<string>("");
@@ -92,7 +98,9 @@ export function enableAPIEvents(enabled: boolean): void {
 
           case "metrics": {
             const newMetrics = JSON.parse(message.data) as ActivityLogEntry[];
-            metrics.update((prevMetrics) => [...newMetrics, ...prevMetrics]);
+            metrics.update((prevMetrics) =>
+              [...newMetrics, ...prevMetrics].slice(0, ACTIVITY_LIMIT)
+            );
             break;
           }
           case "inflight": {


### PR DESCRIPTION
## Why

Limited supply and uncoordinated demand: model capacity is finite, and multiple independent consumers contend for it without any awareness of each other. Someone has to coordinate fair access — and that coordinator belongs at the router, not the clients.

Cooperative scheduling implemented client-side is hard and brittle: each consumer would have to know the others exist, agree on a sharing policy, and back off in concert — with no shared view of contention, they can't. The stock per-model limit only offers a bare 429 with no guidance, so a client can't even tell it's competing with itself, let alone yield to a higher-priority peer. The router is the one place that sees all traffic to a model, so it's the right place to enforce sharing and to report who is contending.

## What

Add opt-in, **configurable** admission scheduling in front of each model's concurrency limit, with the observability to see it working.

When the `scheduling` config section is absent, behavior is unchanged: a request that cannot acquire a concurrency slot gets the legacy bare 429. When present, over-limit requests are queued and admitted according to the configured strategy instead of rejected outright.

- **config:** `scheduling` section — `mode`, `priorityIncreasePerSecondWaiting`, per-caller `priorities`, per-model `modelPriorities`, `defaultPriority`, `maxWait`, `maxQueueDepth`.
- **server:** per-model admission queue with two interchangeable strategies (`absolute` priority / `proportion` weighted-fair-queuing) and optional time-based priority aging that composes with both; admit as slots free; reject with 429 + `Retry-After` only when the queue is full or the estimated wait exceeds `maxWait`. `Retry-After` is a measured EWMA of the model's service time.
- **server:** the 429 carries the model's concurrency on `X-RateLimit-Limit`/`-Inflight`/`-Waiting` and `hint.max_concurrency`, so a caller fanning out past a model's slot count learns the real ceiling.
- **server,router:** streaming requests with `sendLoadingState` see their live **queue position** in the reasoning ("thinking") stream while they wait — the admission-queue analog of the model-swap queue's position display.
- **server,ui:** attribute a masked caller (the API key, or `anonymous`) on every activity entry and add a Caller column; scheduler 429s now appear in the activity stream (they short-circuit before the metrics middleware) with a hint-only capture; cap the UI activity store.
- **proxy:** use an ephemeral startPort in the test harness so a local llama-swap on the default port range no longer makes the suite flake.

## Scheduling strategies

The same priority number is interpreted differently per `mode`, and `priorityIncreasePerSecondWaiting` (aging) composes with either. The default (`mode: absolute`, aging `0`) reproduces strict priority exactly, so existing configs are unaffected.

| | `mode: absolute` | `mode: proportion` |
|---|---|---|
| **Meaning of the number** | rank — higher served first | weight — higher gets a larger share |
| **Under contention** | highest effective priority first, FIFO within a priority | callers admitted in proportion to weight (weighted fair queuing); a weight-10 caller gets ~10× the throughput of a weight-1 caller |
| **Idle classes** | n/a | never hold back a busy one (work-conserving) |
| **Best for** | "interactive always jumps the line" | "guarantee bulk a slice, never fully starved" |

**Aging — `priorityIncreasePerSecondWaiting`.** Adds to a waiter's *effective* priority for every second it has waited. `0` (default) disables it.
- In `absolute` mode it makes scheduling **starvation-free**: a long-waiting low-priority request's effective priority climbs until it overtakes freshly arriving higher-priority traffic.
- In `proportion` mode it grows a long-waiter's share over time.

**Composability.** Three independent dials that combine:
1. **Where the number comes from** — resolved as `priorities[caller]` → `modelPriorities[model]` → `defaultPriority`. An explicitly listed caller always wins (operator intent); otherwise priority can be driven by the model, which is what a single client like Open WebUI (one API key, many models) needs.
2. **How the number is interpreted** — `mode: absolute` (rank) or `proportion` (weight).
3. **How waiting changes it** — `priorityIncreasePerSecondWaiting` ages the effective value up, under either mode.

## Configuration

Add a top-level `scheduling` section. Omitting it preserves current behavior.

```yaml
scheduling:
  # How the priority number is interpreted: absolute (rank) | proportion (weight).
  mode: absolute
  # Aging: effective priority gained per second waited. 0 disables.
  priorityIncreasePerSecondWaiting: 0

  # Caller id (API key) -> priority. An explicit caller always wins.
  priorities:
    sk-interactive: 10   # latency-sensitive front-end
    sk-bulk-indexer: 1   # batch work, yields under load
  # Model id -> priority, for callers not listed above (e.g. a single client
  # that can't be told apart by API key). Falls back to defaultPriority.
  modelPriorities:
    chat-model: 10
    embeddings: 1
  defaultPriority: 5     # callers/models not listed above (and anonymous callers)

  maxWait: 30s           # hold a queued request up to this long before 429
  maxQueueDepth: 16      # max waiters per model before 429 (0 = unlimited)
```

Per-model capacity is the existing `concurrencyLimit` on each model — set it to the model's real slot count (e.g. `concurrencyLimit: 1` for a server started with `--parallel 1`). The scheduler queues against that limit; it doesn't change it.

## Scenarios

- **Interactive must always be snappy.** `mode: absolute`. Give the front-end a high `priority`; bulk jobs a low one. Interactive jumps the queue every time. Risk: under sustained interactive load, bulk can starve → add aging.
- **Don't starve the batch jobs.** `mode: absolute` + `priorityIncreasePerSecondWaiting: 0.5`. Interactive still wins normally, but a bulk request that has waited long enough eventually overtakes fresh interactive traffic — bounded wait, never denied for being low priority.
- **Guarantee proportional throughput.** `mode: proportion`. Weights `10`/`1` give the interactive class ~10× the slot-throughput of bulk while *both* keep flowing — bulk is never fully blocked. Idle classes don't waste share.
- **Single client, many models** (e.g. Open WebUI). One API key can't distinguish callers, so use `modelPriorities` to drive priority by the requested model — high for the chat model, low for a background embeddings model — under either mode.
- **Mixed.** `priorities` (per-service keys) and `modelPriorities` (per-model defaults) coexist; explicit caller keys win, everything else falls to the model default, then `defaultPriority`.

## Downstream clients

The caller id is the **API key on the request** — there is no separate caller header. The key is read with the same precedence as the existing auth (`extractAPIKey`): `Authorization: Basic` password field, then `Authorization: Bearer <key>`, then `x-api-key: <key>`. So a client already sending a key for `apiKeys` auth needs no change beyond using a distinct key per service; that key is matched against `scheduling.priorities`. If `apiKeys` is configured, the same key both authenticates the request and identifies the caller for scheduling — one credential, two uses.

- Give each downstream service its own key and map it in `priorities`.
- A request with no key resolves to `modelPriorities[model]` then `defaultPriority` (shown as `anonymous` in the activity log).
- Streaming clients that send a key and enable `sendLoadingState` see their live queue position in the reasoning stream while they wait.

### Rate-limit response hints

When the scheduler sheds a request it returns `429` with both headers and a JSON body describing the contention, so a client can react without parsing logs:

```
HTTP/1.1 429 Too Many Requests
Retry-After: 4
X-RateLimit-Limit: 1        # the model's hard slot count
X-RateLimit-Inflight: 1     # slots in use right now
X-RateLimit-Waiting: 3      # requests already queued ahead

{"error":"Too many requests","reason":"queue_full","retry_after":4,
 "model":"qwen3","hint":{"max_concurrency":1,"inflight":1,"waiting":3}}
```

- `reason` is `queue_full` or `max_wait`.
- Honor `Retry-After` (whole seconds, derived from the model's measured service time).
- `hint.max_concurrency` (= `X-RateLimit-Limit`) is the actionable number: cap the client's own parallelism to it instead of fanning out and competing with itself. A client firing N concurrent requests at a `max_concurrency: 1` model is queueing behind its own traffic.

## Activity / observability

The activity log and UI gain a per-request **Caller** column so contention is visible:

- Each entry records the caller, **masked** so the key is never exposed in the UI or the in-memory ring: `anonymous` for no key, otherwise a short prefix plus length (e.g. `sk-ra…9`). Distinct callers stay distinguishable without leaking the secret.
- Scheduler `429`s now appear in the activity stream. They short-circuit before the metrics middleware, so they were previously invisible; the scheduler emits them directly with a **hint-only capture** (the 429's response headers + body — no request body, to avoid amplifying memory during a rejection storm).
- The UI activity buffer is capped so a long-running session doesn't grow without bound.
