### PR TITLE
ui: add stacked histograms for token activity

### DIFF
--- a/ui-svelte/src/components/ActivityStats.svelte
+++ b/ui-svelte/src/components/ActivityStats.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { inFlightRequests, metrics } from "../stores/api";
   import { persistentStore } from "../stores/persistent";
-  import { calculateHistogramData } from "../lib/histogram";
+  import { calculateHistogramData, calculateStackedHistogramData, type StackedMetric } from "../lib/histogram";
   import TokenHistogram from "./TokenHistogram.svelte";
 
   const nf = new Intl.NumberFormat();
   const histogramCollapsed = persistentStore<boolean>("activity-histogram-collapsed", false);
+  const histogramStacked = persistentStore<boolean>("activity-histogram-stacked", true);
 
   let stats = $derived.by(() => {
     const totalRequests = $metrics.length;
@@ -13,15 +14,16 @@
     const totalOutputTokens = $metrics.reduce((sum, m) => sum + m.tokens.output_tokens, 0);
     const totalCacheTokens = $metrics.reduce((sum, m) => sum + Math.max(0, m.tokens.cache_tokens), 0);
 
-    const promptPerSecond = $metrics.filter((m) => m.tokens.prompt_per_second > 0).map((m) => m.tokens.prompt_per_second);
+    const promptValues = $metrics.filter((m) => m.tokens.prompt_per_second > 0).map((m) => m.tokens.prompt_per_second);
+    const genValues = $metrics.filter((m) => m.tokens.tokens_per_second > 0).map((m) => m.tokens.tokens_per_second);
 
-    const tokensPerSecond = $metrics.filter((m) => m.tokens.tokens_per_second > 0).map((m) => m.tokens.tokens_per_second);
+    const promptEntries: StackedMetric[] = $metrics
+      .filter((m) => m.tokens.prompt_per_second > 0)
+      .map((m) => ({ model: m.model, value: m.tokens.prompt_per_second }));
 
-    const promptHistogramData =
-      promptPerSecond.length > 0 ? calculateHistogramData(promptPerSecond) : null;
-
-    const genHistogramData =
-      tokensPerSecond.length > 0 ? calculateHistogramData(tokensPerSecond) : null;
+    const genEntries: StackedMetric[] = $metrics
+      .filter((m) => m.tokens.tokens_per_second > 0)
+      .map((m) => ({ model: m.model, value: m.tokens.tokens_per_second }));
 
     return {
       totalRequests,
@@ -29,48 +31,81 @@
       totalOutputTokens,
       totalCacheTokens,
       inFlightRequests: $inFlightRequests,
-      promptHistogramData,
-      genHistogramData,
+      promptFlat: promptValues.length > 0 ? calculateHistogramData(promptValues) : null,
+      genFlat: genValues.length > 0 ? calculateHistogramData(genValues) : null,
+      promptStacked: promptEntries.length > 0 ? calculateStackedHistogramData(promptEntries) : null,
+      genStacked: genEntries.length > 0 ? calculateStackedHistogramData(genEntries) : null,
     };
   });
 </script>
 
 <div class="card relative p-3">
-  <button
-    class="absolute top-2 right-2 w-6 h-6 flex items-center justify-center rounded-full border border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:border-gray-400 dark:hover:border-gray-400 transition-colors"
-    onclick={() => ($histogramCollapsed = !$histogramCollapsed)}
-    title={$histogramCollapsed ? "Show histograms" : "Hide histograms"}
-  >
-    {#if $histogramCollapsed}
-      <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor">
-        <path d="M4.5 6l3.5 4 3.5-4H4.5z" />
-      </svg>
-    {:else}
-      <svg class="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
-        <path d="M3.5 3.5l9 9M12.5 3.5l-9 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none" />
-      </svg>
-    {/if}
-  </button>
+  <div class="absolute top-2 right-2 flex gap-1">
+    <button
+      class="w-6 h-6 flex items-center justify-center rounded-full border border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:border-gray-400 dark:hover:border-gray-400 transition-colors"
+      onclick={() => ($histogramStacked = !$histogramStacked)}
+      title={$histogramStacked ? "Show flat histogram" : "Show stacked by model"}
+    >
+      {#if $histogramStacked}
+        <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor">
+          <rect y="2" width="16" height="3" rx="1" />
+          <rect y="6.5" width="16" height="3" rx="1" />
+          <rect y="11" width="16" height="3" rx="1" />
+        </svg>
+      {:else}
+        <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor">
+          <rect y="2" width="16" height="12" rx="1" />
+        </svg>
+      {/if}
+    </button>
+    <button
+      class="w-6 h-6 flex items-center justify-center rounded-full border border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:border-gray-400 dark:hover:border-gray-400 transition-colors"
+      onclick={() => ($histogramCollapsed = !$histogramCollapsed)}
+      title={$histogramCollapsed ? "Show histograms" : "Hide histograms"}
+    >
+      {#if $histogramCollapsed}
+        <svg class="w-3.5 h-3.5" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M4.5 6l3.5 4 3.5-4H4.5z" />
+        </svg>
+      {:else}
+        <svg class="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
+          <path d="M3.5 3.5l9 9M12.5 3.5l-9 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none" />
+        </svg>
+      {/if}
+    </button>
+  </div>
   {#if !$histogramCollapsed}
     <div class="flex flex-col sm:flex-row gap-6 mb-3">
       <div class="w-full sm:w-1/2 min-w-0">
         <div class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">Prompt Processing</div>
-        {#if stats.promptHistogramData}
-          <TokenHistogram
-            data={stats.promptHistogramData}
-            unit="prompt tokens/sec"
-            colorClass="text-amber-500 dark:text-amber-400"
-          />
+        {#if $histogramStacked}
+          {#if stats.promptStacked}
+            <TokenHistogram data={stats.promptStacked} unit="prompt tokens/sec" stacked={true} />
+          {:else}
+            <div class="py-6 text-center text-sm text-gray-500 dark:text-gray-400">No prompt speed data yet</div>
+          {/if}
         {:else}
-          <div class="py-6 text-center text-sm text-gray-500 dark:text-gray-400">No prompt speed data yet</div>
+          {#if stats.promptFlat}
+            <TokenHistogram data={stats.promptFlat} unit="prompt tokens/sec" colorClass="text-amber-500 dark:text-amber-400" stacked={false} />
+          {:else}
+            <div class="py-6 text-center text-sm text-gray-500 dark:text-gray-400">No prompt speed data yet</div>
+          {/if}
         {/if}
       </div>
       <div class="w-full sm:w-1/2 min-w-0">
         <div class="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">Token Generation</div>
-        {#if stats.genHistogramData}
-          <TokenHistogram data={stats.genHistogramData} unit="tokens/sec" />
+        {#if $histogramStacked}
+          {#if stats.genStacked}
+            <TokenHistogram data={stats.genStacked} unit="tokens/sec" stacked={true} />
+          {:else}
+            <div class="py-6 text-center text-sm text-gray-500 dark:text-gray-400">No generation speed data yet</div>
+          {/if}
         {:else}
-          <div class="py-6 text-center text-sm text-gray-500 dark:text-gray-400">No generation speed data yet</div>
+          {#if stats.genFlat}
+            <TokenHistogram data={stats.genFlat} unit="tokens/sec" stacked={false} />
+          {:else}
+            <div class="py-6 text-center text-sm text-gray-500 dark:text-gray-400">No generation speed data yet</div>
+          {/if}
         {/if}
       </div>
     </div>

--- a/ui-svelte/src/components/ActivityStats.svelte
+++ b/ui-svelte/src/components/ActivityStats.svelte
@@ -44,6 +44,8 @@
     <button
       class="w-6 h-6 flex items-center justify-center rounded-full border border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:border-gray-400 dark:hover:border-gray-400 transition-colors"
       onclick={() => ($histogramStacked = !$histogramStacked)}
+      aria-label={$histogramStacked ? "Switch to flat histogram" : "Switch to stacked histogram"}
+      aria-pressed={$histogramStacked}
       title={$histogramStacked ? "Show flat histogram" : "Show stacked by model"}
     >
       {#if $histogramStacked}
@@ -61,6 +63,8 @@
     <button
       class="w-6 h-6 flex items-center justify-center rounded-full border border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 hover:border-gray-400 dark:hover:border-gray-400 transition-colors"
       onclick={() => ($histogramCollapsed = !$histogramCollapsed)}
+      aria-label={$histogramCollapsed ? "Expand histograms" : "Collapse histograms"}
+      aria-pressed={!$histogramCollapsed}
       title={$histogramCollapsed ? "Show histograms" : "Hide histograms"}
     >
       {#if $histogramCollapsed}

--- a/ui-svelte/src/components/TokenHistogram.svelte
+++ b/ui-svelte/src/components/TokenHistogram.svelte
@@ -1,25 +1,57 @@
 <script lang="ts">
-  import type { HistogramData } from "../lib/types";
+  import type { HistogramData, StackedHistogramData } from "../lib/types";
+  import { stackedHistogramColors } from "../lib/histogram";
 
   let {
     data,
     unit = "tokens/sec",
     colorClass = "text-blue-500 dark:text-blue-400",
+    stacked = true,
   }: {
-    data: HistogramData;
+    data: HistogramData | StackedHistogramData;
     unit?: string;
     colorClass?: string;
+    stacked?: boolean;
   } = $props();
 
-  const height = 250;
-  const padding = { top: 30, right: 20, bottom: 40, left: 75 };
+  const stackedHeight = 300;
+  const flatHeight = 250;
+  const padding = $derived({ top: 30, right: 20, bottom: stacked ? 80 : 40, left: 75 });
   const viewBoxWidth = 1200;
-  const chartWidth = viewBoxWidth - padding.left - padding.right;
-  const chartHeight = height - padding.top - padding.bottom;
+  const height = $derived(stacked ? stackedHeight : flatHeight);
+  const chartWidth = $derived(viewBoxWidth - padding.left - padding.right);
+  const chartHeight = $derived(height - padding.top - padding.bottom);
 
-  let maxCount = $derived(Math.max(...data.bins));
+  // Detect if data is stacked by checking bins[0]
+  let isStacked = $derived(
+    stacked && data.bins.length > 0 && typeof data.bins[0] === "object" && "segments" in data.bins[0]
+  );
+
+  let maxCount = $derived(
+    isStacked
+      ? Math.max(...(data as StackedHistogramData).bins.map((b) => b.totalCount))
+      : Math.max(...(data as HistogramData).bins)
+  );
   let barWidth = $derived(chartWidth / data.bins.length);
   let range = $derived(data.max - data.min);
+
+  let legendItems = $derived.by(() => {
+    if (!isStacked) return [];
+    const sd = data as StackedHistogramData;
+    return sd.models.map((model, i) => ({
+      model,
+      color: stackedHistogramColors[i % stackedHistogramColors.length],
+    }));
+  });
+
+  function getModelColor(model: string): string {
+    if (!isStacked) return "";
+    const sd = data as StackedHistogramData;
+    const idx = sd.models.indexOf(model);
+    return idx >= 0
+      ? stackedHistogramColors[idx % stackedHistogramColors.length]
+      : "#888888";
+  }
 
   function getXPosition(value: number): number {
     return padding.left + ((value - data.min) / range) * chartWidth;
@@ -69,71 +101,101 @@
     />
 
     <!-- Histogram bars -->
-    {#each data.bins as count, i}
-      {@const barHeight = maxCount > 0 ? (count / maxCount) * chartHeight : 0}
-      {@const x = padding.left + i * barWidth}
-      {@const y = height - padding.bottom - barHeight}
-      {@const binStart = data.min + i * data.binSize}
-      {@const binEnd = binStart + data.binSize}
-      <g>
-        <rect
-          {x}
-          {y}
-          width={Math.max(barWidth - 1, 1)}
-          height={barHeight}
-          fill="currentColor"
-          opacity="0.6"
-          class="{colorClass} hover:opacity-90 transition-opacity cursor-pointer"
-        />
-        <title>{`${binStart.toFixed(1)} - ${binEnd.toFixed(1)} ${unit}\nCount: ${count}`}</title>
-      </g>
-    {/each}
+    {#if isStacked}
+      {#each (data as StackedHistogramData).bins as bin, i}
+        {@const barHeight = maxCount > 0 ? (bin.totalCount / maxCount) * chartHeight : 0}
+        {@const x = padding.left + i * barWidth}
+        <g>
+          {#each bin.segments as seg, j}
+            {@const segFraction = bin.totalCount > 0 ? seg.count / bin.totalCount : 0}
+            {@const segHeight = Math.max(segFraction * barHeight, seg.count > 0 ? 2 : 0)}
+            {@const segY = height - padding.bottom - barHeight + barHeight - segHeight - bin.segments.slice(j + 1).reduce((acc, s) => {
+              const frac = bin.totalCount > 0 ? s.count / bin.totalCount : 0;
+              return acc + Math.max(frac * barHeight, s.count > 0 ? 2 : 0);
+            }, 0)}
+            {@const segColor = getModelColor(seg.model)}
+            <rect
+              {x}
+              y={segY}
+              width={Math.max(barWidth - 1, 1)}
+              height={segHeight}
+              fill={segColor}
+              opacity="0.8"
+              class="hover:opacity-100 transition-opacity cursor-pointer"
+            />
+          {/each}
+          <title>{`${bin.binStart.toFixed(1)} - ${bin.binEnd.toFixed(1)} ${unit}\nTotal: ${bin.totalCount}\n${bin.segments.map(s => s.model + ': ' + s.count).join('\n')}`}</title>
+        </g>
+      {/each}
+    {:else}
+      {#each (data as HistogramData).bins as count, i}
+        {@const barHeight = maxCount > 0 ? (count / maxCount) * chartHeight : 0}
+        {@const x = padding.left + i * barWidth}
+        {@const y = height - padding.bottom - barHeight}
+        {@const binStart = data.min + i * data.binSize}
+        {@const binEnd = binStart + data.binSize}
+        <g>
+          <rect
+            {x}
+            {y}
+            width={Math.max(barWidth - 1, 1)}
+            height={barHeight}
+            fill="currentColor"
+            opacity="0.6"
+            class="{colorClass} hover:opacity-90 transition-opacity cursor-pointer"
+          />
+          <title>{`${binStart.toFixed(1)} - ${binEnd.toFixed(1)} ${unit}\nCount: ${count}`}</title>
+        </g>
+      {/each}
+    {/if}
 
     <!-- Percentile lines -->
-    <line
-      x1={getXPosition(data.p50)}
-      y1={padding.top}
-      x2={getXPosition(data.p50)}
-      y2={height - padding.bottom}
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-dasharray="4 2"
-      opacity="0.7"
-      class="text-gray-600 dark:text-gray-400"
-    />
+    {#if range > 0}
+      <line
+        x1={getXPosition(data.p50)}
+        y1={padding.top}
+        x2={getXPosition(data.p50)}
+        y2={height - padding.bottom}
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-dasharray="4 2"
+        opacity="0.7"
+        class="text-gray-600 dark:text-gray-400"
+      />
 
-    <line
-      x1={getXPosition(data.p95)}
-      y1={padding.top}
-      x2={getXPosition(data.p95)}
-      y2={height - padding.bottom}
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-dasharray="4 2"
-      opacity="0.7"
-      class="text-orange-500 dark:text-orange-400"
-    />
+      <line
+        x1={getXPosition(data.p95)}
+        y1={padding.top}
+        x2={getXPosition(data.p95)}
+        y2={height - padding.bottom}
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-dasharray="4 2"
+        opacity="0.7"
+        class="text-orange-500 dark:text-orange-400"
+      />
 
-    <line
-      x1={getXPosition(data.p99)}
-      y1={padding.top}
-      x2={getXPosition(data.p99)}
-      y2={height - padding.bottom}
-      stroke="currentColor"
-      stroke-width="2"
-      stroke-dasharray="4 2"
-      opacity="0.7"
-      class="text-green-500 dark:text-green-400"
-    />
+      <line
+        x1={getXPosition(data.p99)}
+        y1={padding.top}
+        x2={getXPosition(data.p99)}
+        y2={height - padding.bottom}
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-dasharray="4 2"
+        opacity="0.7"
+        class="text-green-500 dark:text-green-400"
+      />
+    {/if}
 
     <!-- X-axis labels -->
-    <text x={padding.left} y={height - 8} font-size="26" fill="currentColor" opacity="0.8" text-anchor="start">
+    <text x={padding.left} y={height - padding.bottom + 20} font-size="26" fill="currentColor" opacity="0.8" text-anchor="start">
       {data.min.toFixed(1)}
     </text>
 
     <text
       x={viewBoxWidth - padding.right}
-      y={height - 8}
+      y={height - padding.bottom + 20}
       font-size="26"
       fill="currentColor"
       opacity="0.8"
@@ -141,5 +203,32 @@
     >
       {data.max.toFixed(1)}
     </text>
+
+    <!-- Legend (stacked only) -->
+    {#if isStacked && legendItems.length > 0}
+      {@const legendY = height - 25}
+      {@const legendStartX = padding.left}
+      {@const legendItemWidth = Math.min(140, (chartWidth - (legendItems.length - 1) * 10) / legendItems.length)}
+      {#each legendItems as item, i}
+        {@const lx = legendStartX + i * (legendItemWidth + 10)}
+        <rect
+          x={lx}
+          y={legendY}
+          width="18"
+          height="18"
+          fill={item.color}
+          rx="3"
+        />
+        <text
+          x={lx + 23}
+          y={legendY + 14}
+          font-size="24"
+          fill="currentColor"
+          opacity="0.85"
+        >
+          {item.model.length > 12 ? item.model.slice(0, 11) + "…" : item.model}
+        </text>
+      {/each}
+    {/if}
   </svg>
 </div>

--- a/ui-svelte/src/components/TokenHistogram.svelte
+++ b/ui-svelte/src/components/TokenHistogram.svelte
@@ -108,11 +108,12 @@
         <g>
           {#each bin.segments as seg, j}
             {@const segFraction = bin.totalCount > 0 ? seg.count / bin.totalCount : 0}
-            {@const segHeight = Math.max(segFraction * barHeight, seg.count > 0 ? 2 : 0)}
-            {@const segY = height - padding.bottom - barHeight + barHeight - segHeight - bin.segments.slice(j + 1).reduce((acc, s) => {
+            {@const segHeight = segFraction * barHeight}
+            {@const stackedBelow = bin.segments.slice(0, j).reduce((acc, s) => {
               const frac = bin.totalCount > 0 ? s.count / bin.totalCount : 0;
-              return acc + Math.max(frac * barHeight, s.count > 0 ? 2 : 0);
+              return acc + frac * barHeight;
             }, 0)}
+            {@const segY = height - padding.bottom - stackedBelow - segHeight}
             {@const segColor = getModelColor(seg.model)}
             <rect
               {x}

--- a/ui-svelte/src/lib/histogram.test.ts
+++ b/ui-svelte/src/lib/histogram.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { calculateHistogramData } from "./histogram";
+import { calculateHistogramData, calculateStackedHistogramData } from "./histogram";
 
 describe("calculateHistogramData", () => {
   describe("edge cases", () => {
@@ -162,6 +162,163 @@ describe("calculateHistogramData", () => {
       const result = calculateHistogramData(values);
       expect(result!.min).toBe(0.5);
       expect(result!.max).toBe(4.99);
+    });
+  });
+});
+
+describe("calculateStackedHistogramData", () => {
+  describe("edge cases", () => {
+    it("returns null for empty input", () => {
+      expect(calculateStackedHistogramData([])).toBeNull();
+    });
+
+    it("handles single model", () => {
+      const entries = [
+        { model: "alpha", value: 10 },
+        { model: "alpha", value: 20 },
+        { model: "alpha", value: 30 },
+      ];
+      const result = calculateStackedHistogramData(entries);
+      expect(result).not.toBeNull();
+      expect(result!.models).toEqual(["alpha"]);
+      const totalSegments = result!.bins.reduce((s, b) => s + b.totalCount, 0);
+      expect(totalSegments).toBe(3);
+    });
+
+    it("handles single value per model", () => {
+      const entries = [
+        { model: "alpha", value: 42 },
+        { model: "beta", value: 42 },
+      ];
+      const result = calculateStackedHistogramData(entries);
+      expect(result).not.toBeNull();
+      expect(result!.min).toBe(42);
+      expect(result!.max).toBe(42);
+      expect(result!.bins.length).toBe(1);
+      expect(result!.bins[0].totalCount).toBe(2);
+    });
+  });
+
+  describe("multi-model stacking", () => {
+    it("groups values by model into segments", () => {
+      const entries = [
+        { model: "alpha", value: 10 },
+        { model: "alpha", value: 15 },
+        { model: "beta", value: 20 },
+        { model: "beta", value: 25 },
+        { model: "beta", value: 30 },
+      ];
+      const result = calculateStackedHistogramData(entries);
+      expect(result).not.toBeNull();
+      expect(result!.models).toEqual(["alpha", "beta"]);
+      const totalSegments = result!.bins.reduce((s, b) => s + b.totalCount, 0);
+      expect(totalSegments).toBe(5);
+    });
+
+    it("segment counts sum to total entries", () => {
+      const entries = [
+        { model: "a", value: 1 },
+        { model: "a", value: 2 },
+        { model: "b", value: 3 },
+        { model: "b", value: 4 },
+        { model: "c", value: 5 },
+      ];
+      const result = calculateStackedHistogramData(entries);
+      expect(result).not.toBeNull();
+      const totalSegments = result!.bins.reduce((s, b) => s + b.totalCount, 0);
+      expect(totalSegments).toBe(5);
+    });
+
+    it("models are sorted alphabetically", () => {
+      const entries = [
+        { model: "zebra", value: 10 },
+        { model: "alpha", value: 20 },
+        { model: "middle", value: 30 },
+      ];
+      const result = calculateStackedHistogramData(entries);
+      expect(result!.models).toEqual(["alpha", "middle", "zebra"]);
+    });
+
+    it("segments within bins are sorted by model", () => {
+      const entries = [
+        { model: "beta", value: 10 },
+        { model: "alpha", value: 10 },
+      ];
+      const result = calculateStackedHistogramData(entries);
+      const firstBin = result!.bins[0];
+      const modelNames = firstBin.segments.map((s) => s.model);
+      expect(modelNames).toEqual(["alpha", "beta"]);
+    });
+
+    it("omits zero-count segments from bins", () => {
+      const entries = [
+        { model: "alpha", value: 1 },
+        { model: "beta", value: 100 },
+      ];
+      const result = calculateStackedHistogramData(entries, { minBins: 3, maxBins: 3 });
+      expect(result).not.toBeNull();
+      // The first bin should only contain alpha (value=1)
+      const firstBin = result!.bins[0];
+      const modelsInFirstBin = firstBin.segments.map((s) => s.model);
+      expect(modelsInFirstBin).toEqual(["alpha"]);
+      // The last bin should only contain beta (value=100)
+      const lastBin = result!.bins[2];
+      const modelsInLastBin = lastBin.segments.map((s) => s.model);
+      expect(modelsInLastBin).toEqual(["beta"]);
+    });
+  });
+
+  describe("bin properties", () => {
+    it("each bin has correct start and end", () => {
+      const entries = [
+        { model: "a", value: 0 },
+        { model: "a", value: 10 },
+      ];
+      const result = calculateStackedHistogramData(entries, { minBins: 2, maxBins: 2 });
+      expect(result!.bins.length).toBe(2);
+      expect(result!.bins[0].binStart).toBe(0);
+      expect(result!.bins[0].binEnd).toBeCloseTo(5);
+      expect(result!.bins[1].binStart).toBeCloseTo(5);
+      expect(result!.bins[1].binEnd).toBe(10);
+    });
+
+    it("totalCount equals sum of segment counts", () => {
+      const entries = [
+        { model: "a", value: 1 },
+        { model: "a", value: 2 },
+        { model: "b", value: 3 },
+        { model: "b", value: 4 },
+        { model: "b", value: 5 },
+      ];
+      const result = calculateStackedHistogramData(entries);
+      for (const bin of result!.bins) {
+        const segmentSum = bin.segments.reduce((s, seg) => s + seg.count, 0);
+        expect(bin.totalCount).toBe(segmentSum);
+      }
+    });
+  });
+
+  describe("percentiles", () => {
+    it("computes percentiles from combined distribution", () => {
+      const entries = [
+        { model: "a", value: 1 },
+        { model: "a", value: 2 },
+        { model: "b", value: 3 },
+        { model: "b", value: 4 },
+      ];
+      const result = calculateStackedHistogramData(entries);
+      // Same as flat histogram of [1,2,3,4]
+      expect(result!.p50).toBe(2.5);
+    });
+
+    it("percentiles are monotonically increasing", () => {
+      const entries: { model: string; value: number }[] = [];
+      for (let i = 0; i < 100; i++) {
+        entries.push({ model: i % 2 === 0 ? "a" : "b", value: Math.random() * 100 });
+      }
+      const result = calculateStackedHistogramData(entries);
+      expect(result!.p50).toBeLessThanOrEqual(result!.p95);
+      expect(result!.p95).toBeLessThanOrEqual(result!.p99);
     });
   });
 });

--- a/ui-svelte/src/lib/histogram.ts
+++ b/ui-svelte/src/lib/histogram.ts
@@ -1,4 +1,19 @@
-import type { HistogramData } from "./types";
+import type { HistogramData, StackedHistogramData } from "./types";
+
+export const stackedHistogramColors = [
+  "#3b82f6", // blue
+  "#f59e0b", // amber
+  "#10b981", // emerald
+  "#ef4444", // red
+  "#8b5cf6", // violet
+  "#06b6d4", // cyan
+  "#ec4899", // pink
+  "#f97316", // orange
+  "#14b8a6", // teal
+  "#6366f1", // indigo
+  "#84cc16", // lime
+  "#e11d48", // rose
+];
 
 export interface HistogramOptions {
   minBins?: number;
@@ -67,5 +82,108 @@ export function calculateHistogramData(
     p50,
     p95,
     p99,
+  };
+}
+
+export interface StackedMetric {
+  model: string;
+  value: number;
+}
+
+export function calculateStackedHistogramData(
+  entries: StackedMetric[],
+  options: HistogramOptions = DEFAULT_OPTIONS,
+): StackedHistogramData | null {
+  const values = entries.map((e) => e.value);
+  if (values.length === 0) return null;
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const min = sorted[0];
+  const max = sorted[sorted.length - 1];
+
+  const p50 = percentile(sorted, 50);
+  const p95 = percentile(sorted, 95);
+  const p99 = percentile(sorted, 99);
+
+  // Group by model, preserving insertion order
+  const modelOrder = new Map<string, number>();
+  const modelValues = new Map<string, number[]>();
+  for (const entry of entries) {
+    if (!modelOrder.has(entry.model)) {
+      modelOrder.set(entry.model, modelOrder.size);
+      modelValues.set(entry.model, []);
+    }
+    modelValues.get(entry.model)!.push(entry.value);
+  }
+
+  // Sort models alphabetically for deterministic stacking order
+  const sortedModels = [...modelOrder.keys()].sort();
+  const modelIndexMap = new Map<string, number>();
+  sortedModels.forEach((m, i) => modelIndexMap.set(m, i));
+
+  if (min === max) {
+    const segments: { model: string; count: number }[] = sortedModels.map((model) => ({
+      model,
+      count: (modelValues.get(model) ?? []).length,
+    }));
+    return {
+      bins: [
+        {
+          binStart: min,
+          binEnd: max,
+          segments,
+          totalCount: values.length,
+        },
+      ],
+      min,
+      max,
+      binSize: 0,
+      p50,
+      p95,
+      p99,
+      models: sortedModels,
+    };
+  }
+
+  const { minBins = 5, maxBins = 20 } = options;
+  const sturges = Math.ceil(Math.log2(values.length)) + 1;
+  const binCount = Math.min(maxBins, Math.max(minBins, sturges));
+  const binSize = (max - min) / binCount;
+
+  const bins: { binStart: number; binEnd: number; segments: { model: string; count: number }[]; totalCount: number }[] =
+    [];
+  for (let i = 0; i < binCount; i++) {
+    const binStart = min + i * binSize;
+    const binEnd = binStart + binSize;
+    const segments: { model: string; count: number }[] = [];
+    let totalCount = 0;
+
+    for (const model of sortedModels) {
+      const mValues = modelValues.get(model) ?? [];
+      let count = 0;
+      for (const v of mValues) {
+        const idx = Math.min(Math.floor((v - min) / binSize), binCount - 1);
+        if (idx === i) {
+          count++;
+        }
+      }
+      if (count > 0) {
+        segments.push({ model, count });
+        totalCount += count;
+      }
+    }
+
+    bins.push({ binStart, binEnd, segments, totalCount });
+  }
+
+  return {
+    bins,
+    min,
+    max,
+    binSize,
+    p50,
+    p95,
+    p99,
+    models: sortedModels,
   };
 }

--- a/ui-svelte/src/lib/types.ts
+++ b/ui-svelte/src/lib/types.ts
@@ -105,6 +105,29 @@ export interface HistogramData {
   p50: number;
 }
 
+export interface StackedSegment {
+  model: string;
+  count: number;
+}
+
+export interface StackedBin {
+  binStart: number;
+  binEnd: number;
+  segments: StackedSegment[];
+  totalCount: number;
+}
+
+export interface StackedHistogramData {
+  bins: StackedBin[];
+  min: number;
+  max: number;
+  binSize: number;
+  p99: number;
+  p95: number;
+  p50: number;
+  models: string[];
+}
+
 export interface VersionInfo {
   build_date: string;
   commit: string;


### PR DESCRIPTION
Add stacked histogram support to the UI token activity charts so histogram bars can be grouped by model (stacked, new) or shown as a flat distribution (existing).
    - Add calculateStackedHistogramData, StackedMetric and stackedHistogramColors to ui-svelte/src/lib/histogram.ts.
    - Introduce StackedHistogramData/segments types in ui-svelte/src/lib/types.ts.
    - Extend TokenHistogram.svelte to render stacked bars, legend, and a stacked/flat switch (prop: stacked); improve axis/legend layout and add safety checks for empty data.
    - Update ActivityStats.svelte to compute stacked vs flat histogram data, add a UI toggle to switch modes, and keep the existing collapse control.
    - Add comprehensive unit tests for calculateStackedHistogramData in ui-svelte/src/lib/histogram.test.ts.
 
Example: 
<img width="1713" height="1266" alt="image" src="https://github.com/user-attachments/assets/1d4c2079-99a7-49cc-b950-c36c9e6fcd44" />
