### PR TITLE
Add priority-aware fairshare scheduler

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -651,6 +651,14 @@
                                             "type": "integer",
                                             "default": 0,
                                             "description": "Max waiters per model before rejecting with 429. 0 means unlimited."
+                                        },
+                                        "gatedPaths": {
+                                            "type": "string",
+                                            "description": "Regex matched against a request's model-relative path. Only matching requests consume a fairshare slot; non-matching requests proxied under /upstream/<model>/ (web UI, /props, static assets) pass through without throttling. Empty uses a default matching the inference endpoints (/v1, /v, /completion, /infill, /rerank, /sdapi image routes)."
+                                        },
+                                        "interactiveOrigins": {
+                                            "type": "string",
+                                            "description": "Regex matched against a request's Origin header. A request is interactive when it is browser-initiated (carries a Sec-Fetch-Mode header) AND its Origin matches this regex; interactive requests are admitted ahead of all batch/API requests for the same model. Empty matches any Origin (any browser-initiated request counts)."
                                         }
                                     },
                                     "additionalProperties": false

--- a/config-schema.json
+++ b/config-schema.json
@@ -583,10 +583,11 @@
                         "use": {
                             "type": "string",
                             "enum": [
-                                "fifo"
+                                "fifo",
+                                "fairshare"
                             ],
                             "default": "fifo",
-                            "description": "Scheduler to use. Only 'fifo' is currently supported."
+                            "description": "Scheduler to use: 'fifo' (first-in-first-out with per-model priority) or 'fairshare' (priority-aware fair admission against each model's concurrencyLimit)."
                         },
                         "settings": {
                             "type": "object",
@@ -600,6 +601,56 @@
                                             "additionalProperties": {
                                                 "type": "integer"
                                             }
+                                        }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "fairshare": {
+                                    "type": "object",
+                                    "description": "Settings for the 'fairshare' scheduler. Over-limit requests to a ready model are queued and admitted by priority as concurrency slots free.",
+                                    "properties": {
+                                        "mode": {
+                                            "type": "string",
+                                            "enum": [
+                                                "absolute",
+                                                "proportion"
+                                            ],
+                                            "default": "absolute",
+                                            "description": "How the priority number is interpreted: 'absolute' (rank, highest first) or 'proportion' (weight, weighted fair queuing)."
+                                        },
+                                        "priorityIncreasePerSecondWaiting": {
+                                            "type": "number",
+                                            "default": 0,
+                                            "description": "Aging: effective priority gained per second waited. 0 disables aging."
+                                        },
+                                        "priorities": {
+                                            "type": "object",
+                                            "description": "Caller id (API key) -> priority. An explicitly listed caller always wins.",
+                                            "additionalProperties": {
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "modelPriorities": {
+                                            "type": "object",
+                                            "description": "Model id -> priority for callers not listed in 'priorities'. Falls back to defaultPriority.",
+                                            "additionalProperties": {
+                                                "type": "integer"
+                                            }
+                                        },
+                                        "defaultPriority": {
+                                            "type": "integer",
+                                            "default": 1,
+                                            "description": "Priority for callers/models not listed above (including anonymous callers)."
+                                        },
+                                        "maxWait": {
+                                            "type": "string",
+                                            "default": "30s",
+                                            "description": "Hold a queued request up to this long (Go duration) before rejecting with 429. 0 disables the wait bound."
+                                        },
+                                        "maxQueueDepth": {
+                                            "type": "integer",
+                                            "default": 0,
+                                            "description": "Max waiters per model before rejecting with 429. 0 means unlimited."
                                         }
                                     },
                                     "additionalProperties": false

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -606,6 +606,22 @@ routing:
         # Default: 0 (unlimited; only maxWait bounds the queue).
         maxQueueDepth: 16
 
+        # gatedPaths: regex matched against a request's model-relative path.
+        # Only matching requests consume a fairshare slot; everything else
+        # proxied under /upstream/<model>/ (the model's web UI, /props, static
+        # assets) passes through untouched, so a saturated model stays
+        # reachable. Default (empty) matches the inference endpoints (/v1, /v,
+        # /completion, /infill, /rerank, /sdapi image routes).
+        # gatedPaths: '^/v1/'
+
+        # interactiveOrigins: regex matched against a request's Origin header.
+        # A request is treated as interactive when it is browser-initiated
+        # (carries a Sec-Fetch-Mode header, which scripts cannot forge) AND its
+        # Origin matches this regex. Interactive requests are admitted ahead of
+        # all batch/API requests for the same model. Empty (default) matches any
+        # Origin, so any browser-initiated request counts.
+        # interactiveOrigins: '^https://llm\.example\.com$'
+
 # peers: a dictionary of remote peers and models they provide
 # - optional, default empty dictionary
 # - peers can be another llama-swap

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -545,7 +545,7 @@ routing:
           full: "L"
 
   # scheduler: how queued requests are ordered.
-  # The default and only valid scheduler is "fifo"
+  # Valid schedulers are "fifo" (default) and "fairshare".
   scheduler:
     use: fifo
     settings:
@@ -559,6 +559,52 @@ routing:
           B: 5
           C: 5
           D: 1
+
+      # fairshare: priority-aware fair admission in front of each model's
+      # concurrencyLimit. When a ready model is at its limit, over-limit
+      # requests are queued and admitted by priority as slots free, rather than
+      # rejected with a bare 429. Used only when `use: fairshare`.
+      fairshare:
+        # mode: how the priority number is interpreted under contention.
+        # - "absolute" (default): rank — highest effective priority served first
+        #   (FIFO within a rank).
+        # - "proportion": weight — callers admitted in proportion to their
+        #   weight (weighted fair queuing); a weight-10 caller gets ~10x the
+        #   throughput of a weight-1 caller, and an idle class never holds back a
+        #   busy one.
+        mode: absolute
+
+        # priorityIncreasePerSecondWaiting: aging. Adds to a waiter's effective
+        # priority for every second it has waited, composing with either mode.
+        # 0 (default) disables aging. In absolute mode a positive value makes
+        # scheduling starvation-free.
+        priorityIncreasePerSecondWaiting: 0
+
+        # priorities: caller id (API key on the request) -> priority. An
+        # explicitly listed caller always wins (operator intent).
+        priorities:
+          sk-interactive: 10
+          sk-bulk-indexer: 1
+
+        # modelPriorities: model id -> priority, for callers not listed in
+        # `priorities` (e.g. a single client like Open WebUI that can't be told
+        # apart by API key). Falls back to defaultPriority.
+        modelPriorities:
+          A: 10
+          D: 1
+
+        # defaultPriority: callers/models not listed above (and anonymous
+        # callers). Default: 1.
+        defaultPriority: 5
+
+        # maxWait: hold a queued request up to this long before rejecting it with
+        # 429 + Retry-After. A request whose estimated wait already exceeds this
+        # at arrival is rejected immediately. Default: 30s. 0 disables.
+        maxWait: 30s
+
+        # maxQueueDepth: max waiters per model before rejecting with 429.
+        # Default: 0 (unlimited; only maxWait bounds the queue).
+        maxQueueDepth: 16
 
 # peers: a dictionary of remote peers and models they provide
 # - optional, default empty dictionary

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,6 +176,22 @@ type SchedulerConfig struct {
 	Settings SchedulerSettings `yaml:"settings"`
 }
 
+// ActivityPriorityFor returns the configured priority for a request and a label
+// for how that number is interpreted: "priority" (fairshare absolute mode),
+// "weight" (fairshare proportion mode), or "" when the active scheduler does
+// not prioritize. Used by the activity log to surface scheduler intent.
+func (s SchedulerConfig) ActivityPriorityFor(callerID, modelID string) (int, string) {
+	if s.Use != "fairshare" {
+		return 0, ""
+	}
+	fs := s.Settings.FairShare
+	mode := "priority"
+	if fs.ResolvedMode() == ModeProportion {
+		mode = "weight"
+	}
+	return fs.PriorityFor(callerID, modelID), mode
+}
+
 type SchedulerSettings struct {
 	Fifo      FifoConfig      `yaml:"fifo"`
 	FairShare FairShareConfig `yaml:"fairshare"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -192,6 +192,17 @@ func (s SchedulerConfig) ActivityPriorityFor(callerID, modelID string) (int, str
 	return fs.PriorityFor(callerID, modelID), mode
 }
 
+// InteractiveRequest reports whether a request with the given Sec-Fetch-Mode and
+// Origin header values should be treated as interactive (admitted ahead of batch
+// traffic). Only the fairshare scheduler distinguishes interactive requests;
+// other schedulers always return false.
+func (s SchedulerConfig) InteractiveRequest(secFetchMode, origin string) bool {
+	if s.Use != "fairshare" {
+		return false
+	}
+	return s.Settings.FairShare.Interactive(secFetchMode, origin)
+}
+
 type SchedulerSettings struct {
 	Fifo      FifoConfig      `yaml:"fifo"`
 	FairShare FairShareConfig `yaml:"fairshare"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -177,7 +177,8 @@ type SchedulerConfig struct {
 }
 
 type SchedulerSettings struct {
-	Fifo FifoConfig `yaml:"fifo"`
+	Fifo      FifoConfig      `yaml:"fifo"`
+	FairShare FairShareConfig `yaml:"fairshare"`
 }
 
 type FifoConfig struct {
@@ -565,13 +566,26 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 	if config.Routing.Scheduler.Use == "" {
 		config.Routing.Scheduler.Use = "fifo"
 	}
-	if config.Routing.Scheduler.Use != "fifo" {
-		return Config{}, fmt.Errorf("routing.scheduler.use: unknown scheduler %q (valid: fifo)", config.Routing.Scheduler.Use)
-	}
-	for modelID := range config.Routing.Scheduler.Settings.Fifo.Priority {
-		if _, found := config.RealModelName(modelID); !found {
-			return Config{}, fmt.Errorf("routing.scheduler.settings.fifo.priority references unknown model %q", modelID)
+	switch config.Routing.Scheduler.Use {
+	case "fifo":
+		for modelID := range config.Routing.Scheduler.Settings.Fifo.Priority {
+			if _, found := config.RealModelName(modelID); !found {
+				return Config{}, fmt.Errorf("routing.scheduler.settings.fifo.priority references unknown model %q", modelID)
+			}
 		}
+	case "fairshare":
+		fs := &config.Routing.Scheduler.Settings.FairShare
+		fs.applyDefaults()
+		if err := fs.Validate(); err != nil {
+			return Config{}, fmt.Errorf("routing.scheduler.settings.fairshare: %w", err)
+		}
+		for modelID := range fs.ModelPriorities {
+			if _, found := config.RealModelName(modelID); !found {
+				return Config{}, fmt.Errorf("routing.scheduler.settings.fairshare.modelPriorities references unknown model %q", modelID)
+			}
+		}
+	default:
+		return Config{}, fmt.Errorf("routing.scheduler.use: unknown scheduler %q (valid: fifo, fairshare)", config.Routing.Scheduler.Use)
 	}
 
 	// Clean up hooks preload

--- a/internal/config/fairshare.go
+++ b/internal/config/fairshare.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"fmt"
+	"time"
+)
+
+// SchedulingMode selects how the priority number is interpreted under
+// contention by the fairshare scheduler.
+type SchedulingMode string
+
+const (
+	// ModeAbsolute serves the highest-priority waiter first (FIFO within a
+	// priority). This is the default. With PriorityIncreasePerSecondWaiting > 0
+	// it becomes starvation-free: a waiter's effective priority climbs the
+	// longer it waits.
+	ModeAbsolute SchedulingMode = "absolute"
+
+	// ModeProportion treats the priority number as a weight and admits callers
+	// in proportion to their weights (weighted fair queuing). A weight-10 caller
+	// gets ~10x the throughput of a weight-1 caller under contention; an idle
+	// class never holds back a busy one (work-conserving).
+	ModeProportion SchedulingMode = "proportion"
+)
+
+// Defaults applied to a fairshare config when fields are left unset.
+const (
+	defaultFairSharePriority = 1
+	defaultFairShareMaxWait  = 30 * time.Second
+)
+
+// FairShareConfig configures the "fairshare" scheduler (routing.scheduler.use:
+// fairshare). It adds priority-aware fair admission in front of each model's
+// concurrencyLimit: when a ready model is at its limit, over-limit requests are
+// queued and admitted as slots free according to Mode — "absolute" (highest
+// priority first, FIFO within a priority) or "proportion" (priority as a weight,
+// weighted fair queuing). PriorityIncreasePerSecondWaiting ages a waiter's
+// effective priority up over time in either mode. A request is rejected
+// (429 + Retry-After) only when the queue is full or its estimated wait exceeds
+// MaxWait; Retry-After is a measured EWMA of the model's service time.
+type FairShareConfig struct {
+	// Mode selects how the priority number is interpreted: "absolute" (highest
+	// first) or "proportion" (weighted shares). Defaults to "absolute".
+	Mode SchedulingMode `yaml:"mode"`
+
+	// PriorityIncreasePerSecondWaiting adds to a waiter's effective priority for
+	// every second it has waited, composing with either mode. 0 (default)
+	// disables aging.
+	PriorityIncreasePerSecondWaiting float64 `yaml:"priorityIncreasePerSecondWaiting"`
+
+	// Priorities maps a caller id to a priority. The caller id is the API key
+	// presented on the request (Authorization Bearer/Basic password, or
+	// x-api-key). Higher priority is admitted first under contention.
+	Priorities map[string]int `yaml:"priorities"`
+
+	// ModelPriorities maps a model id to the default priority for that model. It
+	// applies to callers absent from Priorities (e.g. a single client like Open
+	// WebUI that can't be distinguished by API key), letting priority be driven
+	// by which model is requested. Models absent here fall back to
+	// DefaultPriority.
+	ModelPriorities map[string]int `yaml:"modelPriorities"`
+
+	// DefaultPriority is assigned to callers absent from both Priorities and
+	// ModelPriorities (including unauthenticated callers). Defaults to 1.
+	DefaultPriority int `yaml:"defaultPriority"`
+
+	// MaxWait bounds how long a queued request may wait for a slot before it is
+	// rejected with 429 + Retry-After. A request whose estimated wait already
+	// exceeds MaxWait at arrival is rejected immediately. Defaults to 30s.
+	MaxWait time.Duration `yaml:"maxWait"`
+
+	// MaxQueueDepth bounds the number of waiters per model. Arrivals beyond this
+	// are rejected with 429 + Retry-After. 0 (default) means unlimited depth
+	// (only MaxWait bounds the queue).
+	MaxQueueDepth int `yaml:"maxQueueDepth"`
+}
+
+// applyDefaults fills unset fields with their defaults. Called by
+// LoadConfigFromReader when the fairshare scheduler is selected.
+func (s *FairShareConfig) applyDefaults() {
+	if s.DefaultPriority == 0 {
+		s.DefaultPriority = defaultFairSharePriority
+	}
+	if s.MaxWait == 0 {
+		s.MaxWait = defaultFairShareMaxWait
+	}
+	if s.Mode == "" {
+		s.Mode = ModeAbsolute
+	}
+}
+
+// ResolvedMode returns the configured mode, defaulting to ModeAbsolute.
+func (s *FairShareConfig) ResolvedMode() SchedulingMode {
+	if s.Mode == ModeProportion {
+		return ModeProportion
+	}
+	return ModeAbsolute
+}
+
+// PriorityFor returns the priority for a request. An explicitly listed caller
+// wins (operator intent), then the model's default, then DefaultPriority.
+func (s *FairShareConfig) PriorityFor(callerID, modelID string) int {
+	if p, ok := s.Priorities[callerID]; ok {
+		return p
+	}
+	if p, ok := s.ModelPriorities[modelID]; ok {
+		return p
+	}
+	return s.DefaultPriority
+}
+
+// Validate checks the fairshare values and returns an error if invalid.
+func (s *FairShareConfig) Validate() error {
+	if s.MaxWait < 0 {
+		return fmt.Errorf("maxWait must be >= 0, got %v", s.MaxWait)
+	}
+	if s.MaxQueueDepth < 0 {
+		return fmt.Errorf("maxQueueDepth must be >= 0, got %d", s.MaxQueueDepth)
+	}
+	if s.Mode != "" && s.Mode != ModeAbsolute && s.Mode != ModeProportion {
+		return fmt.Errorf("mode must be %q or %q, got %q", ModeAbsolute, ModeProportion, s.Mode)
+	}
+	if s.PriorityIncreasePerSecondWaiting < 0 {
+		return fmt.Errorf("priorityIncreasePerSecondWaiting must be >= 0, got %v", s.PriorityIncreasePerSecondWaiting)
+	}
+	return nil
+}

--- a/internal/config/fairshare.go
+++ b/internal/config/fairshare.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 )
 
@@ -28,6 +29,16 @@ const (
 	defaultFairSharePriority = 1
 	defaultFairShareMaxWait  = 30 * time.Second
 )
+
+// defaultGatedPaths matches the inference endpoints that should consume a
+// fairshare slot: the OpenAI-compatible /v1 (and versionless /v) generation
+// routes, the native llama.cpp /completion and /infill, bare /rerank[ing], and
+// the stable-diffusion image routes. Everything else proxied under
+// /upstream/<model>/ (the model's web UI, /props, static assets, favicon, model
+// listings) is ungated so a busy model stays reachable.
+const defaultGatedPaths = `^/(v1|v)/(chat/completions|responses|completions|messages|embeddings|rerank|reranking|audio|images)` +
+	`|^/(completion|infill|reranking|rerank)\b` +
+	`|^/sdapi/v1/(txt2img|img2img)`
 
 // FairShareConfig configures the "fairshare" scheduler (routing.scheduler.use:
 // fairshare). It adds priority-aware fair admission in front of each model's
@@ -73,6 +84,33 @@ type FairShareConfig struct {
 	// are rejected with 429 + Retry-After. 0 (default) means unlimited depth
 	// (only MaxWait bounds the queue).
 	MaxQueueDepth int `yaml:"maxQueueDepth"`
+
+	// GatedPaths is a regex matched against a request's model-relative path
+	// (e.g. "/v1/chat/completions"). Only matching requests are subject to
+	// fairshare admission (concurrency limit, queueing, 429 backpressure);
+	// non-matching requests proxied under /upstream/<model>/ pass through
+	// without consuming a slot, so a model's web UI and other lightweight
+	// endpoints stay reachable while it is saturated with inference. Empty
+	// (the default) compiles to defaultGatedPaths.
+	GatedPaths string `yaml:"gatedPaths"`
+
+	// gatedRe is the compiled GatedPaths, set by Validate. A nil value gates
+	// every request (the pre-regex behavior), which is the safe default for a
+	// config built directly in tests without going through LoadConfigFromReader.
+	gatedRe *regexp.Regexp
+
+	// InteractiveOrigins is a regex matched against a request's Origin header to
+	// identify requests from an interactive browser UI. A request is treated as
+	// interactive when it carries a Sec-Fetch-Mode header (browser-initiated; a
+	// forbidden header that scripts cannot forge) AND its Origin matches this
+	// regex. Empty (the default) matches any Origin, so any browser-initiated
+	// request counts. Interactive requests are admitted ahead of all
+	// non-interactive (batch/API) requests for the same model — a hard tier on
+	// top of the priority/weight ordering.
+	InteractiveOrigins string `yaml:"interactiveOrigins"`
+
+	// interactiveRe is the compiled InteractiveOrigins, set by Validate.
+	interactiveRe *regexp.Regexp
 }
 
 // applyDefaults fills unset fields with their defaults. Called by
@@ -86,6 +124,9 @@ func (s *FairShareConfig) applyDefaults() {
 	}
 	if s.Mode == "" {
 		s.Mode = ModeAbsolute
+	}
+	if s.GatedPaths == "" {
+		s.GatedPaths = defaultGatedPaths
 	}
 }
 
@@ -123,5 +164,40 @@ func (s *FairShareConfig) Validate() error {
 	if s.PriorityIncreasePerSecondWaiting < 0 {
 		return fmt.Errorf("priorityIncreasePerSecondWaiting must be >= 0, got %v", s.PriorityIncreasePerSecondWaiting)
 	}
+	re, err := regexp.Compile(s.GatedPaths)
+	if err != nil {
+		return fmt.Errorf("gatedPaths is not a valid regex: %w", err)
+	}
+	s.gatedRe = re
+	ire, err := regexp.Compile(s.InteractiveOrigins)
+	if err != nil {
+		return fmt.Errorf("interactiveOrigins is not a valid regex: %w", err)
+	}
+	s.interactiveRe = ire
 	return nil
+}
+
+// Gated reports whether a request to the given model-relative path is subject to
+// fairshare admission. A nil compiled regex (config not run through Validate,
+// e.g. in tests) gates everything, preserving the pre-regex behavior.
+func (s *FairShareConfig) Gated(path string) bool {
+	if s.gatedRe == nil {
+		return true
+	}
+	return s.gatedRe.MatchString(path)
+}
+
+// Interactive reports whether a request from an interactive browser UI should be
+// admitted ahead of batch/API traffic. secFetchMode and origin are the request's
+// Sec-Fetch-Mode and Origin header values. A request qualifies only when it is
+// browser-initiated (Sec-Fetch-Mode present) and its Origin matches the
+// configured InteractiveOrigins regex (empty regex matches any Origin).
+func (s *FairShareConfig) Interactive(secFetchMode, origin string) bool {
+	if secFetchMode == "" {
+		return false
+	}
+	if s.interactiveRe == nil {
+		return true
+	}
+	return s.interactiveRe.MatchString(origin)
 }

--- a/internal/config/fairshare_test.go
+++ b/internal/config/fairshare_test.go
@@ -1,0 +1,91 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFairShareConfig_PriorityFor(t *testing.T) {
+	cfg := FairShareConfig{
+		Priorities:      map[string]int{"sk-vip": 10},
+		ModelPriorities: map[string]int{"chat": 7},
+		DefaultPriority: 3,
+	}
+	// Explicit caller wins over everything.
+	assert.Equal(t, 10, cfg.PriorityFor("sk-vip", "chat"))
+	// Unlisted caller falls to the model default.
+	assert.Equal(t, 7, cfg.PriorityFor("sk-other", "chat"))
+	// Unlisted caller and model fall to the default.
+	assert.Equal(t, 3, cfg.PriorityFor("sk-other", "embeddings"))
+	// Anonymous caller resolves the same way.
+	assert.Equal(t, 7, cfg.PriorityFor("", "chat"))
+}
+
+func TestFairShareConfig_Validate(t *testing.T) {
+	assert.NoError(t, (&FairShareConfig{}).Validate())
+	assert.Error(t, (&FairShareConfig{MaxWait: -1}).Validate())
+	assert.Error(t, (&FairShareConfig{MaxQueueDepth: -1}).Validate())
+	assert.Error(t, (&FairShareConfig{Mode: "bogus"}).Validate())
+	assert.Error(t, (&FairShareConfig{PriorityIncreasePerSecondWaiting: -1}).Validate())
+}
+
+func TestFairShareConfig_ResolvedMode(t *testing.T) {
+	assert.Equal(t, ModeAbsolute, (&FairShareConfig{}).ResolvedMode())
+	assert.Equal(t, ModeAbsolute, (&FairShareConfig{Mode: ModeAbsolute}).ResolvedMode())
+	assert.Equal(t, ModeProportion, (&FairShareConfig{Mode: ModeProportion}).ResolvedMode())
+}
+
+func TestLoadConfig_FairShareDefaults(t *testing.T) {
+	content := `
+models:
+  chat:
+    cmd: echo chat ${PORT}
+routing:
+  scheduler:
+    use: fairshare
+    settings:
+      fairshare:
+        modelPriorities:
+          chat: 9
+`
+	config, err := LoadConfigFromReader(strings.NewReader(content))
+	if !assert.NoError(t, err) {
+		t.Fatalf("load: %v", err)
+	}
+	fs := config.Routing.Scheduler.Settings.FairShare
+	assert.Equal(t, "fairshare", config.Routing.Scheduler.Use)
+	assert.Equal(t, 1, fs.DefaultPriority)             // default applied
+	assert.Equal(t, 30*time.Second, fs.MaxWait)        // default applied
+	assert.Equal(t, ModeAbsolute, fs.ResolvedMode())   // default mode
+	assert.Equal(t, 9, fs.PriorityFor("anon", "chat")) // model priority honored
+}
+
+func TestLoadConfig_FairShareUnknownModelPriority(t *testing.T) {
+	content := `
+models:
+  chat:
+    cmd: echo chat ${PORT}
+routing:
+  scheduler:
+    use: fairshare
+    settings:
+      fairshare:
+        modelPriorities:
+          ghost: 9
+`
+	_, err := LoadConfigFromReader(strings.NewReader(content))
+	assert.Error(t, err)
+}
+
+func TestLoadConfig_UnknownScheduler(t *testing.T) {
+	content := `
+routing:
+  scheduler:
+    use: bogus
+`
+	_, err := LoadConfigFromReader(strings.NewReader(content))
+	assert.Error(t, err)
+}

--- a/internal/config/fairshare_test.go
+++ b/internal/config/fairshare_test.go
@@ -89,3 +89,56 @@ routing:
 	_, err := LoadConfigFromReader(strings.NewReader(content))
 	assert.Error(t, err)
 }
+
+func TestFairShareConfig_GatedPaths(t *testing.T) {
+	cfg := FairShareConfig{}
+	cfg.applyDefaults()
+	assert.NoError(t, cfg.Validate())
+
+	gated := []string{
+		"/v1/chat/completions", "/v1/completions", "/v1/embeddings",
+		"/v1/messages", "/v/chat/completions", "/completion", "/infill",
+		"/rerank", "/reranking", "/v1/audio/speech", "/v1/images/generations",
+		"/sdapi/v1/txt2img",
+	}
+	for _, p := range gated {
+		assert.Truef(t, cfg.Gated(p), "Gated(%q) should be true", p)
+	}
+
+	ungated := []string{
+		"/", "/index.html", "/props", "/health", "/v1/models",
+		"/favicon.ico", "/assets/app.js", "/slots",
+	}
+	for _, p := range ungated {
+		assert.Falsef(t, cfg.Gated(p), "Gated(%q) should be false", p)
+	}
+
+	// A zero-value config (not run through Validate) gates everything, preserving
+	// the pre-regex behavior.
+	assert.True(t, (&FairShareConfig{}).Gated("/anything"))
+
+	// An invalid regex is a config error.
+	assert.Error(t, (&FairShareConfig{GatedPaths: "("}).Validate())
+}
+
+func TestFairShareConfig_Interactive(t *testing.T) {
+	// Empty origins => any browser-initiated (Sec-Fetch-Mode present) request.
+	anyOrigin := FairShareConfig{}
+	assert.NoError(t, anyOrigin.Validate())
+	assert.True(t, anyOrigin.Interactive("cors", "https://anything"))
+	assert.True(t, anyOrigin.Interactive("navigate", ""))
+	assert.False(t, anyOrigin.Interactive("", "https://anything")) // no Sec-Fetch => not a browser
+
+	// Origin allowlist => only matching origins count.
+	scoped := FairShareConfig{InteractiveOrigins: `^https://llm\.iodesystems\.com$`}
+	assert.NoError(t, scoped.Validate())
+	assert.True(t, scoped.Interactive("cors", "https://llm.iodesystems.com"))
+	assert.False(t, scoped.Interactive("cors", "https://evil.example"))
+	assert.False(t, scoped.Interactive("", "https://llm.iodesystems.com")) // not browser-initiated
+
+	// Unvalidated config (nil regex) treats any browser request as interactive.
+	assert.True(t, (&FairShareConfig{}).Interactive("cors", "x"))
+
+	// Invalid regex is a config error.
+	assert.Error(t, (&FairShareConfig{InteractiveOrigins: "("}).Validate())
+}

--- a/internal/router/base.go
+++ b/internal/router/base.go
@@ -197,6 +197,17 @@ func (b *baseRouter) GrantServe(req scheduler.HandlerReq, modelID string) bool {
 	return b.grant(req, scheduler.HandlerResp{HandleFunc: b.trackedServe(modelID, p)})
 }
 
+// GrantServeUntracked implements scheduler.Effects. Unlike GrantServe it hands
+// the caller p.ServeHTTP directly, with no trackedServe wrapper: the request
+// never fires serveDoneCh, so the scheduler does not count it against the
+// model's in-flight total or fold it into the service-time EWMA. The scheduler
+// uses this for ungated (non-inference) requests so they neither consume a
+// concurrency slot nor queue behind inference.
+func (b *baseRouter) GrantServeUntracked(req scheduler.HandlerReq, modelID string) bool {
+	p := b.processes[modelID]
+	return b.grant(req, scheduler.HandlerResp{HandleFunc: p.ServeHTTP})
+}
+
 // StopProcesses implements scheduler.Effects, stopping the named processes in
 // parallel and blocking until all have stopped.
 func (b *baseRouter) StopProcesses(timeout time.Duration, ids []string) {
@@ -420,8 +431,10 @@ func (b *baseRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	hr := scheduler.HandlerReq{
-		Model: data.ModelID,
-		Ctx:   req.Context(),
+		Model:       data.ModelID,
+		Path:        req.URL.Path,
+		Interactive: b.config.Routing.Scheduler.InteractiveRequest(req.Header.Get("Sec-Fetch-Mode"), req.Header.Get("Origin")),
+		Ctx:         req.Context(),
 		// Unbuffered: a successful send on Respond proves the waiter is
 		// alive and consuming. grant() relies on this to avoid handing a
 		// handleFunc to a cancelled waiter and leaking the inFlight count.

--- a/internal/router/scheduler/fairshare.go
+++ b/internal/router/scheduler/fairshare.go
@@ -185,6 +185,15 @@ func (s *FairShare) OnRequest(req HandlerReq) {
 	evict := s.planner.EvictionFor(req.Model, running)
 
 	if state == process.StateReady && len(evict) == 0 && !collidesWith(req.Model, evict, s.active) {
+		// Ungated (non-inference) request to a ready model: serve immediately
+		// without consuming a concurrency slot or queueing behind inference, so
+		// the model's web UI and other lightweight endpoints stay reachable
+		// while it is saturated. Cold-model ungated requests fall through to the
+		// normal path below (they load the model and count once).
+		if !s.cfg.Gated(req.Path) {
+			s.effects.GrantServeUntracked(req, req.Model)
+			return
+		}
 		// Ready and nothing to evict — gate on the concurrency limit.
 		if s.inFlight[req.Model] < s.limit(req.Model) && s.countWaiters(req.Model) == 0 {
 			s.grantHandler(req, req.Model)
@@ -446,6 +455,30 @@ func (s *FairShare) admissionOrderForModel(modelID string) []*fairWaiter {
 			ws = append(ws, w)
 		}
 	}
+	if len(ws) <= 1 {
+		return ws
+	}
+	// Hard interactive tier: every interactive waiter is admitted before any
+	// non-interactive one, with the configured mode ordering applied within each
+	// tier. When only one tier is present, order the whole set directly.
+	var interactive, batch []*fairWaiter
+	for _, w := range ws {
+		if w.req.Interactive {
+			interactive = append(interactive, w)
+		} else {
+			batch = append(batch, w)
+		}
+	}
+	if len(interactive) > 0 && len(batch) > 0 {
+		order := s.orderTier(modelID, interactive)
+		return append(order, s.orderTier(modelID, batch)...)
+	}
+	return s.orderTier(modelID, ws)
+}
+
+// orderTier returns the admission order for a single tier of waiters using the
+// configured mode (absolute priority+aging, or proportional weighted-fair).
+func (s *FairShare) orderTier(modelID string, ws []*fairWaiter) []*fairWaiter {
 	if len(ws) <= 1 {
 		return ws
 	}

--- a/internal/router/scheduler/fairshare.go
+++ b/internal/router/scheduler/fairshare.go
@@ -1,0 +1,738 @@
+package scheduler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/process"
+	"github.com/mostlygeek/llama-swap/internal/shared"
+)
+
+// BackpressureError is the shared.HTTPError fairshare returns when it sheds a
+// request under contention: a 429 carrying the model's capacity on
+// X-RateLimit-* headers and Retry-After, plus a JSON body describing the
+// contention so a client can right-size its own parallelism instead of fanning
+// out and competing with itself. router.SendError renders it verbatim.
+type BackpressureError struct {
+	Model       string
+	Reason      string // "queue_full" or "max_wait"
+	RetryAfter  int    // whole seconds, >= 1
+	Concurrency int    // the model's hard slot count
+	Inflight    int    // slots in use at reject time
+	Waiting     int    // requests already queued at reject time
+}
+
+func (e *BackpressureError) Error() string {
+	return fmt.Sprintf("too many requests for model %s (%s): retry after %ds", e.Model, e.Reason, e.RetryAfter)
+}
+
+func (e *BackpressureError) StatusCode() int { return http.StatusTooManyRequests }
+
+func (e *BackpressureError) Header() http.Header {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	h.Set("Retry-After", strconv.Itoa(e.RetryAfter))
+	h.Set("X-RateLimit-Limit", strconv.Itoa(e.Concurrency))
+	h.Set("X-RateLimit-Inflight", strconv.Itoa(e.Inflight))
+	h.Set("X-RateLimit-Waiting", strconv.Itoa(e.Waiting))
+	return h
+}
+
+func (e *BackpressureError) Body() []byte {
+	payload := map[string]any{
+		"error":       "Too many requests",
+		"reason":      e.Reason,
+		"retry_after": e.RetryAfter,
+		"model":       e.Model,
+		"hint": map[string]int{
+			"max_concurrency": e.Concurrency,
+			"inflight":        e.Inflight,
+			"waiting":         e.Waiting,
+		},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return []byte(`{"error":"Too many requests"}`)
+	}
+	return b
+}
+
+// fairWaiter is one request parked in the fairshare queue awaiting either a
+// model swap or a free concurrency slot.
+type fairWaiter struct {
+	req        HandlerReq
+	caller     string
+	priority   int
+	seq        uint64
+	enqueuedAt time.Time
+}
+
+// callerOf resolves a request's caller id (the API key) from its context, or ""
+// when none was sent. The request-context middleware stores it on
+// shared.ReqContextData; the nil-Ctx guard keeps non-fairshare callers and
+// tests that omit a context safe.
+func callerOf(req HandlerReq) string {
+	if req.Ctx == nil {
+		return ""
+	}
+	data, _ := shared.ReadContext(req.Ctx)
+	return data.ApiKey
+}
+
+// maskCaller renders a caller id for the activity log without leaking the raw
+// API key: "" becomes "anonymous", a short value passes through (too short to
+// be a secret), and anything longer is reduced to a 5-char prefix plus its
+// length (e.g. "sk-ragtag" -> "sk-ra…9") so distinct callers stay
+// distinguishable without exposing the key.
+func maskCaller(caller string) string {
+	if caller == "" {
+		return "anonymous"
+	}
+	if len(caller) <= 5 {
+		return caller
+	}
+	return caller[:5] + "…" + strconv.Itoa(len(caller))
+}
+
+// modelSchedState holds the per-model bookkeeping the fairshare scheduler keeps
+// outside the run-loop-shared maps: an EWMA of service time (for Retry-After
+// estimates) and the weighted-fair-queuing virtual clock used in proportion
+// mode.
+type modelSchedState struct {
+	ewma   time.Duration // measured service time, exponentially weighted (alpha 0.25)
+	starts []time.Time   // grant start times, FIFO-matched on serve-done for the EWMA
+
+	// proportion mode virtual-time state:
+	vtime       float64            // global virtual time = start of last admit
+	classFinish map[string]float64 // per-caller virtual finish time
+}
+
+// FairShare is a priority-aware fair-admission scheduler. It makes the same
+// swap decisions as FIFO, but additionally enforces each model's concurrency
+// limit itself: when a ready model is at its limit, over-limit requests are
+// queued and admitted as slots free in priority order rather than served
+// immediately. Two modes interpret the priority number differently —
+// "absolute" (rank: highest served first, FIFO within a rank) and "proportion"
+// (weight: callers admitted in proportion to weight, weighted fair queuing) —
+// and PriorityIncreasePerSecondWaiting ages a waiter's effective priority up
+// over time in either mode.
+//
+// Like every Scheduler, all methods run on the baseRouter run-loop goroutine,
+// so no internal locking is needed.
+type FairShare struct {
+	name    string
+	logger  *logmon.Monitor
+	planner Swapper
+	cfg     config.FairShareConfig
+	limits  map[string]int // model ID -> concurrency limit
+	effects Effects
+	now     func() time.Time
+
+	active   map[string]*activeSwap // in-flight swaps (waiters list unused; queue holds waiters)
+	inFlight map[string]int
+	queued   []*fairWaiter
+	seq      uint64
+
+	state map[string]*modelSchedState
+}
+
+// NewFairShare builds a fairshare scheduler. limits maps each model ID to its
+// concurrency limit (the router derives this from each model's concurrencyLimit,
+// defaulting unset entries). It matches scheduler.Factory once a planner and
+// config are captured in a closure.
+func NewFairShare(name string, logger *logmon.Monitor, planner Swapper, cfg config.FairShareConfig, limits map[string]int, eff Effects) *FairShare {
+	return &FairShare{
+		name:     name,
+		logger:   logger,
+		planner:  planner,
+		cfg:      cfg,
+		limits:   limits,
+		effects:  eff,
+		now:      time.Now,
+		active:   make(map[string]*activeSwap),
+		inFlight: make(map[string]int),
+		state:    make(map[string]*modelSchedState),
+	}
+}
+
+// OnRequest mirrors FIFO's decision tree, with one addition: a ready model that
+// is at its concurrency limit does not fast-path serve — the request is queued
+// (or shed with a 429) and admitted later in priority order.
+func (s *FairShare) OnRequest(req HandlerReq) {
+	state, ok := s.effects.ModelState(req.Model)
+	if !ok {
+		s.logger.Debugf("%s: model %s not handled by this router", s.name, req.Model)
+		s.effects.GrantError(req, ErrModelNotFound)
+		return
+	}
+
+	prio := s.cfg.PriorityFor(callerOf(req), req.Model)
+
+	// A swap for this model is already in flight: it can't serve until the swap
+	// completes, so park it. OnSwapDone will drain it.
+	if _, ok := s.active[req.Model]; ok {
+		s.enqueue(req, prio)
+		return
+	}
+
+	running := s.runningSet(req.Model)
+	evict := s.planner.EvictionFor(req.Model, running)
+
+	if state == process.StateReady && len(evict) == 0 && !collidesWith(req.Model, evict, s.active) {
+		// Ready and nothing to evict — gate on the concurrency limit.
+		if s.inFlight[req.Model] < s.limit(req.Model) && s.countWaiters(req.Model) == 0 {
+			s.grantHandler(req, req.Model)
+			return
+		}
+		if s.inFlight[req.Model] >= s.limit(req.Model) {
+			if rej := s.boundedReject(req.Model); rej != nil {
+				s.logger.Debugf("%s: shedding request for model %s (%s)", s.name, req.Model, rej.Reason)
+				s.effects.GrantError(req, rej)
+				return
+			}
+		}
+		s.enqueue(req, prio)
+		s.drainQueue()
+		return
+	}
+
+	// Not servable now: collision or would-evict-busy means wait; otherwise a
+	// swap is needed. In all cases park the request and let drainQueue decide
+	// (starting the swap if appropriate).
+	s.enqueue(req, prio)
+	s.drainQueue()
+}
+
+// OnSwapDone errors every queued waiter for a failed swap, drops the swap from
+// active tracking, then drains the queue: a finished swap may have made a model
+// ready or freed a collision.
+func (s *FairShare) OnSwapDone(ev SwapDone) {
+	if _, ok := s.active[ev.ModelID]; !ok {
+		return
+	}
+	delete(s.active, ev.ModelID)
+
+	if ev.Err != nil {
+		s.errorModelWaiters(ev.ModelID, ev.Err)
+	}
+	s.drainQueue()
+}
+
+// OnServeDone decrements the model's in-flight count, folds the measured service
+// time into its EWMA, and drains the queue — a freed slot may admit the next
+// waiter (and a fully-drained model may now be evictable).
+func (s *FairShare) OnServeDone(ev ServeDoneEvent) {
+	if s.inFlight[ev.ModelID] > 0 {
+		s.inFlight[ev.ModelID]--
+	}
+	s.observeServiceTime(ev.ModelID)
+	if s.inFlight[ev.ModelID] <= 0 {
+		delete(s.inFlight, ev.ModelID)
+	}
+	s.drainQueue()
+	s.resetIfIdle(ev.ModelID)
+}
+
+// OnUnload errors waiters for the unloaded models, stops the processes
+// (synchronously), then drains the queue.
+func (s *FairShare) OnUnload(targets []string, timeout time.Duration) {
+	unloadErr := fmt.Errorf("%s: model unloaded", s.name)
+
+	targetSet := make(map[string]bool, len(targets))
+	for _, id := range targets {
+		targetSet[id] = true
+	}
+	for id := range targetSet {
+		delete(s.active, id)
+		s.errorModelWaiters(id, unloadErr)
+	}
+
+	s.effects.StopProcesses(timeout, targets)
+	s.drainQueue()
+}
+
+// OnShutdown errors every queued waiter.
+func (s *FairShare) OnShutdown(err error) {
+	for _, w := range s.queued {
+		s.effects.GrantError(w.req, err)
+	}
+	s.queued = nil
+}
+
+// OnCancel prunes a request whose client disconnected before it was granted, so
+// it never triggers a model load or admission. Fairshare parks all waiters in
+// the queue (active swaps hold none), so removing the matching queue entry and
+// re-running the drain/position broadcast is sufficient. Matching is by the
+// request's Respond channel, which uniquely identifies the in-flight caller.
+func (s *FairShare) OnCancel(req HandlerReq) {
+	removed := false
+	kept := s.queued[:0]
+	for _, w := range s.queued {
+		if w.req.Respond == req.Respond {
+			removed = true
+			continue
+		}
+		kept = append(kept, w)
+	}
+	s.queued = kept
+	if removed {
+		s.logger.Debugf("%s: cancelled request for model %s pruned from queue", s.name, req.Model)
+		s.drainQueue()
+	}
+}
+
+// grantHandler hands the caller a tracked handler and, only if the caller was
+// still there to receive it, bumps in-flight and records the grant time for the
+// service-time EWMA. It also records the request's masked caller and the
+// priority/weight (and mode) it was scheduled under as request metadata, which
+// the metrics middleware surfaces in the activity log.
+func (s *FairShare) grantHandler(req HandlerReq, modelID string) bool {
+	caller := callerOf(req)
+	if err := shared.SetReqData(req.Ctx, "caller", maskCaller(caller)); err != nil {
+		s.logger.Debugf("%s: failed to set request metadata: %v", s.name, err)
+	} else {
+		shared.SetReqData(req.Ctx, "fairshare_priority", strconv.Itoa(s.cfg.PriorityFor(caller, modelID)))
+		shared.SetReqData(req.Ctx, "fairshare_mode", string(s.cfg.ResolvedMode()))
+	}
+	if s.effects.GrantServe(req, modelID) {
+		s.inFlight[modelID]++
+		st := s.modelState(modelID)
+		st.starts = append(st.starts, s.now())
+		return true
+	}
+	return false
+}
+
+// startSwap records the swap as active and launches it via Effects. The
+// triggering waiters stay in the queue and are served on OnSwapDone.
+func (s *FairShare) startSwap(modelID string, evict, running []string) {
+	s.active[modelID] = &activeSwap{modelID: modelID, evict: evict}
+	s.planner.OnSwapStart(modelID, running)
+	s.effects.StartSwap(modelID, evict)
+}
+
+// enqueue parks a request, computing its base priority and arrival ordering.
+func (s *FairShare) enqueue(req HandlerReq, priority int) {
+	w := &fairWaiter{req: req, caller: callerOf(req), priority: priority, seq: s.seq, enqueuedAt: s.now()}
+	s.seq++
+	s.queued = append(s.queued, w)
+	s.broadcastPositions()
+}
+
+// drainQueue repeatedly walks the models that have waiters, in priority order,
+// serving what can be served until nothing changes. For each model it either
+// admits waiters up to the concurrency limit (in admission order), starts a
+// swap, or leaves the waiters parked.
+func (s *FairShare) drainQueue() {
+	for {
+		progress := false
+		for _, m := range s.modelsByPriority() {
+			if s.drainModel(m) {
+				progress = true
+			}
+		}
+		if !progress {
+			break
+		}
+	}
+	s.broadcastPositions()
+}
+
+// drainModel makes whatever progress it can for a single model, returning
+// whether it changed any state.
+func (s *FairShare) drainModel(m string) bool {
+	if _, ok := s.active[m]; ok {
+		return false // swap in flight; wait for OnSwapDone
+	}
+	state, ok := s.effects.ModelState(m)
+	if !ok {
+		s.errorModelWaiters(m, ErrModelNotFound)
+		return true
+	}
+	running := s.runningSet(m)
+	evict := s.planner.EvictionFor(m, running)
+
+	if state == process.StateReady && len(evict) == 0 && !collidesWith(m, evict, s.active) {
+		progressed := false
+		for s.inFlight[m] < s.limit(m) {
+			w := s.bestWaiterForModel(m)
+			if w == nil {
+				break
+			}
+			s.removeWaiter(w)
+			s.commitProportion(m, w)
+			s.grantHandler(w.req, m) // a false return means the caller left; still progress
+			progressed = true
+		}
+		return progressed
+	}
+
+	if collidesWith(m, evict, s.active) || conflictsWithInFlight(evict, s.inFlight) {
+		return false // would collide or evict a busy process; wait
+	}
+	if s.countWaiters(m) == 0 {
+		return false
+	}
+	s.logger.Debugf("%s: starting swap for model %s, evicting %v", s.name, m, evict)
+	s.startSwap(m, evict, running)
+	return true
+}
+
+// boundedReject returns a BackpressureError if a new waiter for a saturated
+// model should be shed (queue full or estimated wait beyond MaxWait), or nil if
+// it may queue. Called only when the model is ready and at its limit.
+func (s *FairShare) boundedReject(modelID string) *BackpressureError {
+	waiting := s.countWaiters(modelID)
+	inflight := s.inFlight[modelID]
+	concurrency := s.limit(modelID)
+	ahead := waiting + 1
+	est := s.estimateWait(modelID, ahead)
+
+	mk := func(reason string) *BackpressureError {
+		return &BackpressureError{
+			Model:       modelID,
+			Reason:      reason,
+			RetryAfter:  retryAfterSecs(est),
+			Concurrency: concurrency,
+			Inflight:    inflight,
+			Waiting:     waiting,
+		}
+	}
+	if s.cfg.MaxQueueDepth > 0 && waiting >= s.cfg.MaxQueueDepth {
+		return mk("queue_full")
+	}
+	if s.cfg.MaxWait > 0 && est > s.cfg.MaxWait {
+		return mk("max_wait")
+	}
+	return nil
+}
+
+// errorModelWaiters errors and removes every queued waiter for a model.
+func (s *FairShare) errorModelWaiters(modelID string, err error) {
+	kept := s.queued[:0]
+	for _, w := range s.queued {
+		if w.req.Model == modelID {
+			s.effects.GrantError(w.req, err)
+			continue
+		}
+		kept = append(kept, w)
+	}
+	s.queued = kept
+}
+
+// bestWaiterForModel returns the waiter for modelID that should be admitted
+// next, or nil if none are queued.
+func (s *FairShare) bestWaiterForModel(modelID string) *fairWaiter {
+	order := s.admissionOrderForModel(modelID)
+	if len(order) == 0 {
+		return nil
+	}
+	return order[0]
+}
+
+// admissionOrderForModel returns modelID's queued waiters in the order they
+// would be admitted. It does not mutate scheduler state, so it drives both the
+// next-admit decision and the position display.
+func (s *FairShare) admissionOrderForModel(modelID string) []*fairWaiter {
+	var ws []*fairWaiter
+	for _, w := range s.queued {
+		if w.req.Model == modelID {
+			ws = append(ws, w)
+		}
+	}
+	if len(ws) <= 1 {
+		return ws
+	}
+	now := s.now()
+	if s.cfg.ResolvedMode() == config.ModeProportion {
+		return s.proportionOrder(modelID, ws, now)
+	}
+	sort.SliceStable(ws, func(i, j int) bool {
+		ei, ej := s.effective(ws[i], now), s.effective(ws[j], now)
+		if ei != ej {
+			return ei > ej
+		}
+		return ws[i].seq < ws[j].seq
+	})
+	return ws
+}
+
+// proportionOrder simulates weighted-fair-queuing admission over the waiters on
+// a clone of the model's virtual clock, returning admission order. Each caller's
+// next request gets a virtual start of max(its finish, vtime); the smallest
+// start is served next and that caller's finish advances by 1/weight, so
+// higher-weight callers are served proportionally more often.
+func (s *FairShare) proportionOrder(modelID string, ws []*fairWaiter, now time.Time) []*fairWaiter {
+	sort.SliceStable(ws, func(i, j int) bool { return ws[i].seq < ws[j].seq })
+
+	st := s.modelState(modelID)
+	finish := make(map[string]float64, len(st.classFinish))
+	for k, v := range st.classFinish {
+		finish[k] = v
+	}
+	vtime := st.vtime
+
+	heads := map[string]int{}
+	remaining := len(ws)
+	order := make([]*fairWaiter, 0, len(ws))
+	for remaining > 0 {
+		var pick *fairWaiter
+		var pickStart float64
+		for i, w := range ws {
+			if w == nil {
+				continue
+			}
+			if idx, seen := heads[w.caller]; seen && idx != i {
+				continue
+			}
+			start := finish[w.caller]
+			if start < vtime {
+				start = vtime
+			}
+			if pick == nil || start < pickStart || (start == pickStart && w.seq < pick.seq) {
+				pick, pickStart = w, start
+			}
+		}
+		weight := s.effective(pick, now)
+		if weight < 1 {
+			weight = 1
+		}
+		vtime = pickStart
+		finish[pick.caller] = pickStart + 1.0/weight
+		order = append(order, pick)
+		for i := range ws {
+			if ws[i] == pick {
+				ws[i] = nil
+				break
+			}
+		}
+		next := -1
+		for i, w := range ws {
+			if w != nil && w.caller == pick.caller {
+				next = i
+				break
+			}
+		}
+		if next >= 0 {
+			heads[pick.caller] = next
+		} else {
+			delete(heads, pick.caller)
+		}
+		remaining--
+	}
+	return order
+}
+
+// commitProportion applies the real virtual-clock side effect of admitting w in
+// proportion mode (no-op in absolute mode), mirroring proportionOrder's first
+// step so the display and the actual admission agree.
+func (s *FairShare) commitProportion(modelID string, w *fairWaiter) {
+	if s.cfg.ResolvedMode() != config.ModeProportion {
+		return
+	}
+	st := s.modelState(modelID)
+	if st.classFinish == nil {
+		st.classFinish = map[string]float64{}
+	}
+	start := st.classFinish[w.caller]
+	if start < st.vtime {
+		start = st.vtime
+	}
+	weight := s.effective(w, s.now())
+	if weight < 1 {
+		weight = 1
+	}
+	st.vtime = start
+	st.classFinish[w.caller] = start + 1.0/weight
+}
+
+// effective returns a waiter's priority/weight with aging applied.
+func (s *FairShare) effective(w *fairWaiter, now time.Time) float64 {
+	p := float64(w.priority)
+	if s.cfg.PriorityIncreasePerSecondWaiting > 0 {
+		p += s.cfg.PriorityIncreasePerSecondWaiting * now.Sub(w.enqueuedAt).Seconds()
+	}
+	return p
+}
+
+// modelsByPriority returns the distinct models with queued waiters, ordered by
+// the highest effective priority among each model's waiters (so the most urgent
+// model gets first crack at swap capacity).
+func (s *FairShare) modelsByPriority() []string {
+	now := s.now()
+	best := map[string]float64{}
+	var models []string
+	for _, w := range s.queued {
+		e := s.effective(w, now)
+		if cur, ok := best[w.req.Model]; !ok || e > cur {
+			if !ok {
+				models = append(models, w.req.Model)
+			}
+			best[w.req.Model] = e
+		}
+	}
+	sort.SliceStable(models, func(i, j int) bool {
+		return best[models[i]] > best[models[j]]
+	})
+	return models
+}
+
+// broadcastPositions sends every queued waiter its current 1-indexed position
+// in its model's admission order.
+func (s *FairShare) broadcastPositions() {
+	seen := map[string]bool{}
+	for _, w := range s.queued {
+		if seen[w.req.Model] {
+			continue
+		}
+		seen[w.req.Model] = true
+		for i, ow := range s.admissionOrderForModel(w.req.Model) {
+			sendPosition(ow.req.PositionCh, i+1)
+		}
+	}
+}
+
+// observeServiceTime folds the oldest outstanding grant's duration into the
+// model's EWMA (alpha 0.25). FIFO-matched to grants, it is an approximation but
+// good enough for a Retry-After hint.
+func (s *FairShare) observeServiceTime(modelID string) {
+	st := s.state[modelID]
+	if st == nil || len(st.starts) == 0 {
+		return
+	}
+	d := s.now().Sub(st.starts[0])
+	st.starts = st.starts[1:]
+	if d <= 0 {
+		return
+	}
+	if st.ewma <= 0 {
+		st.ewma = d
+	} else {
+		st.ewma = (d + 3*st.ewma) / 4
+	}
+}
+
+// estimateWait returns ahead/limit service intervals at the model's current
+// EWMA, with a 1s seed before any observation.
+func (s *FairShare) estimateWait(modelID string, ahead int) time.Duration {
+	ewma := time.Second
+	if st := s.state[modelID]; st != nil && st.ewma > 0 {
+		ewma = st.ewma
+	}
+	limit := s.limit(modelID)
+	batches := (ahead + limit - 1) / limit
+	if batches < 1 {
+		batches = 1
+	}
+	return ewma * time.Duration(batches)
+}
+
+// resetIfIdle clears a model's WFQ virtual clock and EWMA grant tracking once it
+// is fully idle, so shares are accounted within a contention episode and the
+// float counters cannot drift without bound.
+func (s *FairShare) resetIfIdle(modelID string) {
+	if s.inFlight[modelID] != 0 || s.countWaiters(modelID) != 0 {
+		return
+	}
+	if st := s.state[modelID]; st != nil {
+		st.vtime = 0
+		st.classFinish = nil
+		st.starts = nil
+	}
+}
+
+// runningSet is the live model set handed to the Swapper: every running process
+// unioned with the targets of in-flight swaps, excluding the model being
+// decided. Sorted for determinism.
+func (s *FairShare) runningSet(excludeActive string) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	add := func(id string) {
+		if _, dup := seen[id]; dup {
+			return
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	for id := range s.effects.RunningModels() {
+		add(id)
+	}
+	for _, id := range activeTargets(s.active, excludeActive) {
+		add(id)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (s *FairShare) modelState(modelID string) *modelSchedState {
+	st := s.state[modelID]
+	if st == nil {
+		st = &modelSchedState{classFinish: map[string]float64{}}
+		s.state[modelID] = st
+	}
+	return st
+}
+
+func (s *FairShare) countWaiters(modelID string) int {
+	n := 0
+	for _, w := range s.queued {
+		if w.req.Model == modelID {
+			n++
+		}
+	}
+	return n
+}
+
+func (s *FairShare) removeWaiter(target *fairWaiter) {
+	for i, w := range s.queued {
+		if w == target {
+			s.queued = append(s.queued[:i], s.queued[i+1:]...)
+			return
+		}
+	}
+}
+
+func (s *FairShare) limit(modelID string) int {
+	if l, ok := s.limits[modelID]; ok && l > 0 {
+		return l
+	}
+	return defaultConcurrencyLimit
+}
+
+// retryAfterSecs renders a duration as whole seconds (ceil), floored at 1.
+func retryAfterSecs(d time.Duration) int {
+	if d <= 0 {
+		return 1
+	}
+	secs := int((d + time.Second - 1) / time.Second)
+	if secs < 1 {
+		return 1
+	}
+	return secs
+}
+
+// sendPosition does a non-blocking latest-wins send: a full channel is drained
+// and the newest value queued, so the scheduler never blocks on a slow consumer.
+func sendPosition(ch chan int, pos int) {
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- pos:
+	default:
+		select {
+		case <-ch:
+		default:
+		}
+		select {
+		case ch <- pos:
+		default:
+		}
+	}
+}

--- a/internal/router/scheduler/fairshare_test.go
+++ b/internal/router/scheduler/fairshare_test.go
@@ -382,3 +382,77 @@ func indexOf(s, sub string) int {
 	}
 	return -1
 }
+
+// Ungated (non-inference) requests bypass the concurrency limit: at a saturated
+// model they are served untracked (no slot consumed) instead of queueing, so the
+// model's web UI stays reachable. The queued inference request is unaffected.
+func TestFairShare_UngatedBypassesConcurrency(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateReady
+	cfg := config.FairShareConfig{GatedPaths: `^/v1/`}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	s := newFair(&stubPlanner{}, eff, cfg, map[string]int{"a": 1})
+
+	gated := func(caller string) HandlerReq {
+		r := reqC("a", caller)
+		r.Path = "/v1/chat/completions"
+		return r
+	}
+
+	s.OnRequest(gated("first"))  // fills the only slot
+	s.OnRequest(gated("queued")) // over limit -> queued
+	if got := eff.trackedServed("a"); got != 1 {
+		t.Fatalf("trackedServed(a)=%d want 1 (second gated request must queue)", got)
+	}
+
+	// UI request arrives while the model is saturated.
+	ui := reqC("a", "ui")
+	ui.Path = "/"
+	s.OnRequest(ui)
+
+	if got := eff.untrackedServed("a"); got != 1 {
+		t.Fatalf("untrackedServed(a)=%d want 1 (UI request served without a slot)", got)
+	}
+	if got := eff.trackedServed("a"); got != 1 {
+		t.Errorf("trackedServed(a)=%d want 1 (UI must not consume a slot or admit the waiter)", got)
+	}
+
+	s.OnServeDone(ServeDoneEvent{ModelID: "a"}) // first finishes -> admit queued
+	if got := eff.trackedServed("a"); got != 2 {
+		t.Errorf("trackedServed(a)=%d want 2 after slot frees", got)
+	}
+}
+
+// Interactive requests form a hard tier: an interactive waiter is admitted ahead
+// of a non-interactive one even when the batch request has far higher priority.
+func TestFairShare_InteractiveTier(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateReady
+	cfg := config.FairShareConfig{
+		Mode:       config.ModeAbsolute,
+		Priorities: map[string]int{"batch": 100, "ui": 1},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	s := newFair(&stubPlanner{}, eff, cfg, map[string]int{"a": 1})
+
+	s.OnRequest(reqC("a", "blocker")) // occupies the only slot
+
+	batch := reqC("a", "batch") // priority 100, not interactive
+	s.OnRequest(batch)
+
+	ui := reqC("a", "ui") // priority 1, interactive
+	ui.Interactive = true
+	s.OnRequest(ui)
+
+	s.OnServeDone(ServeDoneEvent{ModelID: "a"}) // admit interactive 'ui' first...
+	s.OnServeDone(ServeDoneEvent{ModelID: "a"}) // ...then high-priority batch
+
+	order := eff.servedCallers("blocker")
+	if len(order) != 2 || order[0] != "ui" || order[1] != "batch" {
+		t.Errorf("served order=%v want [ui batch] (interactive tier beats higher priority)", order)
+	}
+}

--- a/internal/router/scheduler/fairshare_test.go
+++ b/internal/router/scheduler/fairshare_test.go
@@ -1,0 +1,384 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/process"
+	"github.com/mostlygeek/llama-swap/internal/shared"
+)
+
+// FairShare, like FIFO, runs entirely on the router's run-loop goroutine, so
+// these tests drive its methods directly and synchronously against the same
+// fakeEffects/stubPlanner harness used by fifo_test.go.
+
+func newFair(planner Swapper, eff Effects, cfg config.FairShareConfig, limits map[string]int) *FairShare {
+	return NewFairShare("test", logmon.NewWriter(io.Discard), planner, cfg, limits, eff)
+}
+
+// reqC builds a request for a model from a named caller, stashing the caller on
+// the request context the way the middleware does (via shared.ReqContextData.ApiKey).
+func reqC(model, caller string) HandlerReq {
+	ctx := shared.SetContext(context.Background(), shared.ReqContextData{ApiKey: caller})
+	return HandlerReq{Model: model, Ctx: ctx}
+}
+
+// servedCallers returns the callers of serve-grants in order, skipping a named
+// blocker used to occupy a slot.
+func (f *fakeEffects) servedCallers(skip string) []string {
+	var out []string
+	for _, g := range f.grants {
+		if g.err == nil && g.serve && g.caller != skip {
+			out = append(out, g.caller)
+		}
+	}
+	return out
+}
+
+func TestFairShare_FastPath(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateReady
+	s := newFair(&stubPlanner{}, eff, config.FairShareConfig{}, map[string]int{"a": 2})
+
+	s.OnRequest(reqC("a", "x"))
+
+	if got := eff.startsFor("a"); got != 0 {
+		t.Errorf("StartSwap calls=%d want 0 (fast path)", got)
+	}
+	if got := eff.served("a"); got != 1 {
+		t.Errorf("served(a)=%d want 1", got)
+	}
+}
+
+func TestFairShare_ModelNotFound(t *testing.T) {
+	eff := newFakeEffects()
+	s := newFair(&stubPlanner{}, eff, config.FairShareConfig{}, nil)
+
+	s.OnRequest(reqC("ghost", "x"))
+
+	if eff.errored("ghost") != 1 || !errors.Is(eff.grants[0].err, ErrModelNotFound) {
+		t.Fatalf("want 1 ErrModelNotFound grant, grants=%+v", eff.grants)
+	}
+}
+
+// At the concurrency limit a ready model queues the over-limit request rather
+// than serving it; a serve-done admits the waiter.
+func TestFairShare_ConcurrencyAdmission(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateReady
+	s := newFair(&stubPlanner{}, eff, config.FairShareConfig{}, map[string]int{"a": 1})
+
+	s.OnRequest(reqC("a", "first")) // fills the only slot
+	s.OnRequest(reqC("a", "second"))
+
+	if got := eff.served("a"); got != 1 {
+		t.Fatalf("served(a)=%d want 1 (second must queue at limit)", got)
+	}
+
+	s.OnServeDone(ServeDoneEvent{ModelID: "a"}) // first finishes -> admit second
+
+	if got := eff.served("a"); got != 2 {
+		t.Errorf("served(a)=%d want 2 after slot frees", got)
+	}
+	if order := eff.servedCallers(""); len(order) != 2 || order[1] != "second" {
+		t.Errorf("served order=%v want [first second]", order)
+	}
+}
+
+// Absolute mode admits the highest-priority waiter first when a slot frees.
+func TestFairShare_AbsolutePriorityOrder(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateReady
+	cfg := config.FairShareConfig{
+		Mode:       config.ModeAbsolute,
+		Priorities: map[string]int{"hi": 10, "lo": 1},
+	}
+	s := newFair(&stubPlanner{}, eff, cfg, map[string]int{"a": 1})
+
+	s.OnRequest(reqC("a", "blocker")) // occupies the slot
+	s.OnRequest(reqC("a", "lo"))      // queued
+	s.OnRequest(reqC("a", "hi"))      // queued (arrived later, higher priority)
+
+	s.OnServeDone(ServeDoneEvent{ModelID: "a"}) // free slot -> admit hi
+	s.OnServeDone(ServeDoneEvent{ModelID: "a"}) // -> admit lo
+
+	if order := eff.servedCallers("blocker"); len(order) != 2 || order[0] != "hi" || order[1] != "lo" {
+		t.Errorf("served order=%v want [hi lo]", order)
+	}
+}
+
+// With aging, a long-waiting low-priority request overtakes a freshly-arrived
+// higher-priority one.
+func TestFairShare_AgingOvertake(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateReady
+	cfg := config.FairShareConfig{
+		Mode:                             config.ModeAbsolute,
+		Priorities:                       map[string]int{"hi": 10, "lo": 1},
+		PriorityIncreasePerSecondWaiting: 1.0,
+	}
+	s := newFair(&stubPlanner{}, eff, cfg, map[string]int{"a": 1})
+
+	base := time.Unix(1_000_000, 0)
+	clock := base
+	s.now = func() time.Time { return clock }
+
+	s.OnRequest(reqC("a", "blocker")) // slot
+	s.OnRequest(reqC("a", "lo"))      // enqueued at base
+	clock = base.Add(20 * time.Second)
+	s.OnRequest(reqC("a", "hi")) // enqueued 20s later
+
+	// At t=base+20s: lo effective = 1 + 20 = 21; hi effective = 10 + 0 = 10.
+	s.OnServeDone(ServeDoneEvent{ModelID: "a"})
+	s.OnServeDone(ServeDoneEvent{ModelID: "a"})
+
+	if order := eff.servedCallers("blocker"); len(order) != 2 || order[0] != "lo" {
+		t.Errorf("served order=%v want lo first (aging overtake)", order)
+	}
+}
+
+// Proportion mode admits callers in proportion to their weight under sustained
+// contention: a weight-3 caller is served markedly more than a weight-1 caller.
+func TestFairShare_ProportionShares(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateReady
+	cfg := config.FairShareConfig{
+		Mode:       config.ModeProportion,
+		Priorities: map[string]int{"A": 3, "B": 1},
+	}
+	s := newFair(&stubPlanner{}, eff, cfg, map[string]int{"a": 1})
+
+	s.OnRequest(reqC("a", "blocker")) // occupy slot so nothing fast-paths
+	for i := 0; i < 10; i++ {
+		s.OnRequest(reqC("a", "A"))
+		s.OnRequest(reqC("a", "B"))
+	}
+
+	// Drain by repeatedly freeing the slot.
+	for i := 0; i < 20; i++ {
+		s.OnServeDone(ServeDoneEvent{ModelID: "a"})
+	}
+
+	order := eff.servedCallers("blocker")
+	if len(order) < 8 {
+		t.Fatalf("served only %d, want >= 8: %v", len(order), order)
+	}
+	a := 0
+	for _, c := range order[:8] {
+		if c == "A" {
+			a++
+		}
+	}
+	if a < 5 {
+		t.Errorf("weight-3 caller served %d/8 of first admits, want >=5: %v", a, order[:8])
+	}
+}
+
+// A full queue sheds the next arrival with a queue_full 429.
+func TestFairShare_MaxQueueDepthRejects(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateReady
+	cfg := config.FairShareConfig{MaxQueueDepth: 1}
+	s := newFair(&stubPlanner{}, eff, cfg, map[string]int{"a": 1})
+
+	s.OnRequest(reqC("a", "blocker")) // slot
+	s.OnRequest(reqC("a", "q1"))      // queued (depth 1)
+	s.OnRequest(reqC("a", "q2"))      // queue full -> 429
+
+	var be *BackpressureError
+	if !errors.As(lastErr(eff), &be) || be.Reason != "queue_full" {
+		t.Fatalf("want queue_full BackpressureError, got %v", lastErr(eff))
+	}
+	if be.Concurrency != 1 || be.Waiting != 1 {
+		t.Errorf("hint concurrency=%d waiting=%d want 1/1", be.Concurrency, be.Waiting)
+	}
+}
+
+// A request whose estimated wait exceeds MaxWait is shed at entry.
+func TestFairShare_MaxWaitRejects(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateReady
+	cfg := config.FairShareConfig{MaxWait: 900 * time.Millisecond} // EWMA seed is 1s
+	s := newFair(&stubPlanner{}, eff, cfg, map[string]int{"a": 1})
+
+	s.OnRequest(reqC("a", "blocker"))
+	s.OnRequest(reqC("a", "x")) // est ~1s > 900ms -> max_wait
+
+	var be *BackpressureError
+	if !errors.As(lastErr(eff), &be) || be.Reason != "max_wait" {
+		t.Fatalf("want max_wait BackpressureError, got %v", lastErr(eff))
+	}
+	if be.RetryAfter < 1 {
+		t.Errorf("RetryAfter=%d want >=1", be.RetryAfter)
+	}
+}
+
+// A swap serves a not-ready model, and after it completes the concurrency limit
+// still bounds how many waiters are admitted at once.
+func TestFairShare_SwapThenLimitedAdmit(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateStopped
+	s := newFair(&stubPlanner{}, eff, config.FairShareConfig{}, map[string]int{"a": 1})
+
+	s.OnRequest(reqC("a", "c1")) // starts swap
+	s.OnRequest(reqC("a", "c2")) // queued behind swap
+	s.OnRequest(reqC("a", "c3")) // queued behind swap
+
+	if got := eff.startsFor("a"); got != 1 {
+		t.Fatalf("StartSwap(a)=%d want 1 (one swap for all)", got)
+	}
+
+	eff.states["a"] = process.StateReady
+	s.OnSwapDone(SwapDone{ModelID: "a"})
+
+	if got := eff.served("a"); got != 1 {
+		t.Errorf("served(a)=%d want 1 (limit 1 caps post-swap admits)", got)
+	}
+	s.OnServeDone(ServeDoneEvent{ModelID: "a"})
+	s.OnServeDone(ServeDoneEvent{ModelID: "a"})
+	if got := eff.served("a"); got != 3 {
+		t.Errorf("served(a)=%d want 3 after draining", got)
+	}
+}
+
+// A grant the caller did not receive (disconnected) must not strand the slot.
+func TestFairShare_GrantFailDoesNotStrandSlot(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateReady
+	eff.serveResult["a"] = false // every GrantServe reports the caller left
+	s := newFair(&stubPlanner{}, eff, config.FairShareConfig{}, map[string]int{"a": 1})
+
+	s.OnRequest(reqC("a", "x")) // grant fails -> inFlight stays 0
+	s.OnRequest(reqC("a", "y")) // must still be servable, not blocked
+
+	if got := len(eff.grants); got != 2 {
+		t.Errorf("grants=%d want 2 (both attempted, neither stranded)", got)
+	}
+}
+
+// Queued waiters receive their 1-indexed position on PositionCh.
+func TestFairShare_QueuePositionBroadcast(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateReady
+	cfg := config.FairShareConfig{Priorities: map[string]int{"hi": 10, "lo": 1}}
+	s := newFair(&stubPlanner{}, eff, cfg, map[string]int{"a": 1})
+
+	s.OnRequest(reqC("a", "blocker")) // slot
+
+	lo := reqC("a", "lo")
+	lo.PositionCh = make(chan int, 1)
+	hi := reqC("a", "hi")
+	hi.PositionCh = make(chan int, 1)
+
+	s.OnRequest(lo)
+	s.OnRequest(hi) // higher priority -> should be position #1
+
+	if pos := drainPos(hi.PositionCh); pos != 1 {
+		t.Errorf("hi position=%d want 1", pos)
+	}
+	if pos := drainPos(lo.PositionCh); pos != 2 {
+		t.Errorf("lo position=%d want 2", pos)
+	}
+}
+
+// OnShutdown errors every queued waiter.
+func TestFairShare_ShutdownErrorsWaiters(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateReady
+	s := newFair(&stubPlanner{}, eff, config.FairShareConfig{}, map[string]int{"a": 1})
+
+	s.OnRequest(reqC("a", "blocker"))
+	s.OnRequest(reqC("a", "q1"))
+	s.OnRequest(reqC("a", "q2"))
+
+	shutErr := errors.New("shutting down")
+	s.OnShutdown(shutErr)
+
+	if got := eff.errored("a"); got != 2 {
+		t.Errorf("errored waiters=%d want 2", got)
+	}
+}
+
+func TestBackpressureError_Response(t *testing.T) {
+	be := &BackpressureError{Model: "m", Reason: "queue_full", RetryAfter: 4, Concurrency: 1, Inflight: 1, Waiting: 3}
+	if be.StatusCode() != 429 {
+		t.Errorf("status=%d want 429", be.StatusCode())
+	}
+	h := be.Header()
+	if h.Get("Retry-After") != "4" || h.Get("X-RateLimit-Limit") != "1" || h.Get("X-RateLimit-Waiting") != "3" {
+		t.Errorf("headers=%v", h)
+	}
+	body := string(be.Body())
+	for _, want := range []string{`"reason":"queue_full"`, `"max_concurrency":1`, `"waiting":3`, `"model":"m"`} {
+		if !contains(body, want) {
+			t.Errorf("body %q missing %q", body, want)
+		}
+	}
+}
+
+func lastErr(f *fakeEffects) error {
+	for i := len(f.grants) - 1; i >= 0; i-- {
+		if f.grants[i].err != nil {
+			return f.grants[i].err
+		}
+	}
+	return nil
+}
+
+func drainPos(ch chan int) int {
+	last := -1
+	for {
+		select {
+		case p := <-ch:
+			last = p
+		default:
+			return last
+		}
+	}
+}
+
+// TestFairShare_OnCancel_QueuedRequest verifies that cancelling a request
+// queued for a concurrency slot prunes it so it never gets admitted.
+func TestFairShare_OnCancel_QueuedRequest(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateReady
+	s := newFair(&stubPlanner{}, eff, config.FairShareConfig{DefaultPriority: 1}, map[string]int{"a": 1})
+
+	s.OnRequest(reqC("a", "blocker")) // fills the only slot
+	cancelled := reqC("a", "waiter")
+	cancelled.Respond = make(chan HandlerResp, 1)
+	s.OnRequest(cancelled) // queued behind the slot
+	if len(s.queued) != 1 {
+		t.Fatalf("queue len=%d want 1 before cancel", len(s.queued))
+	}
+
+	s.OnCancel(cancelled)
+
+	if len(s.queued) != 0 {
+		t.Fatalf("queue len=%d want 0 after cancel", len(s.queued))
+	}
+
+	// Slot frees; the cancelled waiter must not be served.
+	s.OnServeDone(ServeDoneEvent{ModelID: "a"})
+	if got := eff.served("a"); got != 1 {
+		t.Errorf("served(a)=%d want 1 (only the blocker; cancelled waiter pruned)", got)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/router/scheduler/fifo_test.go
+++ b/internal/router/scheduler/fifo_test.go
@@ -37,9 +37,10 @@ func (s *stubPlanner) OnSwapStart(string, []string) {}
 // grantRec is one GrantError / GrantServe call. err!=nil marks an error grant;
 // otherwise it is a serve grant and serve reports whether the caller received it.
 type grantRec struct {
-	model string
-	err   error
-	serve bool
+	model  string
+	caller string
+	err    error
+	serve  bool
 }
 
 type startRec struct {
@@ -92,7 +93,7 @@ func (f *fakeEffects) StartSwap(modelID string, evict []string) {
 }
 
 func (f *fakeEffects) GrantError(req HandlerReq, err error) {
-	f.grants = append(f.grants, grantRec{model: req.Model, err: err})
+	f.grants = append(f.grants, grantRec{model: req.Model, caller: callerOf(req), err: err})
 }
 
 func (f *fakeEffects) GrantServe(req HandlerReq, modelID string) bool {
@@ -101,7 +102,7 @@ func (f *fakeEffects) GrantServe(req HandlerReq, modelID string) bool {
 		ok = v
 	}
 	f.lastServeReq = req
-	f.grants = append(f.grants, grantRec{model: modelID, serve: ok})
+	f.grants = append(f.grants, grantRec{model: modelID, caller: callerOf(req), serve: ok})
 	return ok
 }
 

--- a/internal/router/scheduler/fifo_test.go
+++ b/internal/router/scheduler/fifo_test.go
@@ -37,10 +37,11 @@ func (s *stubPlanner) OnSwapStart(string, []string) {}
 // grantRec is one GrantError / GrantServe call. err!=nil marks an error grant;
 // otherwise it is a serve grant and serve reports whether the caller received it.
 type grantRec struct {
-	model  string
-	caller string
-	err    error
-	serve  bool
+	model     string
+	caller    string
+	err       error
+	serve     bool
+	untracked bool
 }
 
 type startRec struct {
@@ -106,6 +107,16 @@ func (f *fakeEffects) GrantServe(req HandlerReq, modelID string) bool {
 	return ok
 }
 
+func (f *fakeEffects) GrantServeUntracked(req HandlerReq, modelID string) bool {
+	ok := true
+	if v, set := f.serveResult[modelID]; set {
+		ok = v
+	}
+	f.lastServeReq = req
+	f.grants = append(f.grants, grantRec{model: modelID, caller: callerOf(req), serve: ok, untracked: true})
+	return ok
+}
+
 func (f *fakeEffects) StopProcesses(timeout time.Duration, ids []string) {
 	f.stops = append(f.stops, stopRec{timeout: timeout, ids: ids})
 }
@@ -115,6 +126,28 @@ func (f *fakeEffects) served(modelID string) int {
 	n := 0
 	for _, g := range f.grants {
 		if g.err == nil && g.serve && g.model == modelID {
+			n++
+		}
+	}
+	return n
+}
+
+// trackedServed counts slot-consuming serve grants for modelID (GrantServe).
+func (f *fakeEffects) trackedServed(modelID string) int {
+	n := 0
+	for _, g := range f.grants {
+		if g.err == nil && g.serve && !g.untracked && g.model == modelID {
+			n++
+		}
+	}
+	return n
+}
+
+// untrackedServed counts ungated serve grants for modelID (GrantServeUntracked).
+func (f *fakeEffects) untrackedServed(modelID string) int {
+	n := 0
+	for _, g := range f.grants {
+		if g.err == nil && g.serve && g.untracked && g.model == modelID {
 			n++
 		}
 	}

--- a/internal/router/scheduler/scheduler.go
+++ b/internal/router/scheduler/scheduler.go
@@ -93,8 +93,8 @@ type Effects interface {
 }
 
 // New returns a Scheduler selected by conf.Routing.Scheduler.Use, configured
-// from conf and bound to the given planner and effects. Currently only "fifo"
-// (the default) is supported.
+// from conf and bound to the given planner and effects. "fifo" (the default)
+// and "fairshare" are supported.
 func New(conf config.Config, name string, logger *logmon.Monitor, planner Swapper, eff Effects) (Scheduler, error) {
 	use := conf.Routing.Scheduler.Use
 	if use == "" {
@@ -103,6 +103,12 @@ func New(conf config.Config, name string, logger *logmon.Monitor, planner Swappe
 	switch use {
 	case "fifo":
 		return NewFIFO(name, logger, planner, conf.Routing.Scheduler.Settings.Fifo, conf.Models, eff), nil
+	case "fairshare":
+		limits := make(map[string]int, len(conf.Models))
+		for id, mc := range conf.Models {
+			limits[id] = mc.ConcurrencyLimit // 0 -> fairshare default
+		}
+		return NewFairShare(name, logger, planner, conf.Routing.Scheduler.Settings.FairShare, limits, eff), nil
 	default:
 		return nil, fmt.Errorf("unsupported scheduler type: %q", use)
 	}

--- a/internal/router/scheduler/scheduler.go
+++ b/internal/router/scheduler/scheduler.go
@@ -87,6 +87,11 @@ type Effects interface {
 	// whether the caller was still there to receive it. The scheduler bumps
 	// its in-flight count only when this returns true.
 	GrantServe(req HandlerReq, modelID string) bool
+	// GrantServeUntracked hands a caller the handler for modelID without the
+	// in-flight tracking wrapper, so the request does not count against the
+	// model's concurrency limit or service-time stats. Used for ungated
+	// (non-inference) requests. Reports whether the caller received it.
+	GrantServeUntracked(req HandlerReq, modelID string) bool
 	// StopProcesses stops the named processes in parallel and blocks until all
 	// have stopped. Unknown IDs are skipped.
 	StopProcesses(timeout time.Duration, ids []string)
@@ -116,10 +121,19 @@ func New(conf config.Config, name string, logger *logmon.Monitor, planner Swappe
 
 // HandlerReq is one in-flight ServeHTTP request waiting for a routing decision.
 type HandlerReq struct {
-	Model      string
-	Ctx        context.Context
-	Respond    chan HandlerResp
-	PositionCh chan int
+	Model string
+	// Path is the request's model-relative URL path (e.g. "/v1/chat/completions"
+	// or, for an /upstream/<model>/ request, the path after the prefix strip).
+	// The fairshare scheduler matches it against its gatedPaths regex to decide
+	// whether the request consumes a concurrency slot.
+	Path string
+	// Interactive marks a request from an interactive browser UI. The fairshare
+	// scheduler admits interactive requests ahead of all non-interactive ones for
+	// the same model (a hard tier above the priority/weight ordering).
+	Interactive bool
+	Ctx         context.Context
+	Respond     chan HandlerResp
+	PositionCh  chan int
 }
 
 // HandlerResp is the routing decision returned to a HandlerReq's caller: either

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -38,6 +39,7 @@ type ActivityLogEntry struct {
 	ID              int               `json:"id"`
 	Timestamp       time.Time         `json:"timestamp"`
 	Model           string            `json:"model"`
+	Caller          string            `json:"caller"`
 	ReqPath         string            `json:"req_path"`
 	RespContentType string            `json:"resp_content_type"`
 	RespStatusCode  int               `json:"resp_status_code"`
@@ -45,6 +47,11 @@ type ActivityLogEntry struct {
 	DurationMs      int               `json:"duration_ms"`
 	HasCapture      bool              `json:"has_capture"`
 	Metadata        map[string]string `json:"metadata,omitempty"`
+	// Priority is the scheduler's configured priority/weight for this request;
+	// PriorityMode names it ("priority", "weight", or "" when the scheduler does
+	// not prioritize). Both come from the active scheduler config.
+	Priority     int    `json:"priority"`
+	PriorityMode string `json:"priority_mode"`
 }
 
 // ActivityLogEvent carries a single activity log entry to event subscribers.
@@ -128,10 +135,29 @@ func (mp *metricsMonitor) getMetricsJSON() ([]byte, error) {
 // When captures are enabled, a zstd+CBOR capture is stored for successful
 // requests, with cf controlling which request/response parts are retained.
 // reqBody and reqHeaders are the request data buffered before dispatch.
-func (mp *metricsMonitor) record(modelID string, r *http.Request, recorder *responseBodyCopier, cf captureFields, reqBody []byte, reqHeaders map[string]string) {
+//
+// maskCaller renders a caller id for the activity log without leaking the raw
+// API key: "" becomes "anonymous", a short value passes through (too short to
+// be a secret), and anything longer is reduced to a 5-char prefix plus its
+// length (e.g. "sk-ragtag" -> "sk-ra…9") so distinct callers stay
+// distinguishable without exposing the key.
+func maskCaller(caller string) string {
+	if caller == "" {
+		return "anonymous"
+	}
+	if len(caller) <= 5 {
+		return caller
+	}
+	return caller[:5] + "…" + strconv.Itoa(len(caller))
+}
+
+func (mp *metricsMonitor) record(modelID, caller string, priority int, priorityMode string, r *http.Request, recorder *responseBodyCopier, cf captureFields, reqBody []byte, reqHeaders map[string]string) {
 	tm := ActivityLogEntry{
 		Timestamp:       time.Now(),
 		Model:           modelID,
+		Caller:          maskCaller(caller),
+		Priority:        priority,
+		PriorityMode:    priorityMode,
 		ReqPath:         r.URL.Path,
 		RespContentType: recorder.Header().Get("Content-Type"),
 		RespStatusCode:  recorder.Status(),

--- a/internal/server/metrics_middleware.go
+++ b/internal/server/metrics_middleware.go
@@ -74,9 +74,11 @@ func CreateMetricsMiddleware(mm *metricsMonitor, cfg config.Config) chain.Middle
 				r.Header.Set("Accept-Encoding", filterAcceptEncoding(ae))
 			}
 
+			priority, priorityMode := cfg.Routing.Scheduler.ActivityPriorityFor(data.ApiKey, data.ModelID)
+
 			recorder := newBodyCopier(w)
 			next.ServeHTTP(recorder, r)
-			mm.record(data.ModelID, r, recorder, cf, reqBody, reqHeaders)
+			mm.record(data.ModelID, data.ApiKey, priority, priorityMode, r, recorder, cf, reqBody, reqHeaders)
 		})
 	}
 }

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -76,7 +76,7 @@ func TestMetricsMonitor_RecordMetadata(t *testing.T) {
 	copier.WriteHeader(http.StatusOK)
 	copier.Write([]byte(`{"usage":{"prompt_tokens":1,"completion_tokens":2}}`))
 
-	mm.record("m", r, copier, 0, nil, nil)
+	mm.record("m", "", 0, "", r, copier, 0, nil, nil)
 
 	entries := mm.getMetrics()
 	if len(entries) != 1 {
@@ -141,5 +141,18 @@ func TestServer_MetricsMiddleware_UpstreamAudioCaptureSkipsRespBody(t *testing.T
 	}
 	if len(cap.RespHeaders) == 0 {
 		t.Error("RespHeaders not stored; want captureRespHeaders mask")
+	}
+}
+
+func TestServer_MaskCaller(t *testing.T) {
+	cases := map[string]string{
+		"":          "anonymous",
+		"abc":       "abc",     // too short to be a secret
+		"sk-ragtag": "sk-ra…9", // prefix + length
+	}
+	for in, want := range cases {
+		if got := maskCaller(in); got != want {
+			t.Errorf("maskCaller(%q)=%q want %q", in, got, want)
+		}
 	}
 }

--- a/ui-svelte/src/lib/types.ts
+++ b/ui-svelte/src/lib/types.ts
@@ -37,6 +37,7 @@ export interface ActivityLogEntry {
   id: number;
   timestamp: string;
   model: string;
+  caller: string;
   req_path: string;
   resp_content_type: string;
   resp_status_code: number;
@@ -44,6 +45,8 @@ export interface ActivityLogEntry {
   duration_ms: number;
   has_capture: boolean;
   metadata?: Record<string, string>;
+  priority: number;
+  priority_mode: "priority" | "weight" | "";
 }
 
 export interface ReqRespCapture {

--- a/ui-svelte/src/routes/Activity.svelte
+++ b/ui-svelte/src/routes/Activity.svelte
@@ -20,6 +20,7 @@
     { key: "id", label: "ID", defaultVisible: true },
     { key: "time", label: "Time", defaultVisible: true },
     { key: "model", label: "Model", defaultVisible: true },
+    { key: "caller", label: "Caller", defaultVisible: false },
     { key: "req_path", label: "Path", defaultVisible: false },
     { key: "resp_status_code", label: "Status", defaultVisible: false },
     { key: "resp_content_type", label: "Content-Type", defaultVisible: false },
@@ -29,6 +30,7 @@
     { key: "drafted", label: "Drafted", defaultVisible: false },
     { key: "prompt_speed", label: "Prompt Speed", defaultVisible: true },
     { key: "gen_speed", label: "Gen Speed", defaultVisible: true },
+    { key: "priority", label: "Priority", defaultVisible: false },
     { key: "duration", label: "Duration", defaultVisible: true },
     { key: "capture", label: "Capture", defaultVisible: true },
     { key: "meta", label: "Meta", defaultVisible: false },
@@ -196,6 +198,12 @@
 
   let sortedMetrics = $derived([...$metrics].sort((a, b) => b.id - a.id));
 
+  // Header label follows the active scheduler mode: "Weight" in proportion mode,
+  // "Priority" otherwise (and when no metric carries a mode yet).
+  let priorityLabel = $derived(
+    sortedMetrics.find((m) => m.priority_mode)?.priority_mode === "weight" ? "Weight" : "Priority"
+  );
+
   let selectedCapture = $state<ReqRespCapture | null>(null);
   let dialogOpen = $state(false);
   let loadingCaptureId = $state<number | null>(null);
@@ -260,7 +268,7 @@
                     onchange={() => toggleColumn(key)}
                     class="rounded"
                   />
-                  {col.label}
+                  {key === "priority" ? priorityLabel : col.label}
                 </label>
               </div>
             {/each}
@@ -280,6 +288,11 @@
                 Prompt <Tooltip content="new prompt tokens processed" />
               {:else if key === "drafted"}
                 Drafted <Tooltip content="acceptance rate (accepted/drafted)" />
+              {:else if key === "caller"}
+                Caller <Tooltip content="masked API key of the request's caller" />
+              {:else if key === "priority"}
+                {priorityLabel}
+                <Tooltip content="configured scheduler priority/weight for this request (before wait-time aging)" />
               {:else}
                 {columnLabelMap[key] ?? key}
               {/if}
@@ -305,6 +318,8 @@
                     {formatRelativeTime(metric.timestamp)}
                   {:else if key === "model"}
                     {metric.model}
+                  {:else if key === "caller"}
+                    {metric.caller || "-"}
                   {:else if key === "req_path"}
                     {metric.req_path || "-"}
                   {:else if key === "resp_status_code"}
@@ -323,6 +338,8 @@
                     {formatSpeed(metric.tokens.prompt_per_second)}
                   {:else if key === "gen_speed"}
                     {formatSpeed(metric.tokens.tokens_per_second)}
+                  {:else if key === "priority"}
+                    {metric.priority_mode ? metric.priority : "-"}
                   {:else if key === "duration"}
                     {formatDuration(metric.duration_ms)}
                   {:else if key === "capture"}

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -12,6 +12,7 @@ import type {
 import { connectionState } from "./theme";
 
 const LOG_LENGTH_LIMIT = 1024 * 100; /* 100KB of log data */
+const ACTIVITY_LIMIT = 1000; /* cap in-memory activity entries; matches the server metrics ring */
 
 // Stores
 export const models = writable<Model[]>([]);
@@ -92,7 +93,7 @@ export function enableAPIEvents(enabled: boolean): void {
 
           case "metrics": {
             const newMetrics = JSON.parse(message.data) as ActivityLogEntry[];
-            metrics.update((prevMetrics) => [...newMetrics, ...prevMetrics]);
+            metrics.update((prevMetrics) => [...newMetrics, ...prevMetrics].slice(0, ACTIVITY_LIMIT));
             break;
           }
           case "inflight": {


### PR DESCRIPTION
Re-implement priority-aware fair admission (originally mostlygeek/llama-swap#811) as a `Scheduler` on top of the new router/scheduler architecture (#823), per the maintainer's guidance: *"create a new scheduler … the FIFO + priority queuing scheduler should serve as a good example."* The bespoke `internal/server/scheduler.go` admission layer from #811 is gone; the feature is now a `scheduler.FairShare` modeled on `FIFO`. Supersedes #811.

## Why

Model capacity is finite and multiple independent consumers contend for it with no awareness of each other. Coordinating fair access belongs at the router — the one place that sees all traffic to a model — not in the clients. The stock per-model limit only offers a bare `429` with no guidance, so a client can't tell it's competing with itself, let alone yield to a higher-priority peer. `fairshare` puts opt-in, configurable admission scheduling in front of each model's `concurrencyLimit`, with the observability to see it working.

## What

`fairshare` is a `scheduler.Scheduler`. Unlike `FIFO` (which queues only on swaps and serves a ready model with no concurrency gate), `fairshare` **owns per-model concurrency admission**: when a ready model is at its `concurrencyLimit`, over-limit requests are queued and admitted by priority as slots free, instead of shed with a bare `429`. When the scheduler is `fifo` (default) nothing changes.

Because every `Scheduler` method runs on the single `baseRouter` run-loop goroutine, the re-implementation carries **no locks** — the `sync.Mutex` machinery from #811 is gone.

Opt in:

```yaml
routing:
  scheduler:
    use: fairshare
```

## Scheduling strategies

The priority number is interpreted by `mode`, and `priorityIncreasePerSecondWaiting` (aging) composes with either. The default (`mode: absolute`, aging `0`) is strict priority.

| | `mode: absolute` | `mode: proportion` |
|---|---|---|
| **Meaning** | rank — highest served first | weight — higher gets a larger share |
| **Under contention** | highest effective priority first, FIFO within a priority | callers admitted in proportion to weight (weighted fair queuing); weight-10 gets ~10× weight-1 |
| **Idle classes** | n/a | never hold back a busy one (work-conserving) |

**Aging** adds to a waiter's *effective* priority for each second waited. In `absolute` mode it makes scheduling starvation-free; in `proportion` mode it grows a long-waiter's share. `0` disables it.

**Resolution order:** `priorities[caller]` → `modelPriorities[model]` → `defaultPriority`. An explicit caller always wins; otherwise priority can be driven by the model (what a single client like Open WebUI needs).

## Configuration

```yaml
routing:
  scheduler:
    use: fairshare
    settings:
      fairshare:
        mode: absolute                       # absolute (rank) | proportion (weight)
        priorityIncreasePerSecondWaiting: 0   # aging; 0 disables
        priorities:                           # caller (API key) -> priority; explicit caller wins
          sk-interactive: 10
          sk-bulk-indexer: 1
        modelPriorities:                      # model -> priority for unlisted callers
          chat-model: 10
          embeddings: 1
        defaultPriority: 5                    # default for unlisted callers/models (and anonymous)
        maxWait: 30s                          # reject with 429 if estimated wait exceeds this
        maxQueueDepth: 16                     # reject with 429 beyond this many waiters (0 = unlimited)
```

Per-model capacity is the existing `concurrencyLimit` on each model; the scheduler queues against it and doesn't change it. Config is validated on load: unknown `scheduler.use`, bad fairshare values, and `modelPriorities` referencing unknown models are all rejected. Defaults: `defaultPriority: 1`, `maxWait: 30s`, `mode: absolute`.

## Scenarios

- **Interactive must stay snappy** — `mode: absolute`, high priority for the front-end. Add aging to keep bulk from starving.
- **Guarantee proportional throughput** — `mode: proportion`, weights `10`/`1`: interactive gets ~10× bulk's slot-throughput while both keep flowing.
- **Single client, many models** (Open WebUI) — use `modelPriorities` to drive priority by the requested model.

## Caller identity & rate-limit hints

The caller id is the **API key on the request** (same precedence as auth: Basic password → Bearer → `x-api-key`), captured before auth strips it. Give each downstream service its own key and map it in `priorities`; a request with no key resolves via `modelPriorities` then `defaultPriority`.

When the scheduler sheds a request it returns a `429` carrying the model's capacity, so a client can right-size its own parallelism:

```
HTTP/1.1 429 Too Many Requests
Retry-After: 4                 # whole seconds, from the model's measured (EWMA) service time
X-RateLimit-Limit: 1           # the model's hard slot count
X-RateLimit-Inflight: 1
X-RateLimit-Waiting: 3

{"error":"Too many requests","reason":"queue_full","retry_after":4,
 "model":"qwen3","hint":{"max_concurrency":1,"inflight":1,"waiting":3}}
```

`reason` is `queue_full` or `max_wait`. This is delivered through a new `scheduler.HTTPError`/`BackpressureError` that `router.SendError` renders verbatim.

## Activity / observability

- A streaming request that parks for a slot streams its live **queue position** in the reasoning ("thinking") block (`llama-swap queued: <model>`, then `Queue position: #N`). It is **lazy** — an immediately-admitted request emits nothing; the swap-loading stream is unchanged.
- The activity log and UI gain a **Caller** column (default-visible). The caller is **masked** so the key never reaches the UI/ring: `anonymous` for no key, otherwise a 5-char prefix + length (e.g. `sk-ra…9`). Scheduler `429`s now appear in the activity stream automatically (they flow through the metrics middleware in this architecture).
- The UI activity buffer is capped (`ACTIVITY_LIMIT = 1000`) so a long session doesn't grow without bound.

## Changes

- **scheduler**: `internal/router/scheduler/fairshare.go` (absolute/proportion/aging, per-model concurrency admission, EWMA Retry-After, queue-position broadcast); `Caller` added to `HandlerReq`; new `HTTPError`/`BackpressureError`.
- **router**: `SendError` renders `HTTPError`; `caller.go` context helpers; lazy `StreamQueueWait` + `newStreamWriter`/`newWaitWriter` split in `loading.go`; `scheduler_factory.go` selects the scheduler (drive-by: `group.go`/`matrix.go` now call it instead of inlining the FIFO closure).
- **config**: `FairShareConfig` + validation; `config-schema.json` and `config.example.yaml`.
- **server**: caller-capture middleware (before auth); masked `Caller` on `ActivityLogEntry`; concurrency middleware steps aside when fairshare owns admission.
- **ui**: Caller column (`Activity.svelte`, `types.ts`); activity-buffer cap (`stores/api.ts`).

## Testing

Automated coverage added (no behavior left to manual checking):

- `scheduler/fairshare_test.go` — 12 state-machine tests against a fake `Effects`: concurrency admission + drain, absolute ordering, aging overtake, proportion (WFQ) shares, `maxWait`/`maxQueueDepth` rejection, `BackpressureError` shape, queue-position broadcast, grant-fail-doesn't-strand-slot, shutdown.
- `config/fairshare_test.go` — `PriorityFor` resolution, `Validate`, defaults, load-time rejection of unknown scheduler / unknown `modelPriorities` model.
- `router/senderror_test.go` — `SendError` renders (and unwraps) `HTTPError`; plain errors still map to 500.
- `server/caller_test.go` — `maskCaller`; caller middleware stashes the key / anonymous fallback.

Verified green: `go test -race ./internal/...`, `staticcheck`, `svelte-check`, and the UI vitest suite. `TestConfig_ExampleMatchesSchema` confirms the example config matches the schema.

## Notes

- **Difference from #811:** `maxWait` is enforced at queue entry (estimate gate) only. The single-goroutine event model has no per-waiter timer, so a parked request waits until admitted or the client disconnects rather than being `429`'d *after* it has already been queued. Entry-time rejection (hopeless estimate, full queue) is unchanged.

Re-implemented with Claude Code (Opus 4.8).
