### PR TITLE
proxy: implement /props endpoint compatible with llama.cpp router

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,9 +1,12 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -14,6 +17,7 @@ import (
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/logmon"
 	"github.com/mostlygeek/llama-swap/internal/perf"
+	"github.com/mostlygeek/llama-swap/internal/process"
 	"github.com/mostlygeek/llama-swap/internal/router"
 	"github.com/mostlygeek/llama-swap/internal/shared"
 )
@@ -240,6 +244,10 @@ func (s *Server) routes() {
 	mux.Handle("GET /unload", apiChain.ThenFunc(s.handleUnload))
 	mux.Handle("GET /running", apiChain.ThenFunc(s.handleRunning))
 
+	// /props endpoint (llama.cpp router-compatible)
+	mux.Handle("GET /props", apiChain.ThenFunc(s.handleProps))
+	mux.Handle("POST /props", apiChain.ThenFunc(s.handlePropsPost))
+
 	// Upstream passthrough. Meter only the model-dispatched endpoints that can
 	// produce token usage/timings.
 	upstreamChain := apiChain.Append(CreateMetricsMiddleware(s.metrics, s.cfg))
@@ -304,4 +312,140 @@ func (s *Server) Shutdown(timeout time.Duration) error {
 
 	wg.Wait()
 	return errors.Join(errs...)
+}
+
+// handleProps serves GET /props. When no model query parameter is given it
+// returns router metadata matching llama.cpp's router /props response. With a
+// model parameter it proxies to the backend's /props endpoint, respecting the
+// autoload query parameter.
+func (s *Server) handleProps(w http.ResponseWriter, r *http.Request) {
+	model := r.URL.Query().Get("model")
+
+	if model == "" {
+		buildInfo := fmt.Sprintf("%s (%s, %s)", s.build.Version, s.build.Commit, s.build.Date)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"role":            "router",
+			"models_autoload": true,
+			// TODO: llama.cpp router switching logic caps number of concurrent models using
+			// max_instances. llama-swap has much more complex logic for determining what
+			// models can run conncurently which does not map cleanly to a single number.
+			// omit this max_instances field for now and revist a potential implementation
+			// later if ommision introduces compatibility issues.
+			// "max_instances": 0,
+			"model_alias": "llama-swap",
+			"model_path":  "none",
+			"default_generation_settings": map[string]any{
+				"params": map[string]any{},
+				"n_ctx":  0,
+			},
+			"build_info": buildInfo,
+		})
+		return
+	}
+
+	autoloadStr := r.URL.Query().Get("autoload")
+	autoload := autoloadStr == "" || autoloadStr == "true" || autoloadStr == "1"
+
+	realModelID, found := s.cfg.RealModelName(model)
+	if !found && s.local.Handles(model) {
+		realModelID = model
+		found = true
+	}
+	if !found && s.peer.Handles(model) {
+		realModelID = model
+		found = true
+	}
+
+	if !found {
+		shared.SendResponse(w, r, http.StatusNotFound, fmt.Sprintf("could not find suitable handler for %s", model))
+		return
+	}
+
+	if !autoload {
+		ready := s.peer.Handles(realModelID)
+		if !ready {
+			if st, ok := s.local.RunningModels()[realModelID]; ok && st == process.StateReady {
+				ready = true
+			}
+		}
+		if !ready {
+			shared.SendResponse(w, r, http.StatusBadRequest, "model is not loaded")
+			return
+		}
+	}
+
+	r.URL.Path = "/props"
+	*r = *r.WithContext(shared.SetContext(r.Context(), shared.ReqContextData{
+		Model:    model,
+		ModelID:  realModelID,
+		Metadata: make(map[string]string),
+	}))
+
+	switch {
+	case s.local.Handles(realModelID):
+		s.proxylog.Debugf("/props: using local process for model: %s", realModelID)
+		s.local.ServeHTTP(w, r)
+	case s.peer.Handles(realModelID):
+		s.proxylog.Debugf("/props: using peer for model: %s", realModelID)
+		s.peer.ServeHTTP(w, r)
+	default:
+		shared.SendResponse(w, r, http.StatusNotFound, fmt.Sprintf("no router for model %s", realModelID))
+	}
+}
+
+// handlePropsPost serves POST /props. It reads the model from the JSON request
+// body and proxies the request to the backend's /props endpoint.
+func (s *Server) handlePropsPost(w http.ResponseWriter, r *http.Request) {
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		shared.SendResponse(w, r, http.StatusBadRequest, "could not read request body")
+		return
+	}
+	defer func() { r.Body = io.NopCloser(bytes.NewReader(bodyBytes)) }()
+
+	var body struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		shared.SendResponse(w, r, http.StatusBadRequest, "could not parse request body")
+		return
+	}
+	if body.Model == "" {
+		shared.SendResponse(w, r, http.StatusBadRequest, "missing 'model' key in request body")
+		return
+	}
+
+	realModelID, found := s.cfg.RealModelName(body.Model)
+	if !found && s.local.Handles(body.Model) {
+		realModelID = body.Model
+		found = true
+	}
+	if !found && s.peer.Handles(body.Model) {
+		realModelID = body.Model
+		found = true
+	}
+
+	if !found {
+		shared.SendResponse(w, r, http.StatusNotFound, fmt.Sprintf("could not find suitable handler for %s", body.Model))
+		return
+	}
+
+	r.URL.Path = "/props"
+	*r = *r.WithContext(shared.SetContext(r.Context(), shared.ReqContextData{
+		Model:    body.Model,
+		ModelID:  realModelID,
+		Metadata: make(map[string]string),
+	}))
+
+	switch {
+	case s.local.Handles(realModelID):
+		s.proxylog.Debugf("/props: using local process for model: %s", realModelID)
+		s.local.ServeHTTP(w, r)
+	case s.peer.Handles(realModelID):
+		s.proxylog.Debugf("/props: using peer for model: %s", realModelID)
+		s.peer.ServeHTTP(w, r)
+	default:
+		shared.SendResponse(w, r, http.StatusNotFound, fmt.Sprintf("no router for model %s", realModelID))
+	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,12 +1,10 @@
 package server
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -319,9 +317,8 @@ func (s *Server) Shutdown(timeout time.Duration) error {
 // model parameter it proxies to the backend's /props endpoint, respecting the
 // autoload query parameter.
 func (s *Server) handleProps(w http.ResponseWriter, r *http.Request) {
-	model := r.URL.Query().Get("model")
-
-	if model == "" {
+	data, err := shared.FetchContext(r, s.cfg)
+	if err != nil {
 		buildInfo := fmt.Sprintf("%s (%s, %s)", s.build.Version, s.build.Commit, s.build.Date)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
@@ -344,108 +341,71 @@ func (s *Server) handleProps(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	model := data.Model
 	autoloadStr := r.URL.Query().Get("autoload")
 	autoload := autoloadStr == "" || autoloadStr == "true" || autoloadStr == "1"
 
-	realModelID, found := s.cfg.RealModelName(model)
-	if !found && s.local.Handles(model) {
-		realModelID = model
-		found = true
-	}
-	if !found && s.peer.Handles(model) {
-		realModelID = model
-		found = true
-	}
-
-	if !found {
-		shared.SendResponse(w, r, http.StatusNotFound, fmt.Sprintf("could not find suitable handler for %s", model))
-		return
-	}
+	modelID := data.ModelID
 
 	if !autoload {
-		ready := s.peer.Handles(realModelID)
-		if !ready {
-			if st, ok := s.local.RunningModels()[realModelID]; ok && st == process.StateReady {
-				ready = true
+		if s.local.Handles(modelID) {
+			if st, ok := s.local.RunningModels()[modelID]; !ok || st != process.StateReady {
+				shared.SendResponse(w, r, http.StatusBadRequest, "model is not loaded")
+				return
 			}
-		}
-		if !ready {
-			shared.SendResponse(w, r, http.StatusBadRequest, "model is not loaded")
-			return
 		}
 	}
 
 	r.URL.Path = "/props"
 	*r = *r.WithContext(shared.SetContext(r.Context(), shared.ReqContextData{
 		Model:    model,
-		ModelID:  realModelID,
+		ModelID:  modelID,
 		Metadata: make(map[string]string),
 	}))
 
 	switch {
-	case s.local.Handles(realModelID):
-		s.proxylog.Debugf("/props: using local process for model: %s", realModelID)
+	case s.local.Handles(modelID):
+		s.proxylog.Debugf("/props: using local process for model: %s", modelID)
 		s.local.ServeHTTP(w, r)
-	case s.peer.Handles(realModelID):
-		s.proxylog.Debugf("/props: using peer for model: %s", realModelID)
+	case s.peer.Handles(modelID):
+		s.proxylog.Debugf("/props: using peer for model: %s", modelID)
 		s.peer.ServeHTTP(w, r)
 	default:
-		shared.SendResponse(w, r, http.StatusNotFound, fmt.Sprintf("no router for model %s", realModelID))
+		shared.SendResponse(w, r, http.StatusNotFound, fmt.Sprintf("could not find suitable handler for %s", model))
 	}
 }
 
 // handlePropsPost serves POST /props. It reads the model from the JSON request
 // body and proxies the request to the backend's /props endpoint.
 func (s *Server) handlePropsPost(w http.ResponseWriter, r *http.Request) {
-	bodyBytes, err := io.ReadAll(r.Body)
+	data, err := shared.FetchContext(r, s.cfg)
 	if err != nil {
-		shared.SendResponse(w, r, http.StatusBadRequest, "could not read request body")
-		return
-	}
-	defer func() { r.Body = io.NopCloser(bytes.NewReader(bodyBytes)) }()
-
-	var body struct {
-		Model string `json:"model"`
-	}
-	if err := json.Unmarshal(bodyBytes, &body); err != nil {
-		shared.SendResponse(w, r, http.StatusBadRequest, "could not parse request body")
-		return
-	}
-	if body.Model == "" {
-		shared.SendResponse(w, r, http.StatusBadRequest, "missing 'model' key in request body")
+		if errors.Is(err, shared.ErrNoModelInContext) {
+			shared.SendResponse(w, r, http.StatusBadRequest, "missing 'model' key in request body")
+		} else {
+			shared.SendResponse(w, r, http.StatusBadRequest, "could not read request body")
+		}
 		return
 	}
 
-	realModelID, found := s.cfg.RealModelName(body.Model)
-	if !found && s.local.Handles(body.Model) {
-		realModelID = body.Model
-		found = true
-	}
-	if !found && s.peer.Handles(body.Model) {
-		realModelID = body.Model
-		found = true
-	}
-
-	if !found {
-		shared.SendResponse(w, r, http.StatusNotFound, fmt.Sprintf("could not find suitable handler for %s", body.Model))
-		return
-	}
+	model := data.Model
+	modelID := data.ModelID
 
 	r.URL.Path = "/props"
 	*r = *r.WithContext(shared.SetContext(r.Context(), shared.ReqContextData{
-		Model:    body.Model,
-		ModelID:  realModelID,
+		Model:    model,
+		ModelID:  modelID,
 		Metadata: make(map[string]string),
 	}))
 
 	switch {
-	case s.local.Handles(realModelID):
-		s.proxylog.Debugf("/props: using local process for model: %s", realModelID)
+	case s.local.Handles(modelID):
+		s.proxylog.Debugf("/props: using local process for model: %s", modelID)
 		s.local.ServeHTTP(w, r)
-	case s.peer.Handles(realModelID):
-		s.proxylog.Debugf("/props: using peer for model: %s", realModelID)
+	case s.peer.Handles(modelID):
+		s.proxylog.Debugf("/props: using peer for model: %s", modelID)
 		s.peer.ServeHTTP(w, r)
 	default:
-		shared.SendResponse(w, r, http.StatusNotFound, fmt.Sprintf("no router for model %s", realModelID))
+		shared.SendResponse(w, r, http.StatusNotFound, fmt.Sprintf("could not find suitable handler for %s", model))
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -339,3 +339,116 @@ func TestServer_LogStream_UnknownID_Returns400(t *testing.T) {
 		t.Errorf("status=%d want 400", w.Code)
 	}
 }
+
+func TestServer_PropsHandler_NoModel(t *testing.T) {
+	s := newTestServer(newStubRouter(nil, ""), newStubRouter(nil, ""))
+	s.build = BuildInfo{Version: "v1", Commit: "abc123", Date: "2024-01-01"}
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/props", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v body=%q", err, w.Body.String())
+	}
+	if got, ok := resp["role"].(string); !ok || got != "router" {
+		t.Errorf("role=%v want router", resp["role"])
+	}
+	if got, ok := resp["models_autoload"].(bool); !ok || got != true {
+		t.Errorf("models_autoload=%v want true", resp["models_autoload"])
+	}
+	if got, ok := resp["build_info"].(string); !ok || got != "v1 (abc123, 2024-01-01)" {
+		t.Errorf("build_info=%v want v1 (abc123, 2024-01-01)", resp["build_info"])
+	}
+}
+
+func TestServer_PropsHandler_LocalModel(t *testing.T) {
+	s := newTestServer(newStubRouter([]string{"local-model"}, "local props"), newStubRouter(nil, ""))
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/props?model=local-model", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	if w.Body.String() != "local props" {
+		t.Errorf("body=%q want local props", w.Body.String())
+	}
+}
+
+func TestServer_PropsHandler_PeerModel(t *testing.T) {
+	s := newTestServer(newStubRouter(nil, ""), newStubRouter([]string{"peer-model"}, "peer props"))
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/props?model=peer-model", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	if w.Body.String() != "peer props" {
+		t.Errorf("body=%q want peer props", w.Body.String())
+	}
+}
+
+func TestServer_PropsHandler_AutoloadFalse_NotRunning(t *testing.T) {
+	s := newTestServer(newStubRouter([]string{"m1"}, ""), newStubRouter(nil, ""))
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/props?model=m1&autoload=false", nil))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "model is not loaded") {
+		t.Errorf("body=%q should contain 'model is not loaded'", w.Body.String())
+	}
+}
+
+func TestServer_PropsHandler_AutoloadFalse_Running(t *testing.T) {
+	local := newStubRouter([]string{"m1"}, "m1 props")
+	local.running = map[string]process.ProcessState{"m1": process.StateReady}
+	s := newTestServer(local, newStubRouter(nil, ""))
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/props?model=m1&autoload=false", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	if w.Body.String() != "m1 props" {
+		t.Errorf("body=%q want m1 props", w.Body.String())
+	}
+}
+
+func TestServer_PropsHandler_UnknownModel(t *testing.T) {
+	s := newTestServer(newStubRouter([]string{"m1"}, ""), newStubRouter(nil, ""))
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/props?model=unknown", nil))
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "could not find suitable handler") {
+		t.Errorf("body=%q should contain suitable handler message", w.Body.String())
+	}
+}
+
+func TestServer_PropsPostHandler(t *testing.T) {
+	s := newTestServer(newStubRouter([]string{"local-model"}, "post props"), newStubRouter(nil, ""))
+
+	body := strings.NewReader(`{"model":"local-model"}`)
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/props", body))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	if w.Body.String() != "post props" {
+		t.Errorf("body=%q want post props", w.Body.String())
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -39,7 +39,11 @@ func newStubRouter(models []string, response string) *stubRouter {
 
 func (s *stubRouter) Handles(model string) bool      { return s.models[model] }
 func (s *stubRouter) Shutdown(_ time.Duration) error { s.shutdownCalls.Add(1); return nil }
-func (s *stubRouter) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+func (s *stubRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Read (and discard) body to exercise body-forwarding code paths
+	if r.Body != nil {
+		io.ReadAll(r.Body)
+	}
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(s.response))
 }
@@ -424,6 +428,20 @@ func TestServer_PropsHandler_AutoloadFalse_Running(t *testing.T) {
 	}
 }
 
+func TestServer_PropsHandler_AutoloadFalse_PeerModel(t *testing.T) {
+	s := newTestServer(newStubRouter(nil, ""), newStubRouter([]string{"peer-model"}, "peer props"))
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/props?model=peer-model&autoload=false", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	if w.Body.String() != "peer props" {
+		t.Errorf("body=%q want peer props", w.Body.String())
+	}
+}
+
 func TestServer_PropsHandler_UnknownModel(t *testing.T) {
 	s := newTestServer(newStubRouter([]string{"m1"}, ""), newStubRouter(nil, ""))
 
@@ -442,8 +460,10 @@ func TestServer_PropsPostHandler(t *testing.T) {
 	s := newTestServer(newStubRouter([]string{"local-model"}, "post props"), newStubRouter(nil, ""))
 
 	body := strings.NewReader(`{"model":"local-model"}`)
+	req := httptest.NewRequest(http.MethodPost, "/props", body)
+	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
-	s.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/props", body))
+	s.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())


### PR DESCRIPTION
Implement a /props endpoint that aims to be compatible with how
llama.cpp's /props endpoint functions when llama.cpp is operating
in router mode (conceptually similar to how llama-swap operates)

behavioral differences vs llama.cpp router mode:
- GET /props with no args returns similar metadata about model
  router, except some fields are ommited due to not making sense
  in the context of llama-swap (eg. max_instances, other fields
  related to llama.cpp's web ui, etc.)
- Error responses (eg. incorrect model name) follow existingg
  llama-swap conventions for errors instead of copying structure
  of llama.cpp's error responses.

Testing:
- Verify new test cases are passing.
- manually access /props with no args and manually inspect metadata
- access /props?=model=<model-name> and inspect args.
- verify /props?=model=NOT_A_VALID_MODEL_NAME responds with an error
- unload all models then verify /props?=model=<model-name>&autoload=false fails
- validate pi agent with github.com/huggingface/pi-llama plugin now
  works and autodetects context length when llama-swap is run on
  localhost:8080 instead of giving 404 error on /props.

Fixes #854 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new `/props` endpoint for both GET and POST requests.
  * Requests can now return router metadata when no model is specified, or route to the appropriate local or peer handler when a model is provided.
  * Added support for the `autoload=false` option to block requests for unloaded local models.

* **Bug Fixes**
  * Improved error handling for missing models, unreadable request bodies, and unknown model routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->