### PR TITLE
fix(llama-build): patch qwen35/qwen35moe rope_dimension_sections count (4 → 3)

### DIFF
--- a/docker/unified/Dockerfile
+++ b/docker/unified/Dockerfile
@@ -77,6 +77,7 @@ FROM builder-base AS llama-build
 ARG BACKEND=cuda
 ARG LLAMA_COMMIT_HASH=master
 COPY install-llama.sh /build/
+COPY patches/ /build/patches/
 RUN --mount=type=cache,id=ccache-${BACKEND},target=/ccache \
     --mount=type=cache,id=llama-${BACKEND},target=/src/llama.cpp/build \
     BACKEND=${BACKEND} bash /build/install-llama.sh "${LLAMA_COMMIT_HASH}"

--- a/docker/unified/README.md
+++ b/docker/unified/README.md
@@ -1,8 +1,77 @@
 # Unified Docker Container
 
-These scripts create a custom llama-swap container that contains:
+These scripts build a self-contained llama-swap image that bundles:
 
-- llama-server for LLMs, rerank and embedding model support
-- sd-server (stable-diffusion.cpp) for image generation
-- whisper.cpp for ASR
+- **llama-server** (llama.cpp) — LLM inference, embeddings, reranking
+- **sd-server** (stable-diffusion.cpp) — image generation
+- **whisper-server** (whisper.cpp) — speech recognition
+- **ik-llama-server** (ik_llama.cpp) — CUDA only
 
+Two backend variants are supported: `cuda` (NVIDIA) and `vulkan` (AMD / Intel).
+
+## Building
+
+```bash
+# CUDA (NVIDIA)
+./build-image.sh --cuda
+
+# Vulkan (AMD / Intel)
+./build-image.sh --vulkan
+
+# Force a clean rebuild
+./build-image.sh --cuda --no-cache
+```
+
+Each dependency (llama.cpp, whisper.cpp, stable-diffusion.cpp, ik_llama.cpp) is built
+from source at the latest upstream HEAD by default.  Pin any of them to a specific
+commit, tag, or branch via environment variables:
+
+```bash
+LLAMA_REF=b5000   ./build-image.sh --cuda   # pin llama.cpp to a short hash
+LLAMA_REF=v1.2.3  ./build-image.sh --cuda   # pin to a release tag
+SD_REF=main        ./build-image.sh --vulkan # pin stable-diffusion.cpp to a branch
+```
+
+The script resolves the ref to a full 40-character SHA before passing it to Docker,
+so the build is fully reproducible and cache-friendly.
+
+## Patching llama.cpp
+
+Sometimes a bug exists in the upstream llama.cpp source that blocks important model
+families from loading.  Rather than waiting for a release, patches can be applied to
+the llama.cpp source tree at build time before compilation.
+
+### How it works
+
+`install-llama.sh` scans `docker/unified/patches/*.patch` after checking out llama.cpp
+and applies each patch with `git apply`.  Before applying, it runs `git apply --check`
+to test whether the patch is still needed:
+
+- **Check passes** → patch applied, build continues.
+- **Check fails** → the fix was already merged upstream; patch is skipped silently.
+
+This makes patches self-retiring: once the upstream repo ships the same change, the
+patch becomes a no-op and can be removed from this directory at any time.
+
+### Adding a patch
+
+1. Reproduce the bug against the relevant llama.cpp commit.
+2. Prepare a minimal unified diff rooted at `a/` / `b/` (standard `git diff` output).
+3. Add it as `docker/unified/patches/NNNN-short-description.patch`.
+4. Open a PR that also links the upstream llama.cpp issue so the patch can be tracked
+   and eventually removed.
+
+### Current patches
+
+| File | Affects | Upstream issue |
+|------|---------|---------------|
+| `0001-qwen35-rope-dimension-sections.patch` | `qwen35.cpp`, `qwen35moe.cpp` | Qwen3.5 GGUFs store 3 entries in `qwen35.rope.dimension_sections`; loaders requested 4, causing a hard load failure. |
+
+## CI / automated builds
+
+The unified image is rebuilt daily by the
+[Build Unified Docker Image](.github/workflows/unified-docker.yml) workflow, which
+always resolves each dependency to the latest upstream HEAD unless a specific ref is
+passed as a `workflow_dispatch` input.  Published images are tagged
+`ghcr.io/mostlygeek/llama-swap:unified-{cuda,vulkan}` and
+`ghcr.io/mostlygeek/llama-swap:unified-{cuda,vulkan}-YYYY-MM-DD`.

--- a/docker/unified/README.md
+++ b/docker/unified/README.md
@@ -44,28 +44,43 @@ the llama.cpp source tree at build time before compilation.
 ### How it works
 
 `install-llama.sh` scans `docker/unified/patches/*.patch` after checking out llama.cpp
-and applies each patch with `git apply`.  Before applying, it runs `git apply --check`
-to test whether the patch is still needed:
+and applies each patch using a two-stage check:
 
-- **Check passes** → patch applied, build continues.
-- **Check fails** → the fix was already merged upstream; patch is skipped silently.
+1. **Forward check passes** → patch is applied; build aborts if the apply itself fails.
+2. **Forward check fails, reverse check passes** → the fix is already in the checked-out
+   source (merged upstream); patch is skipped with an explicit "already present" message.
+3. **Both checks fail** → the patch is malformed or its context has drifted; build aborts
+   with a visible error so the problem is caught at build time, not at model load.
 
 This makes patches self-retiring: once the upstream repo ships the same change, the
-patch becomes a no-op and can be removed from this directory at any time.
+patch skips automatically and can then be deleted from this directory.
 
 ### Adding a patch
 
-1. Reproduce the bug against the relevant llama.cpp commit.
-2. Prepare a minimal unified diff rooted at `a/` / `b/` (standard `git diff` output).
-3. Add it as `docker/unified/patches/NNNN-short-description.patch`.
-4. Open a PR that also links the upstream llama.cpp issue so the patch can be tracked
-   and eventually removed.
+1. Pin your local llama.cpp to the same commit the build will use:
+   ```bash
+   LLAMA_REF=<commit> ./build-image.sh --cuda --no-cache
+   # or clone/checkout manually at the same SHA
+   ```
+2. Reproduce the bug, make the minimal fix, and produce the diff:
+   ```bash
+   git diff > docker/unified/patches/NNNN-short-description.patch
+   ```
+   Use sequential zero-padded numbers for `NNNN` (e.g. `0001`, `0002`).
+   Patches are applied in filename sort order, so numbering establishes
+   the application order if patches have dependencies.
+3. Verify locally: `git apply --check docker/unified/patches/NNNN-short-description.patch`
+4. File an issue or PR at [ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp) for
+   the upstream fix and add the link to the table below.
+5. Open a PR here. The patch file will be reviewed as C++ source — see `CODEOWNERS`.
+
+When the upstream fix lands, open a follow-up PR to delete the patch file and the table row.
 
 ### Current patches
 
-| File | Affects | Upstream issue |
-|------|---------|---------------|
-| `0001-qwen35-rope-dimension-sections.patch` | `qwen35.cpp`, `qwen35moe.cpp` | Qwen3.5 GGUFs store 3 entries in `qwen35.rope.dimension_sections`; loaders requested 4, causing a hard load failure. |
+| File | Affects | Track upstream fix |
+|------|---------|-------------------|
+| `0001-qwen35-rope-dimension-sections.patch` | `qwen35.cpp`, `qwen35moe.cpp` | [ggml-org/llama.cpp](https://github.com/ggml-org/llama.cpp) — issue/PR pending |
 
 ## CI / automated builds
 

--- a/docker/unified/install-llama.sh
+++ b/docker/unified/install-llama.sh
@@ -20,18 +20,26 @@ git fetch --depth=1 origin "${COMMIT_HASH}"
 git checkout FETCH_HEAD
 
 # Apply local patches to llama.cpp before building.
-# Each patch is tried with --check first; if upstream has already merged the
-# fix the patch won't apply cleanly and we skip it rather than failing the build.
+# Each patch undergoes a two-stage check:
+#   1. Forward check passes  → apply the patch; abort if the apply itself fails.
+#   2. Forward check fails + reverse check passes → fix is already in source; skip safely.
+#   3. Both checks fail      → patch is malformed or context-mismatched; abort visibly.
+# stderr from the forward check is shown in the build log to aid diagnosis.
 PATCH_DIR="/build/patches"
 if [ -d "${PATCH_DIR}" ]; then
     for patch in "${PATCH_DIR}"/*.patch; do
         [ -f "${patch}" ] || continue
-        echo "=== Checking patch: $(basename "${patch}") ==="
-        if git apply --check "${patch}" 2>/dev/null; then
-            git apply "${patch}"
+        name=$(basename "${patch}")
+        echo "=== Checking patch: ${name} ==="
+        if git apply --check "${patch}" 2>&1; then
+            git apply "${patch}" || { echo "FATAL: ${name} failed to apply" >&2; exit 1; }
             echo "    Applied."
+        elif git apply --check --reverse "${patch}" 2>/dev/null; then
+            echo "    Fix already present upstream — skipping safely."
         else
-            echo "    Already merged upstream or does not apply — skipping."
+            echo "FATAL: ${name} did not apply and cannot be confirmed as already merged." >&2
+            echo "       The patch is likely malformed or mismatched against this llama.cpp commit." >&2
+            exit 1
         fi
     done
 fi

--- a/docker/unified/install-llama.sh
+++ b/docker/unified/install-llama.sh
@@ -19,6 +19,23 @@ fi
 git fetch --depth=1 origin "${COMMIT_HASH}"
 git checkout FETCH_HEAD
 
+# Apply local patches to llama.cpp before building.
+# Each patch is tried with --check first; if upstream has already merged the
+# fix the patch won't apply cleanly and we skip it rather than failing the build.
+PATCH_DIR="/build/patches"
+if [ -d "${PATCH_DIR}" ]; then
+    for patch in "${PATCH_DIR}"/*.patch; do
+        [ -f "${patch}" ] || continue
+        echo "=== Checking patch: $(basename "${patch}") ==="
+        if git apply --check "${patch}" 2>/dev/null; then
+            git apply "${patch}"
+            echo "    Applied."
+        else
+            echo "    Already merged upstream or does not apply — skipping."
+        fi
+    done
+fi
+
 # Common cmake flags
 CMAKE_FLAGS=(
     -DGGML_NATIVE=OFF

--- a/docker/unified/patches/0001-qwen35-rope-dimension-sections.patch
+++ b/docker/unified/patches/0001-qwen35-rope-dimension-sections.patch
@@ -1,3 +1,8 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aditya Aggarwal <aditya@cybersapien.xyz>
+Date: Fri, 27 Jun 2026 12:00:00 +0530
+Subject: [PATCH] fix(llama.cpp): read 3 rope_dimension_sections for Qwen3.5
+
 Qwen3.5 and Qwen3.5-MoE GGUFs encode exactly 3 entries in the
 qwen35.rope.dimension_sections metadata field.  The loaders for
 both architectures pass n=4 to get_key_or_arr(), which validates
@@ -11,9 +16,17 @@ pre-zeroed before any metadata is read, so reading 3 elements
 and leaving index 3 at zero is the correct behaviour: ggml_rope_multi
 treats a zero-length section as "no rotation in that dimension".
 
+---
+ src/models/qwen35.cpp    | 2 +-
+ src/models/qwen35moe.cpp | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/models/qwen35.cpp b/src/models/qwen35.cpp
+index d8ffe43..ac09a30 100644
 --- a/src/models/qwen35.cpp
 +++ b/src/models/qwen35.cpp
 @@ -3,7 +3,7 @@
+
  void llama_model_qwen35::load_arch_hparams(llama_model_loader & ml) {
      ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS,       hparams.f_norm_rms_eps);
 -    ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_SECTIONS,    hparams.rope_sections, 4, true);
@@ -21,9 +34,12 @@ treats a zero-length section as "no rotation in that dimension".
 
      // Load linear attention (gated delta net) parameters
      ml.get_key(LLM_KV_SSM_CONV_KERNEL,    hparams.ssm_d_conv);
+diff --git a/src/models/qwen35moe.cpp b/src/models/qwen35moe.cpp
+index 7b0876c..d4f9fcf 100644
 --- a/src/models/qwen35moe.cpp
 +++ b/src/models/qwen35moe.cpp
-@@ -6,7 +6,7 @@
+@@ -6,7 +6,7 @@ void llama_model_qwen35moe::load_arch_hparams(llama_model_loader & ml) {
+     ml.get_key(LLM_KV_EXPERT_SHARED_FEED_FORWARD_LENGTH, hparams.n_ff_shexp, false);
      ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS,       hparams.f_norm_rms_eps);
 
 -    ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_SECTIONS,    hparams.rope_sections, 4, true);
@@ -31,3 +47,5 @@ treats a zero-length section as "no rotation in that dimension".
 
      // Load linear attention (gated delta net) parameters
      ml.get_key(LLM_KV_SSM_CONV_KERNEL,    hparams.ssm_d_conv);
+--
+2.53.0

--- a/docker/unified/patches/0001-qwen35-rope-dimension-sections.patch
+++ b/docker/unified/patches/0001-qwen35-rope-dimension-sections.patch
@@ -1,0 +1,33 @@
+Qwen3.5 and Qwen3.5-MoE GGUFs encode exactly 3 entries in the
+qwen35.rope.dimension_sections metadata field.  The loaders for
+both architectures pass n=4 to get_key_or_arr(), which validates
+the length strictly and throws at model load time:
+
+    key qwen35.rope.dimension_sections has wrong array length;
+    expected 4, got 3
+
+hparams.rope_sections is declared as std::array<int,4> and is
+pre-zeroed before any metadata is read, so reading 3 elements
+and leaving index 3 at zero is the correct behaviour: ggml_rope_multi
+treats a zero-length section as "no rotation in that dimension".
+
+--- a/src/models/qwen35.cpp
++++ b/src/models/qwen35.cpp
+@@ -3,7 +3,7 @@
+ void llama_model_qwen35::load_arch_hparams(llama_model_loader & ml) {
+     ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS,       hparams.f_norm_rms_eps);
+-    ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_SECTIONS,    hparams.rope_sections, 4, true);
++    ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_SECTIONS,    hparams.rope_sections, 3, true);
+
+     // Load linear attention (gated delta net) parameters
+     ml.get_key(LLM_KV_SSM_CONV_KERNEL,    hparams.ssm_d_conv);
+--- a/src/models/qwen35moe.cpp
++++ b/src/models/qwen35moe.cpp
+@@ -6,7 +6,7 @@
+     ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS,       hparams.f_norm_rms_eps);
+
+-    ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_SECTIONS,    hparams.rope_sections, 4, true);
++    ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_SECTIONS,    hparams.rope_sections, 3, true);
+
+     // Load linear attention (gated delta net) parameters
+     ml.get_key(LLM_KV_SSM_CONV_KERNEL,    hparams.ssm_d_conv);


### PR DESCRIPTION
## Problem

Qwen3.5 and Qwen3.5-MoE GGUFs store **3** entries in the
`qwen35.rope.dimension_sections` metadata field, but both model loaders
pass `n=4` to `get_key_or_arr()`.  That function enforces an exact array
length match and raises at load time:

```
key qwen35.rope.dimension_sections has wrong array length; expected 4, got 3
```

The model never loads—every attempt errors at the metadata-reading stage
regardless of quantisation or context size.

## Root cause

`src/models/qwen35.cpp` and `src/models/qwen35moe.cpp` both call:

```cpp
ml.get_key_or_arr(LLM_KV_ROPE_DIMENSION_SECTIONS, hparams.rope_sections, 4, true);
```

The correct count for the Qwen3.5 architecture is **3**.
`hparams.rope_sections` is `std::array<int,4>` and is pre-zeroed before
any metadata is read (`std::fill(…, 0)` in `llama-model.cpp`), so the
fourth slot stays zero—which is the correct behaviour for `ggml_rope_multi`
(a zero-length section means no rotation in that dimension).

## Fix

This PR adds a lightweight patching mechanism to `install-llama.sh`:

1. Any `*.patch` file found under `docker/unified/patches/` is checked
   with `git apply --check` before being applied.
2. If the check passes the patch is applied; if upstream has already
   merged the same fix the check fails and the patch is silently skipped,
   so the mechanism is self-retiring.

The initial patch (`0001-qwen35-rope-dimension-sections.patch`) changes
the count from 4 to 3 in both `qwen35.cpp` and `qwen35moe.cpp`.

## Testing

Verified against llama.cpp master (`9bebfcb`) that the patch applies
cleanly and that `git apply --check` returns non-zero once the change is
already present (idempotent skip path confirmed).