### PR TITLE
internal/logmon: decouple log broadcast from Write

### DIFF
--- a/internal/logmon/logging.go
+++ b/internal/logmon/logging.go
@@ -160,10 +160,11 @@ func (w *Monitor) Write(p []byte) (n int, err error) {
 	case w.broadcastCh <- bufferCopy:
 	default:
 		// Subscribers (e.g. the web UI log stream) can't keep up. Drop the
-		// live broadcast rather than block: Write runs on the upstream
-		// process's stdout drain, so blocking here stalls llama.cpp itself
-		// (issue #875). GetHistory() still has the data for reconnecting
-		// clients, and the dropped bytes are reported in-stream below.
+		// live broadcast rather than block: for the upstream monitor Write
+		// runs on the process's stdout drain, so blocking here stalls
+		// llama.cpp itself (issue #875). GetHistory() still has the data for
+		// reconnecting clients, and the dropped bytes are reported in-stream
+		// below.
 		w.dropped.Add(uint64(len(p)))
 	}
 	return n, nil

--- a/internal/logmon/logging.go
+++ b/internal/logmon/logging.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/mostlygeek/llama-swap/internal/event"
@@ -107,6 +108,12 @@ type Monitor struct {
 
 	stdout io.Writer
 
+	// broadcastCh hands log data to a dedicated goroutine that owns the
+	// (backpressuring) event bus. Write performs a non-blocking send so that
+	// slow subscribers can never stall the upstream process's stdout drain.
+	broadcastCh chan []byte
+	dropped     atomic.Uint64
+
 	level      Level
 	prefix     string
 	timeFormat string
@@ -117,14 +124,17 @@ func New() *Monitor {
 }
 
 func NewWriter(stdout io.Writer) *Monitor {
-	return &Monitor{
-		eventbus:   event.NewDispatcherConfig(1000),
-		buffer:     nil,
-		stdout:     stdout,
-		level:      LevelInfo,
-		prefix:     "",
-		timeFormat: "",
+	m := &Monitor{
+		eventbus:    event.NewDispatcherConfig(1000),
+		buffer:      nil,
+		stdout:      stdout,
+		broadcastCh: make(chan []byte, 1024),
+		level:       LevelInfo,
+		prefix:      "",
+		timeFormat:  "",
 	}
+	go m.broadcastLoop()
+	return m
 }
 
 func (w *Monitor) Write(p []byte) (n int, err error) {
@@ -146,7 +156,16 @@ func (w *Monitor) Write(p []byte) (n int, err error) {
 
 	bufferCopy := make([]byte, len(p))
 	copy(bufferCopy, p)
-	w.broadcast(bufferCopy)
+	select {
+	case w.broadcastCh <- bufferCopy:
+	default:
+		// Subscribers (e.g. the web UI log stream) can't keep up. Drop the
+		// live broadcast rather than block: Write runs on the upstream
+		// process's stdout drain, so blocking here stalls llama.cpp itself
+		// (issue #875). GetHistory() still has the data for reconnecting
+		// clients, and the dropped bytes are reported in-stream below.
+		w.dropped.Add(uint64(len(p)))
+	}
 	return n, nil
 }
 
@@ -173,8 +192,18 @@ func (w *Monitor) OnLogData(callback func(data []byte)) context.CancelFunc {
 	})
 }
 
-func (w *Monitor) broadcast(msg []byte) {
-	event.Publish(w.eventbus, DataEvent{Data: msg})
+// broadcastLoop is the only place that publishes to the (backpressuring)
+// event bus. If subscribers are slow it blocks here, never on Write. Before
+// delivering a message it flushes any pending dropped-byte count as an
+// in-stream marker so the UI shows where the gap is.
+func (w *Monitor) broadcastLoop() {
+	for msg := range w.broadcastCh {
+		if dropped := w.dropped.Swap(0); dropped > 0 {
+			notice := fmt.Appendf(nil, "\n— %d bytes dropped —\n", dropped)
+			event.Publish(w.eventbus, DataEvent{Data: notice})
+		}
+		event.Publish(w.eventbus, DataEvent{Data: msg})
+	}
 }
 
 func (w *Monitor) SetPrefix(prefix string) {

--- a/internal/logmon/logging_test.go
+++ b/internal/logmon/logging_test.go
@@ -197,6 +197,67 @@ func TestLogMonitor_ClearAndReuse(t *testing.T) {
 	}
 }
 
+// TestLogMonitor_DropsWhenSubscriberBlocked verifies that a stalled subscriber
+// can never block Write (the upstream process's stdout drain) and that dropped
+// data is reported in-stream with a marker once delivery resumes. See #875.
+func TestLogMonitor_DropsWhenSubscriberBlocked(t *testing.T) {
+	lm := NewWriter(io.Discard)
+
+	release := make(chan struct{})
+	var once sync.Once
+	var mu sync.Mutex
+	var received [][]byte
+
+	cancel := lm.OnLogData(func(data []byte) {
+		// Block the first delivery, stalling the broadcaster goroutine so the
+		// hand-off channel and event queue fill and subsequent writes drop.
+		once.Do(func() { <-release })
+		mu.Lock()
+		received = append(received, append([]byte(nil), data...))
+		mu.Unlock()
+	})
+	defer cancel()
+
+	// Flood well past the hand-off channel (1024) + event queue (1000)
+	// capacity. None of these writes may block.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 4000; i++ {
+			lm.Write([]byte("x"))
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Write blocked while subscriber was stalled")
+	}
+
+	close(release)
+
+	deadline := time.After(5 * time.Second)
+	for {
+		mu.Lock()
+		found := false
+		for _, d := range received {
+			if strings.Contains(string(d), "bytes dropped") {
+				found = true
+				break
+			}
+		}
+		mu.Unlock()
+		if found {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("expected a 'bytes dropped' marker after resuming delivery")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
 func BenchmarkLogMonitorWrite(b *testing.B) {
 	smallMsg := []byte("small message\n")
 	mediumMsg := []byte(strings.Repeat("medium message content ", 10) + "\n")


### PR DESCRIPTION
A slow web UI log subscriber could stall request processing. Write runs
on the upstream process's stdout drain, and it published to a bounded,
backpressuring event bus. When a browser tab fell behind on verbose
llama.cpp output, the event queue filled, Broadcast blocked Write, the OS
stdout pipe backed up, and llama.cpp stalled until the tab was closed.

Hand log data to a dedicated broadcaster goroutine over a buffered
channel and make Write's send non-blocking, dropping the live broadcast
instead of blocking. Dropped bytes are accumulated and reported in-stream
as a "— N bytes dropped —" marker when delivery resumes. GetHistory()
remains lossless for reconnecting clients.

- non-blocking, drop-on-full hand-off in Write
- broadcaster goroutine owns the event bus
- in-stream dropped-bytes marker

fixes #875