### PR TITLE
internal/server: gate UI embed behind embed_ui build tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ dist/
 .DS_Store
 .dev/
 
-# UI build output; placeholder.txt is kept so the go:embed succeeds.
+# UI build output; embedded via the `embed_ui` build tag (internal/server/embed.go)
 internal/server/ui_dist/*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,9 @@ version: 2
 builds:
   - env:
       - CGO_ENABLED=0
+    # embed the UI built by `make ui` into ui_dist (see internal/server/embed.go)
+    tags:
+      - embed_ui
     goos:
       - linux
       - darwin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,7 @@ builds:
     # match the version/commit/date vars defined in llama-swap.go:
     #   version = tag, commit = `git rev-parse --short HEAD`, date = RFC3339 UTC
     ldflags:
-      - -X main.version={{ .Version }}
+      - -X main.version={{ .Tag }}
       - -X main.commit={{ .ShortCommit }}
       - -X main.date={{ .Date }}
     goos:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,12 @@ builds:
     # embed the UI built by `make ui` into ui_dist (see internal/server/embed.go)
     tags:
       - embed_ui
+    # match the version/commit/date vars defined in llama-swap.go:
+    #   version = tag, commit = `git rev-parse --short HEAD`, date = RFC3339 UTC
+    ldflags:
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .ShortCommit }}
+      - -X main.date={{ .Date }}
     goos:
       - linux
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -34,31 +34,31 @@ test-all:
 ui/node_modules:
 	cd ui-svelte && npm install
 
-# build react UI
+# build react UI into internal/server/ui_dist; the `embed_ui` build tag embeds
+# this output into the binary (see internal/server/embed.go)
 ui: ui/node_modules
 	cd ui-svelte && npm run build
-	touch internal/server/ui_dist/placeholder.txt
 
 # Build OSX binary
 mac: ui
 	@echo "Building Mac binary..."
-	GOOS=darwin GOARCH=arm64 go build -ldflags="-X main.commit=${GIT_HASH} -X main.version=local_${GIT_HASH} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-darwin-arm64
+	GOOS=darwin GOARCH=arm64 go build -tags embed_ui -ldflags="-X main.commit=${GIT_HASH} -X main.version=local_${GIT_HASH} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-darwin-arm64
 
 # Build Linux binary
 linux: linux-arm64 linux-amd64
 
 linux-amd64: ui
 	@echo "Building Linux AMD64 binary..."
-	GOOS=linux GOARCH=amd64 go build -ldflags="-X main.commit=${GIT_HASH} -X main.version=local_${GIT_HASH} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-linux-amd64
+	GOOS=linux GOARCH=amd64 go build -tags embed_ui -ldflags="-X main.commit=${GIT_HASH} -X main.version=local_${GIT_HASH} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-linux-amd64
 
 linux-arm64: ui
 	@echo "Building Linux ARM64 binary..."
-	GOOS=linux GOARCH=arm64 go build -ldflags="-X main.commit=${GIT_HASH} -X main.version=local_${GIT_HASH} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-linux-arm64
+	GOOS=linux GOARCH=arm64 go build -tags embed_ui -ldflags="-X main.commit=${GIT_HASH} -X main.version=local_${GIT_HASH} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-linux-arm64
 
 # Build Windows binary
 windows: ui
 	@echo "Building Windows binary..."
-	GOOS=windows GOARCH=amd64 go build -ldflags="-X main.commit=${GIT_HASH} -X main.version=local_${GIT_HASH} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-windows-amd64.exe
+	GOOS=windows GOARCH=amd64 go build -tags embed_ui -ldflags="-X main.commit=${GIT_HASH} -X main.version=local_${GIT_HASH} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-windows-amd64.exe
 
 # for testing with real external processes
 simple-responder:

--- a/internal/server/embed.go
+++ b/internal/server/embed.go
@@ -1,0 +1,26 @@
+//go:build embed_ui
+
+package server
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+)
+
+// uiStaticFS holds the embedded UI build. The build is produced into ui_dist by
+// the Makefile's `ui` target. This file is only compiled when the `embed_ui`
+// build tag is set, so the embed directive requires ui_dist to be populated —
+// the Makefile build targets pass `-tags embed_ui` after building the UI.
+//
+//go:embed all:ui_dist
+var uiStaticFS embed.FS
+
+// uiFS is the embedded UI rooted at ui_dist.
+var uiFS = func() http.FileSystem {
+	sub, err := fs.Sub(uiStaticFS, "ui_dist")
+	if err != nil {
+		panic(err)
+	}
+	return http.FS(sub)
+}()

--- a/internal/server/embed_notag.go
+++ b/internal/server/embed_notag.go
@@ -1,0 +1,19 @@
+//go:build !embed_ui
+
+package server
+
+import (
+	"io/fs"
+	"net/http"
+)
+
+// uiFS serves no files when the binary is built without the `embed_ui` tag.
+// This is the default for `go test` and plain `go build`, which keeps those
+// commands from requiring a populated ui_dist directory. Release builds pass
+// `-tags embed_ui` (see the Makefile) to embed the real UI via embed.go.
+var uiFS http.FileSystem = http.FS(emptyUIFS{})
+
+// emptyUIFS is an fs.FS that contains no files.
+type emptyUIFS struct{}
+
+func (emptyUIFS) Open(string) (fs.File, error) { return nil, fs.ErrNotExist }

--- a/internal/server/extras_test.go
+++ b/internal/server/extras_test.go
@@ -177,8 +177,8 @@ func TestServer_HandleUIAndFavicon(t *testing.T) {
 	for _, path := range []string{"/ui/", "/favicon.ico"} {
 		w := httptest.NewRecorder()
 		s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
-		// The embedded ui_dist only carries placeholder.txt in test builds, so
-		// these resolve to 404 — the handlers still execute end to end.
+		// Tests build without the `embed_ui` tag, so uiFS is empty and these
+		// resolve to 404 — the handlers still execute end to end.
 		if w.Code != http.StatusOK && w.Code != http.StatusNotFound {
 			t.Errorf("%s: status = %d", path, w.Code)
 		}

--- a/internal/server/ui.go
+++ b/internal/server/ui.go
@@ -1,28 +1,16 @@
 package server
 
 import (
-	"embed"
 	"io/fs"
 	"net/http"
 	"path"
 	"strings"
 )
 
-// uiStaticFS holds the embedded UI build. The build is copied into ui_dist by
-// the Makefile's `ui` target; placeholder.txt keeps the embed valid before a
-// build has run.
-//
-//go:embed ui_dist
-var uiStaticFS embed.FS
-
-// uiFS is the embedded UI rooted at ui_dist.
-var uiFS = func() http.FileSystem {
-	sub, err := fs.Sub(uiStaticFS, "ui_dist")
-	if err != nil {
-		panic(err)
-	}
-	return http.FS(sub)
-}()
+// uiFS holds the UI build served under /ui/. Its value depends on build tags:
+// embed.go embeds the real ui_dist build when compiled with `-tags embed_ui`,
+// while embed_notag.go provides an empty filesystem for plain builds and tests.
+// See those files for details.
 
 // selectEncoding chooses the best pre-compressed encoding the client accepts.
 // It returns the encoding ("br" or "gzip") and the matching file extension.

--- a/ui-svelte/src/routes/Settings.svelte
+++ b/ui-svelte/src/routes/Settings.svelte
@@ -60,7 +60,7 @@
         <dd class="font-medium">{$connectionState ?? "unknown"}</dd>
       </div>
       <div class="flex justify-between gap-4">
-        <dt class="text-muted-foreground">API Version</dt>
+        <dt class="text-muted-foreground">Version</dt>
         <dd class="font-medium">{$versionInfo?.version ?? "unknown"}</dd>
       </div>
       <div class="flex justify-between gap-4">


### PR DESCRIPTION
Replace the ui_dist placeholder.txt hack with a build-tag guard so plain
`go build`/`go test` no longer require a populated ui_dist directory. The
real embed only happens when compiled with `-tags embed_ui`.

- embed.go (//go:build embed_ui) holds the //go:embed all:ui_dist directive
- embed_notag.go (//go:build !embed_ui) serves an empty FS for tests
- Makefile build targets pass -tags embed_ui and drop the placeholder touch
- .goreleaser.yaml builds add the embed_ui tag so releases ship the UI

Docker images consume the goreleaser binary, and CI runs tests without the
tag, so no changes are needed there.