### PR TITLE
ui-svelte: add playground api key support

### DIFF
--- a/ui-svelte/src/components/playground/SpeechInterface.svelte
+++ b/ui-svelte/src/components/playground/SpeechInterface.svelte
@@ -4,6 +4,7 @@
   import { createPlaygroundInterface } from "../../lib/playgroundInterface";
   import { generateSpeech } from "../../lib/speechApi";
   import { playgroundStores } from "../../stores/playgroundActivity";
+  import { getAuthHeaders } from "../../lib/authUtils";
   import ModelSelector from "./ModelSelector.svelte";
   import ExpandableTextarea from "./ExpandableTextarea.svelte";
   import EmptyState from "../EmptyState.svelte";
@@ -74,7 +75,9 @@
     isLoadingVoices = true;
 
     try {
-      const response = await fetch(`/v1/audio/voices?model=${encodeURIComponent(model)}`);
+      const response = await fetch(`/v1/audio/voices?model=${encodeURIComponent(model)}`, {
+        headers: getAuthHeaders(),
+      });
       if (!response.ok) {
         // Fall back to default voices if API call fails
         availableVoices = defaultVoices;

--- a/ui-svelte/src/lib/audioApi.ts
+++ b/ui-svelte/src/lib/audioApi.ts
@@ -1,4 +1,5 @@
 import type { AudioTranscriptionResponse } from "./types";
+import { getAuthHeaders } from "./authUtils";
 
 export async function transcribeAudio(
   model: string,
@@ -11,6 +12,7 @@ export async function transcribeAudio(
 
   const response = await fetch("/v1/audio/transcriptions", {
     method: "POST",
+    headers: getAuthHeaders(),
     body: formData,
     signal,
   });

--- a/ui-svelte/src/lib/authUtils.ts
+++ b/ui-svelte/src/lib/authUtils.ts
@@ -1,0 +1,11 @@
+import { get } from "svelte/store";
+import { apiKey } from "../stores/auth";
+
+export function getAuthHeaders(existingHeaders: Record<string, string> = {}): Record<string, string> {
+  const headers = { ...existingHeaders };
+  const key = get(apiKey);
+  if (key) {
+    headers["Authorization"] = `Bearer ${key}`;
+  }
+  return headers;
+}

--- a/ui-svelte/src/lib/chatApi.ts
+++ b/ui-svelte/src/lib/chatApi.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage, ContentPart } from "./types";
+import { getAuthHeaders } from "./authUtils";
 
 export type Endpoint = "v1/chat/completions" | "v1/messages" | "v1/responses";
 
@@ -303,9 +304,9 @@ export async function* streamChatCompletion(
 
   const response = await fetch(url, {
     method: "POST",
-    headers: {
+    headers: getAuthHeaders({
       "Content-Type": "application/json",
-    },
+    }),
     body: JSON.stringify(body),
     signal,
   });

--- a/ui-svelte/src/lib/imageApi.ts
+++ b/ui-svelte/src/lib/imageApi.ts
@@ -1,4 +1,5 @@
 import type { ImageGenerationRequest, ImageGenerationResponse } from "./types";
+import { getAuthHeaders } from "./authUtils";
 
 export async function generateImage(
   model: string,
@@ -15,9 +16,9 @@ export async function generateImage(
 
   const response = await fetch("/v1/images/generations", {
     method: "POST",
-    headers: {
+    headers: getAuthHeaders({
       "Content-Type": "application/json",
-    },
+    }),
     body: JSON.stringify(request),
     signal,
   });

--- a/ui-svelte/src/lib/rerankApi.ts
+++ b/ui-svelte/src/lib/rerankApi.ts
@@ -1,3 +1,5 @@
+import { getAuthHeaders } from "./authUtils";
+
 export interface RerankResult {
   index: number;
   relevance_score: number;
@@ -18,7 +20,7 @@ export async function rerank(
 ): Promise<RerankResponse> {
   const response = await fetch("/v1/rerank", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: getAuthHeaders({ "Content-Type": "application/json" }),
     body: JSON.stringify({ model, query, documents }),
     signal,
   });

--- a/ui-svelte/src/lib/sdApi.ts
+++ b/ui-svelte/src/lib/sdApi.ts
@@ -1,4 +1,5 @@
 import type { SdApiTxt2ImgRequest, SdApiResponse, SdApiLora } from "./types";
+import { getAuthHeaders } from "./authUtils";
 
 export async function generateSdImage(
   request: SdApiTxt2ImgRequest,
@@ -6,9 +7,9 @@ export async function generateSdImage(
 ): Promise<SdApiResponse> {
   const response = await fetch("/sdapi/v1/txt2img", {
     method: "POST",
-    headers: {
+    headers: getAuthHeaders({
       "Content-Type": "application/json",
-    },
+    }),
     body: JSON.stringify(request),
     signal,
   });
@@ -27,7 +28,7 @@ export async function fetchSdLoras(
 ): Promise<SdApiLora[]> {
   const response = await fetch(
     `/sdapi/v1/loras?model=${encodeURIComponent(model)}`,
-    { signal }
+    { headers: getAuthHeaders(), signal }
   );
 
   if (!response.ok) {

--- a/ui-svelte/src/lib/speechApi.ts
+++ b/ui-svelte/src/lib/speechApi.ts
@@ -1,4 +1,5 @@
 import type { SpeechGenerationRequest } from "./types";
+import { getAuthHeaders } from "./authUtils";
 
 export async function generateSpeech(
   model: string,
@@ -14,9 +15,9 @@ export async function generateSpeech(
 
   const response = await fetch("/v1/audio/speech", {
     method: "POST",
-    headers: {
+    headers: getAuthHeaders({
       "Content-Type": "application/json",
-    },
+    }),
     body: JSON.stringify(request),
     signal,
   });

--- a/ui-svelte/src/routes/Settings.svelte
+++ b/ui-svelte/src/routes/Settings.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { connectionState, themeName, themeMode, themes, type ThemeMode } from "../stores/theme";
   import { versionInfo } from "../stores/api";
+  import { apiKey } from "../stores/auth";
   import * as Select from "$lib/components/ui/select/index.js";
+  import { Input } from "$lib/components/ui/input/index.js";
 
   const modes: { value: ThemeMode; label: string }[] = [
     { value: "light", label: "Light" },
@@ -49,6 +51,14 @@
           {/each}
         </Select.Content>
       </Select.Root>
+    </div>
+  </div>
+
+  <div class="rounded-lg border p-4 space-y-3 max-w-md mb-4">
+    <h4 class="text-sm font-semibold text-muted-foreground">Authentication</h4>
+    <div class="flex flex-col gap-2">
+      <span class="text-sm">Playground API Key</span>
+      <Input type="password" placeholder="Optional API key for Playground endpoints" bind:value={$apiKey} />
     </div>
   </div>
 

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -10,6 +10,7 @@ import type {
   PerformanceResponse,
 } from "../lib/types";
 import { connectionState } from "./theme";
+import { getAuthHeaders } from "../lib/authUtils";
 
 const LOG_LENGTH_LIMIT = 1024 * 100; /* 100KB of log data */
 
@@ -126,7 +127,7 @@ export function enableAPIEvents(enabled: boolean): void {
 connectionState.subscribe(async (status) => {
   if (status === "connected") {
     try {
-      const response = await fetch("/api/version");
+      const response = await fetch("/api/version", { headers: getAuthHeaders() });
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -140,7 +141,7 @@ connectionState.subscribe(async (status) => {
 
 export async function listModels(): Promise<Model[]> {
   try {
-    const response = await fetch("/api/models/");
+    const response = await fetch("/api/models/", { headers: getAuthHeaders() });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -156,6 +157,7 @@ export async function unloadAllModels(): Promise<void> {
   try {
     const response = await fetch(`/api/models/unload`, {
       method: "POST",
+      headers: getAuthHeaders(),
     });
     if (!response.ok) {
       throw new Error(`Failed to unload models: ${response.status}`);
@@ -170,6 +172,7 @@ export async function unloadSingleModel(model: string): Promise<void> {
   try {
     const response = await fetch(`/api/models/unload/${model}`, {
       method: "POST",
+      headers: getAuthHeaders(),
     });
     if (!response.ok) {
       throw new Error(`Failed to unload model: ${response.status}`);
@@ -184,6 +187,7 @@ export async function loadModel(model: string, signal?: AbortSignal): Promise<vo
   try {
     const response = await fetch(`/upstream/${model}/?_=${Date.now()}`, {
       method: "GET",
+      headers: getAuthHeaders(),
       signal,
     });
     if (!response.ok) {
@@ -200,7 +204,7 @@ export async function loadModel(model: string, signal?: AbortSignal): Promise<vo
 
 export async function getCapture(id: number): Promise<ReqRespCapture | null> {
   try {
-    const response = await fetch(`/api/captures/${id}`);
+    const response = await fetch(`/api/captures/${id}`, { headers: getAuthHeaders() });
     if (response.status === 404) {
       return null;
     }
@@ -216,7 +220,7 @@ export async function getCapture(id: number): Promise<ReqRespCapture | null> {
 
 export async function checkPerformanceEnabled(): Promise<void> {
   try {
-    const response = await fetch("/api/performance");
+    const response = await fetch("/api/performance", { headers: getAuthHeaders() });
     if (!response.ok) {
       performanceEnabled.set(false);
       return;
@@ -231,7 +235,7 @@ export async function checkPerformanceEnabled(): Promise<void> {
 export async function fetchPerformance(after?: string): Promise<PerformanceResponse | null> {
   try {
     const url = after ? `/api/performance?after=${encodeURIComponent(after)}` : "/api/performance";
-    const response = await fetch(url);
+    const response = await fetch(url, { headers: getAuthHeaders() });
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }

--- a/ui-svelte/src/stores/auth.ts
+++ b/ui-svelte/src/stores/auth.ts
@@ -1,0 +1,3 @@
+import { persistentStore } from "./persistent";
+
+export const apiKey = persistentStore<string>("llama-swap-api-key", "");

--- a/ui-svelte/src/stores/modelLogs.ts
+++ b/ui-svelte/src/stores/modelLogs.ts
@@ -1,4 +1,5 @@
 import { writable, type Readable } from "svelte/store";
+import { getAuthHeaders } from "../lib/authUtils";
 
 const LOG_LENGTH_LIMIT = 1024 * 100; /* 100KB of log data */
 
@@ -18,6 +19,7 @@ export function streamModelLog(modelId: string): Readable<string> {
     try {
       const res = await fetch(`/logs/stream/${encodeURIComponent(modelId)}`, {
         method: "GET",
+        headers: getAuthHeaders(),
         signal: controller.signal,
       });
       if (!res.ok || !res.body) {


### PR DESCRIPTION
Currently, there seems to be no way to use the Playground for local models if llama-server is launched with the `--api-key` flag. The only option for users is to remove the `--api-key`.

This PR adds a 'Playground API Key' input to the UI Settings.

<img width="502" height="470" alt="firefox_50nRCx1lB9" src="https://github.com/user-attachments/assets/73954164-2db2-4021-bc0d-a8a50990cc38" />

Changes:

- Add 'Playground API Key' input to the Settings page & Save the key locally via auth.ts
- Attach the key as a Bearer token across all playground features (chat, image, audio, speech, rerank, etc.)

Testing the Playground - Load Test
- Latest llama-Swap V232 (Before)
<img width="1618" height="948" alt="firefox_vc3ORS5SOn" src="https://github.com/user-attachments/assets/f284ea6d-7a99-4673-9660-f36c6f92fa4f" />

- After
<img width="1604" height="954" alt="firefox_BoeFdjBEaa" src="https://github.com/user-attachments/assets/6a1e441a-cf49-4ae8-ba56-2b401a57f4d1" />
