### PR TITLE
perf: implement sysfs GPU memory backend (AMD GTT for APUs/iGPUs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
   - `/health` - just returns "OK"
   - `/metrics` - system and GPU metrics for prometheus
 - ✅ API Key support - define keys to restrict access to API endpoints
+- ✅ Model leases: protect an in-use model from eviction (refuse-don't-break), plus optional global inference serialization ([docs](docs/model-leases.md))
+  - `POST/GET/DELETE /leases`, `POST /leases/{id}/extend`, `POST /leases/kill`, `GET /leases/can-load/{model}`
+  - `X-Llama-Swap-Lease` request header; `scripts/model_lease.py` client + `llama-swap-lease` CLI
 - ✅ Customizable
   - Run concurrent models with a custom DSL swap matrix ([#643](https://github.com/mostlygeek/llama-swap/issues/643))
   - Automatic unloading of models after timeout by setting a `ttl`

--- a/docs/model-leases.md
+++ b/docs/model-leases.md
@@ -1,0 +1,303 @@
+# Model leases and inference serialization
+
+This fork adds two related controls for single-box, memory-constrained setups
+(one GPU / UMA iGPU) where loading a model can evict another model that is doing
+useful work:
+
+1. **In-flight eviction protection** (always on): a model with active requests
+   is never chosen as an eviction victim.
+2. **Model leases** (opt-in, per work session): an explicit, refcounted claim
+   that protects a model from eviction across an idle-between-requests work
+   session (for example an overnight batch). The contract is **refuse-don't-break**:
+   a load that would have to evict a leased model is refused with `503`, never
+   allowed to break the lease.
+3. **Global inference serialization** (opt-in): run at most one upstream
+   inference at a time across all models, so two models don't thrash a single
+   GPU.
+
+These are independent of the GPU memory-budget gate (`gpuBudgetMB` and the
+red-line watchdog); leases sit on top of whatever eviction policy is configured.
+
+## The problem leases solve
+
+On a single-user box, loading model B can silently evict model A under memory
+pressure (LRU). If A was mid-batch or held an active session, that work is lost.
+Static per-model `fifo.priority` can't help, because usefulness is a property of
+the _work_, not the _model_.
+
+The lease reframes accidental eviction from a **silent kill** into a **loud,
+refusable event**. A lease is broken only by:
+
+- the host-OOM **hardline** (safety beats a lease: losing a model is better than
+  a kernel OOM / watchdog reboot), or
+- an explicit operator **`kill`**.
+
+Nothing else. An ordinary competing load is refused, not allowed to evict a
+leased model.
+
+## Configuration
+
+All under the top-level `performance:` block.
+
+```yaml
+performance:
+  # Serialize upstream inference across ALL models: at most one inference runs
+  # at a time. Waiters are ordered by routing.scheduler.settings.fifo.priority.
+  # Default false (historical parallel behaviour).
+  serializeInference: false
+
+  # Cap on how long any single lease can hold (acquire and extend both clamp to
+  # it). Bounds the worst case when a client sets a long TTL and then crashes.
+  # Default 4h. The lease API is always available; it is inert until a lease is
+  # acquired.
+  maxLeaseDuration: 4h
+
+  # Persist the lease table to this file so leases survive a llama-swap restart.
+  # On startup the table is reconciled: expired entries are dropped. Empty
+  # (default) keeps leases in memory only.
+  leaseStatePath: "" # e.g. /var/lib/llama-swap/leases.json
+```
+
+The lease API endpoints are always registered; with no lease acquired, behaviour
+is identical to stock llama-swap (nothing is protected, nothing is refused).
+
+## HTTP API
+
+All endpoints are protected by the same API-key auth as the other llama-swap
+control endpoints. Only **local** models can be leased (peer/remote models are
+not owned by this instance).
+
+### Acquire: `POST /leases`
+
+```json
+{
+  "model": "qwen3.5-9b-vision",
+  "holder": "run_tagging.py",
+  "reason": "tag project-39",
+  "ttl": "5h"
+}
+```
+
+- `ttl` is a Go duration (`30m`, `4h`); omitted or empty means "the server
+  maximum". It is clamped to `maxLeaseDuration`.
+- `holder` (max 64 chars) and `reason` (max 120 chars) are sanitized to a single
+  line.
+
+`201 Created` with the lease:
+
+```json
+{
+  "id": "01KWQZGPMWTT87NJZ5V3HGMRJX",
+  "model": "qwen3.5-9b-vision",
+  "holder": "run_tagging.py",
+  "reason": "tag project-39",
+  "acquired_at": "2026-07-04T18:50:33-07:00",
+  "expires_at": "2026-07-04T23:50:33-07:00",
+  "state": "active"
+}
+```
+
+- `404` if the model is unknown to this router.
+- `409` if the model is currently mid-eviction (the eviction won the race);
+  retry, at which point the model is gone and reloadable.
+
+### List: `GET /leases`
+
+```json
+{
+  "leases": [
+    {
+      "id": "...",
+      "model": "...",
+      "holder": "...",
+      "reason": "...",
+      "acquired_at": "...",
+      "expires_at": "...",
+      "state": "active",
+      "active_requests": 2,
+      "ttl_remaining_ms": 3599895
+    }
+  ]
+}
+```
+
+Only live (unexpired) leases are shown. `active_requests` is the model's current
+in-flight request count.
+
+### Release: `DELETE /leases/{id}`
+
+`204 No Content` on success; `404` if the id is unknown (already expired,
+killed, or never existed, which a client treats as "re-acquire").
+
+### Extend: `POST /leases/{id}/extend`
+
+```json
+{ "ttl": "2h" }
+```
+
+Pushes the expiry out to `now + ttl` (clamped to `maxLeaseDuration`; never
+shortens). `200 OK` with the updated lease; `404` if the id is unknown or
+already expired. There is **no heartbeat**: extend is an explicit action, not a
+keep-alive.
+
+### Kill: `POST /leases/kill`
+
+Operator override. Exactly one selector:
+
+```json
+{ "model": "qwen3.5-9b-vision" } // or {"id": "..."} or {"holder": "run.py"}
+```
+
+`200 OK` with `{ "killed": [ ...leases ] }`. `400` if zero or more than one
+selector is set.
+
+### Can-I-load (preflight): `GET /leases/can-load/{model}`
+
+Read-only "if I load this model now, what happens?":
+
+```json
+{
+  "model": "modelB",
+  "running": false,
+  "would_evict": ["modelA"],
+  "blocked": true,
+  "blocked_by": [
+    {
+      "model": "modelA",
+      "holder": "run.py",
+      "reason": "batch",
+      "expires_in_ms": 3599818
+    }
+  ]
+}
+```
+
+`blocked: true` means a lease would refuse the load. Note this reports the
+**structural + lease** verdict only; a `blocked: false` verdict means "no lease
+refuses it", not "guaranteed to fit under `gpuBudgetMB`" (memory admission is
+still evaluated at actual load time).
+
+### Refusal shape
+
+When an ordinary inference/load request would have to evict a leased model, it
+is refused on the normal request path with `503` and a `blocked_by` body, so the
+thing you were trying to load tells you why:
+
+```
+HTTP 503
+{ "error": "loading modelA refused: blocked by lease(s) on modelA (run.py: batch)",
+  "blocked_by": [ { "model": "modelA", "holder": "run.py", "reason": "batch",
+                    "expires_in_ms": 3588433 } ] }
+```
+
+## Request header: `X-Llama-Swap-Lease`
+
+Optionally tag an inference request with a lease id:
+
+```
+X-Llama-Swap-Lease: 01KWQZGPMWTT87NJZ5V3HGMRJX
+```
+
+- If the header names a **live lease for a different model** than the request,
+  the request is rejected `400` (an obvious mismatch).
+- An **unknown/expired id** is logged and ignored (the client re-acquires on its
+  own), never a hard failure.
+
+## Client library and CLI
+
+`scripts/model_lease.py` (stdlib only) is both an importable context manager and
+the `llama-swap-lease` CLI.
+
+Context manager: acquire on enter, release on exit (and on `SIGTERM`); the TTL is
+the crash backstop, so there is no heartbeat thread:
+
+```python
+from model_lease import model_lease
+
+with model_lease("qwen3.5-9b-vision", holder="run_tagging.py",
+                 reason="tag project-39", ttl="5h") as lease:
+    run_batch(extra_headers=lease.header())   # {"X-Llama-Swap-Lease": "<id>"}
+```
+
+CLI (base URL from `--url` or `$LLAMA_SWAP_URL`, key from `--api-key` or
+`$LLAMA_SWAP_API_KEY`):
+
+```bash
+llama-swap-lease --url http://localhost:8080 acquire qwen3.5-9b-vision \
+    --holder run.py --reason batch --ttl 4h
+llama-swap-lease --url http://localhost:8080 ls
+llama-swap-lease --url http://localhost:8080 can-load qwen3.5-9b-vision
+llama-swap-lease --url http://localhost:8080 extend <id> --ttl 2h
+llama-swap-lease --url http://localhost:8080 release <id>
+llama-swap-lease --url http://localhost:8080 kill --model qwen3.5-9b-vision
+```
+
+Global flags (`--url`, `--api-key`) precede the subcommand.
+
+## Behaviour and invariants
+
+- **In-flight protection is always on**: a model with more than zero
+  scheduler-tracked requests is never an eviction victim (except the host-OOM
+  hardline).
+- **A model is protected while it holds one or more live leases** (refcounted).
+  Releasing one lease does not unprotect a model another lease still holds.
+- **Server-side TTL, no client heartbeat.** Clean exit calls `release`; a crash
+  is caught by TTL expiry. Expiry is evaluated directly at read time, so a lease
+  never outlives its `expires_at` (the background sweeper is GC only).
+- **Refuse-don't-break** applies to both eviction paths: the scheduler's
+  structural eviction (loading B evicts A) and the memory-gate's top-up LRU
+  eviction, plus the runtime red-line watchdog.
+- **Leases break only on** the host-OOM hardline or an explicit `kill`.
+- **Persistence** (`leaseStatePath`) survives a restart; on reload, expired
+  leases are dropped. Across a restart, clients treat an "unknown lease id" as a
+  signal to re-acquire.
+
+## For maintainers: implementation notes
+
+Code lives in `internal/router` (lease core + eviction integration),
+`internal/server` (HTTP API), and `internal/config` (config fields). Built in
+four phases: (1) in-flight protection + serialization, (2) lease core +
+refuse-don't-break, (3) persistence, (4) header.
+
+Key files:
+
+- `internal/router/lease.go`: the `leaseTable`: refcounted per-model leases,
+  ULID ids, server-side TTL, **eviction claims**, async persistence.
+- `internal/router/lease_api.go`: router-level lease methods + `CanLoad`.
+- `internal/router/memgate.go`, `redline.go`: victim selection excludes leased
+  models (hardline overrides) and claims a victim before stopping it.
+- `internal/router/base.go`: wires the table in, implements
+  `Effects.TryClaimEviction`, releases claims in `doSwap`, validates the header.
+- `internal/router/scheduler/fifo.go`: refuse-don't-break in
+  `OnRequest`/`drainQueue`.
+- `internal/server/leases.go`: the HTTP handlers.
+
+### The one careful piece: eviction claims
+
+Checking "is this model leased?" at victim-selection time is **not** enough: a
+lease can be acquired between the check and the `Stop`. `TryClaimEviction` /
+`ReleaseEvictionClaim` make an eviction claim and a lease **mutually exclusive**
+under a single lock: a claim refuses if the model is leased, and an acquire
+refuses if the model is claimed. Both eviction paths (scheduler structural and
+memGate/redline top-up) claim a victim before stopping it, closing the
+check-then-stop TOCTOU. The scheduler places the claim on the run loop; `doSwap`
+releases it once the stops complete.
+
+### Locking
+
+- `leaseTable.mu` is a strict **leaf** lock: nothing under it calls `Stop`, waits
+  on a goroutine or the run loop, takes `memGate.mu`, or does blocking I/O
+  (persistence is handed to a dedicated writer goroutine). This is what makes it
+  safe to consult from the single-threaded run loop.
+- Lock order is `memGate.mu` then `leaseTable.mu` (the memGate top-up path); the
+  reverse never happens.
+- `List` snapshots live leases under the lock and queries the in-flight callback
+  **after** releasing it: the callback round-trips through the run loop, which
+  itself takes `leaseTable.mu`, so calling it under the lock would deadlock.
+
+### Deferred (not implemented, by design)
+
+Importance / preemption / auto-break arbitration was rejected (livelock-prone
+for this context). The single-user insight, refuse instead of arbitrate, removes
+the need for it. Revisit only if two simultaneous leased jobs regularly contend
+for the same slot and manual `kill` is too slow.

--- a/internal/config/model_config.go
+++ b/internal/config/model_config.go
@@ -80,6 +80,13 @@ type ModelConfig struct {
 	// Limit concurrency of HTTP requests to process
 	ConcurrencyLimit int `yaml:"concurrencyLimit"`
 
+	// VramEstimateMB is an optional estimate, in MiB, of the GPU memory this
+	// model needs once loaded. It is used only by the GPU budget gate
+	// (performance.gpuBudgetMB) to project the post-load footprint before a
+	// swap. 0 (default) makes the gate reactive for this model: it evicts only
+	// once live usage already exceeds the budget. See internal/router/memgate.go.
+	VramEstimateMB int `yaml:"vramEstimateMB"`
+
 	// Model filters see issue #174
 	Filters ModelFilters `yaml:"filters"`
 

--- a/internal/config/performance.go
+++ b/internal/config/performance.go
@@ -53,6 +53,11 @@ type PerformanceConfig struct {
 	// the kernel TTM eviction stall / hardware-watchdog reboot that follows
 	// unchecked growth. Should be >= GpuRedlineMB.
 	GpuHardlineMB int `yaml:"gpuHardlineMB"`
+
+	// SerializeInference, when true, allows at most one upstream inference
+	// handler to execute at a time across all local models. Default false
+	// preserves historical parallel behaviour.
+	SerializeInference bool `yaml:"serializeInference"`
 }
 
 func (p *PerformanceConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/internal/config/performance.go
+++ b/internal/config/performance.go
@@ -58,6 +58,19 @@ type PerformanceConfig struct {
 	// handler to execute at a time across all local models. Default false
 	// preserves historical parallel behaviour.
 	SerializeInference bool `yaml:"serializeInference"`
+
+	// MaxLeaseDuration caps the TTL any single model lease can hold (acquire
+	// and extend both clamp to it). A lease protects its model from eviction
+	// until it expires, is released, or is killed; the cap bounds the worst
+	// case when a client sets a long TTL and then crashes. Default 4h. The
+	// lease API is always available; it is inert until a lease is acquired.
+	MaxLeaseDuration time.Duration `yaml:"maxLeaseDuration"`
+
+	// LeaseStatePath, when non-empty, is a file the lease table is persisted to
+	// so leases survive a llama-swap restart. On startup the table is
+	// reconciled: expired entries are dropped and surviving leases are marked
+	// so clients re-acquire. Empty (default) keeps leases in memory only.
+	LeaseStatePath string `yaml:"leaseStatePath"`
 }
 
 func (p *PerformanceConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -65,6 +78,7 @@ func (p *PerformanceConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 	defaults := rawPerformanceConfig{
 		Every:            5 * time.Second,
 		AdmissionMaxWait: 30 * time.Second,
+		MaxLeaseDuration: 4 * time.Hour,
 	}
 
 	if err := unmarshal(&defaults); err != nil {
@@ -85,6 +99,9 @@ func (p *PerformanceConfig) Validate() error {
 	}
 	if p.AdmissionMaxWait < 0 {
 		return fmt.Errorf("admissionMaxWait must be >= 0, got %v", p.AdmissionMaxWait)
+	}
+	if p.MaxLeaseDuration < 0 {
+		return fmt.Errorf("maxLeaseDuration must be >= 0, got %v", p.MaxLeaseDuration)
 	}
 	if p.GpuRedlineMB > 0 && p.GpuBudgetMB > 0 && p.GpuRedlineMB < p.GpuBudgetMB {
 		return fmt.Errorf("gpuRedlineMB (%d) must be >= gpuBudgetMB (%d)", p.GpuRedlineMB, p.GpuBudgetMB)

--- a/internal/config/performance.go
+++ b/internal/config/performance.go
@@ -10,18 +10,56 @@ type PerformanceConfig struct {
 	Disabled bool          `yaml:"disabled"`
 	Every    time.Duration `yaml:"every"`
 
-	// GpuBudgetMB is an optional soft ceiling, in MiB, on total GPU-managed
+	// GpuBudgetMB is an optional ceiling, in MiB, on total GPU-managed
 	// memory (VRAM + GTT, as reported by the perf monitor). When > 0 and the
 	// monitor is active, the router evicts least-recently-used models before
 	// a swap so the projected footprint stays under budget. 0 (default)
 	// disables the gate entirely. See internal/router/memgate.go.
 	GpuBudgetMB int `yaml:"gpuBudgetMB"`
+
+	// GpuStrictAdmission upgrades the budget gate from fail-open to
+	// fail-closed. When true, a model load that would exceed GpuBudgetMB
+	// (after LRU eviction and up to AdmissionMaxWait of waiting for memory to
+	// free) is REJECTED with HTTP 503 + Retry-After instead of proceeding.
+	// Models without a vramEstimateMB are also rejected, since the gate
+	// cannot reason about their footprint. Default false preserves the
+	// historical fail-open behavior.
+	GpuStrictAdmission bool `yaml:"gpuStrictAdmission"`
+
+	// AdmissionMaxWait bounds how long a strict-mode admission will wait
+	// (re-checking every few seconds) for memory to free up — e.g. a TTL
+	// unload or another model finishing its swap — before rejecting with
+	// 503. Only used when GpuStrictAdmission is true. Default 30s.
+	AdmissionMaxWait time.Duration `yaml:"admissionMaxWait"`
+
+	// HostMemFloorMB, when > 0, adds a host-RAM admission check: a load is
+	// only admitted when the projected host MemAvailable after the load
+	// (current available - vramEstimateMB) stays above this floor. On UMA
+	// systems (APUs/iGPUs) GPU memory is carved out of the same physical
+	// RAM, so gating GTT alone lets host memory starve; this closes that gap.
+	HostMemFloorMB int `yaml:"hostMemFloorMB"`
+
+	// GpuRedlineMB, when > 0, enables the runtime red-line watchdog: a ~1s
+	// ticker that reads live GPU memory directly and evicts idle
+	// least-recently-used models whenever usage exceeds this value (or host
+	// MemAvailable drops below HostMemFloorMB). This catches what admission
+	// cannot: estimate drift, post-load growth, and out-of-band allocations.
+	// Should be >= GpuBudgetMB.
+	GpuRedlineMB int `yaml:"gpuRedlineMB"`
+
+	// GpuHardlineMB, when > 0, is the emergency tier of the red-line
+	// watchdog: above this value ALL models — including actively serving
+	// ones — are eligible for eviction, oldest first. Losing a model beats
+	// the kernel TTM eviction stall / hardware-watchdog reboot that follows
+	// unchecked growth. Should be >= GpuRedlineMB.
+	GpuHardlineMB int `yaml:"gpuHardlineMB"`
 }
 
 func (p *PerformanceConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type rawPerformanceConfig PerformanceConfig
 	defaults := rawPerformanceConfig{
-		Every: 5 * time.Second,
+		Every:            5 * time.Second,
+		AdmissionMaxWait: 30 * time.Second,
 	}
 
 	if err := unmarshal(&defaults); err != nil {
@@ -36,6 +74,23 @@ func (p *PerformanceConfig) UnmarshalYAML(unmarshal func(interface{}) error) err
 func (p *PerformanceConfig) Validate() error {
 	if p.Every < 5*time.Second {
 		return fmt.Errorf("every must be at least 5s, got %v", p.Every)
+	}
+	if p.GpuStrictAdmission && p.GpuBudgetMB <= 0 {
+		return fmt.Errorf("gpuStrictAdmission requires gpuBudgetMB > 0")
+	}
+	if p.AdmissionMaxWait < 0 {
+		return fmt.Errorf("admissionMaxWait must be >= 0, got %v", p.AdmissionMaxWait)
+	}
+	if p.GpuRedlineMB > 0 && p.GpuBudgetMB > 0 && p.GpuRedlineMB < p.GpuBudgetMB {
+		return fmt.Errorf("gpuRedlineMB (%d) must be >= gpuBudgetMB (%d)", p.GpuRedlineMB, p.GpuBudgetMB)
+	}
+	if p.GpuHardlineMB > 0 {
+		if p.GpuRedlineMB <= 0 {
+			return fmt.Errorf("gpuHardlineMB requires gpuRedlineMB > 0")
+		}
+		if p.GpuHardlineMB < p.GpuRedlineMB {
+			return fmt.Errorf("gpuHardlineMB (%d) must be >= gpuRedlineMB (%d)", p.GpuHardlineMB, p.GpuRedlineMB)
+		}
 	}
 	return nil
 }

--- a/internal/config/performance.go
+++ b/internal/config/performance.go
@@ -9,6 +9,13 @@ import (
 type PerformanceConfig struct {
 	Disabled bool          `yaml:"disabled"`
 	Every    time.Duration `yaml:"every"`
+
+	// GpuBudgetMB is an optional soft ceiling, in MiB, on total GPU-managed
+	// memory (VRAM + GTT, as reported by the perf monitor). When > 0 and the
+	// monitor is active, the router evicts least-recently-used models before
+	// a swap so the projected footprint stays under budget. 0 (default)
+	// disables the gate entirely. See internal/router/memgate.go.
+	GpuBudgetMB int `yaml:"gpuBudgetMB"`
 }
 
 func (p *PerformanceConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/internal/config/performance_test.go
+++ b/internal/config/performance_test.go
@@ -19,6 +19,7 @@ models:
 
 	// When performance section is missing, defaults should be applied
 	assert.False(t, config.Performance.Disabled)
+	assert.False(t, config.Performance.SerializeInference)
 	assert.Equal(t, 5*time.Second, config.Performance.Every)
 }
 
@@ -27,6 +28,7 @@ func TestPerformanceConfig_CustomValues(t *testing.T) {
 performance:
   enable: true
   every: 30s
+  serializeInference: true
 models:
   model1:
     cmd: path/to/cmd --port ${PORT}
@@ -35,6 +37,7 @@ models:
 	assert.NoError(t, err)
 
 	assert.False(t, config.Performance.Disabled)
+	assert.True(t, config.Performance.SerializeInference)
 	assert.Equal(t, 30*time.Second, config.Performance.Every)
 }
 

--- a/internal/perf/hostmem.go
+++ b/internal/perf/hostmem.go
@@ -1,0 +1,15 @@
+package perf
+
+import "github.com/shirou/gopsutil/v4/mem"
+
+// ReadHostMemAvailableMB returns the host's currently available RAM in MiB
+// (MemAvailable on Linux). It is a fresh, synchronous read. ok is false when
+// the platform reading fails. On UMA systems (APUs/iGPUs) GPU allocations and
+// host memory share one physical pool, so budget gates need both numbers.
+func ReadHostMemAvailableMB() (availMB int, ok bool) {
+	vm, err := mem.VirtualMemory()
+	if err != nil || vm == nil {
+		return 0, false
+	}
+	return int(vm.Available / (1024 * 1024)), true
+}

--- a/internal/perf/live_other.go
+++ b/internal/perf/live_other.go
@@ -1,0 +1,9 @@
+//go:build !unix || darwin
+
+package perf
+
+// ReadLiveGpuMemUsedMB is only implemented for the amdgpu sysfs backend on
+// non-darwin unix. Elsewhere callers fall back to the monitor's polled sample.
+func ReadLiveGpuMemUsedMB() (usedMB int, ok bool) {
+	return 0, false
+}

--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -333,8 +333,56 @@ func parseRocmSmiLine(header string, line string) *GpuStat {
 	return result
 }
 
+// drmClassPath is the sysfs directory containing DRM card entries. It is a
+// variable (rather than a const) so tests can point it at a temp-dir fixture.
+var drmClassPath = "/sys/class/drm"
+
+// trySysfs is the fallback GPU backend used when no userspace tool (LACT,
+// nvidia-smi, rocm-smi) is available. It reads amdgpu memory accounting
+// directly from sysfs. This is the only backend that correctly reports memory
+// on AMD APUs/iGPUs, where the "VRAM" sysfs is a tiny BIOS carveout (often
+// 512 MiB) and the model actually lives in GTT (GPU-accessible system RAM).
+// rocm-smi only reports the VRAM carveout there and is effectively blind to
+// the real working set; see readSysfs for the combined vram+gtt accounting.
 func trySysfs(ctx context.Context, every time.Duration, logger *logmon.Monitor) (chan []GpuStat, error) {
-	return nil, ErrNotImplemented
+	// Probe once up front so we can fail fast (and fall through to
+	// ErrNoGpuTool) when there is no amdgpu card to read.
+	if _, err := readSysfs(); err != nil {
+		return nil, err
+	}
+
+	if every < time.Second {
+		every = time.Second
+	}
+
+	ch := make(chan []GpuStat, 1)
+
+	go func() {
+		defer close(ch)
+		ticker := time.NewTicker(every)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				stats, err := readSysfs()
+				if err != nil {
+					logger.Debugf("sysfs read failed: %s", err.Error())
+					continue
+				}
+				if len(stats) > 0 {
+					select {
+					case ch <- stats:
+					default:
+					}
+				}
+			}
+		}
+	}()
+
+	return ch, nil
 }
 
 func lactSocketPath() string {
@@ -524,8 +572,139 @@ func lactGetDeviceStats(conn net.Conn, id string, name string, index int) (GpuSt
 	}, nil
 }
 
+// readSysfs enumerates amdgpu cards under drmClassPath and returns one GpuStat
+// per card. Memory is reported as the sum of VRAM and GTT:
+//
+//	MemTotalMB = (vram_total + gtt_total) / MiB
+//	MemUsedMB  = (vram_used  + gtt_used)  / MiB
+//	MemUtilPct = used / total * 100
+//
+// GTT (Graphics Translation Table) is GPU-accessible system RAM. On dGPUs it
+// is small relative to dedicated VRAM, so this sum is dominated by VRAM and
+// matches the other backends. On APUs/iGPUs the dedicated "VRAM" is only a
+// small BIOS carveout and models are allocated in GTT, so including GTT is
+// required to report the real GPU-managed memory footprint.
 func readSysfs() ([]GpuStat, error) {
-	return nil, ErrNotImplemented
+	// Only "cardN" entries are real DRM cards. Connector entries such as
+	// "card0-DP-1" also match card* globs but have no memory accounting.
+	matches, err := filepath.Glob(filepath.Join(drmClassPath, "card[0-9]*"))
+	if err != nil {
+		return nil, err
+	}
+
+	const toMB = 1024 * 1024
+
+	stats := make([]GpuStat, 0, len(matches))
+	for _, cardPath := range matches {
+		base := filepath.Base(cardPath)
+
+		// Skip connector entries (e.g. "card0-DP-1", "card0-HDMI-A-1").
+		if strings.Contains(base, "-") {
+			continue
+		}
+
+		id, err := strconv.Atoi(strings.TrimPrefix(base, "card"))
+		if err != nil {
+			continue
+		}
+
+		devicePath := filepath.Join(cardPath, "device")
+
+		// gtt_total is the marker for an amdgpu card with memory accounting;
+		// skip anything (other drivers, render-only nodes) that lacks it.
+		gttTotal, ok := readSysfsUint(filepath.Join(devicePath, "mem_info_gtt_total"))
+		if !ok {
+			continue
+		}
+
+		// Best-effort: amdgpu is the only driver exposing mem_info_gtt_*, but
+		// confirm via uevent when present so we never misreport another driver.
+		if driver, ok := readSysfsString(filepath.Join(devicePath, "uevent")); ok {
+			if drv := ueventValue(driver, "DRIVER"); drv != "" && drv != "amdgpu" {
+				continue
+			}
+		}
+
+		vramTotal, _ := readSysfsUint(filepath.Join(devicePath, "mem_info_vram_total"))
+		vramUsed, _ := readSysfsUint(filepath.Join(devicePath, "mem_info_vram_used"))
+		gttUsed, _ := readSysfsUint(filepath.Join(devicePath, "mem_info_gtt_used"))
+
+		memTotal := vramTotal + gttTotal
+		memUsed := vramUsed + gttUsed
+
+		var memUtil float64
+		if memTotal > 0 {
+			memUtil = float64(memUsed) / float64(memTotal) * 100
+		}
+
+		stat := GpuStat{
+			Timestamp:  time.Now(),
+			ID:         id,
+			Name:       sysfsDeviceName(devicePath, base),
+			MemTotalMB: int(memTotal / toMB),
+			MemUsedMB:  int(memUsed / toMB),
+			MemUtilPct: memUtil,
+		}
+
+		// gpu_busy_percent is exposed by amdgpu as a 0-100 integer.
+		if busy, ok := readSysfsUint(filepath.Join(devicePath, "gpu_busy_percent")); ok {
+			stat.GpuUtilPct = float64(busy)
+		}
+
+		stats = append(stats, stat)
+	}
+
+	if len(stats) == 0 {
+		return nil, ErrNoGpuTool
+	}
+
+	return stats, nil
+}
+
+// readSysfsUint reads a sysfs file expected to contain a single unsigned
+// integer. The bool result is false when the file is missing or unparseable.
+func readSysfsUint(path string) (uint64, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// readSysfsString reads a sysfs file as a trimmed string.
+func readSysfsString(path string) (string, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(data)), true
+}
+
+// ueventValue extracts KEY=value from sysfs uevent contents.
+func ueventValue(uevent, key string) string {
+	for _, line := range strings.Split(uevent, "\n") {
+		if v, ok := strings.CutPrefix(strings.TrimSpace(line), key+"="); ok {
+			return v
+		}
+	}
+	return ""
+}
+
+// sysfsDeviceName derives a human-readable device name. amdgpu does not expose
+// a product string in sysfs, so we fall back to the PCI ID from uevent and
+// finally to the card slot (e.g. "amdgpu card0 (1002:1681)").
+func sysfsDeviceName(devicePath, base string) string {
+	name := "amdgpu " + base
+	if uevent, ok := readSysfsString(filepath.Join(devicePath, "uevent")); ok {
+		if pciID := ueventValue(uevent, "PCI_ID"); pciID != "" {
+			name = name + " (" + pciID + ")"
+		}
+	}
+	return name
 }
 
 func readSysStats() (SysStat, error) {

--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -24,6 +24,22 @@ import (
 )
 
 func getGpuStats(ctx context.Context, every time.Duration, logger *logmon.Monitor) (chan []GpuStat, error) {
+	// On AMD APUs/iGPUs every userspace tool (LACT, rocm-smi) reports only the
+	// tiny "VRAM" BIOS carveout (often 512 MiB) and is blind to GTT, where the
+	// models and KV cache actually live. Any consumer that budgets against
+	// GPU memory (the memgate) would then compare near-zero "used" numbers
+	// against a multi-GiB budget and never fire. When the carveout pattern is
+	// present, sysfs (which sums vram+gtt) is the only correct backend, so it
+	// must win over ALL tools, not just rocm-smi.
+	if sysfsHasApuCarveout() {
+		if ch, err := trySysfs(ctx, every, logger); err == nil {
+			logger.Info("using sysfs for GPU monitoring (amdgpu APU carveout detected; GTT-aware)")
+			return ch, nil
+		} else {
+			logger.Debugf("sysfs (APU carveout): %s", err.Error())
+		}
+	}
+
 	if ch, err := tryLACT(ctx, every, logger); err == nil {
 		logger.Info("using LACT for GPU monitoring")
 		return ch, nil
@@ -671,6 +687,24 @@ func readSysfs() ([]GpuStat, error) {
 	}
 
 	return stats, nil
+}
+
+// ReadLiveGpuMemUsedMB performs a fresh, synchronous sysfs read of total
+// GPU-managed memory in use (VRAM + GTT, in MiB) summed across amdgpu cards.
+// Unlike Monitor.Current() it is never stale: it reads
+// /sys/class/drm/cardN/device/mem_info_* at call time (a few microseconds).
+// ok is false when no amdgpu sysfs accounting is available; callers should
+// then fall back to the monitor's last polled sample.
+func ReadLiveGpuMemUsedMB() (usedMB int, ok bool) {
+	stats, err := readSysfs()
+	if err != nil {
+		return 0, false
+	}
+	total := 0
+	for _, s := range stats {
+		total += s.MemUsedMB
+	}
+	return total, true
 }
 
 // apuCarveoutGttVramRatio is the discriminator between an APU/iGPU UMA carveout

--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -188,6 +188,18 @@ func tryRocmSmi(ctx context.Context, every time.Duration, logger *logmon.Monitor
 	if _, err := exec.LookPath("rocm-smi"); err != nil {
 		return nil, ErrNoGpuTool
 	}
+
+	// On AMD APUs/iGPUs rocm-smi only reports the tiny "VRAM" BIOS carveout
+	// (often 512 MiB) and is blind to GTT, where the model actually lives.
+	// When sysfs shows that carveout pattern, defer to the sysfs backend
+	// (which sums vram+gtt) instead of reporting a misleadingly small number.
+	// dGPUs, where VRAM is the real pool, are unaffected and rocm-smi still
+	// wins. See sysfsHasApuCarveout and readSysfs.
+	if sysfsHasApuCarveout() {
+		logger.Debug("rocm-smi: amdgpu APU carveout detected, deferring to sysfs (GTT)")
+		return nil, ErrNoGpuTool
+	}
+
 	if every < time.Second {
 		every = time.Second
 	}
@@ -659,6 +671,53 @@ func readSysfs() ([]GpuStat, error) {
 	}
 
 	return stats, nil
+}
+
+// apuCarveoutMaxVramBytes is the upper bound for what we treat as a "VRAM"
+// BIOS carveout on an APU/iGPU. Real dGPUs expose VRAM well above this (the
+// smallest modern AMD dGPUs ship 2+ GiB), while APU carveouts are typically
+// 256-512 MiB. 1 GiB leaves comfortable headroom on both sides.
+const apuCarveoutMaxVramBytes = 1 * 1024 * 1024 * 1024
+
+// sysfsHasApuCarveout reports whether any amdgpu card looks like an APU/iGPU
+// whose dedicated "VRAM" is just a small BIOS carveout backed by a much larger
+// GTT pool. In that case rocm-smi (which only reports the carveout) is not
+// authoritative and the sysfs backend should be used instead.
+//
+// It is deliberately conservative: it requires a small VRAM total AND a GTT
+// pool that dwarfs it, so a dGPU (large VRAM, comparatively small GTT) never
+// matches and rocm-smi continues to win there.
+func sysfsHasApuCarveout() bool {
+	matches, err := filepath.Glob(filepath.Join(drmClassPath, "card[0-9]*"))
+	if err != nil {
+		return false
+	}
+
+	for _, cardPath := range matches {
+		base := filepath.Base(cardPath)
+		if strings.Contains(base, "-") {
+			continue // connector entry, not a real card
+		}
+
+		devicePath := filepath.Join(cardPath, "device")
+
+		gttTotal, ok := readSysfsUint(filepath.Join(devicePath, "mem_info_gtt_total"))
+		if !ok {
+			continue // not an amdgpu card with memory accounting
+		}
+		vramTotal, ok := readSysfsUint(filepath.Join(devicePath, "mem_info_vram_total"))
+		if !ok {
+			continue
+		}
+
+		// APU carveout: small dedicated VRAM, and a GTT pool far larger than
+		// it (the model's real home).
+		if vramTotal <= apuCarveoutMaxVramBytes && gttTotal > vramTotal {
+			return true
+		}
+	}
+
+	return false
 }
 
 // readSysfsUint reads a sysfs file expected to contain a single unsigned

--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -673,20 +673,28 @@ func readSysfs() ([]GpuStat, error) {
 	return stats, nil
 }
 
-// apuCarveoutMaxVramBytes is the upper bound for what we treat as a "VRAM"
-// BIOS carveout on an APU/iGPU. Real dGPUs expose VRAM well above this (the
-// smallest modern AMD dGPUs ship 2+ GiB), while APU carveouts are typically
-// 256-512 MiB. 1 GiB leaves comfortable headroom on both sides.
-const apuCarveoutMaxVramBytes = 1 * 1024 * 1024 * 1024
+// apuCarveoutGttVramRatio is the discriminator between an APU/iGPU UMA carveout
+// and a dGPU. On an APU the dedicated "VRAM" is a BIOS UMA carveout and the real
+// pool is GTT (GPU-accessible system RAM), so gtt_total dwarfs vram_total. On a
+// dGPU the opposite holds: VRAM is the large dedicated pool and GTT is a
+// comparatively small fraction.
+//
+// We require gtt_total >= 2 * vram_total. An absolute VRAM bound (the old 1 GiB
+// cap) wrongly excluded boards with a 2-4 GiB BIOS UMA carveout (common on
+// Radeon 680M/780M), which then fell through to rocm-smi and reported only the
+// carveout. A ratio is carveout-size independent: a 4 GiB carveout on a board
+// with 32+ GiB GTT still passes, while a dGPU (24 GiB VRAM, sub-GiB GTT) never
+// does.
+const apuCarveoutGttVramRatio = 2
 
 // sysfsHasApuCarveout reports whether any amdgpu card looks like an APU/iGPU
-// whose dedicated "VRAM" is just a small BIOS carveout backed by a much larger
+// whose dedicated "VRAM" is just a BIOS UMA carveout backed by a much larger
 // GTT pool. In that case rocm-smi (which only reports the carveout) is not
 // authoritative and the sysfs backend should be used instead.
 //
-// It is deliberately conservative: it requires a small VRAM total AND a GTT
-// pool that dwarfs it, so a dGPU (large VRAM, comparatively small GTT) never
-// matches and rocm-smi continues to win there.
+// It is deliberately conservative: it requires a GTT pool that is at least
+// apuCarveoutGttVramRatio times the VRAM total, so a dGPU (large VRAM,
+// comparatively small GTT) never matches and rocm-smi continues to win there.
 func sysfsHasApuCarveout() bool {
 	matches, err := filepath.Glob(filepath.Join(drmClassPath, "card[0-9]*"))
 	if err != nil {
@@ -710,9 +718,10 @@ func sysfsHasApuCarveout() bool {
 			continue
 		}
 
-		// APU carveout: small dedicated VRAM, and a GTT pool far larger than
-		// it (the model's real home).
-		if vramTotal <= apuCarveoutMaxVramBytes && gttTotal > vramTotal {
+		// APU carveout: a GTT pool that dwarfs the dedicated VRAM (the model's
+		// real home), regardless of the carveout's absolute size. vramTotal==0
+		// would falsely match, so guard against it.
+		if vramTotal > 0 && gttTotal >= apuCarveoutGttVramRatio*vramTotal {
 			return true
 		}
 	}

--- a/internal/perf/monitor_unix_test.go
+++ b/internal/perf/monitor_unix_test.go
@@ -134,3 +134,70 @@ func TestReadSysfs_MissingFilesGraceful(t *testing.T) {
 	assert.Greater(t, stats[0].MemTotalMB, 0)
 	assert.Equal(t, 0, stats[0].MemUsedMB)
 }
+
+func TestSysfsHasApuCarveout_APUDetected(t *testing.T) {
+	root := t.TempDir()
+	// Radeon 680M: 512 MiB VRAM carveout, 23 GiB GTT. rocm-smi would only see
+	// the carveout, so we must defer to sysfs.
+	makeAmdgpuCard(t, root, "card0",
+		"536870912",   // vram_total = 512 MiB
+		"519950336",   // vram_used
+		"24696061952", // gtt_total ~ 23 GiB
+		"14810259456", // gtt_used
+	)
+
+	old := drmClassPath
+	drmClassPath = root
+	defer func() { drmClassPath = old }()
+
+	assert.True(t, sysfsHasApuCarveout(),
+		"APU with tiny VRAM carveout and large GTT should be detected")
+}
+
+func TestSysfsHasApuCarveout_DGPUNotDetected(t *testing.T) {
+	root := t.TempDir()
+	// dGPU: 24 GiB real VRAM, small GTT. rocm-smi is authoritative here, so
+	// this must NOT trigger the deferral.
+	makeAmdgpuCard(t, root, "card0",
+		"25769803776", // vram_total = 24 GiB
+		"10737418240", // vram_used
+		"268435456",   // gtt_total = 256 MiB
+		"16777216",    // gtt_used
+	)
+
+	old := drmClassPath
+	drmClassPath = root
+	defer func() { drmClassPath = old }()
+
+	assert.False(t, sysfsHasApuCarveout(),
+		"dGPU with large VRAM should not be treated as an APU carveout")
+}
+
+func TestSysfsHasApuCarveout_NoAmdgpu(t *testing.T) {
+	root := t.TempDir()
+	// Non-amdgpu card: no mem_info_gtt_total. Nothing to defer for.
+	dev := filepath.Join(root, "card0", "device")
+	writeFile(t, filepath.Join(dev, "uevent"), "DRIVER=i915\n")
+	writeFile(t, filepath.Join(dev, "mem_info_vram_total"), "536870912")
+
+	old := drmClassPath
+	drmClassPath = root
+	defer func() { drmClassPath = old }()
+
+	assert.False(t, sysfsHasApuCarveout())
+}
+
+func TestSysfsHasApuCarveout_SkipsConnectorEntries(t *testing.T) {
+	root := t.TempDir()
+	makeAmdgpuCard(t, root, "card0",
+		"536870912", "519950336", "24696061952", "14810259456")
+	// Connector nodes also match card* but have no memory accounting; they
+	// must not affect the result.
+	writeFile(t, filepath.Join(root, "card0-DP-1", "device", "uevent"), "DRIVER=amdgpu\n")
+
+	old := drmClassPath
+	drmClassPath = root
+	defer func() { drmClassPath = old }()
+
+	assert.True(t, sysfsHasApuCarveout())
+}

--- a/internal/perf/monitor_unix_test.go
+++ b/internal/perf/monitor_unix_test.go
@@ -1,0 +1,136 @@
+//go:build unix && !darwin
+
+package perf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFile writes a sysfs-style file, creating parent dirs as needed.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+// makeAmdgpuCard creates a fake amdgpu card directory under root.
+func makeAmdgpuCard(t *testing.T, root, card string, vramTotal, vramUsed, gttTotal, gttUsed string) {
+	t.Helper()
+	dev := filepath.Join(root, card, "device")
+	if vramTotal != "" {
+		writeFile(t, filepath.Join(dev, "mem_info_vram_total"), vramTotal)
+	}
+	if vramUsed != "" {
+		writeFile(t, filepath.Join(dev, "mem_info_vram_used"), vramUsed)
+	}
+	if gttTotal != "" {
+		writeFile(t, filepath.Join(dev, "mem_info_gtt_total"), gttTotal)
+	}
+	if gttUsed != "" {
+		writeFile(t, filepath.Join(dev, "mem_info_gtt_used"), gttUsed)
+	}
+	writeFile(t, filepath.Join(dev, "uevent"), "DRIVER=amdgpu\nPCI_ID=1002:1681\n")
+	writeFile(t, filepath.Join(dev, "gpu_busy_percent"), "42")
+}
+
+func TestReadSysfs_APU_CombinesVramAndGtt(t *testing.T) {
+	root := t.TempDir()
+	// APU profile from a Radeon 680M: 512 MiB VRAM carveout, ~23 GiB GTT,
+	// ~13.8 GiB GTT used. The model lives in GTT, not VRAM.
+	const mib = 1024 * 1024
+	makeAmdgpuCard(t, root, "card0",
+		"536870912",   // vram_total = 512 MiB
+		"519950336",   // vram_used  ~ 496 MiB
+		"24696061952", // gtt_total ~ 23552 MiB
+		"14810259456", // gtt_used  ~ 14124 MiB
+	)
+	// Connector entries must be ignored.
+	writeFile(t, filepath.Join(root, "card0-DP-1", "device", "uevent"), "DRIVER=amdgpu\n")
+	writeFile(t, filepath.Join(root, "card0-HDMI-A-1", "device", "uevent"), "DRIVER=amdgpu\n")
+
+	old := drmClassPath
+	drmClassPath = root
+	defer func() { drmClassPath = old }()
+
+	stats, err := readSysfs()
+	require.NoError(t, err)
+	require.Len(t, stats, 1)
+
+	s := stats[0]
+	assert.Equal(t, 0, s.ID)
+	assert.Equal(t, int((536870912+24696061952)/mib), s.MemTotalMB)
+	assert.Equal(t, int((519950336+14810259456)/mib), s.MemUsedMB)
+	// Used should reflect the real GTT working set (~14 GiB), not 512 MiB.
+	assert.Greater(t, s.MemUsedMB, 13000)
+	assert.Greater(t, s.MemTotalMB, 23000)
+	assert.InDelta(t, float64(519950336+14810259456)/float64(536870912+24696061952)*100, s.MemUtilPct, 0.01)
+	assert.Equal(t, float64(42), s.GpuUtilPct)
+	assert.Contains(t, s.Name, "1002:1681")
+}
+
+func TestReadSysfs_SkipsNonAmdgpu(t *testing.T) {
+	root := t.TempDir()
+
+	// A non-amdgpu card (no mem_info_gtt_total) must be skipped.
+	dev := filepath.Join(root, "card0", "device")
+	writeFile(t, filepath.Join(dev, "uevent"), "DRIVER=i915\n")
+	writeFile(t, filepath.Join(dev, "mem_info_vram_total"), "1073741824")
+
+	old := drmClassPath
+	drmClassPath = root
+	defer func() { drmClassPath = old }()
+
+	stats, err := readSysfs()
+	require.ErrorIs(t, err, ErrNoGpuTool)
+	require.Nil(t, stats)
+}
+
+func TestReadSysfs_DGPU_VramDominates(t *testing.T) {
+	root := t.TempDir()
+	const mib = 1024 * 1024
+	// dGPU: 24 GiB VRAM, small GTT. Sum is dominated by VRAM, matching
+	// what rocm-smi/nvidia-smi would report.
+	makeAmdgpuCard(t, root, "card1",
+		"25769803776", // vram_total = 24 GiB
+		"10737418240", // vram_used  = 10 GiB
+		"268435456",   // gtt_total  = 256 MiB
+		"16777216",    // gtt_used   = 16 MiB
+	)
+
+	old := drmClassPath
+	drmClassPath = root
+	defer func() { drmClassPath = old }()
+
+	stats, err := readSysfs()
+	require.NoError(t, err)
+	require.Len(t, stats, 1)
+
+	s := stats[0]
+	assert.Equal(t, 1, s.ID)
+	assert.Equal(t, int((25769803776+268435456)/mib), s.MemTotalMB)
+	assert.Equal(t, int((10737418240+16777216)/mib), s.MemUsedMB)
+}
+
+func TestReadSysfs_MissingFilesGraceful(t *testing.T) {
+	root := t.TempDir()
+	// gtt_total present but vram_* and gtt_used missing: should still report
+	// what it can without erroring.
+	dev := filepath.Join(root, "card0", "device")
+	writeFile(t, filepath.Join(dev, "mem_info_gtt_total"), "24696061952")
+	writeFile(t, filepath.Join(dev, "uevent"), "DRIVER=amdgpu\n")
+
+	old := drmClassPath
+	drmClassPath = root
+	defer func() { drmClassPath = old }()
+
+	stats, err := readSysfs()
+	require.NoError(t, err)
+	require.Len(t, stats, 1)
+	assert.Greater(t, stats[0].MemTotalMB, 0)
+	assert.Equal(t, 0, stats[0].MemUsedMB)
+}

--- a/internal/perf/monitor_unix_test.go
+++ b/internal/perf/monitor_unix_test.go
@@ -154,6 +154,27 @@ func TestSysfsHasApuCarveout_APUDetected(t *testing.T) {
 		"APU with tiny VRAM carveout and large GTT should be detected")
 }
 
+func TestSysfsHasApuCarveout_LargeUMACarveoutDetected(t *testing.T) {
+	root := t.TempDir()
+	// M3 regression: some 680M/780M boards expose a 2-4 GiB BIOS UMA carveout,
+	// not the typical 512 MiB. The old absolute 1 GiB VRAM bound missed these,
+	// so rocm-smi (carveout-only) wrongly won. The ratio discriminator
+	// (gtt >= 2*vram) detects them regardless of carveout size.
+	makeAmdgpuCard(t, root, "card0",
+		"4294967296",  // vram_total = 4 GiB UMA carveout
+		"2147483648",  // vram_used  = 2 GiB
+		"30064771072", // gtt_total  = 28 GiB (dwarfs the 4 GiB carveout)
+		"10737418240", // gtt_used   = 10 GiB
+	)
+
+	old := drmClassPath
+	drmClassPath = root
+	defer func() { drmClassPath = old }()
+
+	assert.True(t, sysfsHasApuCarveout(),
+		"APU with a 4 GiB UMA carveout and far larger GTT must be detected via the ratio")
+}
+
 func TestSysfsHasApuCarveout_DGPUNotDetected(t *testing.T) {
 	root := t.TempDir()
 	// dGPU: 24 GiB real VRAM, small GTT. rocm-smi is authoritative here, so

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -39,6 +39,12 @@ type Process interface {
 	// and may change at any time after the call returns.
 	State() ProcessState
 
+	// LastUse returns the unix-nano timestamp of the most recent completed
+	// ServeHTTP call, or 0 if the process has never served a request. It is
+	// used to pick least-recently-used eviction victims. Like State(), this is
+	// a snapshot that may change immediately after the call returns.
+	LastUse() int64
+
 	// ServeHTTP forwards requests to the underlying process
 	// Calling it when the process is not ready will result in a
 	// 503 response with a body indicating it is a llama-swap-error

--- a/internal/process/process_command.go
+++ b/internal/process/process_command.go
@@ -669,6 +669,12 @@ func (p *ProcessCommand) State() ProcessState {
 	return StateStopped
 }
 
+// LastUse returns the unix-nano timestamp of the most recent completed
+// ServeHTTP call (see the p.lastUse store in ServeHTTP), or 0 if never served.
+func (p *ProcessCommand) LastUse() int64 {
+	return p.lastUse.Load()
+}
+
 func (p *ProcessCommand) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fn := p.handler.Load()
 	if fn == nil {

--- a/internal/router/base.go
+++ b/internal/router/base.go
@@ -138,6 +138,9 @@ func newBaseRouter(
 	}
 	sched, err := scheduler.New(conf, name, logger, planner, b)
 	if err != nil {
+		// The lease table's sweeper (and persistence writer, if configured) are
+		// already running; stop them so a failed construction leaks nothing.
+		b.leases.stop()
 		return nil, err
 	}
 	b.schedule = sched

--- a/internal/router/base.go
+++ b/internal/router/base.go
@@ -37,6 +37,12 @@ type baseRouter struct {
 	logger    *logmon.Monitor
 	schedule  scheduler.Scheduler
 
+	// memGate, when non-nil, is an optional fail-open admission gate that
+	// evicts LRU models before a swap to keep total GPU memory under a
+	// configured budget. nil disables it (no budget configured or no perf
+	// monitor). See memgate.go.
+	memGate *memGate
+
 	// shutdownCtx governs the request machinery: cancelling it tells grant()
 	// and ServeHTTP to stop granting and reject callers. It is deliberately
 	// separate from procCtx — see procCtx below.
@@ -75,6 +81,7 @@ func newBaseRouter(
 	processes map[string]process.Process,
 	logger *logmon.Monitor,
 	planner scheduler.Swapper,
+	gate *memGate,
 ) (*baseRouter, error) {
 	shutdownCtx, shutdownFn := context.WithCancel(context.Background())
 	procCtx, procCancel := context.WithCancel(context.Background())
@@ -83,6 +90,7 @@ func newBaseRouter(
 		config:      conf,
 		processes:   processes,
 		logger:      logger,
+		memGate:     gate,
 		shutdownCtx: shutdownCtx,
 		shutdownFn:  shutdownFn,
 		procCtx:     procCtx,
@@ -253,6 +261,16 @@ func (b *baseRouter) doSwap(modelID string, toStop []string) {
 		}(b.processes[mID], mID)
 	}
 	wg.Wait()
+
+	// Live-GTT budget gate: the solver-decided evictions (toStop) are now
+	// stopped and their GPU memory freed. Before launching the target, evict
+	// additional LRU models if the projected footprint would still exceed the
+	// configured GPU budget. This single chokepoint covers the matrix, group,
+	// and solo load paths. nil gate (no budget / no monitor) is a no-op, and
+	// the gate itself is fail-open, so it never blocks a load.
+	if b.memGate != nil {
+		b.memGate.EnsureFits(modelID, b.processes, toStop, b.logger)
+	}
 
 	target := b.processes[modelID]
 	if target.State() == process.StateStopped {

--- a/internal/router/base.go
+++ b/internal/router/base.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -42,6 +43,9 @@ type baseRouter struct {
 	processes map[string]process.Process
 	logger    *logmon.Monitor
 	schedule  scheduler.Scheduler
+	// planner is the eviction policy, retained for the read-only can-i-load
+	// preflight (CanLoad); the scheduler owns it for live decisions.
+	planner scheduler.Swapper
 
 	// memGate, when non-nil, is an optional fail-open admission gate that
 	// evicts LRU models before a swap to keep total GPU memory under a
@@ -76,6 +80,11 @@ type baseRouter struct {
 
 	serializeGate *serializeGate
 	serializeSeq  atomic.Int64
+
+	// leases, when non-nil, is the model-lease table. It backs refuse-don't-break
+	// admission (a load that would evict a leased model is refused) and the
+	// /leases API. nil disables leases entirely.
+	leases *leaseTable
 
 	// testProcessed, when non-nil, receives one event after each handlerReq
 	// or swapDone has been fully processed by run(). Tests use it to wait
@@ -113,12 +122,19 @@ func newBaseRouter(
 		serveDoneCh:     make(chan scheduler.ServeDoneEvent),
 		inFlightQueryCh: make(chan inFlightQuery),
 		runDone:         make(chan struct{}),
+		planner:         planner,
 	}
 	if conf.Performance.SerializeInference {
 		b.serializeGate = newSerializeGate()
 	}
+	b.leases = newLeaseTable(conf.Performance.MaxLeaseDuration, conf.Performance.LeaseStatePath)
+	if err := b.leases.loadAndReconcile(conf.Performance.LeaseStatePath); err != nil {
+		logger.Warnf("%s: could not load lease state from %s: %v", name, conf.Performance.LeaseStatePath, err)
+	}
+	go b.leases.runSweeper(defaultLeaseSweep)
 	if b.memGate != nil {
 		b.memGate.inFlight = b.InFlight
+		b.memGate.leases = b.leases
 	}
 	sched, err := scheduler.New(conf, name, logger, planner, b)
 	if err != nil {
@@ -214,6 +230,21 @@ func (b *baseRouter) StartSwap(modelID string, evict []string) {
 	go b.doSwap(modelID, evict)
 }
 
+// TryClaimEviction implements scheduler.Effects. It enforces refuse-don't-break:
+// a nil return means the eviction set holds no live lease and has been claimed
+// (doSwap releases the claim once the stops complete); a non-nil return is a
+// LeaseBlockedError (503 + blocked_by) that the scheduler grants to the caller
+// instead of starting the swap. Leases disabled -> always nil.
+func (b *baseRouter) TryClaimEviction(evict []string) error {
+	if b.leases == nil || len(evict) == 0 {
+		return nil
+	}
+	if blockers := b.leases.TryClaimEviction(evict); len(blockers) > 0 {
+		return &LeaseBlockedError{Model: strings.Join(evict, ","), BlockedBy: blockers}
+	}
+	return nil
+}
+
 // GrantError implements scheduler.Effects.
 func (b *baseRouter) GrantError(req scheduler.HandlerReq, err error) {
 	b.grant(req, scheduler.HandlerResp{Err: err})
@@ -288,6 +319,30 @@ func (b *baseRouter) trackedServe(modelID string, p process.Process) http.Handle
 	}
 }
 
+// validateLeaseHeader enforces the optional X-Llama-Swap-Lease header: a header
+// naming a live lease for a different model than the request is an obvious
+// mismatch and is rejected; an unknown/expired id is logged and ignored so a
+// client that lost its lease (e.g. across a restart) is not hard-failed.
+func (b *baseRouter) validateLeaseHeader(r *http.Request, modelID string) error {
+	if b.leases == nil {
+		return nil
+	}
+	id := r.Header.Get(LeaseHeader)
+	if id == "" {
+		return nil
+	}
+	lease, ok := b.leases.Lookup(id)
+	if !ok {
+		b.logger.Debugf("%s: request for %s references unknown lease %s; ignoring", b.name, modelID, id)
+		return nil
+	}
+	if lease.Model != modelID {
+		return &LeaseMismatchError{LeaseID: id, LeaseModel: lease.Model, RequestModel: modelID}
+	}
+	b.logger.Debugf("%s: request for %s references lease %s (holder=%s)", b.name, modelID, id, lease.Holder)
+	return nil
+}
+
 func (b *baseRouter) InFlight(modelID string) int {
 	respond := make(chan int, 1)
 	select {
@@ -305,6 +360,14 @@ func (b *baseRouter) InFlight(modelID string) int {
 
 func (b *baseRouter) doSwap(modelID string, toStop []string) {
 	timeout := b.healthCheckTimeout()
+
+	// Release the eviction claim the scheduler placed on toStop once this swap
+	// finishes stopping them: at that point they are gone and re-leasing them is
+	// safe. Deferred so every exit path (including an admission rejection below)
+	// clears it. A nil lease table or empty toStop makes this a no-op.
+	if b.leases != nil && len(toStop) > 0 {
+		defer b.leases.ReleaseEvictionClaim(toStop)
+	}
 
 	var wg sync.WaitGroup
 	for _, mID := range toStop {
@@ -369,6 +432,10 @@ func (b *baseRouter) handleShutdown(req shutdownReq) {
 	b.shutdownFn()
 
 	b.schedule.OnShutdown(shutdownErr)
+
+	if b.leases != nil {
+		b.leases.stop()
+	}
 
 	stopTimeout := req.timeout
 	if stopTimeout <= 0 {
@@ -500,6 +567,11 @@ func (b *baseRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	data, err := shared.FetchContext(req, b.config)
 	if err != nil {
+		shared.SendError(w, req, err)
+		return
+	}
+
+	if err := b.validateLeaseHeader(req, data.ModelID); err != nil {
 		shared.SendError(w, req, err)
 		return
 	}

--- a/internal/router/base.go
+++ b/internal/router/base.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -24,6 +25,11 @@ type unloadReq struct {
 	targets []string
 	timeout time.Duration
 	respond chan struct{}
+}
+
+type inFlightQuery struct {
+	modelID string
+	respond chan int
 }
 
 // baseRouter owns the channels, run-loop, and process machinery shared by every
@@ -58,14 +64,18 @@ type baseRouter struct {
 	procCtx    context.Context
 	procCancel context.CancelFunc
 
-	handlerCh   chan scheduler.HandlerReq
-	cancelCh    chan scheduler.HandlerReq
-	shutdownCh  chan shutdownReq
-	unloadCh    chan unloadReq
-	swapDoneCh  chan scheduler.SwapDone
-	serveDoneCh chan scheduler.ServeDoneEvent
+	handlerCh       chan scheduler.HandlerReq
+	cancelCh        chan scheduler.HandlerReq
+	shutdownCh      chan shutdownReq
+	unloadCh        chan unloadReq
+	swapDoneCh      chan scheduler.SwapDone
+	serveDoneCh     chan scheduler.ServeDoneEvent
+	inFlightQueryCh chan inFlightQuery
 
 	runDone chan struct{}
+
+	serializeGate *serializeGate
+	serializeSeq  atomic.Int64
 
 	// testProcessed, when non-nil, receives one event after each handlerReq
 	// or swapDone has been fully processed by run(). Tests use it to wait
@@ -86,22 +96,29 @@ func newBaseRouter(
 	shutdownCtx, shutdownFn := context.WithCancel(context.Background())
 	procCtx, procCancel := context.WithCancel(context.Background())
 	b := &baseRouter{
-		name:        name,
-		config:      conf,
-		processes:   processes,
-		logger:      logger,
-		memGate:     gate,
-		shutdownCtx: shutdownCtx,
-		shutdownFn:  shutdownFn,
-		procCtx:     procCtx,
-		procCancel:  procCancel,
-		handlerCh:   make(chan scheduler.HandlerReq),
-		cancelCh:    make(chan scheduler.HandlerReq),
-		shutdownCh:  make(chan shutdownReq),
-		unloadCh:    make(chan unloadReq),
-		swapDoneCh:  make(chan scheduler.SwapDone),
-		serveDoneCh: make(chan scheduler.ServeDoneEvent),
-		runDone:     make(chan struct{}),
+		name:            name,
+		config:          conf,
+		processes:       processes,
+		logger:          logger,
+		memGate:         gate,
+		shutdownCtx:     shutdownCtx,
+		shutdownFn:      shutdownFn,
+		procCtx:         procCtx,
+		procCancel:      procCancel,
+		handlerCh:       make(chan scheduler.HandlerReq),
+		cancelCh:        make(chan scheduler.HandlerReq),
+		shutdownCh:      make(chan shutdownReq),
+		unloadCh:        make(chan unloadReq),
+		swapDoneCh:      make(chan scheduler.SwapDone),
+		serveDoneCh:     make(chan scheduler.ServeDoneEvent),
+		inFlightQueryCh: make(chan inFlightQuery),
+		runDone:         make(chan struct{}),
+	}
+	if conf.Performance.SerializeInference {
+		b.serializeGate = newSerializeGate()
+	}
+	if b.memGate != nil {
+		b.memGate.inFlight = b.InFlight
 	}
 	sched, err := scheduler.New(conf, name, logger, planner, b)
 	if err != nil {
@@ -151,6 +168,9 @@ func (b *baseRouter) run() {
 
 		case ev := <-b.serveDoneCh:
 			b.schedule.OnServeDone(ev)
+
+		case q := <-b.inFlightQueryCh:
+			q.respond <- b.schedule.InFlight(q.modelID)
 		}
 	}
 }
@@ -249,7 +269,37 @@ func (b *baseRouter) trackedServe(modelID string, p process.Process) http.Handle
 			case <-b.shutdownCtx.Done():
 			}
 		}()
+
+		if b.serializeGate != nil {
+			priority := 0
+			if data, ok := shared.ReadContext(r.Context()); ok {
+				if p, err := strconv.Atoi(data.Metadata["fifo_priority"]); err == nil {
+					priority = p
+				}
+			}
+			release, ok := b.serializeGate.acquire(r.Context(), priority, b.serializeSeq.Add(1))
+			if !ok {
+				return
+			}
+			defer release()
+		}
+
 		p.ServeHTTP(w, r)
+	}
+}
+
+func (b *baseRouter) InFlight(modelID string) int {
+	respond := make(chan int, 1)
+	select {
+	case b.inFlightQueryCh <- inFlightQuery{modelID: modelID, respond: respond}:
+	case <-b.runDone:
+		return 0
+	}
+	select {
+	case n := <-respond:
+		return n
+	case <-b.runDone:
+		return 0
 	}
 }
 

--- a/internal/router/base.go
+++ b/internal/router/base.go
@@ -120,6 +120,12 @@ func (b *baseRouter) notifyProcessed() {
 func (b *baseRouter) run() {
 	defer close(b.runDone)
 
+	// Runtime memory enforcement. Started here rather than in newBaseRouter
+	// because the constructors populate b.processes AFTER newBaseRouter
+	// returns but BEFORE `go run()`; starting the watchdog any earlier would
+	// race that map fill. The map is never mutated once run() starts.
+	go b.redlineLoop()
+
 	for {
 		select {
 		case req := <-b.shutdownCh:
@@ -266,10 +272,21 @@ func (b *baseRouter) doSwap(modelID string, toStop []string) {
 	// stopped and their GPU memory freed. Before launching the target, evict
 	// additional LRU models if the projected footprint would still exceed the
 	// configured GPU budget. This single chokepoint covers the matrix, group,
-	// and solo load paths. nil gate (no budget / no monitor) is a no-op, and
-	// the gate itself is fail-open, so it never blocks a load.
+	// and solo load paths. nil gate (no budget / no monitor) is a no-op. In
+	// strict mode an unfittable load is REJECTED here: the error fans out to
+	// every waiter as a 503 via OnSwapDone, and the target never launches.
+	// A granted admission holds a reservation until the swap completes, so
+	// concurrent admissions cannot jointly overshoot the budget.
 	if b.memGate != nil {
-		b.memGate.EnsureFits(modelID, b.processes, toStop, b.logger)
+		if err := b.memGate.EnsureFits(modelID, b.processes, toStop, b.logger); err != nil {
+			b.logger.Warnf("%s: admission rejected for %s: %v", b.name, modelID, err)
+			select {
+			case b.swapDoneCh <- scheduler.SwapDone{ModelID: modelID, Err: err}:
+			case <-b.shutdownCtx.Done():
+			}
+			return
+		}
+		defer b.memGate.Release(modelID)
 	}
 
 	target := b.processes[modelID]

--- a/internal/router/base_test.go
+++ b/internal/router/base_test.go
@@ -29,7 +29,7 @@ func (s *stubPlanner) OnSwapStart(string, []string)          {}
 func newTestBase(t *testing.T, processes map[string]process.Process, planner scheduler.Swapper) *baseRouter {
 	t.Helper()
 	conf := config.Config{HealthCheckTimeout: 5}
-	b, err := newBaseRouter("test", conf, processes, logmon.NewWriter(io.Discard), planner)
+	b, err := newBaseRouter("test", conf, processes, logmon.NewWriter(io.Discard), planner, nil)
 	if err != nil {
 		t.Fatalf("newBaseRouter: %v", err)
 	}

--- a/internal/router/group.go
+++ b/internal/router/group.go
@@ -42,6 +42,7 @@ func NewGroup(conf config.Config, proxylog, upstreamlog *logmon.Monitor, perfMon
 		if !ok {
 			base.shutdownFn()
 			base.procCancel()
+			base.leases.stop()
 			return nil, fmt.Errorf("no model config for %q", mid)
 		}
 		procLog := logmon.NewWriter(upstreamlog)
@@ -49,6 +50,7 @@ func NewGroup(conf config.Config, proxylog, upstreamlog *logmon.Monitor, perfMon
 		if err != nil {
 			base.shutdownFn()
 			base.procCancel()
+			base.leases.stop()
 			return nil, fmt.Errorf("creating process for %q: %w", mid, err)
 		}
 		processes[mid] = p

--- a/internal/router/group.go
+++ b/internal/router/group.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/perf"
 	"github.com/mostlygeek/llama-swap/internal/process"
 )
 
@@ -12,7 +13,7 @@ type Group struct {
 	*baseRouter
 }
 
-func NewGroup(conf config.Config, proxylog, upstreamlog *logmon.Monitor) (*Group, error) {
+func NewGroup(conf config.Config, proxylog, upstreamlog *logmon.Monitor, perfMon *perf.Monitor) (*Group, error) {
 	modelToGroup := make(map[string]string)
 	for gid, gcfg := range conf.Routing.Router.Settings.Groups {
 		for _, mid := range gcfg.Members {
@@ -28,8 +29,10 @@ func NewGroup(conf config.Config, proxylog, upstreamlog *logmon.Monitor) (*Group
 		modelToGroup: modelToGroup,
 	}
 
+	gate := newMemGateFromConfig(conf, perfMon)
+
 	processes := make(map[string]process.Process, len(modelToGroup))
-	base, err := newBaseRouter("group", conf, processes, proxylog, swapper)
+	base, err := newBaseRouter("group", conf, processes, proxylog, swapper, gate)
 	if err != nil {
 		return nil, fmt.Errorf("creating base router: %w", err)
 	}

--- a/internal/router/group_test.go
+++ b/internal/router/group_test.go
@@ -26,7 +26,7 @@ func newTestGroup(t *testing.T, conf config.Config, processes map[string]process
 		config:       conf,
 		modelToGroup: modelToGroup,
 	}
-	base, err := newBaseRouter("group", conf, processes, logmon.NewWriter(io.Discard), swapper)
+	base, err := newBaseRouter("group", conf, processes, logmon.NewWriter(io.Discard), swapper, nil)
 	if err != nil {
 		t.Fatalf("newBaseRouter: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestGroup_NewGroup_DuplicateMembership(t *testing.T) {
 		},
 	}
 	log := logmon.NewWriter(io.Discard)
-	if _, err := NewGroup(conf, log, log); err == nil {
+	if _, err := NewGroup(conf, log, log, nil); err == nil {
 		t.Fatalf("expected error for duplicate membership")
 	}
 }

--- a/internal/router/helpers_test.go
+++ b/internal/router/helpers_test.go
@@ -59,6 +59,11 @@ type fakeProcess struct {
 	stopCalls  atomic.Int32
 	serveCalls atomic.Int32
 
+	// lastUse mirrors ProcessCommand.lastUse: unix-nano of the last completed
+	// ServeHTTP, used by the memGate to pick LRU eviction victims. Tests set it
+	// directly to control LRU ordering deterministically.
+	lastUse atomic.Int64
+
 	// inFlightServe counts ServeHTTP calls currently inside the handler.
 	// stoppedWhileServing flips true if Stop is ever called while that
 	// counter is non-zero — a direct, race-free observation of the
@@ -99,6 +104,8 @@ func (f *fakeProcess) State() process.ProcessState {
 }
 
 func (f *fakeProcess) markReady() { f.setState(process.StateReady) }
+
+func (f *fakeProcess) LastUse() int64 { return f.lastUse.Load() }
 
 func (f *fakeProcess) Run(_ time.Duration) error {
 	f.runCalls.Add(1)

--- a/internal/router/lease.go
+++ b/internal/router/lease.go
@@ -1,0 +1,647 @@
+package router
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// LeaseState is the lifecycle position of a lease.
+type LeaseState string
+
+const (
+	// LeasePending is a lease whose model load has not yet been confirmed. It
+	// still protects the model from eviction and counts as live. (Reserved for
+	// the load-admission integration; client-created leases start active.)
+	LeasePending LeaseState = "pending"
+	// LeaseActive is a live lease protecting its model from eviction.
+	LeaseActive LeaseState = "active"
+)
+
+// defaultLeaseSweep is how often the GC sweeper drops expired leases. Expiry is
+// always evaluated directly against now() at read time, so the sweeper is
+// garbage-collection only and never authoritative for a protection decision.
+const defaultLeaseSweep = time.Minute
+
+// Lease protects a single llama-swap model from eviction across a work session.
+// Protection is refcounted per model: a model is protected while it has at least
+// one live (non-expired) lease. A lease is broken only by the host-OOM hardline
+// or an explicit kill; ordinary loads that would need to evict a leased model
+// are refused, not allowed to break it.
+type Lease struct {
+	ID         string     `json:"id"`
+	Model      string     `json:"model"`
+	Holder     string     `json:"holder"`
+	Reason     string     `json:"reason"`
+	AcquiredAt time.Time  `json:"acquired_at"`
+	ExpiresAt  time.Time  `json:"expires_at"`
+	State      LeaseState `json:"state"`
+}
+
+// LeaseView is a lease plus derived, point-in-time fields for the API response.
+type LeaseView struct {
+	Lease
+	ActiveRequests int   `json:"active_requests"`
+	TTLRemainingMS int64 `json:"ttl_remaining_ms"`
+}
+
+// Blocker names one lease standing in the way of a load that would have evicted
+// its model. It is the body of the refuse-don't-break rejection.
+type Blocker struct {
+	Model       string `json:"model"`
+	Holder      string `json:"holder"`
+	Reason      string `json:"reason"`
+	ExpiresInMS int64  `json:"expires_in_ms"`
+}
+
+// leaseTable is the in-memory, mutex-guarded set of active leases plus the
+// eviction claims that make lease protection race-free.
+//
+// It is consulted by both eviction paths — the scheduler's structural planning
+// on the run loop, and the memGate's top-up eviction in a swap goroutine — to
+// decide which models must not be evicted. Its mutex is a strict LEAF: nothing
+// under it calls Stop, waits on a goroutine or the run loop, takes memGate.mu,
+// or performs blocking I/O. Persistence snapshots are handed to a dedicated
+// writer goroutine, so no disk write ever happens under the lock. This keeps the
+// lock safe to take from the single-threaded run loop.
+//
+// Lock order: memGate.mu may be held while taking leaseTable.mu (the memGate
+// top-up path claims a victim before stopping it). The reverse never happens.
+type leaseTable struct {
+	mu     sync.Mutex
+	leases map[string]*Lease
+	// evicting refcounts models currently being stopped for a swap. A lease
+	// cannot be acquired on an eviction-claimed model, and a model with a live
+	// lease cannot be claimed for eviction. This closes the check-then-stop
+	// TOCTOU on both eviction paths: a claim and a lease are mutually exclusive.
+	evicting    map[string]int
+	maxDuration time.Duration
+	now         func() time.Time
+
+	persistCh chan []Lease
+	stopCh    chan struct{}
+	stopOnce  sync.Once
+}
+
+func newLeaseTable(maxDuration time.Duration, persistPath string) *leaseTable {
+	if maxDuration <= 0 {
+		maxDuration = 4 * time.Hour
+	}
+	t := &leaseTable{
+		leases:      make(map[string]*Lease),
+		evicting:    make(map[string]int),
+		maxDuration: maxDuration,
+		now:         time.Now,
+		stopCh:      make(chan struct{}),
+	}
+	if persistPath != "" {
+		t.persistCh = make(chan []Lease, 1)
+		go t.persistLoop(persistPath)
+	}
+	return t
+}
+
+// stop tears down the persistence writer. Safe to call more than once.
+func (t *leaseTable) stop() {
+	t.stopOnce.Do(func() { close(t.stopCh) })
+}
+
+// clampTTL bounds a requested TTL to (0, maxDuration]. A non-positive request
+// is treated as the maximum, matching "protect until I say otherwise, capped".
+func (t *leaseTable) clampTTL(ttl time.Duration) time.Duration {
+	if ttl <= 0 || ttl > t.maxDuration {
+		return t.maxDuration
+	}
+	return ttl
+}
+
+// Acquire creates and returns a new active lease for model. It fails when the
+// model is currently being evicted (the eviction already won the race); the
+// client should retry, at which point the model is gone and reloadable. holder
+// and reason are sanitized; the TTL is clamped to maxDuration.
+func (t *leaseTable) Acquire(model, holder, reason string, ttl time.Duration) (Lease, error) {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return Lease{}, fmt.Errorf("lease requires a model")
+	}
+	now := t.now()
+	l := &Lease{
+		ID:         newLeaseID(now),
+		Model:      model,
+		Holder:     sanitizeField(holder, 64),
+		Reason:     sanitizeField(reason, 120),
+		AcquiredAt: now,
+		ExpiresAt:  now.Add(t.clampTTL(ttl)),
+		State:      LeaseActive,
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.evicting[model] > 0 {
+		return Lease{}, &evictingError{model: model}
+	}
+	t.leases[l.ID] = l
+	t.saveLocked()
+	return *l, nil
+}
+
+// Release removes the caller's own lease by id. It reports whether a lease was
+// removed (false = unknown/already-gone id, which the client treats as "re-acquire").
+func (t *leaseTable) Release(id string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if _, ok := t.leases[id]; !ok {
+		return false
+	}
+	delete(t.leases, id)
+	t.saveLocked()
+	return true
+}
+
+// Extend pushes a live lease's expiry to now+ttl (clamped). It never shortens
+// below the existing expiry and cannot exceed the cap. An expired or unknown
+// lease returns false, which the client treats as "re-acquire".
+func (t *leaseTable) Extend(id string, ttl time.Duration) (Lease, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	l, ok := t.leases[id]
+	if !ok || !t.liveLocked(l) {
+		return Lease{}, false
+	}
+	newExpiry := t.now().Add(t.clampTTL(ttl))
+	if newExpiry.After(l.ExpiresAt) {
+		l.ExpiresAt = newExpiry
+	}
+	t.saveLocked()
+	return *l, true
+}
+
+// Kill removes every live lease matching the selector (exactly one of id,
+// model, or holder must be set) and returns what it removed. It is the
+// deliberate operator override; nothing else breaks a lease short of host-OOM.
+func (t *leaseTable) Kill(id, model, holder string) []Lease {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	var killed []Lease
+	for lid, l := range t.leases {
+		match := (id != "" && lid == id) ||
+			(model != "" && l.Model == model) ||
+			(holder != "" && l.Holder == holder)
+		if match {
+			killed = append(killed, *l)
+			delete(t.leases, lid)
+		}
+	}
+	if len(killed) > 0 {
+		t.saveLocked()
+	}
+	sort.Slice(killed, func(i, j int) bool { return killed[i].ID < killed[j].ID })
+	return killed
+}
+
+// List returns a point-in-time view of every live lease, sorted by model then
+// id. inFlight, when non-nil, supplies each model's active request count.
+func (t *leaseTable) List(inFlight func(string) int) []LeaseView {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.now()
+	out := make([]LeaseView, 0, len(t.leases))
+	for _, l := range t.leases {
+		if !l.ExpiresAt.After(now) {
+			continue
+		}
+		reqs := 0
+		if inFlight != nil {
+			reqs = inFlight(l.Model)
+		}
+		out = append(out, LeaseView{
+			Lease:          *l,
+			ActiveRequests: reqs,
+			TTLRemainingMS: l.ExpiresAt.Sub(now).Milliseconds(),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Model != out[j].Model {
+			return out[i].Model < out[j].Model
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// TryClaimEviction atomically verifies that none of `models` holds a live lease
+// and, if the set is clear, marks every model eviction-claimed. It returns the
+// blocking leases when any model is protected (in which case NOTHING is
+// claimed); an empty return means the caller now owns an eviction claim on the
+// whole set and MUST call ReleaseEvictionClaim once the stops complete.
+//
+// An empty `models` claims nothing and always succeeds (the no-eviction case).
+func (t *leaseTable) TryClaimEviction(models []string) []Blocker {
+	if len(models) == 0 {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.now()
+
+	set := make(map[string]struct{}, len(models))
+	for _, m := range models {
+		set[m] = struct{}{}
+	}
+	var blockers []Blocker
+	for _, l := range t.leases {
+		if _, hit := set[l.Model]; !hit {
+			continue
+		}
+		if !l.ExpiresAt.After(now) {
+			continue
+		}
+		blockers = append(blockers, Blocker{
+			Model:       l.Model,
+			Holder:      l.Holder,
+			Reason:      l.Reason,
+			ExpiresInMS: l.ExpiresAt.Sub(now).Milliseconds(),
+		})
+	}
+	if len(blockers) > 0 {
+		sort.Slice(blockers, func(i, j int) bool {
+			if blockers[i].Model != blockers[j].Model {
+				return blockers[i].Model < blockers[j].Model
+			}
+			return blockers[i].Holder < blockers[j].Holder
+		})
+		return blockers
+	}
+	for _, m := range models {
+		t.evicting[m]++
+	}
+	return nil
+}
+
+// Blockers returns, read-only, the live leases protecting any of `models`. It
+// claims nothing; it exists to explain a rejection ("these leases are why the
+// load could not free memory").
+func (t *leaseTable) Blockers(models []string) []Blocker {
+	if len(models) == 0 {
+		return nil
+	}
+	set := make(map[string]struct{}, len(models))
+	for _, m := range models {
+		set[m] = struct{}{}
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.now()
+	var blockers []Blocker
+	for _, l := range t.leases {
+		if _, hit := set[l.Model]; !hit {
+			continue
+		}
+		if !l.ExpiresAt.After(now) {
+			continue
+		}
+		blockers = append(blockers, Blocker{
+			Model:       l.Model,
+			Holder:      l.Holder,
+			Reason:      l.Reason,
+			ExpiresInMS: l.ExpiresAt.Sub(now).Milliseconds(),
+		})
+	}
+	sort.Slice(blockers, func(i, j int) bool {
+		if blockers[i].Model != blockers[j].Model {
+			return blockers[i].Model < blockers[j].Model
+		}
+		return blockers[i].Holder < blockers[j].Holder
+	})
+	return blockers
+}
+
+// Lookup returns the live lease with the given id. ok is false for an unknown
+// or expired id.
+func (t *leaseTable) Lookup(id string) (Lease, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	l, ok := t.leases[id]
+	if !ok || !t.liveLocked(l) {
+		return Lease{}, false
+	}
+	return *l, true
+}
+
+// IsProtected reports whether model has at least one live lease. It is the
+// per-model exclusion used by memGate victim selection.
+func (t *leaseTable) IsProtected(model string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.now()
+	for _, l := range t.leases {
+		if l.Model == model && l.ExpiresAt.After(now) {
+			return true
+		}
+	}
+	return false
+}
+
+// ReleaseEvictionClaim clears the claims placed by a successful
+// TryClaimEviction. It must be called exactly once per successful claim, with
+// the same set of models.
+func (t *leaseTable) ReleaseEvictionClaim(models []string) {
+	if len(models) == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, m := range models {
+		if t.evicting[m] <= 1 {
+			delete(t.evicting, m)
+			continue
+		}
+		t.evicting[m]--
+	}
+}
+
+// sweepExpired drops expired leases. Purely GC: protection decisions never rely
+// on it having run.
+func (t *leaseTable) sweepExpired() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	now := t.now()
+	changed := false
+	for id, l := range t.leases {
+		if !l.ExpiresAt.After(now) {
+			delete(t.leases, id)
+			changed = true
+		}
+	}
+	if changed {
+		t.saveLocked()
+	}
+}
+
+// runSweeper periodically GCs expired leases until stopped.
+func (t *leaseTable) runSweeper(every time.Duration) {
+	if every <= 0 {
+		every = defaultLeaseSweep
+	}
+	ticker := time.NewTicker(every)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			t.sweepExpired()
+		case <-t.stopCh:
+			return
+		}
+	}
+}
+
+// liveLocked reports whether a lease is unexpired. Caller holds t.mu.
+func (t *leaseTable) liveLocked(l *Lease) bool {
+	return l.ExpiresAt.After(t.now())
+}
+
+// saveLocked hands the current lease set to the persistence writer. Caller holds
+// t.mu. It builds the snapshot under the lock (cheap; the set is small) but does
+// NOT touch the disk here — the write happens on the writer goroutine, so the
+// lock is never held across I/O and the run loop can always take it promptly.
+// A drain-and-replace send keeps only the latest snapshot; because every caller
+// holds t.mu, sends are totally ordered and the writer converges on newest state.
+func (t *leaseTable) saveLocked() {
+	if t.persistCh == nil {
+		return
+	}
+	snap := make([]Lease, 0, len(t.leases))
+	for _, l := range t.leases {
+		snap = append(snap, *l)
+	}
+	select {
+	case t.persistCh <- snap:
+	default:
+		select {
+		case <-t.persistCh:
+		default:
+		}
+		select {
+		case t.persistCh <- snap:
+		default:
+		}
+	}
+}
+
+// persistLoop owns the state file: it is the only goroutine that writes it.
+func (t *leaseTable) persistLoop(path string) {
+	for {
+		select {
+		case snap := <-t.persistCh:
+			writeLeaseFile(path, snap)
+		case <-t.stopCh:
+			// Flush a final pending snapshot if one is queued.
+			select {
+			case snap := <-t.persistCh:
+				writeLeaseFile(path, snap)
+			default:
+			}
+			return
+		}
+	}
+}
+
+// writeLeaseFile atomically replaces path with the JSON-encoded leases. Failures
+// are silent: leases remain authoritative in memory, and persistence is a
+// best-effort convenience for surviving restarts.
+func writeLeaseFile(path string, leases []Lease) {
+	data, err := json.Marshal(leases)
+	if err != nil {
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, path)
+}
+
+// loadAndReconcile reads a persisted table (if any) and re-populates the
+// in-memory map, dropping entries that have already expired against the current
+// wall clock. Persisted expiry is wall-clock (monotonic readings do not survive
+// a restart), so reconciliation compares against time.Now directly. Unreadable
+// or absent state is not an error: the table simply starts empty. Called once at
+// startup, before the table serves any request.
+func (t *leaseTable) loadAndReconcile(path string) error {
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	var leases []Lease
+	if err := json.Unmarshal(data, &leases); err != nil {
+		return err
+	}
+	now := t.now()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i := range leases {
+		l := leases[i]
+		if !l.ExpiresAt.After(now) {
+			continue
+		}
+		if l.State == LeasePending {
+			// A pending lease's load never confirmed before the restart; do not
+			// resurrect it as protection.
+			continue
+		}
+		lc := l
+		t.leases[lc.ID] = &lc
+	}
+	t.saveLocked()
+	return nil
+}
+
+// LeaseBlockedError is the refuse-don't-break rejection: a load was refused
+// because completing it would have evicted one or more lease-protected models.
+// It renders as HTTP 503 with a blocked_by body naming the holding leases, so
+// the client that tried to load learns exactly which lease stopped it.
+type LeaseBlockedError struct {
+	// Model is the model whose load was refused (comma-joined when the refusal
+	// covered an eviction set).
+	Model     string
+	BlockedBy []Blocker
+}
+
+func (e *LeaseBlockedError) Error() string {
+	holders := make([]string, 0, len(e.BlockedBy))
+	for _, b := range e.BlockedBy {
+		holders = append(holders, fmt.Sprintf("%s (%s: %s)", b.Model, b.Holder, b.Reason))
+	}
+	return fmt.Sprintf("loading %s refused: blocked by lease(s) on %s", e.Model, strings.Join(holders, ", "))
+}
+
+func (e *LeaseBlockedError) StatusCode() int { return http.StatusServiceUnavailable }
+
+func (e *LeaseBlockedError) Header() http.Header {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	h.Set("Retry-After", "10")
+	return h
+}
+
+func (e *LeaseBlockedError) Body() []byte {
+	b, _ := json.Marshal(map[string]any{
+		"error":      e.Error(),
+		"blocked_by": e.BlockedBy,
+	})
+	return b
+}
+
+// LeaseHeader is the optional request header linking a request to a lease. When
+// present and naming a live lease for a DIFFERENT model than the request, the
+// request is rejected as an obvious mismatch; an unknown/expired id is ignored
+// (the client re-acquires on its own).
+const LeaseHeader = "X-Llama-Swap-Lease"
+
+// LeaseMismatchError is returned when an X-Llama-Swap-Lease header names a lease
+// whose model does not match the request's model. It renders as HTTP 400.
+type LeaseMismatchError struct {
+	LeaseID      string
+	LeaseModel   string
+	RequestModel string
+}
+
+func (e *LeaseMismatchError) Error() string {
+	return fmt.Sprintf("lease %s protects model %q but the request targets %q",
+		e.LeaseID, e.LeaseModel, e.RequestModel)
+}
+
+func (e *LeaseMismatchError) StatusCode() int { return http.StatusBadRequest }
+
+func (e *LeaseMismatchError) Header() http.Header {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	return h
+}
+
+func (e *LeaseMismatchError) Body() []byte {
+	b, _ := json.Marshal(map[string]string{"error": e.Error()})
+	return b
+}
+
+// evictingError is returned by Acquire when the model is mid-eviction.
+type evictingError struct{ model string }
+
+func (e *evictingError) Error() string {
+	return fmt.Sprintf("model %q is being evicted; retry to re-acquire once it reloads", e.model)
+}
+
+// sanitizeField trims a user-supplied string to a single line and a max length.
+func sanitizeField(s string, max int) string {
+	s = strings.TrimSpace(s)
+	s = strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\r' || r == '\t' {
+			return ' '
+		}
+		return r
+	}, s)
+	if len(s) > max {
+		s = s[:max]
+	}
+	return s
+}
+
+// crockford is the ULID base32 alphabet.
+const crockford = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+// newLeaseID returns a lexicographically sortable, unique id: a 48-bit
+// millisecond timestamp followed by 80 bits of randomness, Crockford base32
+// encoded (a ULID). Sortable-by-time makes tie-breaks and logs read naturally.
+func newLeaseID(now time.Time) string {
+	var b [16]byte
+	ms := uint64(now.UnixMilli())
+	b[0] = byte(ms >> 40)
+	b[1] = byte(ms >> 32)
+	b[2] = byte(ms >> 24)
+	b[3] = byte(ms >> 16)
+	b[4] = byte(ms >> 8)
+	b[5] = byte(ms)
+	_, _ = rand.Read(b[6:])
+
+	var out [26]byte
+	// Encode 128 bits as 26 base32 chars (Crockford), high bits first.
+	out[0] = crockford[(b[0]&224)>>5]
+	out[1] = crockford[b[0]&31]
+	out[2] = crockford[(b[1]&248)>>3]
+	out[3] = crockford[((b[1]&7)<<2)|((b[2]&192)>>6)]
+	out[4] = crockford[(b[2]&62)>>1]
+	out[5] = crockford[((b[2]&1)<<4)|((b[3]&240)>>4)]
+	out[6] = crockford[((b[3]&15)<<1)|((b[4]&128)>>7)]
+	out[7] = crockford[(b[4]&124)>>2]
+	out[8] = crockford[((b[4]&3)<<3)|((b[5]&224)>>5)]
+	out[9] = crockford[b[5]&31]
+	out[10] = crockford[(b[6]&248)>>3]
+	out[11] = crockford[((b[6]&7)<<2)|((b[7]&192)>>6)]
+	out[12] = crockford[(b[7]&62)>>1]
+	out[13] = crockford[((b[7]&1)<<4)|((b[8]&240)>>4)]
+	out[14] = crockford[((b[8]&15)<<1)|((b[9]&128)>>7)]
+	out[15] = crockford[(b[9]&124)>>2]
+	out[16] = crockford[((b[9]&3)<<3)|((b[10]&224)>>5)]
+	out[17] = crockford[b[10]&31]
+	out[18] = crockford[(b[11]&248)>>3]
+	out[19] = crockford[((b[11]&7)<<2)|((b[12]&192)>>6)]
+	out[20] = crockford[(b[12]&62)>>1]
+	out[21] = crockford[((b[12]&1)<<4)|((b[13]&240)>>4)]
+	out[22] = crockford[((b[13]&15)<<1)|((b[14]&128)>>7)]
+	out[23] = crockford[(b[14]&124)>>2]
+	out[24] = crockford[((b[14]&3)<<3)|((b[15]&224)>>5)]
+	out[25] = crockford[b[15]&31]
+	return string(out[:])
+}

--- a/internal/router/lease.go
+++ b/internal/router/lease.go
@@ -4,11 +4,13 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -207,21 +209,32 @@ func (t *leaseTable) Kill(id, model, holder string) []Lease {
 
 // List returns a point-in-time view of every live lease, sorted by model then
 // id. inFlight, when non-nil, supplies each model's active request count.
+//
+// inFlight is queried AFTER the lock is released: the production callback
+// (baseRouter.InFlight) round-trips through the single run loop, and the run
+// loop itself takes t.mu (via TryClaimEviction). Calling it under t.mu would
+// deadlock the whole router. The lock is a strict leaf; nothing that waits on
+// the run loop may run under it.
 func (t *leaseTable) List(inFlight func(string) int) []LeaseView {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 	now := t.now()
-	out := make([]LeaseView, 0, len(t.leases))
+	live := make([]Lease, 0, len(t.leases))
 	for _, l := range t.leases {
-		if !l.ExpiresAt.After(now) {
-			continue
+		if l.ExpiresAt.After(now) {
+			live = append(live, *l)
 		}
+	}
+	t.mu.Unlock()
+
+	out := make([]LeaseView, 0, len(live))
+	for i := range live {
+		l := live[i]
 		reqs := 0
 		if inFlight != nil {
 			reqs = inFlight(l.Model)
 		}
 		out = append(out, LeaseView{
-			Lease:          *l,
+			Lease:          l,
 			ActiveRequests: reqs,
 			TTLRemainingMS: l.ExpiresAt.Sub(now).Milliseconds(),
 		})
@@ -601,6 +614,9 @@ func sanitizeField(s string, max int) string {
 // crockford is the ULID base32 alphabet.
 const crockford = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
+// leaseIDFallback seeds id randomness only if crypto/rand ever fails.
+var leaseIDFallback atomic.Uint64
+
 // newLeaseID returns a lexicographically sortable, unique id: a 48-bit
 // millisecond timestamp followed by 80 bits of randomness, Crockford base32
 // encoded (a ULID). Sortable-by-time makes tie-breaks and logs read naturally.
@@ -613,7 +629,16 @@ func newLeaseID(now time.Time) string {
 	b[3] = byte(ms >> 16)
 	b[4] = byte(ms >> 8)
 	b[5] = byte(ms)
-	_, _ = rand.Read(b[6:])
+	if _, err := io.ReadFull(rand.Reader, b[6:]); err != nil {
+		// crypto/rand should never fail; if it does, fall back to a strictly
+		// increasing counter mixed with the nanosecond clock so ids in the same
+		// millisecond still differ rather than colliding on a zeroed suffix.
+		n := leaseIDFallback.Add(1)
+		mix := uint64(now.UnixNano()) ^ n
+		for i := range 10 {
+			b[6+i] = byte(mix >> (uint(i%8) * 8))
+		}
+	}
 
 	var out [26]byte
 	// Encode 128 bits as 26 base32 chars (Crockford), high bits first.

--- a/internal/router/lease_api.go
+++ b/internal/router/lease_api.go
@@ -1,0 +1,102 @@
+package router
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/process"
+)
+
+// ErrUnknownModel is returned when a lease operation names a model this router
+// does not handle.
+var ErrUnknownModel = fmt.Errorf("model not handled by this router")
+
+// LoadVerdict is the read-only answer to "if I load this model now, what
+// happens?" — the can-i-load preflight. It reports the structural eviction the
+// planner would perform and any leases that would refuse it. Memory-budget
+// admission is still evaluated at actual load time; a Fits==true verdict means
+// "not blocked by a lease", not "guaranteed to fit under the GPU budget".
+type LoadVerdict struct {
+	Model      string    `json:"model"`
+	Running    bool      `json:"running"`
+	WouldEvict []string  `json:"would_evict"`
+	Blocked    bool      `json:"blocked"`
+	BlockedBy  []Blocker `json:"blocked_by,omitempty"`
+}
+
+// AcquireLease creates a lease protecting model from eviction. It rejects
+// unknown models and models that are currently mid-eviction.
+func (b *baseRouter) AcquireLease(model, holder, reason string, ttl time.Duration) (Lease, error) {
+	if b.leases == nil {
+		return Lease{}, fmt.Errorf("leases are disabled")
+	}
+	if !b.Handles(model) {
+		return Lease{}, ErrUnknownModel
+	}
+	return b.leases.Acquire(model, holder, reason, ttl)
+}
+
+// ReleaseLease drops a lease by id. false means the id was unknown (already
+// expired, killed, or never existed); clients treat that as "re-acquire".
+func (b *baseRouter) ReleaseLease(id string) bool {
+	if b.leases == nil {
+		return false
+	}
+	return b.leases.Release(id)
+}
+
+// ExtendLease pushes a live lease's expiry out by ttl (clamped to the cap).
+// false means the id was unknown or already expired.
+func (b *baseRouter) ExtendLease(id string, ttl time.Duration) (Lease, bool) {
+	if b.leases == nil {
+		return Lease{}, false
+	}
+	return b.leases.Extend(id, ttl)
+}
+
+// KillLeases force-removes every live lease matching the selector (exactly one
+// of id/model/holder). It is the deliberate operator override.
+func (b *baseRouter) KillLeases(id, model, holder string) []Lease {
+	if b.leases == nil {
+		return nil
+	}
+	return b.leases.Kill(id, model, holder)
+}
+
+// ListLeases returns a point-in-time view of every live lease, each annotated
+// with its model's active request count.
+func (b *baseRouter) ListLeases() []LeaseView {
+	if b.leases == nil {
+		return nil
+	}
+	return b.leases.List(b.InFlight)
+}
+
+// CanLoad answers the can-i-load preflight for model: which models the planner
+// would evict to make room, and whether any of those hold a live lease that
+// would refuse the load. Read-only; it starts nothing.
+func (b *baseRouter) CanLoad(model string) (LoadVerdict, error) {
+	if !b.Handles(model) {
+		return LoadVerdict{}, ErrUnknownModel
+	}
+	v := LoadVerdict{Model: model}
+
+	running := make([]string, 0, len(b.processes))
+	for id, p := range b.RunningModels() {
+		running = append(running, id)
+		if id == model && p == process.StateReady {
+			v.Running = true
+		}
+	}
+	sort.Strings(running)
+
+	if b.planner != nil {
+		v.WouldEvict = b.planner.EvictionFor(model, running)
+	}
+	if b.leases != nil {
+		v.BlockedBy = b.leases.Blockers(v.WouldEvict)
+		v.Blocked = len(v.BlockedBy) > 0
+	}
+	return v, nil
+}

--- a/internal/router/lease_integration_test.go
+++ b/internal/router/lease_integration_test.go
@@ -139,3 +139,35 @@ func TestBaseRouter_LeaseHeaderValidation(t *testing.T) {
 		t.Fatalf("absent header must pass; got %v", err)
 	}
 }
+
+// TestLeaseTable_ListReleasesLockBeforeInFlight is the regression guard for the
+// run-loop deadlock (H1). In production the inFlight callback (baseRouter.InFlight)
+// round-trips through the single run loop, and the run loop itself takes the
+// lease lock via TryClaimEviction. If List holds t.mu across the callback, the
+// two deadlock. This test makes the callback assert it can take t.mu, which is
+// only possible if List released it first.
+func TestLeaseTable_ListReleasesLockBeforeInFlight(t *testing.T) {
+	lt, _ := newTestLeaseTable(t)
+	lt.Acquire("m", "holder", "reason", time.Hour)
+
+	done := make(chan struct{})
+	go func() {
+		lt.List(func(string) int {
+			// The lock must be free here; a real inFlight callback needs the run
+			// loop, which needs this same lock.
+			if !lt.mu.TryLock() {
+				t.Error("List held t.mu while calling the inFlight callback (deadlock risk)")
+			} else {
+				lt.mu.Unlock()
+			}
+			return 0
+		})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("List deadlocked calling inFlight under its own lock")
+	}
+}

--- a/internal/router/lease_integration_test.go
+++ b/internal/router/lease_integration_test.go
@@ -1,0 +1,141 @@
+package router
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/process"
+)
+
+// leaseTableFor returns a lease table with a real-clock now for integration
+// tests that only need "live" leases (hour-long TTLs never expire mid-test).
+func leaseTableFor(t *testing.T) *leaseTable {
+	t.Helper()
+	lt := newLeaseTable(4*time.Hour, "")
+	t.Cleanup(lt.stop)
+	return lt
+}
+
+func TestMemGate_SkipsLeasedVictim(t *testing.T) {
+	perModel := map[string]int{"leased-lru": 5000, "idle": 5000}
+	leased := readyProc("leased-lru", 100) // oldest -> would be the LRU victim
+	idle := readyProc("idle", 200)
+	procs := map[string]process.Process{"leased-lru": leased, "idle": idle}
+
+	g := newTestGate(6000, nil, nil)
+	g.probe = residentProbe(procs, perModel)
+	lt := leaseTableFor(t)
+	lt.Acquire("leased-lru", "batch.py", "overnight", time.Hour)
+	g.leases = lt
+
+	g.EnsureFits("incoming", procs, nil, gateLog())
+
+	if leased.stopCalls.Load() != 0 {
+		t.Fatalf("leased LRU model must not be evicted; stops=%d", leased.stopCalls.Load())
+	}
+	if idle.stopCalls.Load() != 1 {
+		t.Fatalf("idle non-leased model should be evicted instead; stops=%d", idle.stopCalls.Load())
+	}
+}
+
+func TestMemGate_HardlineCanEvictLeasedVictim(t *testing.T) {
+	leased := readyProc("leased-lru", 100)
+	idle := readyProc("idle", 200)
+	procs := map[string]process.Process{"leased-lru": leased, "idle": idle}
+	g := newTestGate(1000, nil, nil)
+	lt := leaseTableFor(t)
+	lt.Acquire("leased-lru", "batch.py", "overnight", time.Hour)
+	g.leases = lt
+
+	// allowInFlight==true is the hard-line/host-OOM tier: leases are ignored.
+	victim, ok := g.pickLRUVictim(procs, nil, false, true)
+	if !ok || victim != "leased-lru" {
+		t.Fatalf("hard-line selection must be able to pick a leased model; victim=%q ok=%v", victim, ok)
+	}
+}
+
+func TestMemGate_StrictRejectionNamesBlockingLease(t *testing.T) {
+	// Budget too small: the only resident model is leased, so a strict load
+	// cannot free room and must reject with the blocking lease named.
+	perModel := map[string]int{"leased": 5000}
+	leased := readyProc("leased", 100)
+	procs := map[string]process.Process{"leased": leased}
+
+	g := newTestGate(4000, nil, map[string]int{"incoming": 3000})
+	g.strict = true
+	g.maxWait = 0
+	g.probe = residentProbe(procs, perModel)
+	lt := leaseTableFor(t)
+	lt.Acquire("leased", "batch.py", "important run", time.Hour)
+	g.leases = lt
+
+	err := g.EnsureFits("incoming", procs, nil, gateLog())
+	if err == nil {
+		t.Fatal("strict admission should reject when all candidates are leased")
+	}
+	be, ok := err.(*MemoryBudgetError)
+	if !ok {
+		t.Fatalf("want *MemoryBudgetError, got %T", err)
+	}
+	if len(be.BlockedBy) != 1 || be.BlockedBy[0].Model != "leased" || be.BlockedBy[0].Holder != "batch.py" {
+		t.Fatalf("rejection must name the blocking lease; got %+v", be.BlockedBy)
+	}
+}
+
+func TestBaseRouter_TryClaimEviction_RefusesLeased(t *testing.T) {
+	a := newFakeProcess("a")
+	a.markReady()
+	b := newSerializeTestBase(t, map[string]process.Process{"a": a}, nil)
+	b.leases.Acquire("a", "holder", "reason", time.Hour)
+
+	err := b.TryClaimEviction([]string{"a"})
+	if err == nil {
+		t.Fatal("claiming a leased model for eviction must be refused")
+	}
+	if _, ok := err.(*LeaseBlockedError); !ok {
+		t.Fatalf("want *LeaseBlockedError, got %T", err)
+	}
+
+	// An unleased model claims cleanly, and releasing lets a later lease land.
+	if err := b.TryClaimEviction([]string{"b-model"}); err != nil {
+		t.Fatalf("unleased claim should succeed; got %v", err)
+	}
+	b.leases.ReleaseEvictionClaim([]string{"b-model"})
+}
+
+func TestBaseRouter_LeaseHeaderValidation(t *testing.T) {
+	a := newFakeProcess("a")
+	a.markReady()
+	bp := newFakeProcess("b")
+	bp.markReady()
+	b := newSerializeTestBase(t, map[string]process.Process{"a": a, "b": bp}, nil)
+	lease, _ := b.leases.Acquire("a", "holder", "reason", time.Hour)
+
+	// Header naming a lease for "a" while the request targets "b" is a mismatch.
+	rMismatch := newRequest("b")
+	rMismatch.Header.Set(LeaseHeader, lease.ID)
+	if err := b.validateLeaseHeader(rMismatch, "b"); err == nil {
+		t.Fatal("mismatched lease/model must be rejected")
+	} else if _, ok := err.(*LeaseMismatchError); !ok {
+		t.Fatalf("want *LeaseMismatchError, got %T", err)
+	}
+
+	// Matching model is accepted.
+	rMatch := newRequest("a")
+	rMatch.Header.Set(LeaseHeader, lease.ID)
+	if err := b.validateLeaseHeader(rMatch, "a"); err != nil {
+		t.Fatalf("matching lease/model must pass; got %v", err)
+	}
+
+	// Unknown lease id is ignored (client re-acquires), not rejected.
+	rUnknown := newRequest("a")
+	rUnknown.Header.Set(LeaseHeader, "NONEXISTENT")
+	if err := b.validateLeaseHeader(rUnknown, "a"); err != nil {
+		t.Fatalf("unknown lease id must be ignored; got %v", err)
+	}
+
+	// No header is always fine.
+	if err := b.validateLeaseHeader(newRequest("a"), "a"); err != nil {
+		t.Fatalf("absent header must pass; got %v", err)
+	}
+}

--- a/internal/router/lease_test.go
+++ b/internal/router/lease_test.go
@@ -1,0 +1,288 @@
+package router
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// fixedClock returns a controllable now() for deterministic expiry tests.
+func fixedClock(start time.Time) (func() time.Time, *time.Time) {
+	cur := start
+	return func() time.Time { return cur }, &cur
+}
+
+func newTestLeaseTable(t *testing.T) (*leaseTable, *time.Time) {
+	t.Helper()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	nowFn, cur := fixedClock(base)
+	lt := newLeaseTable(4*time.Hour, "")
+	lt.now = nowFn
+	t.Cleanup(lt.stop)
+	return lt, cur
+}
+
+func TestLeaseTable_AcquireReleaseProtects(t *testing.T) {
+	lt, _ := newTestLeaseTable(t)
+
+	l, err := lt.Acquire("m1", "runner.py", "batch", time.Hour)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if l.ID == "" || l.Model != "m1" || l.State != LeaseActive {
+		t.Fatalf("unexpected lease: %+v", l)
+	}
+	if !lt.IsProtected("m1") {
+		t.Fatal("m1 should be protected while a live lease exists")
+	}
+	if lt.IsProtected("m2") {
+		t.Fatal("m2 has no lease and must not be protected")
+	}
+
+	if !lt.Release(l.ID) {
+		t.Fatal("release of a known id should return true")
+	}
+	if lt.IsProtected("m1") {
+		t.Fatal("m1 must not be protected after release")
+	}
+	if lt.Release(l.ID) {
+		t.Fatal("second release of the same id should return false")
+	}
+}
+
+func TestLeaseTable_Refcounting(t *testing.T) {
+	lt, _ := newTestLeaseTable(t)
+	a, _ := lt.Acquire("m", "A", "", time.Hour)
+	b, _ := lt.Acquire("m", "B", "", time.Hour)
+
+	lt.Release(a.ID)
+	if !lt.IsProtected("m") {
+		t.Fatal("model must stay protected while B's lease is live")
+	}
+	lt.Release(b.ID)
+	if lt.IsProtected("m") {
+		t.Fatal("model must be unprotected after the last lease is released")
+	}
+}
+
+func TestLeaseTable_ExpiryIsAuthoritativeWithoutSweep(t *testing.T) {
+	lt, cur := newTestLeaseTable(t)
+	lt.Acquire("m", "A", "", 10*time.Minute)
+
+	*cur = cur.Add(9 * time.Minute)
+	if !lt.IsProtected("m") {
+		t.Fatal("still protected before expiry")
+	}
+	*cur = cur.Add(2 * time.Minute) // now past expiry, without any sweep
+	if lt.IsProtected("m") {
+		t.Fatal("expired lease must not protect even before the sweeper runs")
+	}
+	if got := lt.List(nil); len(got) != 0 {
+		t.Fatalf("expired lease must not appear in List; got %d", len(got))
+	}
+}
+
+func TestLeaseTable_TTLClampedToMax(t *testing.T) {
+	lt, cur := newTestLeaseTable(t)
+	l, _ := lt.Acquire("m", "A", "", 10*time.Hour) // cap is 4h
+	want := cur.Add(4 * time.Hour)
+	if !l.ExpiresAt.Equal(want) {
+		t.Fatalf("ttl not clamped: expires=%v want=%v", l.ExpiresAt, want)
+	}
+
+	// ttl <= 0 also means "the maximum".
+	l2, _ := lt.Acquire("m2", "A", "", 0)
+	if !l2.ExpiresAt.Equal(cur.Add(4 * time.Hour)) {
+		t.Fatalf("zero ttl should map to the cap; got %v", l2.ExpiresAt)
+	}
+}
+
+func TestLeaseTable_ExtendCannotExceedCap(t *testing.T) {
+	lt, cur := newTestLeaseTable(t)
+	l, _ := lt.Acquire("m", "A", "", time.Hour)
+	*cur = cur.Add(30 * time.Minute)
+
+	ext, ok := lt.Extend(l.ID, 10*time.Hour)
+	if !ok {
+		t.Fatal("extend of a live lease should succeed")
+	}
+	want := cur.Add(4 * time.Hour)
+	if !ext.ExpiresAt.Equal(want) {
+		t.Fatalf("extend must clamp to cap: got %v want %v", ext.ExpiresAt, want)
+	}
+
+	*cur = cur.Add(5 * time.Hour) // now expired
+	if _, ok := lt.Extend(l.ID, time.Hour); ok {
+		t.Fatal("extend of an expired lease must fail")
+	}
+}
+
+func TestLeaseTable_Kill(t *testing.T) {
+	lt, _ := newTestLeaseTable(t)
+	lt.Acquire("m1", "A", "", time.Hour)
+	lt.Acquire("m1", "B", "", time.Hour)
+	lt.Acquire("m2", "A", "", time.Hour)
+
+	killed := lt.Kill("", "m1", "")
+	if len(killed) != 2 {
+		t.Fatalf("kill by model should remove both m1 leases; got %d", len(killed))
+	}
+	if lt.IsProtected("m1") {
+		t.Fatal("m1 must be unprotected after kill")
+	}
+	if !lt.IsProtected("m2") {
+		t.Fatal("m2 must remain protected")
+	}
+
+	killed = lt.Kill("", "", "A")
+	if len(killed) != 1 || killed[0].Model != "m2" {
+		t.Fatalf("kill by holder should remove the remaining A lease; got %+v", killed)
+	}
+}
+
+func TestLeaseTable_ClaimBlockedByLease(t *testing.T) {
+	lt, _ := newTestLeaseTable(t)
+	lt.Acquire("m", "A", "batch", time.Hour)
+
+	blockers := lt.TryClaimEviction([]string{"m", "other"})
+	if len(blockers) != 1 || blockers[0].Model != "m" || blockers[0].Holder != "A" {
+		t.Fatalf("claim of a leased model must be blocked with the holder; got %+v", blockers)
+	}
+	// Nothing should have been claimed on a blocked attempt.
+	if lt.evicting["m"] != 0 || lt.evicting["other"] != 0 {
+		t.Fatalf("a blocked claim must not mark anything evicting; got %v", lt.evicting)
+	}
+}
+
+func TestLeaseTable_ClaimThenAcquireRace(t *testing.T) {
+	lt, _ := newTestLeaseTable(t)
+
+	// Model is clear: eviction wins the claim.
+	if blockers := lt.TryClaimEviction([]string{"m"}); blockers != nil {
+		t.Fatalf("claim of an unleased model should succeed; got %+v", blockers)
+	}
+	// A lease acquire on a claimed (mid-eviction) model must fail: eviction won.
+	if _, err := lt.Acquire("m", "late", "", time.Hour); err == nil {
+		t.Fatal("acquire on an eviction-claimed model must fail")
+	}
+	// After the eviction completes, acquire works again.
+	lt.ReleaseEvictionClaim([]string{"m"})
+	if _, err := lt.Acquire("m", "later", "", time.Hour); err != nil {
+		t.Fatalf("acquire after claim release should succeed; got %v", err)
+	}
+}
+
+func TestLeaseTable_AcquireThenClaimRace(t *testing.T) {
+	lt, _ := newTestLeaseTable(t)
+	// Lease acquired first: a subsequent eviction claim must be refused.
+	lt.Acquire("m", "holder", "reason", time.Hour)
+	if blockers := lt.TryClaimEviction([]string{"m"}); len(blockers) != 1 {
+		t.Fatalf("claim must be refused once a lease exists; got %+v", blockers)
+	}
+}
+
+func TestLeaseTable_ClaimRefcount(t *testing.T) {
+	lt, _ := newTestLeaseTable(t)
+	lt.TryClaimEviction([]string{"m"})
+	lt.TryClaimEviction([]string{"m"}) // second concurrent claim on same model
+	lt.ReleaseEvictionClaim([]string{"m"})
+	if _, err := lt.Acquire("m", "x", "", time.Hour); err == nil {
+		t.Fatal("model must remain claimed until every claim is released")
+	}
+	lt.ReleaseEvictionClaim([]string{"m"})
+	if _, err := lt.Acquire("m", "x", "", time.Hour); err != nil {
+		t.Fatalf("acquire should work after all claims released; got %v", err)
+	}
+}
+
+func TestLeaseTable_ListAnnotatesInFlight(t *testing.T) {
+	lt, _ := newTestLeaseTable(t)
+	lt.Acquire("m", "A", "r", time.Hour)
+	views := lt.List(func(model string) int {
+		if model == "m" {
+			return 3
+		}
+		return 0
+	})
+	if len(views) != 1 || views[0].ActiveRequests != 3 || views[0].TTLRemainingMS <= 0 {
+		t.Fatalf("list view not annotated: %+v", views)
+	}
+}
+
+func TestLeaseTable_Persistence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "leases.json")
+
+	lt := newLeaseTable(4*time.Hour, path)
+	l, _ := lt.Acquire("m", "A", "batch", time.Hour)
+	// Give the writer goroutine a moment, then stop to flush.
+	waitFor(t, func() bool {
+		_, err := os.Stat(path)
+		return err == nil
+	})
+	lt.stop()
+
+	// Reload into a fresh table.
+	lt2 := newLeaseTable(4*time.Hour, path)
+	t.Cleanup(lt2.stop)
+	if err := lt2.loadAndReconcile(path); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	got, ok := lt2.Lookup(l.ID)
+	if !ok || got.Model != "m" || got.Holder != "A" {
+		t.Fatalf("persisted lease not restored: %+v ok=%v", got, ok)
+	}
+}
+
+func TestLeaseTable_PersistenceDropsExpiredOnReload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "leases.json")
+	// Hand-write an already-expired lease.
+	writeLeaseFile(path, []Lease{{
+		ID: "OLD", Model: "m", Holder: "A", State: LeaseActive,
+		AcquiredAt: time.Now().Add(-2 * time.Hour),
+		ExpiresAt:  time.Now().Add(-time.Hour),
+	}})
+
+	lt := newLeaseTable(4*time.Hour, path)
+	t.Cleanup(lt.stop)
+	if err := lt.loadAndReconcile(path); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if _, ok := lt.Lookup("OLD"); ok {
+		t.Fatal("expired lease must be dropped on reload")
+	}
+}
+
+func TestNewLeaseID_SortableAndUnique(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	a := newLeaseID(base)
+	b := newLeaseID(base.Add(time.Millisecond))
+	if len(a) != 26 || len(b) != 26 {
+		t.Fatalf("ULID must be 26 chars; got %d and %d", len(a), len(b))
+	}
+	if a >= b {
+		t.Fatalf("later timestamp must sort after earlier: %s !< %s", a, b)
+	}
+	seen := map[string]bool{}
+	for range 1000 {
+		id := newLeaseID(base)
+		if seen[id] {
+			t.Fatalf("duplicate id generated: %s", id)
+		}
+		seen[id] = true
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("condition not met within timeout")
+}

--- a/internal/router/matrix.go
+++ b/internal/router/matrix.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/perf"
 	"github.com/mostlygeek/llama-swap/internal/process"
 )
 
@@ -12,7 +13,7 @@ type Matrix struct {
 	*baseRouter
 }
 
-func NewMatrix(conf config.Config, proxylog, upstreamlog *logmon.Monitor) (*Matrix, error) {
+func NewMatrix(conf config.Config, proxylog, upstreamlog *logmon.Monitor, perfMon *perf.Monitor) (*Matrix, error) {
 	mtx := conf.Routing.Router.Settings.Matrix
 	if mtx == nil {
 		return nil, fmt.Errorf("matrix router requires a matrix configuration")
@@ -23,10 +24,12 @@ func NewMatrix(conf config.Config, proxylog, upstreamlog *logmon.Monitor) (*Matr
 		logger: proxylog,
 	}
 
+	gate := newMemGateFromConfig(conf, perfMon)
+
 	// Build a process for every model in the config. Any model can run alone
 	// even if it is not part of a set; this mirrors proxy.NewMatrix.
 	processes := make(map[string]process.Process, len(conf.Models))
-	base, err := newBaseRouter("matrix", conf, processes, proxylog, swapper)
+	base, err := newBaseRouter("matrix", conf, processes, proxylog, swapper, gate)
 	if err != nil {
 		return nil, fmt.Errorf("creating base router: %w", err)
 	}

--- a/internal/router/matrix.go
+++ b/internal/router/matrix.go
@@ -40,6 +40,7 @@ func NewMatrix(conf config.Config, proxylog, upstreamlog *logmon.Monitor, perfMo
 		if err != nil {
 			base.shutdownFn()
 			base.procCancel()
+			base.leases.stop()
 			return nil, fmt.Errorf("creating process for %q: %w", mid, err)
 		}
 		processes[mid] = p

--- a/internal/router/matrix_test.go
+++ b/internal/router/matrix_test.go
@@ -21,7 +21,7 @@ func newTestMatrix(t *testing.T, conf config.Config, expanded []config.ExpandedS
 		solver: newMatrixSolver(expanded, evictCosts),
 		logger: logger,
 	}
-	base, err := newBaseRouter("matrix", conf, processes, logger, swapper)
+	base, err := newBaseRouter("matrix", conf, processes, logger, swapper, nil)
 	if err != nil {
 		t.Fatalf("newBaseRouter: %v", err)
 	}

--- a/internal/router/memgate.go
+++ b/internal/router/memgate.go
@@ -73,6 +73,10 @@ type MemoryBudgetError struct {
 	Model      string
 	Detail     string
 	RetryAfter int
+	// BlockedBy names the leases that prevented the gate from freeing memory,
+	// when the load was refused specifically because every model it could have
+	// evicted is lease-protected. Empty when the rejection is plain over-budget.
+	BlockedBy []Blocker
 }
 
 func (e *MemoryBudgetError) Error() string {
@@ -93,7 +97,11 @@ func (e *MemoryBudgetError) Header() http.Header {
 }
 
 func (e *MemoryBudgetError) Body() []byte {
-	b, _ := json.Marshal(map[string]string{"error": e.Error()})
+	payload := map[string]any{"error": e.Error()}
+	if len(e.BlockedBy) > 0 {
+		payload["blocked_by"] = e.BlockedBy
+	}
+	b, _ := json.Marshal(payload)
 	return b
 }
 
@@ -151,6 +159,38 @@ type memGate struct {
 	// admission and red-line eviction skip models with in-flight requests;
 	// hard-line emergency eviction intentionally ignores it.
 	inFlight func(modelID string) int
+
+	// leases, when non-nil, is the lease table. Normal admission and red-line
+	// eviction never pick a leased model as a victim and CLAIM each victim
+	// before stopping it (closing the pick->stop race against a concurrent
+	// lease acquire); hard-line emergency eviction ignores leases entirely
+	// (safety beats a lease). nil disables all lease awareness in the gate.
+	leases *leaseTable
+}
+
+// leaseProtected reports whether model currently holds a live lease.
+func (g *memGate) leaseProtected(modelID string) bool {
+	return g.leases != nil && g.leases.IsProtected(modelID)
+}
+
+// claimVictim reserves victim for eviction so a lease cannot be acquired on it
+// while it is being stopped. allowLeased (the hard-line/host-OOM tier) skips the
+// claim entirely: safety eviction breaks leases. It returns false only when a
+// live lease exists on the victim right now, telling the caller to pick another.
+func (g *memGate) claimVictim(victim string, allowLeased bool) bool {
+	if g.leases == nil || allowLeased {
+		return true
+	}
+	return g.leases.TryClaimEviction([]string{victim}) == nil
+}
+
+// releaseVictim clears a claim taken by claimVictim. It must be paired with a
+// claimVictim that returned true (and matching allowLeased).
+func (g *memGate) releaseVictim(victim string, allowLeased bool) {
+	if g.leases == nil || allowLeased {
+		return
+	}
+	g.leases.ReleaseEvictionClaim([]string{victim})
 }
 
 // newMemGate returns a gate, or nil when it should be disabled (no budget or no
@@ -311,7 +351,7 @@ func (g *memGate) EnsureFits(
 		}
 		if time.Now().After(deadline) {
 			log.Warnf("memgate: rejecting %s after %s: %s", incoming, g.maxWait, detail)
-			return &MemoryBudgetError{Model: incoming, Detail: detail, RetryAfter: 10}
+			return &MemoryBudgetError{Model: incoming, Detail: detail, RetryAfter: 10, BlockedBy: g.residentBlockers(procs, incoming)}
 		}
 		log.Infof("memgate: %s does not fit yet (%s); waiting up to %s for memory to free",
 			incoming, detail, time.Until(deadline).Round(time.Second))
@@ -387,12 +427,21 @@ func (g *memGate) tryFit(
 			return false, detail
 		}
 
+		// Claim the victim before stopping it so a lease cannot be acquired in
+		// the pick->stop window. A false return means a lease landed on it just
+		// now: leave it running, exclude it, and pick a different victim.
+		if !g.claimVictim(victim, false) {
+			excluded[victim] = struct{}{}
+			continue
+		}
+
 		victimEst := g.estimateMB(victim)
 
 		log.Infof("memgate: evicting LRU model %s to free memory for %s", victim, incoming)
 		if err := procs[victim].Stop(g.stopTimeout); err != nil {
 			log.Warnf("memgate: stopping %s failed: %v", victim, err)
 		}
+		g.releaseVictim(victim, false)
 		excluded[victim] = struct{}{}
 
 		used, ok = g.settleAfterEviction(used, victimEst)
@@ -495,6 +544,9 @@ func (g *memGate) pickLRUVictim(
 		if !allowInFlight && g.inFlight != nil && g.inFlight(id) > 0 {
 			continue
 		}
+		if !allowInFlight && g.leaseProtected(id) {
+			continue
+		}
 		switch p.State() {
 		case process.StateStopped, process.StateShutdown:
 			continue // not resident, frees no GPU memory
@@ -523,6 +575,27 @@ func (g *memGate) pickLRUVictim(
 		return candidates[i].id < candidates[j].id
 	})
 	return candidates[0].id, true
+}
+
+// residentBlockers returns the leases protecting any currently-resident model
+// other than incoming, to explain a strict rejection. Empty when leases are
+// disabled or no resident model is leased.
+func (g *memGate) residentBlockers(procs map[string]process.Process, incoming string) []Blocker {
+	if g.leases == nil {
+		return nil
+	}
+	models := make([]string, 0, len(procs))
+	for id, p := range procs {
+		if id == incoming {
+			continue
+		}
+		switch p.State() {
+		case process.StateStopped, process.StateShutdown:
+			continue
+		}
+		models = append(models, id)
+	}
+	return g.leases.Blockers(models)
 }
 
 // estimateMB returns the incoming model's configured VRAM estimate in MiB, or 0

--- a/internal/router/memgate.go
+++ b/internal/router/memgate.go
@@ -162,19 +162,46 @@ func (g *memGate) EnsureFits(
 			return
 		}
 
+		victimEst := g.estimateMB(victim)
+
 		log.Infof("memgate: evicting LRU model %s to free GPU memory for %s", victim, incoming)
 		if err := procs[victim].Stop(g.stopTimeout); err != nil {
 			log.Warnf("memgate: stopping %s failed: %v", victim, err)
 		}
 		excluded[victim] = struct{}{}
 
-		// Re-read live usage: the Stop above has freed the victim's GPU memory,
-		// so the next decision is based on the real post-eviction footprint
-		// rather than arithmetic guesswork.
-		if reUsed, ok := g.probe.liveUsedMB(); ok {
+		// Account for the freed memory ARITHMETICALLY. A fresh live re-read is
+		// not trustworthy here: the perf monitor polls on a >=5s interval, so
+		// immediately after Stop the probe almost always still reports the
+		// pre-eviction value. Trusting that stale reading would keep `projected`
+		// over budget and evict the entire resident set. Instead, subtract the
+		// victim's estimated footprint and only believe a live reading when it
+		// reports LESS than the arithmetic projection (i.e. it has actually
+		// observed the freeing, or other memory was released too).
+		used -= victimEst
+		if used < 0 {
+			used = 0
+		}
+		liveProgressed := false
+		if reUsed, ok := g.probe.liveUsedMB(); ok && reUsed < used {
 			used = reUsed
+			liveProgressed = true
 		}
 		projected = used + estimate
+
+		// Unknown-size victim (no estimate) where the live re-read also showed
+		// no drop below the arithmetic projection: we made no measurable
+		// progress and the >=5s-stale probe can't be trusted. Continuing would
+		// evict the entire resident set on a single unknown model. Bound to this
+		// one eviction and fail open. If the live reading DID drop (real freeing
+		// observed), keep looping normally.
+		if victimEst <= 0 && !liveProgressed {
+			if projected > g.budgetMB {
+				log.Warnf("memgate: evicted unknown-size model %s but cannot confirm %s fits (projected=%dMB > budget=%dMB); loading anyway",
+					victim, incoming, projected, g.budgetMB)
+			}
+			return
+		}
 	}
 
 	log.Infof("memgate: %s now fits (projected=%dMB <= budget=%dMB)", incoming, projected, g.budgetMB)
@@ -198,6 +225,14 @@ func (g *memGate) pickLRUVictim(
 		switch p.State() {
 		case process.StateStopped, process.StateShutdown:
 			continue // not resident, frees no GPU memory
+		case process.StateStarting, process.StateStopping:
+			// In transition under another (parallel) swap: Starting is a model
+			// some other swap is mid-loading, Stopping is one already being
+			// torn down. Evicting either races that swap. Skipping Starting
+			// also fixes a subtler bug: a never-served model has LastUse()==0,
+			// which sorts it FIRST, so a just-launched target would otherwise
+			// be the preferred victim.
+			continue
 		}
 		candidates = append(candidates, candidate{id: id, lastUse: p.LastUse()})
 	}

--- a/internal/router/memgate.go
+++ b/internal/router/memgate.go
@@ -146,6 +146,11 @@ type memGate struct {
 	// admitted but not yet Released. They count toward every projection and
 	// their holders are never picked as eviction victims.
 	reservations map[string]int
+
+	// inFlight reports scheduler-owned per-model active request counts. Normal
+	// admission and red-line eviction skip models with in-flight requests;
+	// hard-line emergency eviction intentionally ignores it.
+	inFlight func(modelID string) int
 }
 
 // newMemGate returns a gate, or nil when it should be disabled (no budget or no
@@ -370,7 +375,7 @@ func (g *memGate) tryFit(
 	}
 
 	for projected > g.budgetMB || hostShort != "" {
-		victim, ok := g.pickLRUVictim(procs, excluded, false)
+		victim, ok := g.pickLRUVictim(procs, excluded, false, false)
 		if !ok {
 			detail := fmt.Sprintf("projected=%dMB > budget=%dMB with no evictable models", projected, g.budgetMB)
 			if hostShort != "" {
@@ -469,12 +474,14 @@ func (g *memGate) Release(modelID string) {
 
 // pickLRUVictim returns the resident (non-stopped) model with the oldest
 // LastUse() that is not excluded. When spareMRU is true the single
-// most-recently-used candidate is spared — the best available proxy for "the
-// model actively serving right now". ok is false when no candidate exists.
+// most-recently-used candidate is spared. Unless allowInFlight is true, models
+// with active scheduler-tracked requests are also excluded. ok is false when no
+// candidate exists.
 func (g *memGate) pickLRUVictim(
 	procs map[string]process.Process,
 	excluded map[string]struct{},
 	spareMRU bool,
+	allowInFlight bool,
 ) (string, bool) {
 	type candidate struct {
 		id      string
@@ -483,6 +490,9 @@ func (g *memGate) pickLRUVictim(
 	var candidates []candidate
 	for id, p := range procs {
 		if _, skip := excluded[id]; skip {
+			continue
+		}
+		if !allowInFlight && g.inFlight != nil && g.inFlight(id) > 0 {
 			continue
 		}
 		switch p.State() {

--- a/internal/router/memgate.go
+++ b/internal/router/memgate.go
@@ -1,7 +1,12 @@
 package router
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"sort"
+	"strconv"
+	"sync"
 	"time"
 
 	"github.com/mostlygeek/llama-swap/internal/config"
@@ -9,6 +14,15 @@ import (
 	"github.com/mostlygeek/llama-swap/internal/perf"
 	"github.com/mostlygeek/llama-swap/internal/process"
 )
+
+// admissionRetryInterval is how often a strict-mode admission re-checks the
+// budget while waiting (up to AdmissionMaxWait) for memory to free up.
+const admissionRetryInterval = 2 * time.Second
+
+// evictionSettleTimeout bounds how long, after stopping a victim, the gate
+// polls a fresh memory reading waiting to observe the freed memory before
+// falling back to arithmetic accounting.
+const evictionSettleTimeout = 2 * time.Second
 
 // memProbe reports current GPU-managed memory usage in MiB. It is an interface
 // so the gate can be unit-tested with a fake; the production implementation is
@@ -50,23 +64,88 @@ func (p perfMemProbe) liveUsedMB() (int, bool) {
 	return total, true
 }
 
-// memGate is an optional, fail-open admission gate that keeps total GPU memory
-// under a configured budget by evicting least-recently-used models before a
-// swap. It is a standalone control at the single launch chokepoint
-// (baseRouter.doSwap) and deliberately does NOT participate in the matrix
-// solver's eviction decisions: it only adds further evictions when live usage
-// (which includes hard-to-predict GTT + KV-cache growth) would push the next
-// load over budget.
+// MemoryBudgetError is the typed rejection a strict-mode admission returns
+// when a model load cannot fit under the configured memory budget. It
+// implements shared.HTTPError so the renderer sends a 503 with Retry-After
+// instead of a generic 500: the condition is transient (TTL unloads and
+// finished swaps free memory), so clients should back off and retry.
+type MemoryBudgetError struct {
+	Model      string
+	Detail     string
+	RetryAfter int
+}
+
+func (e *MemoryBudgetError) Error() string {
+	return fmt.Sprintf("memory budget exceeded loading %s: %s", e.Model, e.Detail)
+}
+
+func (e *MemoryBudgetError) StatusCode() int { return http.StatusServiceUnavailable }
+
+func (e *MemoryBudgetError) Header() http.Header {
+	h := http.Header{}
+	h.Set("Content-Type", "application/json")
+	retry := e.RetryAfter
+	if retry <= 0 {
+		retry = 10
+	}
+	h.Set("Retry-After", strconv.Itoa(retry))
+	return h
+}
+
+func (e *MemoryBudgetError) Body() []byte {
+	b, _ := json.Marshal(map[string]string{"error": e.Error()})
+	return b
+}
+
+// memGate is an admission gate at the single launch chokepoint
+// (baseRouter.doSwap) that keeps total GPU memory under a configured budget by
+// evicting least-recently-used models before a swap. It deliberately does NOT
+// participate in the matrix solver's eviction decisions: it only adds further
+// evictions when live usage (which includes hard-to-predict GTT + KV-cache
+// growth) would push the next load over budget.
+//
+// Admissions are SERIALIZED (one mutex) and RESERVED: every admitted load
+// holds a reservation of its configured estimate until the caller Releases it
+// after the swap completes. Without this, two concurrent doSwap goroutines
+// both compare against the same live reading and jointly overshoot — a big
+// model loads over minutes while its memory climbs, and admissions during
+// that window see only the partial footprint.
+//
+// In strict mode the gate is FAIL-CLOSED: a load that cannot fit (after LRU
+// eviction and a bounded wait) is rejected with a MemoryBudgetError (HTTP 503).
+// In non-strict mode it preserves the historical fail-open behavior: any
+// condition it cannot resolve results in a warning and the load proceeding.
 type memGate struct {
-	budgetMB int
-	probe    memProbe
+	budgetMB    int
+	strict      bool
+	hostFloorMB int
+	maxWait     time.Duration
+	redlineMB   int
+	hardlineMB  int
+
+	probe memProbe
+	// liveRead, when non-nil, performs a fresh synchronous read of GPU memory
+	// in use (never stale, unlike the polled probe). Production wires it to
+	// perf.ReadLiveGpuMemUsedMB.
+	liveRead func() (int, bool)
+	// hostAvail, when non-nil, returns the host's available RAM in MiB. On
+	// UMA systems the GPU and host share one pool, so the gate checks both.
+	hostAvail func() (int, bool)
+
 	// estimates maps model id -> configured VramEstimateMB, used to project a
-	// load's footprint before it happens. Missing/zero means "unknown" and the
-	// gate behaves reactively for that model.
+	// load's footprint before it happens. Missing/zero means "unknown": the
+	// gate behaves reactively for that model (non-strict) or rejects it
+	// (strict).
 	estimates map[string]int
 	// stopTimeout bounds each synchronous victim Stop. Stopping a process frees
-	// its GPU memory, so EnsureFits waits for it before re-checking the budget.
+	// its GPU memory, so admission waits for it before re-checking the budget.
 	stopTimeout time.Duration
+
+	mu sync.Mutex
+	// reservations maps model id -> reserved MiB for loads that have been
+	// admitted but not yet Released. They count toward every projection and
+	// their holders are never picked as eviction victims.
+	reservations map[string]int
 }
 
 // newMemGate returns a gate, or nil when it should be disabled (no budget or no
@@ -76,10 +155,12 @@ func newMemGate(budgetMB int, mon *perf.Monitor, estimates map[string]int, stopT
 		return nil
 	}
 	return &memGate{
-		budgetMB:    budgetMB,
-		probe:       perfMemProbe{mon: mon},
-		estimates:   estimates,
-		stopTimeout: stopTimeout,
+		budgetMB:     budgetMB,
+		maxWait:      30 * time.Second,
+		probe:        perfMemProbe{mon: mon},
+		estimates:    estimates,
+		stopTimeout:  stopTimeout,
+		reservations: make(map[string]int),
 	}
 }
 
@@ -104,17 +185,79 @@ func newMemGateFromConfig(conf config.Config, mon *perf.Monitor) *memGate {
 		stopTimeout = 30 * time.Second
 	}
 
-	return newMemGate(budget, mon, estimates, stopTimeout)
+	g := newMemGate(budget, mon, estimates, stopTimeout)
+	g.strict = conf.Performance.GpuStrictAdmission
+	g.hostFloorMB = conf.Performance.HostMemFloorMB
+	if conf.Performance.AdmissionMaxWait > 0 {
+		g.maxWait = conf.Performance.AdmissionMaxWait
+	}
+	g.redlineMB = conf.Performance.GpuRedlineMB
+	g.hardlineMB = conf.Performance.GpuHardlineMB
+	g.liveRead = perf.ReadLiveGpuMemUsedMB
+	g.hostAvail = perf.ReadHostMemAvailableMB
+	return g
 }
 
-// EnsureFits evicts least-recently-used resident models, synchronously, until
-// the projected footprint (current live usage + the incoming model's estimate)
-// fits under the budget, or there is nothing left to evict.
+// usedMB returns the freshest available GPU memory reading: a direct
+// synchronous read when the platform supports it, otherwise the monitor's
+// last polled sample.
+func (g *memGate) usedMB() (int, bool) {
+	if g.liveRead != nil {
+		if used, ok := g.liveRead(); ok {
+			return used, true
+		}
+	}
+	if g.probe != nil {
+		return g.probe.liveUsedMB()
+	}
+	return 0, false
+}
+
+// reservedMB sums all reservations except the named model's own.
+func (g *memGate) reservedMB(excluding string) int {
+	total := 0
+	for id, mb := range g.reservations {
+		if id == excluding {
+			continue
+		}
+		total += mb
+	}
+	return total
+}
+
+// hostShortfall returns a non-empty description when loading `estimate` MiB
+// would drop host available RAM below the configured floor. It returns "" when
+// the check is disabled, unreadable, or passing.
+func (g *memGate) hostShortfall(estimate int) string {
+	if g.hostFloorMB <= 0 || g.hostAvail == nil {
+		return ""
+	}
+	avail, ok := g.hostAvail()
+	if !ok {
+		return ""
+	}
+	if avail-estimate < g.hostFloorMB {
+		return fmt.Sprintf("host MemAvailable %dMB - est %dMB < floor %dMB", avail, estimate, g.hostFloorMB)
+	}
+	return ""
+}
+
+// EnsureFits admits, or in strict mode rejects, the load of `incoming`. It
+// serializes all admissions, projects `fresh live usage + in-flight
+// reservations + incoming's estimate` against the budget (and host floor),
+// evicts least-recently-used resident models synchronously to make room, and
+// on success records a reservation the caller MUST Release once the swap
+// completes (success or failure).
 //
-// It is FAIL-OPEN by design: any condition it cannot resolve (no probe reading
-// yet, no eligible victim, budget still exceeded after evicting everything it
-// may) results in a warning and a return that lets the load proceed. Starving a
-// load is worse than briefly overshooting a soft budget.
+// Strict mode: when the load still cannot fit, waits up to maxWait
+// (re-checking every admissionRetryInterval with the lock released) for
+// memory to free — a TTL unload, another swap finishing — then returns a
+// *MemoryBudgetError (rendered as HTTP 503 + Retry-After). Models without an
+// estimate are rejected immediately: the gate cannot reason about them.
+//
+// Non-strict mode: preserves the historical FAIL-OPEN behavior. Any condition
+// it cannot resolve (no reading, no victims, unknown-size victim) results in a
+// warning and a nil return that lets the load proceed.
 //
 // incoming is the model about to be loaded (never evicted). alreadyEvicting are
 // models the caller is already stopping for this swap (the solver's decision);
@@ -124,94 +267,214 @@ func (g *memGate) EnsureFits(
 	procs map[string]process.Process,
 	alreadyEvicting []string,
 	log *logmon.Monitor,
-) {
+) error {
 	if g == nil || g.budgetMB <= 0 {
-		return
-	}
-
-	used, ok := g.probe.liveUsedMB()
-	if !ok {
-		// No reading available; fail open rather than blindly evicting.
-		log.Debugf("memgate: no GPU reading available, skipping budget check for %s", incoming)
-		return
+		return nil
 	}
 
 	estimate := g.estimateMB(incoming)
-	projected := used + estimate
-	if projected <= g.budgetMB {
-		log.Debugf("memgate: %s fits (used=%dMB + est=%dMB = %dMB <= budget=%dMB)",
-			incoming, used, estimate, projected, g.budgetMB)
-		return
+	if g.strict && estimate <= 0 {
+		return &MemoryBudgetError{
+			Model:  incoming,
+			Detail: "model has no vramEstimateMB configured; strict admission cannot project its footprint",
+			// Not transient: config must change. Still 503 so clients treat
+			// it as a load failure, but a long Retry-After discourages tight
+			// retry loops.
+			RetryAfter: 300,
+		}
 	}
 
-	log.Infof("memgate: %s over budget (used=%dMB + est=%dMB = %dMB > budget=%dMB), evicting LRU models",
-		incoming, used, estimate, projected, g.budgetMB)
+	g.mu.Lock()
+	defer g.mu.Unlock()
 
-	excluded := make(map[string]struct{}, len(alreadyEvicting)+1)
+	if g.reservations == nil {
+		g.reservations = make(map[string]int)
+	}
+
+	deadline := time.Now().Add(g.maxWait)
+	for {
+		fits, detail := g.tryFit(incoming, estimate, procs, alreadyEvicting, log)
+		if fits {
+			if estimate > 0 {
+				g.reservations[incoming] = estimate
+			}
+			return nil
+		}
+		if !g.strict {
+			// tryFit already logged the specifics; fail open.
+			return nil
+		}
+		if time.Now().After(deadline) {
+			log.Warnf("memgate: rejecting %s after %s: %s", incoming, g.maxWait, detail)
+			return &MemoryBudgetError{Model: incoming, Detail: detail, RetryAfter: 10}
+		}
+		log.Infof("memgate: %s does not fit yet (%s); waiting up to %s for memory to free",
+			incoming, detail, time.Until(deadline).Round(time.Second))
+
+		// Wait with the lock RELEASED so releases (finished swaps) and other
+		// admissions that do fit are not blocked behind this one.
+		g.mu.Unlock()
+		time.Sleep(admissionRetryInterval)
+		g.mu.Lock()
+	}
+}
+
+// tryFit performs one admission attempt under g.mu: project, evict LRU models
+// as needed, and report whether the load fits. On a false return, detail
+// explains what blocked it. In non-strict mode unresolvable conditions are
+// treated as fitting (fail-open), matching the historical behavior.
+func (g *memGate) tryFit(
+	incoming string,
+	estimate int,
+	procs map[string]process.Process,
+	alreadyEvicting []string,
+	log *logmon.Monitor,
+) (bool, string) {
+	used, ok := g.usedMB()
+	if !ok {
+		if !g.strict {
+			// No reading available; fail open rather than blindly evicting.
+			log.Debugf("memgate: no GPU reading available, skipping budget check for %s", incoming)
+			return true, ""
+		}
+		return false, "no GPU memory reading available"
+	}
+
+	reserved := g.reservedMB(incoming)
+	projected := used + reserved + estimate
+	hostShort := g.hostShortfall(estimate)
+	if projected <= g.budgetMB && hostShort == "" {
+		log.Debugf("memgate: %s fits (used=%dMB + reserved=%dMB + est=%dMB = %dMB <= budget=%dMB)",
+			incoming, used, reserved, estimate, projected, g.budgetMB)
+		return true, ""
+	}
+
+	if hostShort != "" {
+		log.Infof("memgate: %s blocked by host floor (%s), evicting LRU models", incoming, hostShort)
+	} else {
+		log.Infof("memgate: %s over budget (used=%dMB + reserved=%dMB + est=%dMB = %dMB > budget=%dMB), evicting LRU models",
+			incoming, used, reserved, estimate, projected, g.budgetMB)
+	}
+
+	excluded := make(map[string]struct{}, len(alreadyEvicting)+len(g.reservations)+1)
 	excluded[incoming] = struct{}{}
 	for _, id := range alreadyEvicting {
 		excluded[id] = struct{}{}
 	}
+	// Reservation holders are mid-load under another admission; evicting them
+	// races that swap. A just-admitted model that has not started yet is also
+	// still StateStopped with LastUse()==0, which would otherwise make it the
+	// PREFERRED victim.
+	for id := range g.reservations {
+		excluded[id] = struct{}{}
+	}
 
-	for projected > g.budgetMB {
-		victim, ok := g.pickLRUVictim(procs, excluded)
+	for projected > g.budgetMB || hostShort != "" {
+		victim, ok := g.pickLRUVictim(procs, excluded, false)
 		if !ok {
-			// Nothing left to evict: fail open.
-			log.Warnf("memgate: %s still over budget (projected=%dMB > budget=%dMB) but no evictable models remain; loading anyway",
-				incoming, projected, g.budgetMB)
-			return
+			detail := fmt.Sprintf("projected=%dMB > budget=%dMB with no evictable models", projected, g.budgetMB)
+			if hostShort != "" {
+				detail = hostShort + " with no evictable models"
+			}
+			if !g.strict {
+				log.Warnf("memgate: %s still over budget (%s); loading anyway", incoming, detail)
+			}
+			return false, detail
 		}
 
 		victimEst := g.estimateMB(victim)
 
-		log.Infof("memgate: evicting LRU model %s to free GPU memory for %s", victim, incoming)
+		log.Infof("memgate: evicting LRU model %s to free memory for %s", victim, incoming)
 		if err := procs[victim].Stop(g.stopTimeout); err != nil {
 			log.Warnf("memgate: stopping %s failed: %v", victim, err)
 		}
 		excluded[victim] = struct{}{}
 
-		// Account for the freed memory ARITHMETICALLY. A fresh live re-read is
-		// not trustworthy here: the perf monitor polls on a >=5s interval, so
-		// immediately after Stop the probe almost always still reports the
-		// pre-eviction value. Trusting that stale reading would keep `projected`
-		// over budget and evict the entire resident set. Instead, subtract the
-		// victim's estimated footprint and only believe a live reading when it
-		// reports LESS than the arithmetic projection (i.e. it has actually
-		// observed the freeing, or other memory was released too).
-		used -= victimEst
-		if used < 0 {
-			used = 0
-		}
-		liveProgressed := false
-		if reUsed, ok := g.probe.liveUsedMB(); ok && reUsed < used {
-			used = reUsed
-			liveProgressed = true
-		}
-		projected = used + estimate
-
-		// Unknown-size victim (no estimate) where the live re-read also showed
-		// no drop below the arithmetic projection: we made no measurable
-		// progress and the >=5s-stale probe can't be trusted. Continuing would
-		// evict the entire resident set on a single unknown model. Bound to this
-		// one eviction and fail open. If the live reading DID drop (real freeing
-		// observed), keep looping normally.
-		if victimEst <= 0 && !liveProgressed {
+		used, ok = g.settleAfterEviction(used, victimEst)
+		if !ok && victimEst <= 0 {
+			// Unknown-size victim and no way to observe the freeing: we made
+			// no measurable progress. Continuing would evict the entire
+			// resident set on a single unknown model. Bound to this one
+			// eviction.
+			projected = used + g.reservedMB(incoming) + estimate
 			if projected > g.budgetMB {
-				log.Warnf("memgate: evicted unknown-size model %s but cannot confirm %s fits (projected=%dMB > budget=%dMB); loading anyway",
-					victim, incoming, projected, g.budgetMB)
+				detail := fmt.Sprintf("evicted unknown-size model %s but cannot confirm fit (projected=%dMB > budget=%dMB)",
+					victim, projected, g.budgetMB)
+				if !g.strict {
+					log.Warnf("memgate: %s: %s; loading anyway", incoming, detail)
+				}
+				return false, detail
 			}
-			return
+			return true, ""
 		}
+
+		projected = used + g.reservedMB(incoming) + estimate
+		hostShort = g.hostShortfall(estimate)
 	}
 
 	log.Infof("memgate: %s now fits (projected=%dMB <= budget=%dMB)", incoming, projected, g.budgetMB)
+	return true, ""
+}
+
+// settleAfterEviction returns the best post-eviction usage figure. With a
+// fresh reader available it polls (bounded by evictionSettleTimeout) until the
+// reading drops below the pre-eviction value, i.e. the freeing was actually
+// observed. Without one it falls back to arithmetic: the polled probe refreshes
+// on a >=5s interval, so immediately after Stop it almost always still reports
+// the pre-eviction value; trusting that stale reading would keep the projection
+// over budget and evict the entire resident set. observed reports whether a
+// real (non-arithmetic) drop was seen.
+func (g *memGate) settleAfterEviction(preStopUsed, victimEst int) (used int, observed bool) {
+	if g.liveRead != nil {
+		deadline := time.Now().Add(evictionSettleTimeout)
+		for {
+			if fresh, ok := g.liveRead(); ok && fresh < preStopUsed {
+				return fresh, true
+			}
+			if time.Now().After(deadline) {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	// Arithmetic fallback: subtract the victim's estimated footprint and only
+	// believe a probe reading when it reports LESS than the arithmetic
+	// projection (i.e. it has actually observed the freeing, or other memory
+	// was released too).
+	used = preStopUsed - victimEst
+	if used < 0 {
+		used = 0
+	}
+	if g.probe != nil {
+		if reUsed, ok := g.probe.liveUsedMB(); ok && reUsed < used {
+			return reUsed, true
+		}
+	}
+	return used, false
+}
+
+// Release drops the reservation recorded by a successful EnsureFits. Callers
+// must invoke it once the swap completes (whether the load succeeded or
+// failed): from that point the model's real footprint is visible to fresh
+// reads, or gone.
+func (g *memGate) Release(modelID string) {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	delete(g.reservations, modelID)
+	g.mu.Unlock()
 }
 
 // pickLRUVictim returns the resident (non-stopped) model with the oldest
-// LastUse() that is not excluded. ok is false when no candidate exists.
+// LastUse() that is not excluded. When spareMRU is true the single
+// most-recently-used candidate is spared — the best available proxy for "the
+// model actively serving right now". ok is false when no candidate exists.
 func (g *memGate) pickLRUVictim(
 	procs map[string]process.Process,
 	excluded map[string]struct{},
+	spareMRU bool,
 ) (string, bool) {
 	type candidate struct {
 		id      string
@@ -237,6 +500,9 @@ func (g *memGate) pickLRUVictim(
 		candidates = append(candidates, candidate{id: id, lastUse: p.LastUse()})
 	}
 	if len(candidates) == 0 {
+		return "", false
+	}
+	if spareMRU && len(candidates) == 1 {
 		return "", false
 	}
 	// Oldest LastUse first; tie-break on id for deterministic behaviour.

--- a/internal/router/memgate.go
+++ b/internal/router/memgate.go
@@ -1,0 +1,222 @@
+package router
+
+import (
+	"sort"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/perf"
+	"github.com/mostlygeek/llama-swap/internal/process"
+)
+
+// memProbe reports current GPU-managed memory usage in MiB. It is an interface
+// so the gate can be unit-tested with a fake; the production implementation is
+// perfMemProbe, backed by perf.Monitor.
+type memProbe interface {
+	// liveUsedMB returns the most recent total GPU memory in use across all
+	// GPUs (VRAM + GTT, per the sysfs backend), or (0, false) when no reading
+	// is available yet.
+	liveUsedMB() (int, bool)
+}
+
+// perfMemProbe adapts a perf.Monitor to memProbe. After the sysfs/GTT patch,
+// GpuStat.MemUsedMB already includes GTT (where APU/iGPU models and their KV
+// cache actually live), which is exactly what we want to budget against.
+type perfMemProbe struct {
+	mon *perf.Monitor
+}
+
+func (p perfMemProbe) liveUsedMB() (int, bool) {
+	_, gpuStats := p.mon.Current()
+	if len(gpuStats) == 0 {
+		return 0, false
+	}
+
+	// Current() returns a flat slice spanning several poll timestamps for each
+	// GPU. Collapse to the latest sample per GPU id, then sum across GPUs so a
+	// multi-GPU box budgets against its whole pool.
+	latest := make(map[int]perf.GpuStat)
+	for _, g := range gpuStats {
+		if prev, ok := latest[g.ID]; !ok || g.Timestamp.After(prev.Timestamp) {
+			latest[g.ID] = g
+		}
+	}
+
+	total := 0
+	for _, g := range latest {
+		total += g.MemUsedMB
+	}
+	return total, true
+}
+
+// memGate is an optional, fail-open admission gate that keeps total GPU memory
+// under a configured budget by evicting least-recently-used models before a
+// swap. It is a standalone control at the single launch chokepoint
+// (baseRouter.doSwap) and deliberately does NOT participate in the matrix
+// solver's eviction decisions: it only adds further evictions when live usage
+// (which includes hard-to-predict GTT + KV-cache growth) would push the next
+// load over budget.
+type memGate struct {
+	budgetMB int
+	probe    memProbe
+	// estimates maps model id -> configured VramEstimateMB, used to project a
+	// load's footprint before it happens. Missing/zero means "unknown" and the
+	// gate behaves reactively for that model.
+	estimates map[string]int
+	// stopTimeout bounds each synchronous victim Stop. Stopping a process frees
+	// its GPU memory, so EnsureFits waits for it before re-checking the budget.
+	stopTimeout time.Duration
+}
+
+// newMemGate returns a gate, or nil when it should be disabled (no budget or no
+// probe). A nil *memGate is safe: callers guard with `if b.memGate != nil`.
+func newMemGate(budgetMB int, mon *perf.Monitor, estimates map[string]int, stopTimeout time.Duration) *memGate {
+	if budgetMB <= 0 || mon == nil {
+		return nil
+	}
+	return &memGate{
+		budgetMB:    budgetMB,
+		probe:       perfMemProbe{mon: mon},
+		estimates:   estimates,
+		stopTimeout: stopTimeout,
+	}
+}
+
+// newMemGateFromConfig builds the gate for a router from the parsed config and
+// the (possibly nil) perf monitor. It returns nil when the budget is unset or
+// no monitor is available, leaving the gate disabled.
+func newMemGateFromConfig(conf config.Config, mon *perf.Monitor) *memGate {
+	budget := conf.Performance.GpuBudgetMB
+	if budget <= 0 || mon == nil {
+		return nil
+	}
+
+	estimates := make(map[string]int, len(conf.Models))
+	for id, mc := range conf.Models {
+		if mc.VramEstimateMB > 0 {
+			estimates[id] = mc.VramEstimateMB
+		}
+	}
+
+	stopTimeout := time.Duration(conf.HealthCheckTimeout) * time.Second
+	if stopTimeout <= 0 {
+		stopTimeout = 30 * time.Second
+	}
+
+	return newMemGate(budget, mon, estimates, stopTimeout)
+}
+
+// EnsureFits evicts least-recently-used resident models, synchronously, until
+// the projected footprint (current live usage + the incoming model's estimate)
+// fits under the budget, or there is nothing left to evict.
+//
+// It is FAIL-OPEN by design: any condition it cannot resolve (no probe reading
+// yet, no eligible victim, budget still exceeded after evicting everything it
+// may) results in a warning and a return that lets the load proceed. Starving a
+// load is worse than briefly overshooting a soft budget.
+//
+// incoming is the model about to be loaded (never evicted). alreadyEvicting are
+// models the caller is already stopping for this swap (the solver's decision);
+// they are excluded from victim selection and assumed already freed.
+func (g *memGate) EnsureFits(
+	incoming string,
+	procs map[string]process.Process,
+	alreadyEvicting []string,
+	log *logmon.Monitor,
+) {
+	if g == nil || g.budgetMB <= 0 {
+		return
+	}
+
+	used, ok := g.probe.liveUsedMB()
+	if !ok {
+		// No reading available; fail open rather than blindly evicting.
+		log.Debugf("memgate: no GPU reading available, skipping budget check for %s", incoming)
+		return
+	}
+
+	estimate := g.estimateMB(incoming)
+	projected := used + estimate
+	if projected <= g.budgetMB {
+		log.Debugf("memgate: %s fits (used=%dMB + est=%dMB = %dMB <= budget=%dMB)",
+			incoming, used, estimate, projected, g.budgetMB)
+		return
+	}
+
+	log.Infof("memgate: %s over budget (used=%dMB + est=%dMB = %dMB > budget=%dMB), evicting LRU models",
+		incoming, used, estimate, projected, g.budgetMB)
+
+	excluded := make(map[string]struct{}, len(alreadyEvicting)+1)
+	excluded[incoming] = struct{}{}
+	for _, id := range alreadyEvicting {
+		excluded[id] = struct{}{}
+	}
+
+	for projected > g.budgetMB {
+		victim, ok := g.pickLRUVictim(procs, excluded)
+		if !ok {
+			// Nothing left to evict: fail open.
+			log.Warnf("memgate: %s still over budget (projected=%dMB > budget=%dMB) but no evictable models remain; loading anyway",
+				incoming, projected, g.budgetMB)
+			return
+		}
+
+		log.Infof("memgate: evicting LRU model %s to free GPU memory for %s", victim, incoming)
+		if err := procs[victim].Stop(g.stopTimeout); err != nil {
+			log.Warnf("memgate: stopping %s failed: %v", victim, err)
+		}
+		excluded[victim] = struct{}{}
+
+		// Re-read live usage: the Stop above has freed the victim's GPU memory,
+		// so the next decision is based on the real post-eviction footprint
+		// rather than arithmetic guesswork.
+		if reUsed, ok := g.probe.liveUsedMB(); ok {
+			used = reUsed
+		}
+		projected = used + estimate
+	}
+
+	log.Infof("memgate: %s now fits (projected=%dMB <= budget=%dMB)", incoming, projected, g.budgetMB)
+}
+
+// pickLRUVictim returns the resident (non-stopped) model with the oldest
+// LastUse() that is not excluded. ok is false when no candidate exists.
+func (g *memGate) pickLRUVictim(
+	procs map[string]process.Process,
+	excluded map[string]struct{},
+) (string, bool) {
+	type candidate struct {
+		id      string
+		lastUse int64
+	}
+	var candidates []candidate
+	for id, p := range procs {
+		if _, skip := excluded[id]; skip {
+			continue
+		}
+		switch p.State() {
+		case process.StateStopped, process.StateShutdown:
+			continue // not resident, frees no GPU memory
+		}
+		candidates = append(candidates, candidate{id: id, lastUse: p.LastUse()})
+	}
+	if len(candidates) == 0 {
+		return "", false
+	}
+	// Oldest LastUse first; tie-break on id for deterministic behaviour.
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].lastUse != candidates[j].lastUse {
+			return candidates[i].lastUse < candidates[j].lastUse
+		}
+		return candidates[i].id < candidates[j].id
+	})
+	return candidates[0].id, true
+}
+
+// estimateMB returns the incoming model's configured VRAM estimate in MiB, or 0
+// when unknown. A 0 estimate makes the gate reactive: it evicts only once live
+// usage already exceeds the budget, never pre-emptively.
+func (g *memGate) estimateMB(incoming string) int {
+	return g.estimates[incoming]
+}

--- a/internal/router/memgate_strict_test.go
+++ b/internal/router/memgate_strict_test.go
@@ -1,0 +1,209 @@
+package router
+
+import (
+	"errors"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/process"
+	"github.com/mostlygeek/llama-swap/internal/shared"
+)
+
+// strictTestGate returns a strict-mode gate with a zero maxWait so rejection
+// tests do not sit in the bounded-wait loop.
+func strictTestGate(budgetMB int, probe memProbe, estimates map[string]int) *memGate {
+	g := newTestGate(budgetMB, probe, estimates)
+	g.strict = true
+	g.maxWait = 0
+	return g
+}
+
+func TestMemGate_Strict_RejectsModelWithoutEstimate(t *testing.T) {
+	g := strictTestGate(1000, staticProbe(0, true), nil)
+
+	err := g.EnsureFits("mystery", map[string]process.Process{}, nil, gateLog())
+
+	var mbe *MemoryBudgetError
+	if !errors.As(err, &mbe) {
+		t.Fatalf("expected MemoryBudgetError, got %v", err)
+	}
+	if mbe.StatusCode() != 503 {
+		t.Fatalf("expected 503, got %d", mbe.StatusCode())
+	}
+}
+
+func TestMemGate_Strict_RejectsWhenNoReading(t *testing.T) {
+	g := strictTestGate(1000, staticProbe(0, false), map[string]int{"b": 100})
+
+	err := g.EnsureFits("b", map[string]process.Process{}, nil, gateLog())
+
+	if err == nil {
+		t.Fatal("strict mode must reject when no memory reading is available")
+	}
+}
+
+func TestMemGate_Strict_RejectsOverBudgetWithNoVictims(t *testing.T) {
+	// used 900 + estimate 500 > budget 1000 and nothing to evict.
+	g := strictTestGate(1000, staticProbe(900, true), map[string]int{"b": 500})
+
+	err := g.EnsureFits("b", map[string]process.Process{}, nil, gateLog())
+
+	var mbe *MemoryBudgetError
+	if !errors.As(err, &mbe) {
+		t.Fatalf("expected MemoryBudgetError, got %v", err)
+	}
+	if got := mbe.Header().Get("Retry-After"); got == "" {
+		t.Fatal("expected Retry-After header on budget rejection")
+	}
+}
+
+func TestMemGate_Strict_AdmitsAfterEviction(t *testing.T) {
+	perModel := map[string]int{"a": 600}
+	a := readyProc("a", 100)
+	procs := map[string]process.Process{"a": a}
+
+	g := strictTestGate(1000, nil, map[string]int{"b": 500})
+	g.probe = residentProbe(procs, perModel)
+
+	if err := g.EnsureFits("b", procs, nil, gateLog()); err != nil {
+		t.Fatalf("expected admission after evicting a, got %v", err)
+	}
+	if a.stopCalls.Load() == 0 {
+		t.Fatal("expected a to be evicted")
+	}
+	if g.reservations["b"] != 500 {
+		t.Fatalf("expected reservation of 500 for b, got %d", g.reservations["b"])
+	}
+}
+
+func TestMemGate_Reservations_BlockJointOvershoot(t *testing.T) {
+	// Live usage stays at 1000 (m1's load has not materialized yet), budget
+	// 10000. m1 (est 6000) admits and reserves. m2 (est 6000) must then be
+	// rejected: 1000 + 6000 reserved + 6000 = 13000 > 10000. This is the
+	// 2026-07-01 co-load scenario.
+	g := strictTestGate(10000, staticProbe(1000, true), map[string]int{"m1": 6000, "m2": 6000})
+
+	if err := g.EnsureFits("m1", map[string]process.Process{}, nil, gateLog()); err != nil {
+		t.Fatalf("m1 should fit: %v", err)
+	}
+	if err := g.EnsureFits("m2", map[string]process.Process{}, nil, gateLog()); err == nil {
+		t.Fatal("m2 must be rejected while m1's reservation is held")
+	}
+
+	g.Release("m1")
+	if err := g.EnsureFits("m2", map[string]process.Process{}, nil, gateLog()); err != nil {
+		t.Fatalf("m2 should fit after m1's release: %v", err)
+	}
+}
+
+func TestMemGate_Reservations_HolderNeverEvicted(t *testing.T) {
+	// m1 holds a reservation and is resident with the OLDEST LastUse; the
+	// victim must still be m2.
+	perModel := map[string]int{"m1": 400, "m2": 400}
+	m1 := readyProc("m1", 100)
+	m2 := readyProc("m2", 200)
+	procs := map[string]process.Process{"m1": m1, "m2": m2}
+
+	g := strictTestGate(1000, nil, map[string]int{"m3": 500})
+	g.probe = residentProbe(procs, perModel)
+	g.reservations = map[string]int{"m1": 400}
+
+	// live 800 + reserved(m1, but m1 is also resident: reservation double
+	// counts here, which is conservative) + est 500 is over budget either
+	// way; what matters is WHO gets evicted.
+	_ = g.EnsureFits("m3", procs, nil, gateLog())
+
+	if m1.stopCalls.Load() != 0 {
+		t.Fatal("reservation holder m1 must never be picked as victim")
+	}
+	if m2.stopCalls.Load() == 0 {
+		t.Fatal("expected m2 to be evicted")
+	}
+}
+
+func TestMemGate_HostFloor_BlocksAdmission(t *testing.T) {
+	// GPU budget fits comfortably, but the host floor does not:
+	// avail 2000 - est 1000 = 1000 < floor 1500.
+	g := strictTestGate(10000, staticProbe(100, true), map[string]int{"b": 1000})
+	g.hostFloorMB = 1500
+	g.hostAvail = func() (int, bool) { return 2000, true }
+
+	err := g.EnsureFits("b", map[string]process.Process{}, nil, gateLog())
+
+	if err == nil {
+		t.Fatal("expected rejection on host floor breach")
+	}
+}
+
+func TestMemGate_HostFloor_PassesWithHeadroom(t *testing.T) {
+	g := strictTestGate(10000, staticProbe(100, true), map[string]int{"b": 1000})
+	g.hostFloorMB = 1500
+	g.hostAvail = func() (int, bool) { return 5000, true }
+
+	if err := g.EnsureFits("b", map[string]process.Process{}, nil, gateLog()); err != nil {
+		t.Fatalf("expected admission with host headroom, got %v", err)
+	}
+}
+
+func TestMemGate_Strict_WaitsForRelease(t *testing.T) {
+	// m2 does not fit while m1's reservation is held, but fits once it is
+	// released. With a generous maxWait the admission must block, observe the
+	// release, and succeed rather than reject.
+	g := strictTestGate(10000, staticProbe(1000, true), map[string]int{"m1": 6000, "m2": 6000})
+	g.maxWait = 10 * time.Second
+
+	if err := g.EnsureFits("m1", map[string]process.Process{}, nil, gateLog()); err != nil {
+		t.Fatalf("m1 should fit: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- g.EnsureFits("m2", map[string]process.Process{}, nil, gateLog())
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	g.Release("m1")
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("m2 should be admitted after m1's release, got %v", err)
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("m2 admission did not complete after release")
+	}
+}
+
+func TestMemGate_NonStrict_StillFailsOpen(t *testing.T) {
+	// The historical contract: non-strict gates never return an error, even
+	// when hopelessly over budget with nothing to evict.
+	g := newTestGate(1000, staticProbe(5000, true), map[string]int{"b": 500})
+
+	if err := g.EnsureFits("b", map[string]process.Process{}, nil, gateLog()); err != nil {
+		t.Fatalf("non-strict gate must fail open, got %v", err)
+	}
+}
+
+func TestMemGate_ReleaseNilSafe(t *testing.T) {
+	var g *memGate
+	g.Release("x") // must not panic
+
+	g2 := newTestGate(100, staticProbe(0, true), nil)
+	g2.Release("never-reserved") // nil map delete must not panic
+}
+
+func TestMemoryBudgetError_RendersAs503(t *testing.T) {
+	err := &MemoryBudgetError{Model: "big", Detail: "over budget", RetryAfter: 7}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	shared.SendError(rec, req, err)
+
+	if rec.Code != 503 {
+		t.Fatalf("expected 503, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Retry-After"); got != "7" {
+		t.Fatalf("expected Retry-After 7, got %q", got)
+	}
+}

--- a/internal/router/memgate_test.go
+++ b/internal/router/memgate_test.go
@@ -214,6 +214,114 @@ func TestMemGate_FailOpen_WhenNothingLeftToEvict(t *testing.T) {
 	}
 }
 
+func TestMemGate_OverEviction_ConstantProbeDoesNotEvictEverything(t *testing.T) {
+	// H1 regression: the perf monitor polls on a >=5s interval, so immediately
+	// after a victim Stop the probe still reports the PRE-eviction value. A gate
+	// that re-reads and trusts that stale number would keep `projected` over
+	// budget and evict the ENTIRE resident set. constProbe models exactly that
+	// (usage never drops). With arithmetic decrement, evicting the single oldest
+	// 5000 MiB model must be enough; b and c must remain resident.
+	perModel := map[string]int{"a": 5000, "b": 5000, "c": 5000}
+	a := readyProc("a", 100)
+	b := readyProc("b", 200)
+	c := readyProc("c", 300)
+	procs := map[string]process.Process{"a": a, "b": b, "c": c}
+
+	// live=15000 (constant, never drops), estimate(d)=0, budget=11000 => one
+	// 5000 model must be dropped (15000-5000=10000 <= 11000). A stale-trusting
+	// loop would never see the drop and evict all three.
+	g := newTestGate(11000, staticProbe(15000, true), map[string]int{
+		"a": 5000, "b": 5000, "c": 5000,
+	})
+
+	g.EnsureFits("d", procs, nil, gateLog())
+
+	if a.stopCalls.Load() != 1 {
+		t.Fatalf("oldest model a must be evicted; a stops=%d", a.stopCalls.Load())
+	}
+	if b.stopCalls.Load() != 0 || c.stopCalls.Load() != 0 {
+		t.Fatalf("only the necessary victim should be evicted, not the whole resident set; b=%d c=%d",
+			b.stopCalls.Load(), c.stopCalls.Load())
+	}
+	_ = perModel
+}
+
+func TestMemGate_OverEviction_UnknownSizeVictimBoundsToOneEviction(t *testing.T) {
+	// H1 fail-open: a victim with an unknown (0) estimate frees an unknown
+	// amount, so arithmetic makes no progress and the stale live re-read can't
+	// be trusted. The gate must evict exactly one such victim and then stop,
+	// never looping to evict everything.
+	a := readyProc("a", 100)
+	b := readyProc("b", 200)
+	c := readyProc("c", 300)
+	procs := map[string]process.Process{"a": a, "b": b, "c": c}
+
+	// No estimates at all (all unknown), constant probe well over budget.
+	g := newTestGate(1000, staticProbe(15000, true), nil)
+
+	g.EnsureFits("d", procs, nil, gateLog())
+
+	totalStops := int(a.stopCalls.Load() + b.stopCalls.Load() + c.stopCalls.Load())
+	if totalStops != 1 {
+		t.Fatalf("unknown-size victim must bound eviction to exactly one (fail-open); got %d stops", totalStops)
+	}
+	// It must be the oldest (a).
+	if a.stopCalls.Load() != 1 {
+		t.Fatalf("oldest unknown-size model a should be the single eviction; a stops=%d", a.stopCalls.Load())
+	}
+}
+
+func TestMemGate_SkipsStartingVictim(t *testing.T) {
+	// H2 regression: a model another parallel swap is mid-loading is in
+	// StateStarting. It must never be chosen as a victim. Crucially, a
+	// never-served Starting model has LastUse()==0, which sorts FIRST, so it
+	// would otherwise be the preferred victim.
+	perModel := map[string]int{"starting": 5000, "old": 5000}
+	starting := readyProc("starting", 0) // never served => LastUse 0, sorts first
+	starting.setState(process.StateStarting)
+	old := readyProc("old", 100)
+	procs := map[string]process.Process{"starting": starting, "old": old}
+
+	// live=10000, estimate(d)=0, budget=6000 => must drop one 5000 model. The
+	// only eligible victim is "old"; "starting" must be skipped despite sorting
+	// first by LastUse.
+	g := newTestGate(6000, nil, nil)
+	g.probe = residentProbe(procs, perModel)
+
+	g.EnsureFits("d", procs, nil, gateLog())
+
+	if starting.stopCalls.Load() != 0 {
+		t.Fatalf("a StateStarting model (another swap's incoming target) must never be evicted; stops=%d",
+			starting.stopCalls.Load())
+	}
+	if old.stopCalls.Load() != 1 {
+		t.Fatalf("the resident, non-transitioning model should be evicted; old stops=%d", old.stopCalls.Load())
+	}
+}
+
+func TestMemGate_SkipsStoppingVictim(t *testing.T) {
+	// H2: a model already being torn down by another swap is in StateStopping.
+	// Re-evicting it races that swap and frees nothing new, so it must be
+	// skipped.
+	perModel := map[string]int{"stopping": 5000, "old": 5000}
+	stopping := readyProc("stopping", 50)
+	stopping.setState(process.StateStopping)
+	old := readyProc("old", 100)
+	procs := map[string]process.Process{"stopping": stopping, "old": old}
+
+	g := newTestGate(6000, nil, nil)
+	g.probe = residentProbe(procs, perModel)
+
+	g.EnsureFits("d", procs, nil, gateLog())
+
+	if stopping.stopCalls.Load() != 0 {
+		t.Fatalf("a StateStopping model must not be re-evicted; stops=%d", stopping.stopCalls.Load())
+	}
+	if old.stopCalls.Load() != 1 {
+		t.Fatalf("the resident model should be evicted; old stops=%d", old.stopCalls.Load())
+	}
+}
+
 func TestMemGate_DoesNotEvictIncomingOrStopped(t *testing.T) {
 	// "incoming" is resident (e.g. a warm restart) and must never be chosen as
 	// a victim. A stopped model must also be skipped. Only "old" is evictable.

--- a/internal/router/memgate_test.go
+++ b/internal/router/memgate_test.go
@@ -1,0 +1,241 @@
+package router
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/process"
+)
+
+// fakeProbe is a memProbe whose reading is computed on each call, so a test can
+// model GPU memory shrinking as victims are stopped.
+type fakeProbe struct {
+	read func() (int, bool)
+}
+
+func (p fakeProbe) liveUsedMB() (int, bool) { return p.read() }
+
+// staticProbe always reports the same usage.
+func staticProbe(usedMB int, ok bool) fakeProbe {
+	return fakeProbe{read: func() (int, bool) { return usedMB, ok }}
+}
+
+// residentProbe reports per-model MiB summed over models that are still
+// resident (not stopped/shutdown). This lets EnsureFits's post-Stop re-read see
+// freed memory, exercising the real eviction loop.
+func residentProbe(procs map[string]process.Process, perModelMB map[string]int) fakeProbe {
+	return fakeProbe{read: func() (int, bool) {
+		total := 0
+		for id, p := range procs {
+			switch p.State() {
+			case process.StateStopped, process.StateShutdown:
+				continue
+			}
+			total += perModelMB[id]
+		}
+		return total, true
+	}}
+}
+
+// gateLog returns a discard logger for memgate tests (the package-level
+// testLogger writes to stdout; the gate's debug/info lines would be noisy).
+func gateLog() *logmon.Monitor { return logmon.NewWriter(io.Discard) }
+
+// readyProc returns a fakeProcess in the ready (resident) state with a given
+// LRU timestamp.
+func readyProc(id string, lastUseNano int64) *fakeProcess {
+	p := newFakeProcess(id)
+	p.setState(process.StateReady)
+	p.lastUse.Store(lastUseNano)
+	return p
+}
+
+func newTestGate(budgetMB int, probe memProbe, estimates map[string]int) *memGate {
+	return &memGate{
+		budgetMB:    budgetMB,
+		probe:       probe,
+		estimates:   estimates,
+		stopTimeout: time.Second,
+	}
+}
+
+func TestMemGate_NoOp_WhenBudgetZero(t *testing.T) {
+	a := readyProc("a", 1)
+	procs := map[string]process.Process{"a": a}
+	// budget 0 => the gate is disabled even though usage is huge.
+	g := newTestGate(0, staticProbe(99999, true), nil)
+
+	g.EnsureFits("b", procs, nil, gateLog())
+
+	if a.stopCalls.Load() != 0 {
+		t.Fatalf("budget==0 must be a no-op; got %d stops", a.stopCalls.Load())
+	}
+}
+
+func TestMemGate_NoOp_WhenGateNil(t *testing.T) {
+	// A nil *memGate must be safe to call (matches the `if b.memGate != nil`
+	// guard being optional from the gate's own perspective).
+	var g *memGate
+	g.EnsureFits("b", map[string]process.Process{}, nil, gateLog())
+}
+
+func TestMemGate_NoOp_WhenNewMemGateDisabled(t *testing.T) {
+	// newMemGate returns nil when budget<=0 or monitor is nil.
+	if newMemGate(0, nil, nil, time.Second) != nil {
+		t.Fatal("expected nil gate for budget 0")
+	}
+	if newMemGate(1000, nil, nil, time.Second) != nil {
+		t.Fatal("expected nil gate for nil monitor")
+	}
+}
+
+func TestMemGate_FailOpen_WhenNoReading(t *testing.T) {
+	a := readyProc("a", 1)
+	procs := map[string]process.Process{"a": a}
+	// Probe reports "not ok": gate must fail open and evict nothing.
+	g := newTestGate(100, staticProbe(0, false), nil)
+
+	g.EnsureFits("b", procs, nil, gateLog())
+
+	if a.stopCalls.Load() != 0 {
+		t.Fatalf("no reading must fail open; got %d stops", a.stopCalls.Load())
+	}
+}
+
+func TestMemGate_FitsWithoutEviction(t *testing.T) {
+	a := readyProc("a", 1)
+	procs := map[string]process.Process{"a": a}
+	// used 40 + estimate 50 = 90 <= budget 100: nothing should be evicted.
+	g := newTestGate(100, staticProbe(40, true), map[string]int{"b": 50})
+
+	g.EnsureFits("b", procs, nil, gateLog())
+
+	if a.stopCalls.Load() != 0 {
+		t.Fatalf("load fits under budget; got %d stops", a.stopCalls.Load())
+	}
+}
+
+func TestMemGate_EvictsToFit_ReducesProjectedUnderBudget(t *testing.T) {
+	// Three resident models, 5000 MiB each, budget 12000. Loading "d"
+	// (estimate 5000) projects 15000+5000 over budget; evicting brings it
+	// under. residentProbe models the freeing as victims stop.
+	perModel := map[string]int{"a": 5000, "b": 5000, "c": 5000}
+	a := readyProc("a", 100)
+	b := readyProc("b", 200)
+	c := readyProc("c", 300)
+	procs := map[string]process.Process{"a": a, "b": b, "c": c}
+
+	g := newTestGate(12000, nil, map[string]int{"d": 5000})
+	g.probe = residentProbe(procs, perModel)
+
+	g.EnsureFits("d", procs, nil, gateLog())
+
+	// Final projected = live(resident) + estimate(5000) must be <= budget.
+	live, _ := g.probe.liveUsedMB()
+	if live+5000 > g.budgetMB {
+		t.Fatalf("projected %d still over budget %d after eviction", live+5000, g.budgetMB)
+	}
+	// At least one eviction must have occurred (3*5000 + 5000 = 20000 > 12000).
+	totalStops := a.stopCalls.Load() + b.stopCalls.Load() + c.stopCalls.Load()
+	if totalStops == 0 {
+		t.Fatal("expected at least one eviction")
+	}
+}
+
+func TestMemGate_LRUOrder_OldestEvictedFirst(t *testing.T) {
+	// a is oldest (lastUse 100), then b (200), then c (300). Budget forces
+	// exactly one eviction; it must be "a".
+	perModel := map[string]int{"a": 5000, "b": 5000, "c": 5000}
+	a := readyProc("a", 100)
+	b := readyProc("b", 200)
+	c := readyProc("c", 300)
+	procs := map[string]process.Process{"a": a, "b": b, "c": c}
+
+	// live = 15000, estimate(d)=0 (reactive). budget 11000 => need to drop one
+	// 5000 model to reach 10000.
+	g := newTestGate(11000, nil, nil)
+	g.probe = residentProbe(procs, perModel)
+
+	g.EnsureFits("d", procs, nil, gateLog())
+
+	if a.stopCalls.Load() != 1 {
+		t.Fatalf("oldest model a must be evicted first; a stops=%d", a.stopCalls.Load())
+	}
+	if b.stopCalls.Load() != 0 || c.stopCalls.Load() != 0 {
+		t.Fatalf("only the LRU victim should be evicted; b=%d c=%d",
+			b.stopCalls.Load(), c.stopCalls.Load())
+	}
+}
+
+func TestMemGate_LRUOrder_EvictsMultipleOldestFirst(t *testing.T) {
+	// Need to evict two of three to fit. Order must be a then b (oldest two),
+	// leaving c (newest) resident.
+	perModel := map[string]int{"a": 5000, "b": 5000, "c": 5000}
+	a := readyProc("a", 100)
+	b := readyProc("b", 200)
+	c := readyProc("c", 300)
+	procs := map[string]process.Process{"a": a, "b": b, "c": c}
+
+	// live 15000, estimate(d) 0, budget 6000 => must drop two (down to 5000).
+	g := newTestGate(6000, nil, nil)
+	g.probe = residentProbe(procs, perModel)
+
+	g.EnsureFits("d", procs, nil, gateLog())
+
+	if a.stopCalls.Load() != 1 || b.stopCalls.Load() != 1 {
+		t.Fatalf("two oldest must be evicted; a=%d b=%d", a.stopCalls.Load(), b.stopCalls.Load())
+	}
+	if c.stopCalls.Load() != 0 {
+		t.Fatalf("newest model c must remain resident; c stops=%d", c.stopCalls.Load())
+	}
+	if c.State() == process.StateStopped {
+		t.Fatal("c should still be resident")
+	}
+}
+
+func TestMemGate_FailOpen_WhenNothingLeftToEvict(t *testing.T) {
+	// Single resident model "a", but it is excluded because it is already in
+	// alreadyEvicting. Budget cannot be met; gate must fail open (no panic, no
+	// extra stop) and let the load proceed.
+	perModel := map[string]int{"a": 5000}
+	a := readyProc("a", 100)
+	procs := map[string]process.Process{"a": a}
+
+	g := newTestGate(1000, nil, map[string]int{"d": 5000})
+	g.probe = residentProbe(procs, perModel)
+
+	// "a" is already being evicted by the solver, so it is not a candidate.
+	g.EnsureFits("d", procs, []string{"a"}, gateLog())
+
+	if a.stopCalls.Load() != 0 {
+		t.Fatalf("excluded model must not be evicted by the gate; a stops=%d", a.stopCalls.Load())
+	}
+}
+
+func TestMemGate_DoesNotEvictIncomingOrStopped(t *testing.T) {
+	// "incoming" is resident (e.g. a warm restart) and must never be chosen as
+	// a victim. A stopped model must also be skipped. Only "old" is evictable.
+	perModel := map[string]int{"incoming": 5000, "old": 5000, "dead": 5000}
+	incoming := readyProc("incoming", 50) // oldest, but it's the incoming model
+	old := readyProc("old", 100)
+	dead := readyProc("dead", 10) // oldest overall, but stopped
+	dead.setState(process.StateStopped)
+	procs := map[string]process.Process{"incoming": incoming, "old": old, "dead": dead}
+
+	g := newTestGate(6000, nil, nil)
+	g.probe = residentProbe(procs, perModel)
+
+	g.EnsureFits("incoming", procs, nil, gateLog())
+
+	if incoming.stopCalls.Load() != 0 {
+		t.Fatalf("incoming model must never be evicted; stops=%d", incoming.stopCalls.Load())
+	}
+	if dead.stopCalls.Load() != 0 {
+		t.Fatalf("already-stopped model must not be stopped again; stops=%d", dead.stopCalls.Load())
+	}
+	if old.stopCalls.Load() != 1 {
+		t.Fatalf("only the resident, non-incoming model should be evicted; old stops=%d", old.stopCalls.Load())
+	}
+}

--- a/internal/router/phase1_test.go
+++ b/internal/router/phase1_test.go
@@ -1,0 +1,241 @@
+package router
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/process"
+)
+
+func newSerializeTestBase(t *testing.T, processes map[string]process.Process, priority map[string]int) *baseRouter {
+	t.Helper()
+	models := make(map[string]config.ModelConfig, len(processes))
+	for id := range processes {
+		models[id] = config.ModelConfig{}
+	}
+	conf := config.Config{
+		HealthCheckTimeout: 5,
+		Models:             models,
+		Performance:        config.PerformanceConfig{SerializeInference: true},
+		Routing: config.RoutingConfig{Scheduler: config.SchedulerConfig{Settings: config.SchedulerSettings{
+			Fifo: config.FifoConfig{Priority: priority},
+		}}},
+	}
+	b, err := newBaseRouter("test", conf, processes, logmon.NewWriter(io.Discard), &stubPlanner{}, nil)
+	if err != nil {
+		t.Fatalf("newBaseRouter: %v", err)
+	}
+	b.testProcessed = make(chan struct{}, 64)
+	go b.run()
+	t.Cleanup(func() {
+		if !b.shuttingDown.Load() {
+			_ = b.Shutdown(time.Second)
+		}
+	})
+	return b
+}
+
+func TestMemGate_SkipsInFlightLRUVictim(t *testing.T) {
+	perModel := map[string]int{"busy-lru": 5000, "idle": 5000}
+	busy := readyProc("busy-lru", 100)
+	idle := readyProc("idle", 200)
+	procs := map[string]process.Process{"busy-lru": busy, "idle": idle}
+
+	g := newTestGate(6000, nil, nil)
+	g.probe = residentProbe(procs, perModel)
+	g.inFlight = func(modelID string) int {
+		if modelID == "busy-lru" {
+			return 1
+		}
+		return 0
+	}
+
+	g.EnsureFits("incoming", procs, nil, gateLog())
+
+	if busy.stopCalls.Load() != 0 {
+		t.Fatalf("in-flight LRU model must not be evicted; stops=%d", busy.stopCalls.Load())
+	}
+	if idle.stopCalls.Load() != 1 {
+		t.Fatalf("idle non-LRU should be evicted instead; stops=%d", idle.stopCalls.Load())
+	}
+}
+
+func TestMemGate_HardlineCanEvictInFlightLRUVictim(t *testing.T) {
+	busy := readyProc("busy-lru", 100)
+	idle := readyProc("idle", 200)
+	procs := map[string]process.Process{"busy-lru": busy, "idle": idle}
+	g := newTestGate(1000, nil, nil)
+	g.inFlight = func(modelID string) int {
+		if modelID == "busy-lru" {
+			return 1
+		}
+		return 0
+	}
+
+	victim, ok := g.pickLRUVictim(procs, nil, false, true)
+	if !ok || victim != "busy-lru" {
+		t.Fatalf("hardline selection should be able to pick in-flight LRU; victim=%q ok=%v", victim, ok)
+	}
+}
+
+func TestBaseRouter_SerializeInference_OneAtATime(t *testing.T) {
+	a := newFakeProcess("a")
+	a.markReady()
+	a.serveBlock = make(chan struct{})
+	pb := newFakeProcess("b")
+	pb.markReady()
+	pb.serveBlock = make(chan struct{})
+	b := newSerializeTestBase(t, map[string]process.Process{"a": a, "b": pb}, nil)
+
+	doneA := make(chan struct{})
+	go func() {
+		b.ServeHTTP(httptest.NewRecorder(), newRequest("a"))
+		close(doneA)
+	}()
+	<-a.serveStarted
+
+	doneB := make(chan struct{})
+	go func() {
+		b.ServeHTTP(httptest.NewRecorder(), newRequest("b"))
+		close(doneB)
+	}()
+	waitProcessed(t, b.testProcessed, 2)
+
+	select {
+	case <-pb.serveStarted:
+		t.Fatal("second upstream handler started while first was still running")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(a.serveBlock)
+	select {
+	case <-pb.serveStarted:
+	case <-time.After(time.Second):
+		t.Fatal("second upstream handler did not start after first released gate")
+	}
+	close(pb.serveBlock)
+	<-doneA
+	<-doneB
+}
+
+func TestBaseRouter_SerializeInference_PriorityOrdering(t *testing.T) {
+	a := newFakeProcess("a")
+	a.markReady()
+	a.serveBlock = make(chan struct{})
+	low := newFakeProcess("low")
+	low.markReady()
+	high := newFakeProcess("high")
+	high.markReady()
+	high.serveBlock = make(chan struct{})
+	b := newSerializeTestBase(t, map[string]process.Process{"a": a, "low": low, "high": high}, map[string]int{"high": 10})
+
+	go b.ServeHTTP(httptest.NewRecorder(), newRequest("a"))
+	<-a.serveStarted
+
+	lowDone := make(chan struct{})
+	go func() { b.ServeHTTP(httptest.NewRecorder(), newRequest("low")); close(lowDone) }()
+	waitProcessed(t, b.testProcessed, 2)
+	highDone := make(chan struct{})
+	go func() { b.ServeHTTP(httptest.NewRecorder(), newRequest("high")); close(highDone) }()
+	waitProcessed(t, b.testProcessed, 1)
+	// Let both granted HTTP goroutines reach the serialize gate before releasing
+	// the running request; the gate orders the waiters present at release time.
+	time.Sleep(50 * time.Millisecond)
+
+	close(a.serveBlock)
+	select {
+	case <-high.serveStarted:
+	case <-time.After(time.Second):
+		t.Fatal("high-priority waiter did not start after release")
+	}
+	select {
+	case <-low.serveStarted:
+		t.Fatal("low-priority waiter started before high-priority waiter")
+	default:
+	}
+	close(high.serveBlock)
+	<-highDone
+	select {
+	case <-low.serveStarted:
+	case <-time.After(time.Second):
+		t.Fatal("low-priority waiter did not start after high-priority request completed")
+	}
+	<-lowDone
+}
+
+func TestBaseRouter_SerializeInference_ReleasesOnClientCancel(t *testing.T) {
+	a := newFakeProcess("a")
+	a.markReady()
+	a.serveBlock = make(chan struct{})
+	pb := newFakeProcess("b")
+	pb.markReady()
+	b := newSerializeTestBase(t, map[string]process.Process{"a": a, "b": pb}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	doneA := make(chan struct{})
+	go func() { b.ServeHTTP(httptest.NewRecorder(), newRequestCtx(ctx, "a")); close(doneA) }()
+	<-a.serveStarted
+
+	cancel()
+	close(a.serveBlock)
+	select {
+	case <-doneA:
+	case <-time.After(time.Second):
+		t.Fatal("cancelled request did not return")
+	}
+
+	doneB := make(chan struct{})
+	go func() { b.ServeHTTP(httptest.NewRecorder(), newRequest("b")); close(doneB) }()
+	select {
+	case <-pb.serveStarted:
+	case <-time.After(time.Second):
+		t.Fatal("gate was not released after client-cancelled request returned")
+	}
+	<-doneB
+}
+
+type errorProcess struct {
+	*fakeProcess
+	inFlight *atomic.Int32
+}
+
+func (e *errorProcess) ServeHTTP(http.ResponseWriter, *http.Request) {
+	e.serveCalls.Add(1)
+	e.inFlight.Add(1)
+	defer e.inFlight.Add(-1)
+	close(e.serveStarted)
+}
+
+func TestBaseRouter_SerializeInference_ReleasesOnErrorReturn(t *testing.T) {
+	var inFlight atomic.Int32
+	errp := &errorProcess{fakeProcess: newFakeProcess("err"), inFlight: &inFlight}
+	errp.markReady()
+	ok := newFakeProcess("ok")
+	ok.markReady()
+	b := newSerializeTestBase(t, map[string]process.Process{"err": errp, "ok": ok}, nil)
+
+	w := httptest.NewRecorder()
+	b.ServeHTTP(w, newRequest("err"))
+	if inFlight.Load() != 0 {
+		t.Fatalf("erroring handler returned but test in-flight counter is %d", inFlight.Load())
+	}
+
+	done := make(chan struct{})
+	go func() { b.ServeHTTP(httptest.NewRecorder(), newRequest("ok")); close(done) }()
+	select {
+	case <-ok.serveStarted:
+	case <-time.After(time.Second):
+		t.Fatal("gate was not released after upstream error/early return")
+	}
+	<-done
+}
+
+func (e *errorProcess) String() string { return fmt.Sprintf("errorProcess(%s)", e.id) }

--- a/internal/router/redline.go
+++ b/internal/router/redline.go
@@ -112,7 +112,7 @@ func (g *memGate) enforceRedline(procs map[string]process.Process, log *logmon.M
 	}
 
 	for used > g.budgetMB || g.hostBreach() > 0 {
-		victim, ok := g.pickLRUVictim(procs, excluded, !hard)
+		victim, ok := g.pickLRUVictim(procs, excluded, !hard, hard)
 		if !ok {
 			log.Warnf("redline: still over (used=%dMB, budget=%dMB) but no evictable models remain", used, g.budgetMB)
 			return

--- a/internal/router/redline.go
+++ b/internal/router/redline.go
@@ -1,0 +1,137 @@
+package router
+
+import (
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/process"
+)
+
+// redlineInterval is how often the runtime watchdog samples memory. It is
+// deliberately much faster than the perf monitor's >=5s poll: enforcement is
+// racing allocation, and each sample is a couple of sysfs/procfs reads
+// (microseconds).
+const redlineInterval = time.Second
+
+// redlineLoop is the runtime enforcement tier of the memory gate. Admission
+// (EnsureFits) can only reason about footprints it was told about; this loop
+// catches everything admission cannot see: stale vramEstimateMB values,
+// KV/compute growth after load, and out-of-band allocations. When live usage
+// crosses the red line (or host MemAvailable drops under the floor) it evicts
+// least-recently-used models until usage is back under the BUDGET (not the red
+// line: the gap is hysteresis so it does not immediately re-trigger).
+//
+// Two tiers:
+//   - red line: evict LRU models but spare the most-recently-used one (the
+//     best proxy for "actively serving").
+//   - hard line (or host floor halved): spare nothing. Losing an active model
+//     beats the kernel TTM eviction stall -> hardware-watchdog reboot that
+//     follows unchecked growth on a UMA box.
+//
+// The loop only acts on FRESH reads (direct sysfs); if the platform cannot
+// provide them the watchdog stays dormant rather than acting on stale data.
+func (b *baseRouter) redlineLoop() {
+	g := b.memGate
+	if g == nil || g.redlineMB <= 0 {
+		return
+	}
+	if g.liveRead == nil {
+		b.logger.Warn("redline: no fresh GPU memory reader available on this platform; runtime enforcement disabled")
+		return
+	}
+
+	ticker := time.NewTicker(redlineInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-b.shutdownCtx.Done():
+			return
+		case <-ticker.C:
+			g.enforceRedline(b.processes, b.logger)
+		}
+	}
+}
+
+// hostBreach classifies the host-RAM condition: 0 = fine (or unreadable),
+// 1 = below floor (red), 2 = below half the floor (hard).
+func (g *memGate) hostBreach() int {
+	if g.hostFloorMB <= 0 || g.hostAvail == nil {
+		return 0
+	}
+	avail, ok := g.hostAvail()
+	if !ok {
+		return 0
+	}
+	switch {
+	case avail < g.hostFloorMB/2:
+		return 2
+	case avail < g.hostFloorMB:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// enforceRedline performs one watchdog pass: sample, classify, and evict until
+// usage is back under budget and the host floor. Safe to call concurrently
+// with admissions; it takes the same mutex, so a pass and an admission never
+// interleave their evictions.
+func (g *memGate) enforceRedline(procs map[string]process.Process, log *logmon.Monitor) {
+	if g == nil || g.redlineMB <= 0 || g.liveRead == nil {
+		return
+	}
+
+	used, ok := g.liveRead()
+	if !ok {
+		return
+	}
+	host := g.hostBreach()
+	if used <= g.redlineMB && host == 0 {
+		return
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	hard := host >= 2 || (g.hardlineMB > 0 && used > g.hardlineMB)
+	if hard {
+		log.Warnf("redline: HARD breach (used=%dMB, hardline=%dMB, hostBreach=%d); evicting including active models",
+			used, g.hardlineMB, host)
+	} else {
+		log.Warnf("redline: breach (used=%dMB > redline=%dMB or host floor); evicting idle LRU models",
+			used, g.redlineMB)
+	}
+
+	// Reservation holders are mid-load under an admission; killing them races
+	// that swap. The admission that reserved them already fit under budget, so
+	// they are not the runaway.
+	excluded := make(map[string]struct{}, len(g.reservations))
+	for id := range g.reservations {
+		excluded[id] = struct{}{}
+	}
+
+	for used > g.budgetMB || g.hostBreach() > 0 {
+		victim, ok := g.pickLRUVictim(procs, excluded, !hard)
+		if !ok {
+			log.Warnf("redline: still over (used=%dMB, budget=%dMB) but no evictable models remain", used, g.budgetMB)
+			return
+		}
+
+		log.Warnf("redline: evicting %s (used=%dMB, budget=%dMB)", victim, used, g.budgetMB)
+		if err := procs[victim].Stop(g.stopTimeout); err != nil {
+			log.Warnf("redline: stopping %s failed: %v", victim, err)
+		}
+		excluded[victim] = struct{}{}
+
+		settled, observed := g.settleAfterEviction(used, g.estimateMB(victim))
+		used = settled
+		if !observed && g.estimateMB(victim) <= 0 {
+			// Unknown-size victim with no observable drop: bound to one
+			// eviction per pass rather than draining the resident set blind.
+			return
+		}
+	}
+
+	log.Infof("redline: recovered (used=%dMB <= budget=%dMB)", used, g.budgetMB)
+}

--- a/internal/router/redline.go
+++ b/internal/router/redline.go
@@ -118,10 +118,19 @@ func (g *memGate) enforceRedline(procs map[string]process.Process, log *logmon.M
 			return
 		}
 
+		// Claim the victim before stopping so a lease cannot be acquired in the
+		// pick->stop window. On the hard tier leases are ignored (safety beats a
+		// lease); on the soft tier a just-arrived lease means we skip this victim.
+		if !g.claimVictim(victim, hard) {
+			excluded[victim] = struct{}{}
+			continue
+		}
+
 		log.Warnf("redline: evicting %s (used=%dMB, budget=%dMB)", victim, used, g.budgetMB)
 		if err := procs[victim].Stop(g.stopTimeout); err != nil {
 			log.Warnf("redline: stopping %s failed: %v", victim, err)
 		}
+		g.releaseVictim(victim, hard)
 		excluded[victim] = struct{}{}
 
 		settled, observed := g.settleAfterEviction(used, g.estimateMB(victim))

--- a/internal/router/redline_test.go
+++ b/internal/router/redline_test.go
@@ -1,0 +1,174 @@
+package router
+
+import (
+	"testing"
+
+	"github.com/mostlygeek/llama-swap/internal/process"
+)
+
+// liveReadOverResidents wires g.liveRead to the resident set, so enforceRedline
+// observes memory dropping as victims stop.
+func liveReadOverResidents(procs map[string]process.Process, perModelMB map[string]int) func() (int, bool) {
+	return func() (int, bool) {
+		total := 0
+		for id, p := range procs {
+			switch p.State() {
+			case process.StateStopped, process.StateShutdown:
+				continue
+			}
+			total += perModelMB[id]
+		}
+		return total, true
+	}
+}
+
+func TestMemGate_Redline_NoActionUnderRedline(t *testing.T) {
+	a := readyProc("a", 100)
+	procs := map[string]process.Process{"a": a}
+
+	g := newTestGate(6000, nil, nil)
+	g.redlineMB = 8000
+	g.liveRead = func() (int, bool) { return 7000, true } // between budget and redline
+
+	g.enforceRedline(procs, gateLog())
+
+	if a.stopCalls.Load() != 0 {
+		t.Fatalf("under the red line nothing may be evicted; got %d stops", a.stopCalls.Load())
+	}
+}
+
+func TestMemGate_Redline_EvictsLRUDownToBudget_SparesMRU(t *testing.T) {
+	// Three residents at 5000 each = 15000, red line 8000, budget 6000.
+	// The pass must evict a (oldest) then b, and SPARE c (most recently used)
+	// even though 5000 is still not under... it is: 5000 <= 6000. Then stop.
+	perModel := map[string]int{"a": 5000, "b": 5000, "c": 5000}
+	a := readyProc("a", 100)
+	b := readyProc("b", 200)
+	c := readyProc("c", 300)
+	procs := map[string]process.Process{"a": a, "b": b, "c": c}
+
+	g := newTestGate(6000, nil, map[string]int{"a": 5000, "b": 5000, "c": 5000})
+	g.redlineMB = 8000
+	g.liveRead = liveReadOverResidents(procs, perModel)
+
+	g.enforceRedline(procs, gateLog())
+
+	if a.stopCalls.Load() == 0 || b.stopCalls.Load() == 0 {
+		t.Fatal("expected a and b (LRU order) to be evicted")
+	}
+	if c.stopCalls.Load() != 0 {
+		t.Fatal("soft tier must spare the most-recently-used model")
+	}
+}
+
+func TestMemGate_Redline_SoftTier_NeverEvictsLastModel(t *testing.T) {
+	// One resident over the red line: the soft tier spares the MRU, and with a
+	// single candidate that IS the MRU, so nothing may be evicted.
+	perModel := map[string]int{"a": 9000}
+	a := readyProc("a", 100)
+	procs := map[string]process.Process{"a": a}
+
+	g := newTestGate(6000, nil, map[string]int{"a": 9000})
+	g.redlineMB = 8000
+	g.liveRead = liveReadOverResidents(procs, perModel)
+
+	g.enforceRedline(procs, gateLog())
+
+	if a.stopCalls.Load() != 0 {
+		t.Fatal("soft tier must not evict the only (most recently used) model")
+	}
+}
+
+func TestMemGate_Redline_HardTier_EvictsEverything(t *testing.T) {
+	// Above the hard line the MRU is no longer spared.
+	perModel := map[string]int{"a": 9000}
+	a := readyProc("a", 100)
+	procs := map[string]process.Process{"a": a}
+
+	g := newTestGate(6000, nil, map[string]int{"a": 9000})
+	g.redlineMB = 8000
+	g.hardlineMB = 8500
+	g.liveRead = liveReadOverResidents(procs, perModel)
+
+	g.enforceRedline(procs, gateLog())
+
+	if a.stopCalls.Load() == 0 {
+		t.Fatal("hard tier must evict even the most-recently-used model")
+	}
+}
+
+func TestMemGate_Redline_HostFloorBreachTriggersEviction(t *testing.T) {
+	// GPU usage is fine, but host MemAvailable is under the floor: the
+	// watchdog must still evict (UMA: freeing GTT frees host RAM).
+	perModel := map[string]int{"a": 3000, "b": 3000}
+	a := readyProc("a", 100)
+	b := readyProc("b", 200)
+	procs := map[string]process.Process{"a": a, "b": b}
+
+	g := newTestGate(10000, nil, map[string]int{"a": 3000, "b": 3000})
+	g.redlineMB = 12000
+	g.hostFloorMB = 2000
+	g.liveRead = liveReadOverResidents(procs, perModel)
+
+	hostAvail := 1500 // below floor
+	g.hostAvail = func() (int, bool) { return hostAvail, true }
+
+	// Freeing a model recovers host memory in this fake.
+	stopped := func() int {
+		n := 0
+		if a.stopCalls.Load() > 0 {
+			n++
+		}
+		if b.stopCalls.Load() > 0 {
+			n++
+		}
+		return n
+	}
+	g.hostAvail = func() (int, bool) { return hostAvail + stopped()*3000, true }
+
+	g.enforceRedline(procs, gateLog())
+
+	if a.stopCalls.Load() == 0 {
+		t.Fatal("expected LRU eviction on host floor breach")
+	}
+	if b.stopCalls.Load() != 0 {
+		t.Fatal("one eviction recovers the floor; MRU must be spared")
+	}
+}
+
+func TestMemGate_Redline_ReservationHoldersExcluded(t *testing.T) {
+	perModel := map[string]int{"a": 5000, "b": 5000}
+	a := readyProc("a", 100) // oldest, but holds a reservation
+	b := readyProc("b", 200)
+	procs := map[string]process.Process{"a": a, "b": b}
+
+	g := newTestGate(4000, nil, map[string]int{"a": 5000, "b": 5000})
+	g.redlineMB = 8000
+	g.hardlineMB = 8500 // hard: even MRU is fair game, only reservations protect
+	g.liveRead = liveReadOverResidents(procs, perModel)
+	g.reservations = map[string]int{"a": 5000}
+
+	g.enforceRedline(procs, gateLog())
+
+	if a.stopCalls.Load() != 0 {
+		t.Fatal("reservation holder must never be evicted by the watchdog")
+	}
+	if b.stopCalls.Load() == 0 {
+		t.Fatal("expected b to be evicted")
+	}
+}
+
+func TestMemGate_Redline_NoFreshReader_NoAction(t *testing.T) {
+	a := readyProc("a", 100)
+	procs := map[string]process.Process{"a": a}
+
+	g := newTestGate(6000, staticProbe(99999, true), nil)
+	g.redlineMB = 8000
+	g.liveRead = nil // stale probe alone must not drive enforcement
+
+	g.enforceRedline(procs, gateLog())
+
+	if a.stopCalls.Load() != 0 {
+		t.Fatal("watchdog must stay dormant without a fresh reader")
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -49,4 +49,18 @@ type LocalRouter interface {
 	// modelID must be a real (non-alias) config key. Returns false when the
 	// model is not known to this router.
 	ProcessLogger(modelID string) (*logmon.Monitor, bool)
+
+	// AcquireLease creates a lease protecting model from eviction for up to ttl
+	// (clamped to the configured cap). Rejects unknown or mid-eviction models.
+	AcquireLease(model, holder, reason string, ttl time.Duration) (Lease, error)
+	// ReleaseLease drops a lease by id, reporting whether one was removed.
+	ReleaseLease(id string) bool
+	// ExtendLease pushes a live lease's expiry out by ttl; false if unknown/expired.
+	ExtendLease(id string, ttl time.Duration) (Lease, bool)
+	// KillLeases force-removes every live lease matching the selector.
+	KillLeases(id, model, holder string) []Lease
+	// ListLeases returns a point-in-time view of every live lease.
+	ListLeases() []LeaseView
+	// CanLoad is the read-only can-i-load preflight for model.
+	CanLoad(model string) (LoadVerdict, error)
 }

--- a/internal/router/scheduler/fifo.go
+++ b/internal/router/scheduler/fifo.go
@@ -129,7 +129,16 @@ func (s *FIFO) OnRequest(req HandlerReq) {
 		return
 	}
 
-	// (6) Start a new (possibly parallel) swap.
+	// (6) Refuse-don't-break: if starting this swap would evict a lease-protected
+	// model, reject with 503 + blocked_by rather than breaking the lease. A
+	// clear claim is held until the swap's stops finish.
+	if err := s.effects.TryClaimEviction(evict); err != nil {
+		s.logger.Debugf("%s: refusing swap for model %s: %v", s.name, req.Model, err)
+		s.effects.GrantError(req, err)
+		return
+	}
+
+	// (7) Start a new (possibly parallel) swap.
 	s.logger.Debugf("%s: starting swap for model %s, evicting %v", s.name, req.Model, evict)
 	s.startSwap(req, evict, running)
 }
@@ -371,6 +380,13 @@ func (s *FIFO) drainQueue() {
 		}
 		if conflictsWithInFlight(evict, s.inFlight) {
 			remaining = append(remaining, req)
+			continue
+		}
+		// Refuse-don't-break: a queued request that could only proceed by
+		// evicting a leased model is rejected, not parked for hours.
+		if err := s.effects.TryClaimEviction(evict); err != nil {
+			s.logger.Debugf("%s: refusing queued swap for model %s: %v", s.name, req.Model, err)
+			s.effects.GrantError(req, err)
 			continue
 		}
 		s.logger.Debugf("%s: queued request for model %s now starting swap, evicting %v", s.name, req.Model, evict)

--- a/internal/router/scheduler/fifo.go
+++ b/internal/router/scheduler/fifo.go
@@ -269,6 +269,13 @@ func (s *FIFO) OnShutdown(err error) {
 	}
 }
 
+// InFlight returns the current per-model in-flight request count. The scheduler
+// owns this state on the router run loop; callers must query it through that
+// same loop or otherwise know no concurrent scheduler mutation is happening.
+func (s *FIFO) InFlight(modelID string) int {
+	return s.inFlight[modelID]
+}
+
 // grantHandler hands the caller a tracked handler for modelID and, only if the
 // caller was still there to receive it, bumps the in-flight count. Incrementing
 // when the grant failed would strand the counter and block future evictions.

--- a/internal/router/scheduler/fifo_test.go
+++ b/internal/router/scheduler/fifo_test.go
@@ -62,6 +62,9 @@ type fakeEffects struct {
 	starts []startRec
 	grants []grantRec
 	stops  []stopRec
+
+	claimBlock func(evict []string) error
+	claimed    [][]string
 }
 
 func newFakeEffects() *fakeEffects {
@@ -89,6 +92,19 @@ func (f *fakeEffects) RunningModels() map[string]process.ProcessState {
 
 func (f *fakeEffects) StartSwap(modelID string, evict []string) {
 	f.starts = append(f.starts, startRec{model: modelID, evict: evict})
+}
+
+// claimBlock, when non-nil, decides TryClaimEviction's result for a given evict
+// set: a non-nil return refuses the swap (refuse-don't-break). Default nil never
+// blocks. claimed records every claimed (non-refused) eviction set.
+func (f *fakeEffects) TryClaimEviction(evict []string) error {
+	if f.claimBlock != nil {
+		if err := f.claimBlock(evict); err != nil {
+			return err
+		}
+	}
+	f.claimed = append(f.claimed, evict)
+	return nil
 }
 
 func (f *fakeEffects) GrantError(req HandlerReq, err error) {
@@ -775,5 +791,59 @@ func TestFIFO_ConcurrencyLimit_SwapWaiters(t *testing.T) {
 	}
 	if got := eff.errored("a"); got != 1 {
 		t.Fatalf("errored(a)=%d want 1 (excess waiter rejected)", got)
+	}
+}
+
+// leaseBlocked is a stand-in HTTPError-free error the fake returns to model a
+// refuse-don't-break rejection.
+type leaseBlockedStub struct{ msg string }
+
+func (e leaseBlockedStub) Error() string { return e.msg }
+
+func TestFIFO_RefuseDontBreak_RejectsEvictionOfLeasedModel(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["target"] = process.StateStopped
+	eff.states["leased"] = process.StateReady
+	// Loading target would evict "leased".
+	planner := &stubPlanner{evict: map[string][]string{"target": {"leased"}}}
+	// The lease table refuses any eviction touching "leased".
+	eff.claimBlock = func(evict []string) error {
+		for _, m := range evict {
+			if m == "leased" {
+				return leaseBlockedStub{msg: "blocked by lease on leased"}
+			}
+		}
+		return nil
+	}
+	s := newFIFO(planner, eff)
+
+	s.OnRequest(req("target"))
+
+	if got := eff.startsFor("target"); got != 0 {
+		t.Fatalf("StartSwap(target)=%d want 0 (must be refused, not started)", got)
+	}
+	if got := eff.errored("target"); got != 1 {
+		t.Fatalf("errored(target)=%d want 1 (refuse-don't-break 503)", got)
+	}
+	if len(eff.claimed) != 0 {
+		t.Fatalf("a blocked claim must not record a claim; got %v", eff.claimed)
+	}
+}
+
+func TestFIFO_RefuseDontBreak_AllowsEvictionOfUnleasedModel(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["target"] = process.StateStopped
+	eff.states["idle"] = process.StateReady
+	planner := &stubPlanner{evict: map[string][]string{"target": {"idle"}}}
+	// No claimBlock => nothing is lease-protected.
+	s := newFIFO(planner, eff)
+
+	s.OnRequest(req("target"))
+
+	if got := eff.startsFor("target"); got != 1 {
+		t.Fatalf("StartSwap(target)=%d want 1 (unleased eviction proceeds)", got)
+	}
+	if len(eff.claimed) != 1 {
+		t.Fatalf("a successful swap must claim its eviction set exactly once; got %v", eff.claimed)
 	}
 }

--- a/internal/router/scheduler/scheduler.go
+++ b/internal/router/scheduler/scheduler.go
@@ -83,6 +83,14 @@ type Effects interface {
 	RunningModels() map[string]process.ProcessState
 	// StartSwap launches the swap goroutine for modelID, stopping evict first.
 	StartSwap(modelID string, evict []string)
+	// TryClaimEviction enforces refuse-don't-break: it atomically checks that
+	// no model in evict holds a live lease and, if clear, claims them for
+	// eviction (released when the swap's stops complete). It returns a non-nil
+	// HTTPError (503 + blocked_by) when a lease blocks the eviction, in which
+	// case NOTHING is claimed and the caller must not start the swap. A nil
+	// return means the caller owns the claim and may proceed to StartSwap.
+	// Always nil when leases are disabled.
+	TryClaimEviction(evict []string) error
 	// GrantError responds to a caller with an error.
 	GrantError(req HandlerReq, err error)
 	// GrantServe hands a caller the wrapped handler for modelID and reports

--- a/internal/router/scheduler/scheduler.go
+++ b/internal/router/scheduler/scheduler.go
@@ -66,6 +66,8 @@ type Scheduler interface {
 	// swap waiters and queued requests). Process teardown is the baseRouter's
 	// responsibility.
 	OnShutdown(err error)
+	// InFlight returns the number of scheduler-tracked active requests for a model.
+	InFlight(modelID string) int
 }
 
 // Effects is implemented by the baseRouter. The scheduler calls back through it

--- a/internal/router/serialize_gate.go
+++ b/internal/router/serialize_gate.go
@@ -1,0 +1,131 @@
+package router
+
+import (
+	"container/list"
+	"context"
+)
+
+// serializeGate is an optional depth-1 gate for upstream inference handlers.
+// It is independent from the scheduler's per-model in-flight accounting: the
+// scheduler may grant many handlers, but each granted handler acquires this gate
+// immediately before calling the upstream process and releases it when that call
+// returns.
+type serializeGate struct {
+	reqCh     chan serializeAcquireReq
+	releaseCh chan struct{}
+}
+
+type serializeAcquireReq struct {
+	priority int
+	seq      int64
+	grant    chan struct{}
+	done     <-chan struct{}
+}
+
+func newSerializeGate() *serializeGate {
+	g := &serializeGate{
+		reqCh:     make(chan serializeAcquireReq),
+		releaseCh: make(chan struct{}),
+	}
+	go g.run()
+	return g
+}
+
+func (g *serializeGate) acquire(ctx context.Context, priority int, seq int64) (func(), bool) {
+	if g == nil {
+		return func() {}, true
+	}
+	grant := make(chan struct{})
+	req := serializeAcquireReq{priority: priority, seq: seq, grant: grant, done: ctx.Done()}
+	select {
+	case g.reqCh <- req:
+	case <-ctx.Done():
+		return nil, false
+	}
+	select {
+	case <-grant:
+		return func() {
+			select {
+			case g.releaseCh <- struct{}{}:
+			case <-ctx.Done():
+				g.releaseCh <- struct{}{}
+			}
+		}, true
+	case <-ctx.Done():
+		select {
+		case <-grant:
+			return func() {
+				select {
+				case g.releaseCh <- struct{}{}:
+				case <-ctx.Done():
+					g.releaseCh <- struct{}{}
+				}
+			}, true
+		default:
+			return nil, false
+		}
+	}
+}
+
+func (g *serializeGate) run() {
+	var busy bool
+	waiters := list.New()
+	for {
+		if !busy {
+			for {
+				front := bestSerializeWaiter(waiters)
+				if front == nil {
+					break
+				}
+				req := waiters.Remove(front).(serializeAcquireReq)
+				select {
+				case req.grant <- struct{}{}:
+					busy = true
+				case <-req.done:
+					continue
+				}
+				break
+			}
+		}
+
+		select {
+		case req := <-g.reqCh:
+			if busy {
+				insertSerializeWaiter(waiters, req)
+				continue
+			}
+			select {
+			case req.grant <- struct{}{}:
+				busy = true
+			case <-req.done:
+			}
+		case <-g.releaseCh:
+			busy = false
+		}
+	}
+}
+
+func insertSerializeWaiter(waiters *list.List, req serializeAcquireReq) {
+	for e := waiters.Front(); e != nil; e = e.Next() {
+		cur := e.Value.(serializeAcquireReq)
+		if cur.priority < req.priority || (cur.priority == req.priority && cur.seq > req.seq) {
+			waiters.InsertBefore(req, e)
+			return
+		}
+	}
+	waiters.PushBack(req)
+}
+
+func bestSerializeWaiter(waiters *list.List) *list.Element {
+	for e := waiters.Front(); e != nil; e = e.Next() {
+		req := e.Value.(serializeAcquireReq)
+		select {
+		case <-req.done:
+			waiters.Remove(e)
+			continue
+		default:
+			return e
+		}
+	}
+	return nil
+}

--- a/internal/server/leases.go
+++ b/internal/server/leases.go
@@ -3,7 +3,9 @@ package server
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/mostlygeek/llama-swap/internal/router"
@@ -82,7 +84,7 @@ func (s *Server) handleLeaseRelease(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleLeaseExtend(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	var req extendRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err.Error() != "EOF" {
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
 		return
 	}
@@ -111,6 +113,9 @@ func (s *Server) handleLeaseKill(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
 		return
 	}
+	req.ID = strings.TrimSpace(req.ID)
+	req.Model = strings.TrimSpace(req.Model)
+	req.Holder = strings.TrimSpace(req.Holder)
 	set := 0
 	for _, v := range []string{req.ID, req.Model, req.Holder} {
 		if v != "" {

--- a/internal/server/leases.go
+++ b/internal/server/leases.go
@@ -1,0 +1,161 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/router"
+)
+
+// leaseRequest is the POST /leases body.
+type leaseRequest struct {
+	Model  string `json:"model"`
+	Holder string `json:"holder"`
+	Reason string `json:"reason"`
+	// TTL is a Go duration string ("5h", "30m"); empty means "the maximum".
+	TTL string `json:"ttl"`
+}
+
+// extendRequest is the POST /leases/{id}/extend body.
+type extendRequest struct {
+	TTL string `json:"ttl"`
+}
+
+// killRequest is the POST /leases/kill body. Exactly one field must be set.
+type killRequest struct {
+	ID     string `json:"id"`
+	Model  string `json:"model"`
+	Holder string `json:"holder"`
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// handleLeaseAcquire handles POST /leases.
+func (s *Server) handleLeaseAcquire(w http.ResponseWriter, r *http.Request) {
+	var req leaseRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+		return
+	}
+	if req.Model == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "model is required"})
+		return
+	}
+	ttl, err := parseTTL(req.TTL)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	lease, err := s.local.AcquireLease(req.Model, req.Holder, req.Reason, ttl)
+	if err != nil {
+		if errors.Is(err, router.ErrUnknownModel) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			return
+		}
+		// Mid-eviction or leases-disabled: transient/again-later.
+		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusCreated, lease)
+}
+
+// handleLeaseRelease handles DELETE /leases/{id}.
+func (s *Server) handleLeaseRelease(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if s.local.ReleaseLease(id) {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	// Unknown id: the client treats this as "re-acquire", so it is not an error
+	// condition per se, but 404 tells it the id is gone.
+	writeJSON(w, http.StatusNotFound, map[string]string{"error": "unknown lease id"})
+}
+
+// handleLeaseExtend handles POST /leases/{id}/extend.
+func (s *Server) handleLeaseExtend(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var req extendRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err.Error() != "EOF" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+		return
+	}
+	ttl, err := parseTTL(req.TTL)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	lease, ok := s.local.ExtendLease(id, ttl)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "unknown or expired lease id"})
+		return
+	}
+	writeJSON(w, http.StatusOK, lease)
+}
+
+// handleLeaseList handles GET /leases.
+func (s *Server) handleLeaseList(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{"leases": s.local.ListLeases()})
+}
+
+// handleLeaseKill handles POST /leases/kill.
+func (s *Server) handleLeaseKill(w http.ResponseWriter, r *http.Request) {
+	var req killRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+		return
+	}
+	set := 0
+	for _, v := range []string{req.ID, req.Model, req.Holder} {
+		if v != "" {
+			set++
+		}
+	}
+	if set != 1 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "exactly one of id, model, or holder is required"})
+		return
+	}
+	killed := s.local.KillLeases(req.ID, req.Model, req.Holder)
+	writeJSON(w, http.StatusOK, map[string]any{"killed": killed})
+}
+
+// handleCanLoad handles GET /leases/can-load/{model...}.
+func (s *Server) handleCanLoad(w http.ResponseWriter, r *http.Request) {
+	model := r.PathValue("model")
+	if model == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "model is required"})
+		return
+	}
+	verdict, err := s.local.CanLoad(model)
+	if err != nil {
+		if errors.Is(err, router.ErrUnknownModel) {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, verdict)
+}
+
+// parseTTL parses an optional Go duration string. Empty => 0 (meaning "the
+// server maximum"). A negative or unparseable value is an error.
+func parseTTL(s string) (time.Duration, error) {
+	if s == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, errors.New("invalid ttl: use a Go duration like 30m or 4h")
+	}
+	if d < 0 {
+		return 0, errors.New("ttl must not be negative")
+	}
+	return d, nil
+}

--- a/internal/server/leases_test.go
+++ b/internal/server/leases_test.go
@@ -1,0 +1,186 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/router"
+)
+
+func doJSON(t *testing.T, s *Server, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, path, nil)
+	} else {
+		r = httptest.NewRequest(method, path, strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, r)
+	return w
+}
+
+func TestLeaseAPI_Acquire(t *testing.T) {
+	local := newStubRouter([]string{"m1"}, "")
+	var gotModel, gotHolder, gotReason string
+	var gotTTL time.Duration
+	local.acquireLease = func(model, holder, reason string, ttl time.Duration) (router.Lease, error) {
+		gotModel, gotHolder, gotReason, gotTTL = model, holder, reason, ttl
+		return router.Lease{ID: "L1", Model: model, Holder: holder, Reason: reason, State: router.LeaseActive}, nil
+	}
+	s := newTestServer(local, newStubRouter(nil, ""))
+
+	w := doJSON(t, s, http.MethodPost, "/leases", `{"model":"m1","holder":"run.py","reason":"batch","ttl":"2h"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	if gotModel != "m1" || gotHolder != "run.py" || gotReason != "batch" || gotTTL != 2*time.Hour {
+		t.Fatalf("handler passed model=%q holder=%q reason=%q ttl=%v", gotModel, gotHolder, gotReason, gotTTL)
+	}
+	var lease router.Lease
+	if err := json.Unmarshal(w.Body.Bytes(), &lease); err != nil || lease.ID != "L1" {
+		t.Fatalf("bad lease body: %v %q", err, w.Body.String())
+	}
+}
+
+func TestLeaseAPI_AcquireValidatesBody(t *testing.T) {
+	s := newTestServer(newStubRouter([]string{"m1"}, ""), newStubRouter(nil, ""))
+
+	if w := doJSON(t, s, http.MethodPost, "/leases", `not json`); w.Code != http.StatusBadRequest {
+		t.Errorf("invalid json: status=%d want 400", w.Code)
+	}
+	if w := doJSON(t, s, http.MethodPost, "/leases", `{"holder":"x"}`); w.Code != http.StatusBadRequest {
+		t.Errorf("missing model: status=%d want 400", w.Code)
+	}
+	if w := doJSON(t, s, http.MethodPost, "/leases", `{"model":"m1","ttl":"banana"}`); w.Code != http.StatusBadRequest {
+		t.Errorf("bad ttl: status=%d want 400", w.Code)
+	}
+}
+
+func TestLeaseAPI_AcquireUnknownModel(t *testing.T) {
+	local := newStubRouter([]string{"m1"}, "")
+	local.acquireLease = func(_, _, _ string, _ time.Duration) (router.Lease, error) {
+		return router.Lease{}, router.ErrUnknownModel
+	}
+	s := newTestServer(local, newStubRouter(nil, ""))
+
+	w := doJSON(t, s, http.MethodPost, "/leases", `{"model":"ghost"}`)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status=%d want 404", w.Code)
+	}
+}
+
+func TestLeaseAPI_Release(t *testing.T) {
+	local := newStubRouter(nil, "")
+	var gotID string
+	local.releaseLease = func(id string) bool { gotID = id; return true }
+	s := newTestServer(local, newStubRouter(nil, ""))
+
+	w := doJSON(t, s, http.MethodDelete, "/leases/ABC", "")
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status=%d want 204", w.Code)
+	}
+	if gotID != "ABC" {
+		t.Fatalf("release id=%q want ABC", gotID)
+	}
+
+	local.releaseLease = func(string) bool { return false }
+	if w := doJSON(t, s, http.MethodDelete, "/leases/GONE", ""); w.Code != http.StatusNotFound {
+		t.Fatalf("unknown id: status=%d want 404", w.Code)
+	}
+}
+
+func TestLeaseAPI_Extend(t *testing.T) {
+	local := newStubRouter(nil, "")
+	var gotID string
+	var gotTTL time.Duration
+	local.extendLease = func(id string, ttl time.Duration) (router.Lease, bool) {
+		gotID, gotTTL = id, ttl
+		return router.Lease{ID: id, State: router.LeaseActive}, true
+	}
+	s := newTestServer(local, newStubRouter(nil, ""))
+
+	w := doJSON(t, s, http.MethodPost, "/leases/XYZ/extend", `{"ttl":"1h"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	if gotID != "XYZ" || gotTTL != time.Hour {
+		t.Fatalf("extend id=%q ttl=%v", gotID, gotTTL)
+	}
+
+	local.extendLease = func(string, time.Duration) (router.Lease, bool) { return router.Lease{}, false }
+	if w := doJSON(t, s, http.MethodPost, "/leases/GONE/extend", `{"ttl":"1h"}`); w.Code != http.StatusNotFound {
+		t.Fatalf("expired: status=%d want 404", w.Code)
+	}
+}
+
+func TestLeaseAPI_Kill_RequiresExactlyOneSelector(t *testing.T) {
+	local := newStubRouter(nil, "")
+	local.killLeases = func(id, model, holder string) []router.Lease {
+		return []router.Lease{{ID: "L1", Model: model}}
+	}
+	s := newTestServer(local, newStubRouter(nil, ""))
+
+	if w := doJSON(t, s, http.MethodPost, "/leases/kill", `{}`); w.Code != http.StatusBadRequest {
+		t.Errorf("no selector: status=%d want 400", w.Code)
+	}
+	if w := doJSON(t, s, http.MethodPost, "/leases/kill", `{"id":"a","model":"b"}`); w.Code != http.StatusBadRequest {
+		t.Errorf("two selectors: status=%d want 400", w.Code)
+	}
+	w := doJSON(t, s, http.MethodPost, "/leases/kill", `{"model":"m1"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("one selector: status=%d want 200", w.Code)
+	}
+	var resp struct {
+		Killed []router.Lease `json:"killed"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil || len(resp.Killed) != 1 {
+		t.Fatalf("kill body=%q err=%v", w.Body.String(), err)
+	}
+}
+
+func TestLeaseAPI_List(t *testing.T) {
+	local := newStubRouter(nil, "")
+	local.listLeases = func() []router.LeaseView {
+		return []router.LeaseView{{Lease: router.Lease{ID: "L1", Model: "m"}, ActiveRequests: 2, TTLRemainingMS: 1000}}
+	}
+	s := newTestServer(local, newStubRouter(nil, ""))
+
+	w := doJSON(t, s, http.MethodGet, "/leases", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d", w.Code)
+	}
+	var resp struct {
+		Leases []router.LeaseView `json:"leases"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil || len(resp.Leases) != 1 || resp.Leases[0].ActiveRequests != 2 {
+		t.Fatalf("list body=%q err=%v", w.Body.String(), err)
+	}
+}
+
+func TestLeaseAPI_CanLoad(t *testing.T) {
+	local := newStubRouter([]string{"m1"}, "")
+	local.canLoad = func(model string) (router.LoadVerdict, error) {
+		return router.LoadVerdict{
+			Model:      model,
+			WouldEvict: []string{"other"},
+			Blocked:    true,
+			BlockedBy:  []router.Blocker{{Model: "other", Holder: "h", Reason: "r"}},
+		}, nil
+	}
+	s := newTestServer(local, newStubRouter(nil, ""))
+
+	w := doJSON(t, s, http.MethodGet, "/leases/can-load/m1", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	var v router.LoadVerdict
+	if err := json.Unmarshal(w.Body.Bytes(), &v); err != nil || !v.Blocked || len(v.BlockedBy) != 1 {
+		t.Fatalf("verdict body=%q err=%v", w.Body.String(), err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -240,6 +240,14 @@ func (s *Server) routes() {
 	mux.Handle("GET /unload", apiChain.ThenFunc(s.handleUnload))
 	mux.Handle("GET /running", apiChain.ThenFunc(s.handleRunning))
 
+	// Model-lease endpoints (refuse-don't-break eviction protection).
+	mux.Handle("POST /leases", apiChain.ThenFunc(s.handleLeaseAcquire))
+	mux.Handle("GET /leases", apiChain.ThenFunc(s.handleLeaseList))
+	mux.Handle("POST /leases/kill", apiChain.ThenFunc(s.handleLeaseKill))
+	mux.Handle("POST /leases/{id}/extend", apiChain.ThenFunc(s.handleLeaseExtend))
+	mux.Handle("DELETE /leases/{id}", apiChain.ThenFunc(s.handleLeaseRelease))
+	mux.Handle("GET /leases/can-load/{model...}", apiChain.ThenFunc(s.handleCanLoad))
+
 	// Upstream passthrough. Meter only the model-dispatched endpoints that can
 	// produce token usage/timings.
 	upstreamChain := apiChain.Append(CreateMetricsMiddleware(s.metrics, s.cfg))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -123,12 +123,12 @@ func New(cfg config.Config, muxlog *logmon.Monitor, proxylog *logmon.Monitor, up
 
 	switch cfg.Routing.Router.Use {
 	case "matrix":
-		local, err = router.NewMatrix(cfg, proxylog, upstreamlog)
+		local, err = router.NewMatrix(cfg, proxylog, upstreamlog, perfMon)
 		if err != nil {
 			return nil, fmt.Errorf("creating matrix router: %w", err)
 		}
 	default: // "group"
-		local, err = router.NewGroup(cfg, proxylog, upstreamlog)
+		local, err = router.NewGroup(cfg, proxylog, upstreamlog, perfMon)
 		if err != nil {
 			return nil, fmt.Errorf("creating group router: %w", err)
 		}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -27,6 +27,13 @@ type stubRouter struct {
 	running       map[string]process.ProcessState
 	unloadCalls   atomic.Int32
 	loggers       map[string]*logmon.Monitor
+
+	acquireLease func(model, holder, reason string, ttl time.Duration) (router.Lease, error)
+	releaseLease func(id string) bool
+	extendLease  func(id string, ttl time.Duration) (router.Lease, bool)
+	killLeases   func(id, model, holder string) []router.Lease
+	listLeases   func() []router.LeaseView
+	canLoad      func(model string) (router.LoadVerdict, error)
 }
 
 func newStubRouter(models []string, response string) *stubRouter {
@@ -53,6 +60,43 @@ func (s *stubRouter) ProcessLogger(modelID string) (*logmon.Monitor, bool) {
 		}
 	}
 	return nil, false
+}
+
+func (s *stubRouter) AcquireLease(model, holder, reason string, ttl time.Duration) (router.Lease, error) {
+	if s.acquireLease != nil {
+		return s.acquireLease(model, holder, reason, ttl)
+	}
+	return router.Lease{}, nil
+}
+func (s *stubRouter) ReleaseLease(id string) bool {
+	if s.releaseLease != nil {
+		return s.releaseLease(id)
+	}
+	return false
+}
+func (s *stubRouter) ExtendLease(id string, ttl time.Duration) (router.Lease, bool) {
+	if s.extendLease != nil {
+		return s.extendLease(id, ttl)
+	}
+	return router.Lease{}, false
+}
+func (s *stubRouter) KillLeases(id, model, holder string) []router.Lease {
+	if s.killLeases != nil {
+		return s.killLeases(id, model, holder)
+	}
+	return nil
+}
+func (s *stubRouter) ListLeases() []router.LeaseView {
+	if s.listLeases != nil {
+		return s.listLeases()
+	}
+	return nil
+}
+func (s *stubRouter) CanLoad(model string) (router.LoadVerdict, error) {
+	if s.canLoad != nil {
+		return s.canLoad(model)
+	}
+	return router.LoadVerdict{Model: model}, nil
 }
 
 // newTestServer wires a Server with stub routers and a built mux.

--- a/scripts/model_lease.py
+++ b/scripts/model_lease.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Client for the llama-swap model-lease API.
+
+A lease protects a model from being evicted while another model loads. It is the
+refuse-don't-break contract: with a live lease, a competing load is refused
+(503 + blocked_by) instead of silently evicting your model. There is NO
+heartbeat; the server expires the lease after its TTL, so a clean exit should
+release and a crash is caught by the TTL.
+
+Use as a context manager around a work session:
+
+    from model_lease import model_lease
+
+    with model_lease("qwen3.5-9b-vision", holder="run_tagging.py",
+                     reason="tag project-39", ttl="5h") as lease:
+        # lease.header() -> {"X-Llama-Swap-Lease": "<id>"} for your requests
+        run_batch(extra_headers=lease.header())
+
+Or as a CLI:
+
+    llama-swap-lease acquire qwen3.5-9b-vision --holder run.py --reason batch --ttl 4h
+    llama-swap-lease ls
+    llama-swap-lease can-load qwen3.5-9b-vision
+    llama-swap-lease extend <id> --ttl 2h
+    llama-swap-lease release <id>
+    llama-swap-lease kill --model qwen3.5-9b-vision
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import signal
+import sys
+import urllib.error
+import urllib.request
+from typing import Any, Optional
+
+DEFAULT_BASE_URL = os.environ.get("LLAMA_SWAP_URL", "http://localhost:8080")
+LEASE_HEADER = "X-Llama-Swap-Lease"
+
+
+class LeaseError(RuntimeError):
+    """A lease API call failed. `status` and `body` carry the HTTP detail."""
+
+    def __init__(self, message: str, status: int = 0, body: Any = None):
+        super().__init__(message)
+        self.status = status
+        self.body = body
+
+
+def _request(method: str, url: str, api_key: Optional[str], payload: Optional[dict] = None) -> tuple[int, Any]:
+    data = None
+    headers = {"Accept": "application/json"}
+    if payload is not None:
+        data = json.dumps(payload).encode()
+        headers["Content-Type"] = "application/json"
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            raw = resp.read()
+            return resp.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as e:
+        raw = e.read()
+        body = None
+        with contextlib.suppress(Exception):
+            body = json.loads(raw) if raw else None
+        return e.code, body
+    except urllib.error.URLError as e:
+        raise LeaseError(f"cannot reach llama-swap at {url}: {e.reason}") from e
+
+
+class Lease:
+    """A live lease handle. `header()` gives the request header to tag work with."""
+
+    def __init__(self, base_url: str, api_key: Optional[str], data: dict):
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self.id = data["id"]
+        self.model = data["model"]
+        self.data = data
+
+    def header(self) -> dict[str, str]:
+        return {LEASE_HEADER: self.id}
+
+    def extend(self, ttl: str) -> "Lease":
+        status, body = _request(
+            "POST", f"{self._base_url}/leases/{self.id}/extend", self._api_key, {"ttl": ttl}
+        )
+        if status != 200:
+            raise LeaseError(f"extend failed: {body}", status, body)
+        self.data = body
+        return self
+
+    def release(self) -> bool:
+        status, _ = _request("DELETE", f"{self._base_url}/leases/{self.id}", self._api_key)
+        # 204 released; 404 already gone (expired/killed) — both mean "not held".
+        return status in (204, 404)
+
+
+def acquire(model: str, holder: str = "", reason: str = "", ttl: str = "",
+            base_url: str = DEFAULT_BASE_URL, api_key: Optional[str] = None) -> Lease:
+    payload = {"model": model, "holder": holder, "reason": reason, "ttl": ttl}
+    status, body = _request("POST", f"{base_url.rstrip('/')}/leases", api_key, payload)
+    if status != 201:
+        raise LeaseError(f"acquire failed ({status}): {body}", status, body)
+    return Lease(base_url, api_key, body)
+
+
+@contextlib.contextmanager
+def model_lease(model: str, holder: str = "", reason: str = "", ttl: str = "",
+                base_url: str = DEFAULT_BASE_URL, api_key: Optional[str] = None):
+    """Acquire on enter, release on exit (also on SIGTERM). TTL is the crash backstop."""
+    lease = acquire(model, holder=holder, reason=reason, ttl=ttl, base_url=base_url, api_key=api_key)
+
+    released = {"done": False}
+
+    def _release_once(*_):
+        if not released["done"]:
+            released["done"] = True
+            with contextlib.suppress(Exception):
+                lease.release()
+
+    prev = signal.getsignal(signal.SIGTERM)
+
+    def _on_sigterm(signum, frame):
+        _release_once()
+        if callable(prev):
+            prev(signum, frame)
+        else:
+            raise SystemExit(143)
+
+    with contextlib.suppress(ValueError):  # not in main thread => cannot set signal
+        signal.signal(signal.SIGTERM, _on_sigterm)
+    try:
+        yield lease
+    finally:
+        _release_once()
+        with contextlib.suppress(ValueError):
+            signal.signal(signal.SIGTERM, prev)
+
+
+# --------------------------------------------------------------------------- CLI
+
+
+def _print(obj: Any) -> None:
+    print(json.dumps(obj, indent=2, sort_keys=True))
+
+
+def _cli(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(prog="llama-swap-lease", description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--url", default=DEFAULT_BASE_URL, help="llama-swap base URL")
+    p.add_argument("--api-key", default=os.environ.get("LLAMA_SWAP_API_KEY"), help="API key (Bearer)")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    a = sub.add_parser("acquire", help="acquire a lease")
+    a.add_argument("model")
+    a.add_argument("--holder", default="")
+    a.add_argument("--reason", default="")
+    a.add_argument("--ttl", default="", help="Go duration, e.g. 4h or 30m (default: server max)")
+
+    r = sub.add_parser("release", help="release a lease by id")
+    r.add_argument("id")
+
+    e = sub.add_parser("extend", help="extend a lease by id")
+    e.add_argument("id")
+    e.add_argument("--ttl", required=True)
+
+    k = sub.add_parser("kill", help="force-remove leases (exactly one selector)")
+    g = k.add_mutually_exclusive_group(required=True)
+    g.add_argument("--id")
+    g.add_argument("--model")
+    g.add_argument("--holder")
+
+    sub.add_parser("ls", help="list live leases")
+
+    c = sub.add_parser("can-load", help="preflight: what happens if I load this model")
+    c.add_argument("model")
+
+    args = p.parse_args(argv)
+    base = args.url.rstrip("/")
+
+    try:
+        if args.cmd == "acquire":
+            lease = acquire(args.model, args.holder, args.reason, args.ttl, base, args.api_key)
+            _print(lease.data)
+        elif args.cmd == "release":
+            status, _ = _request("DELETE", f"{base}/leases/{args.id}", args.api_key)
+            if status not in (204, 404):
+                print(f"release failed: {status}", file=sys.stderr)
+                return 1
+            _print({"released": status == 204, "id": args.id})
+        elif args.cmd == "extend":
+            status, body = _request("POST", f"{base}/leases/{args.id}/extend", args.api_key, {"ttl": args.ttl})
+            if status != 200:
+                print(f"extend failed ({status}): {body}", file=sys.stderr)
+                return 1
+            _print(body)
+        elif args.cmd == "kill":
+            sel = {"id": args.id or "", "model": args.model or "", "holder": args.holder or ""}
+            status, body = _request("POST", f"{base}/leases/kill", args.api_key, sel)
+            if status != 200:
+                print(f"kill failed ({status}): {body}", file=sys.stderr)
+                return 1
+            _print(body)
+        elif args.cmd == "ls":
+            status, body = _request("GET", f"{base}/leases", args.api_key)
+            if status != 200:
+                print(f"list failed ({status}): {body}", file=sys.stderr)
+                return 1
+            _print(body)
+        elif args.cmd == "can-load":
+            status, body = _request("GET", f"{base}/leases/can-load/{args.model}", args.api_key)
+            if status != 200:
+                print(f"can-load failed ({status}): {body}", file=sys.stderr)
+                return 1
+            _print(body)
+    except LeaseError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Implements the `trySysfs` / `readSysfs` GPU backend, which was previously a stub returning `ErrNotImplemented`. This is the last-resort fallback in `getGpuStats` (`tryLACT -> tryNvidiaSmi -> tryRocmSmi -> trySysfs`), and it's the only backend that reports correct memory on **AMD APUs / iGPUs**.

It also fixes the backend **ordering** for that case: because `tryRocmSmi` runs before `trySysfs` and "succeeds" on APUs (reporting just the tiny VRAM carveout), `trySysfs` never ran on boxes that have rocm-smi installed. `tryRocmSmi` now detects the APU carveout from sysfs and defers, so the sysfs/GTT path wins where it matters while dGPU behavior is unchanged.

## The problem: VRAM carveout vs GTT on APUs

On AMD APUs/iGPUs there is no dedicated VRAM. The `mem_info_vram_*` sysfs nodes only expose a small BIOS carveout (commonly **512 MiB**). The model actually lives in **GTT** (Graphics Translation Table = GPU-accessible system RAM). `rocm-smi` reports only the VRAM carveout there, so it is effectively blind to the real working set: it shows ~512 MiB total no matter how large the loaded model is.

This implementation reads amdgpu memory accounting directly from sysfs and reports the **combined** figure:

```
MemTotalMB = (vram_total + gtt_total) / MiB
MemUsedMB  = (vram_used  + gtt_used)  / MiB
MemUtilPct = used / total * 100
```

This is correct on both ends of the spectrum:

- **dGPU**: GTT is tiny relative to dedicated VRAM, so the sum is dominated by VRAM and matches what nvidia-smi / rocm-smi report.
- **APU/iGPU**: VRAM is a tiny carveout, so GTT dominates and the number finally reflects reality.

## Implementation notes

- Enumerates `/sys/class/drm/card[0-9]*/device/` entries. Only directories that expose `mem_info_gtt_total` are treated as amdgpu cards; connector nodes like `card0-DP-1` / `card0-HDMI-A-1` (which also match `card*`) and non-amdgpu drivers are skipped. The amdgpu driver is additionally confirmed via `uevent` `DRIVER=` when present.
- All sysfs reads are best-effort; missing files degrade gracefully rather than erroring.
- Populates `GpuUtilPct` from `gpu_busy_percent` when available, and a device name derived from the PCI ID in `uevent` (amdgpu does not expose a product string in sysfs).
- Returns `ErrNoGpuTool` when no amdgpu card is found, so `getGpuStats` falls through cleanly.
- The sysfs root is a package var so the parsing can be unit-tested against a temp-dir fixture. Tests cover the APU carveout case, the dGPU case, non-amdgpu skip, and missing-file handling.
- No new dependencies; matches the existing rocm-smi backend's MB conversion and struct-population style.

### rocm-smi deferral on APU carveouts

`tryRocmSmi` now calls `sysfsHasApuCarveout()` before claiming the backend. That helper returns true only when an amdgpu card has small dedicated VRAM (**<= 1 GiB**) backed by a much larger GTT pool, i.e. the APU/iGPU carveout pattern. In that case `tryRocmSmi` returns `ErrNoGpuTool` so the chain falls through to `trySysfs`. The bound is conservative: the smallest modern AMD dGPUs ship 2+ GiB VRAM, so dGPUs never match and rocm-smi keeps winning there.

## Validation

Validated on a **Radeon 680M (gfx1035)** APU, read-only (no model loaded during this capture), **with `rocm-smi` installed and on `PATH`** (i.e. the real-world case the ordering fix targets). The monitor log now shows `using sysfs for GPU monitoring` (previously `using rocm-smi`):

```
# Monitor (sysfs backend, with rocm-smi present):
llamaswap_gpu_memory_total_bytes{...,name="amdgpu card0 (1002:1681)"} 2.5232932864e+10   # 23.5 GiB
llamaswap_gpu_memory_used_bytes{...}                                  9.15406848e+08      # ~0.85 GiB

# Live sysfs at the same moment:
vram_total=536870912  vram_used=91729920
gtt_total=24696061952 gtt_used=823828480
# combined total = 25232932864 bytes  -> matches monitor exactly
# combined used  = 915558400 bytes    -> matches monitor (sub-sampling-interval delta)

# What rocm-smi reported here BEFORE the deferral (the bug this fixes):
#   using rocm-smi for GPU monitoring
llamaswap_gpu_memory_total_bytes  5.36870912e+08   # 512 MiB VRAM carveout only
llamaswap_gpu_memory_used_bytes   9.1226112e+07    # ~87 MiB, blind to GTT
```

Under real model load this box has been observed at ~13.8 GiB GTT used (vs the static ~512 MiB rocm-smi ceiling). The combined sysfs number tracks that working set; rocm-smi cannot.

## Optional: live-GTT budget gate (config-gated, fail-open, default off)

The sysfs backend makes GTT _visible_; this commit makes it _actionable_. It adds an optional admission gate that keeps total GPU-managed memory (VRAM + GTT) under a configured ceiling by evicting least-recently-used models before a swap. On APUs this matters because model weights **and the KV cache** grow in GTT, which the matrix/group solvers don't account for — so an otherwise-valid load can push the box past its real memory limit.

It is entirely opt-in and safe by construction:

- **Default off.** Disabled unless `performance.gpuBudgetMB > 0` _and_ the perf monitor is active. A nil gate is a plain no-op.
- **Fail-open.** Any unresolved condition (no monitor reading yet, no evictable victim, still over budget after evicting everything it may) logs a warning and lets the load proceed. Starving a load is worse than briefly overshooting a soft budget.
- **One chokepoint, no solver changes.** A single `memGate.EnsureFits(...)` call sits in `baseRouter.doSwap`, after the solver-decided evictions are stopped and before the target launches, so it covers the matrix, group, and solo paths without touching the matrix solver.

How it works:

```
for liveUsedMB() + estimateMB(incoming) > budgetMB:
    victim = LRU resident model        # lowest Process.LastUse()
             excluding incoming + models the solver is already evicting
    procs[victim].Stop(timeout)        # synchronous: frees GTT before re-check
    re-read liveUsedMB()
```

`liveUsedMB()` comes from `perf.Monitor.Current()` (latest sample per GPU, summed across GPUs); thanks to the sysfs backend above, that figure already includes GTT. New config: `performance.gpuBudgetMB` (MiB, 0 = disabled) and per-model `vramEstimateMB` (MiB; 0 = reactive, i.e. evict only once live usage already exceeds the budget). `Process` gains a `LastUse() int64` accessor (backed by the existing `lastUse` atomic) for LRU selection.

Unit tests (`internal/router/memgate_test.go`, fake monitor + fake processes) cover: evict-to-fit reduces the projected footprint under budget; LRU order (oldest first, including multi-evict); fail-open when nothing is left to evict; no-op at `budgetMB==0` / nil gate; and never evicting the incoming or already-stopped models.

Validated on the same Radeon 680M with the gate enabled (`gpuBudgetMB: 20000`, model `vramEstimateMB: 2000`): loading a model logged the gate evaluating at the chokepoint and then proceeding —

```
[DEBUG] group: starting swap for model qwen3.5-2b, evicting []
[DEBUG] memgate: qwen3.5-2b fits (used=14623MB + est=2000MB = 16623MB <= budget=20000MB)
[DEBUG] <qwen3.5-2b> Executing start command: ...llama-server...
[INFO]  <qwen3.5-2b> Health check passed
```

The gate read live GTT (14623 MB) via the sysfs backend, projected the load under budget, and let it through; the request returned HTTP 200.

## Out of scope / follow-up

This backend (like the others) reports **one number per GPU**. Per-process / per-model attribution on amdgpu requires reading `/proc/<pid>/fdinfo/*` (`drm-memory-gtt` etc.) and a data-model change in the monitor, so it's left as a follow-up. `amdgpu_top` already covers per-process accounting standalone.


---

## Update 2026-07-03: LACT deferral + fail-closed budget gate

Two follow-up commits after production incidents on the validation box (hard lockups -> hardware watchdog reboots when co-loaded models overshot GTT):

**`internal/perf: prefer sysfs over LACT on APU carveouts`** - the rocm-smi deferral above was not enough: `tryLACT` runs first in the chain and has the exact same blindness (LACT reports the 512 MiB carveout on APUs, not GTT). Any consumer budgeting against GPU memory then compares near-zero "used" against a multi-GiB budget and never fires. The carveout check now runs before ALL tools; sysfs wins when the pattern is present. Also adds `ReadLiveGpuMemUsedMB()` (fresh synchronous sysfs read) and `ReadHostMemAvailableMB()` for admission-time checks that cannot tolerate the >=5s poll staleness.

**`internal/router,config: strict admission, reservations, runtime red-line watchdog`** - upgrades the (still default-off) budget gate into a real admission controller:

- admissions serialized + reservation ledger, so concurrent swaps cannot jointly overshoot while a big model's footprint is still materializing during a multi-minute load
- fresh sysfs reads at admission; post-eviction settling observes the actual drop
- optional host MemAvailable floor (`performance.hostMemFloorMB`) - on UMA boxes GPU memory and host RAM are one physical pool
- optional strict mode (`performance.gpuStrictAdmission`): evict LRU -> bounded wait (`admissionMaxWait`) -> reject with typed 503 + Retry-After via the existing `shared.HTTPError` seam; models without `vramEstimateMB` are rejected since the gate cannot project them
- optional runtime red-line watchdog (`performance.gpuRedlineMB` / `gpuHardlineMB`): 1s fresh-read ticker evicts LRU models back under budget, catching estimate drift and post-admission KV growth; soft tier spares the most-recently-used model, hard tier spares nothing

Defaults unchanged: everything above is opt-in; non-strict behavior remains fail-open with identical LRU semantics. 22 unit tests added (`TestMemGate_*`). Production validation on the 680M box: the co-load scenario that previously hit 22 GB GTT and watchdog-rebooted now peaks at 17.8 GB with orderly LRU eviction, all requests served.
