### PR TITLE
add /props to modelGetRoutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
   - `v1/rerank`, `v1/reranking`, `/rerank`
   - `/infill` - for code infilling
   - `/completion` - for completion endpoint
+  - `/props` - requires `model` to be specified in request.
 - ✅ SDAPI via [stable-diffusion.cpp's server](https://github.com/leejet/stable-diffusion.cpp/tree/master/examples/server)
   - `/sdapi/v1/txt2img`
   - `/sdapi/v1/img2img`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
   - `v1/rerank`, `v1/reranking`, `/rerank`
   - `/infill` - for code infilling
   - `/completion` - for completion endpoint
-  - `/props` - requires `model` to be specified in request.
+  - `/props` - requires `model` to be specified in request. note llama-server's autoload param is not supported and will be ignored if specified.
 - ✅ SDAPI via [stable-diffusion.cpp's server](https://github.com/leejet/stable-diffusion.cpp/tree/master/examples/server)
   - `/sdapi/v1/txt2img`
   - `/sdapi/v1/img2img`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
   - `v1/rerank`, `v1/reranking`, `/rerank`
   - `/infill` - for code infilling
   - `/completion` - for completion endpoint
-  - `/props` - requires `model` to be specified in request. note llama-server's autoload param is not supported and will be ignored if specified.
+  - `/props` - requires `?model={model_id}` query parameter to be provided. The autoload parameter is not supported and will be ignored.
 - ✅ SDAPI via [stable-diffusion.cpp's server](https://github.com/leejet/stable-diffusion.cpp/tree/master/examples/server)
   - `/sdapi/v1/txt2img`
   - `/sdapi/v1/img2img`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -87,6 +87,7 @@ var modelPostFormRoutes = []string{
 var modelGetRoutes = []string{
 	"/v1/audio/voices",
 	"/sdapi/v1/loras",
+	"/props",
 }
 
 // isMetricsRecordPath reports whether path is one of the model-dispatched


### PR DESCRIPTION
add /props to modelGetRotes so that 3p tools like huggingface's official
Pi agent plugin can use this to determine context length for the hosted
model. This mimics the behavior of how llama-server operates in routing
mode when the model name is pased.

This is a partial implementation of the llama.cpp's /props endpoint. A
full implementation was not done to both provide the majority of the value
while also keeping the code change extremely minimal.

Similarities/differences vs llama-server in router mode:
- /props?model=<model_name>   - llama-server and llama-swap have same behavior
- /props?model=<model_name>&autoload=false   - llama-server throws error if model is not loaded, but llama-swap ignores parameter and loads the model anyways.
- /props?model=NOT_A_VALID_MODEL   - llama-server and llama-swap both throw errors
- /props    - llama-server prints some metadata bout the llama-server process. llama-swap gives error.

implements #854
