### PR TITLE
internal/router: reject concurrency excess before streaming

### DIFF
--- a/internal/router/base.go
+++ b/internal/router/base.go
@@ -425,6 +425,7 @@ func (b *baseRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// Unbuffered: a successful send on Respond proves the waiter is
 		// alive and consuming. grant() relies on this to avoid handing a
 		// handleFunc to a cancelled waiter and leaking the inFlight count.
+		Admit:      make(chan error, 1),
 		Respond:    make(chan scheduler.HandlerResp),
 		PositionCh: make(chan int, 1),
 	}
@@ -435,6 +436,24 @@ func (b *baseRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	case <-b.shutdownCtx.Done():
 		shared.SendError(w, req, fmt.Errorf("%s is shutting down", b.name))
+		return
+	}
+
+	var admissionErr error
+	select {
+	case admissionErr = <-hr.Admit:
+	case <-req.Context().Done():
+		select {
+		case b.cancelCh <- hr:
+		case <-b.shutdownCtx.Done():
+		}
+		return
+	case <-b.shutdownCtx.Done():
+		shared.SendError(w, req, fmt.Errorf("%s is shutting down", b.name))
+		return
+	}
+	if admissionErr != nil {
+		shared.SendError(w, req, admissionErr)
 		return
 	}
 

--- a/internal/router/base_test.go
+++ b/internal/router/base_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,16 +20,28 @@ import (
 // scheduling decision logic (queueing, collation, eviction collisions) lives in
 // the scheduler package and is tested directly there; see fifo_test.go.
 
-// stubPlanner evicts nothing. baseRouter tests drive the run loop through the
-// default FIFO scheduler without exercising any particular eviction policy.
-type stubPlanner struct{}
+// stubPlanner evicts configured targets. baseRouter tests drive the run loop
+// through the default FIFO scheduler without exercising router planner details.
+type stubPlanner struct {
+	evict map[string][]string
+}
 
-func (s *stubPlanner) EvictionFor(string, []string) []string { return nil }
-func (s *stubPlanner) OnSwapStart(string, []string)          {}
+func (s *stubPlanner) EvictionFor(target string, _ []string) []string {
+	if s.evict == nil {
+		return nil
+	}
+	return s.evict[target]
+}
+func (s *stubPlanner) OnSwapStart(string, []string) {}
 
 func newTestBase(t *testing.T, processes map[string]process.Process, planner scheduler.Swapper) *baseRouter {
 	t.Helper()
 	conf := config.Config{HealthCheckTimeout: 5}
+	return newTestBaseWithConfig(t, conf, processes, planner)
+}
+
+func newTestBaseWithConfig(t *testing.T, conf config.Config, processes map[string]process.Process, planner scheduler.Swapper) *baseRouter {
+	t.Helper()
 	b, err := newBaseRouter("test", conf, processes, logmon.NewWriter(io.Discard), planner)
 	if err != nil {
 		t.Fatalf("newBaseRouter: %v", err)
@@ -227,6 +240,63 @@ func TestBaseRouter_ModelNotFound(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status=%d want %d body=%q", w.Code, http.StatusNotFound, w.Body.String())
+	}
+}
+
+func TestBaseRouter_ConcurrencyLimitRejectsBeforeLoadingStream(t *testing.T) {
+	sendLoading := true
+	conf := config.Config{
+		HealthCheckTimeout: 5,
+		Models: map[string]config.ModelConfig{
+			"a": {ConcurrencyLimit: 2, SendLoadingState: &sendLoading},
+			"b": {},
+		},
+	}
+	a := newFakeProcess("a")
+	a.autoReady = true
+	bProc := newFakeProcess("b")
+	bProc.autoReady = true
+	bProc.serveBlock = make(chan struct{})
+
+	b := newTestBaseWithConfig(t, conf, map[string]process.Process{"a": a, "b": bProc}, &stubPlanner{
+		evict: map[string][]string{"a": {"b"}},
+	})
+
+	bDone := make(chan struct{})
+	go func() {
+		b.ServeHTTP(httptest.NewRecorder(), newStreamRequest("b"))
+		close(bDone)
+	}()
+	waitSignal(t, bProc.serveStarted, "b request start")
+	waitProcessed(t, b.testProcessed, 2)
+
+	aDone1 := make(chan struct{})
+	aDone2 := make(chan struct{})
+	go func() {
+		b.ServeHTTP(httptest.NewRecorder(), newStreamRequest("a"))
+		close(aDone1)
+	}()
+	go func() {
+		b.ServeHTTP(httptest.NewRecorder(), newStreamRequest("a"))
+		close(aDone2)
+	}()
+	waitProcessed(t, b.testProcessed, 2)
+
+	w := httptest.NewRecorder()
+	b.ServeHTTP(w, newStreamRequest("a"))
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status=%d want 429 body=%q", w.Code, w.Body.String())
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type=%q want application/json", got)
+	}
+	if strings.Contains(w.Body.String(), "llama-swap loading model") {
+		t.Fatalf("429 body contains loading stream: %q", w.Body.String())
+	}
+
+	close(bProc.serveBlock)
+	for name, ch := range map[string]chan struct{}{"b": bDone, "a1": aDone1, "a2": aDone2} {
+		waitSignal(t, ch, name+" request finish")
 	}
 }
 

--- a/internal/router/helpers_test.go
+++ b/internal/router/helpers_test.go
@@ -200,14 +200,30 @@ func waitProcessed(t *testing.T, ch chan struct{}, n int) {
 	for i := 0; i < n; i++ {
 		select {
 		case <-ch:
-		case <-time.After(2 * time.Second):
-			t.Fatalf("waitProcessed: only %d/%d events received", i, n)
+		case <-t.Context().Done():
+			t.Fatalf("waitProcessed: only %d/%d events received: %v", i, n, context.Cause(t.Context()))
 		}
+	}
+}
+
+func waitSignal(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-t.Context().Done():
+		t.Fatalf("%s did not signal: %v", name, context.Cause(t.Context()))
 	}
 }
 
 func newRequest(model string) *http.Request {
 	body := fmt.Sprintf(`{"model":%q}`, model)
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	return r
+}
+
+func newStreamRequest(model string) *http.Request {
+	body := fmt.Sprintf(`{"model":%q,"stream":true}`, model)
 	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
 	r.Header.Set("Content-Type", "application/json")
 	return r

--- a/internal/router/loading.go
+++ b/internal/router/loading.go
@@ -66,6 +66,7 @@ func newLoadingWriter(logger *logmon.Monitor, modelName string, w http.ResponseW
 		startTime:     time.Now(),
 		tickDuration:  750 * time.Millisecond,
 		charPerSecond: 75,
+		done:          make(chan struct{}),
 	}
 
 	s.Header().Set("Content-Type", "text/event-stream")
@@ -84,7 +85,6 @@ func (s *loadingWriter) setUpdate(msg string) {
 }
 
 func (s *loadingWriter) start(ctx context.Context) {
-	s.done = make(chan struct{})
 	defer close(s.done)
 
 	defer func() {

--- a/internal/router/scheduler/fifo.go
+++ b/internal/router/scheduler/fifo.go
@@ -325,10 +325,16 @@ func sendAdmission(req HandlerReq, err error) bool {
 	if req.Admit == nil {
 		return true
 	}
+	done := reqDone(req)
+	select {
+	case <-done:
+		return false
+	default:
+	}
 	select {
 	case req.Admit <- err:
 		return true
-	case <-reqDone(req):
+	case <-done:
 		return false
 	}
 }
@@ -341,8 +347,11 @@ func reqDone(req HandlerReq) <-chan struct{} {
 }
 
 func (s *FIFO) release(modelID string) {
-	s.reserved[modelID]--
 	if s.reserved[modelID] <= 0 {
+		panic(fmt.Sprintf("%s: release without reservation for model %s", s.name, modelID))
+	}
+	s.reserved[modelID]--
+	if s.reserved[modelID] == 0 {
 		delete(s.reserved, modelID)
 	}
 }

--- a/internal/router/scheduler/fifo.go
+++ b/internal/router/scheduler/fifo.go
@@ -41,6 +41,7 @@ type FIFO struct {
 
 	limits   map[string]int
 	active   map[string]*activeSwap
+	reserved map[string]int
 	inFlight map[string]int
 	queued   []HandlerReq
 }
@@ -66,6 +67,7 @@ func NewFIFO(name string, logger *logmon.Monitor, planner Swapper, cfg config.Fi
 		effects:  eff,
 		limits:   limits,
 		active:   make(map[string]*activeSwap),
+		reserved: make(map[string]int),
 		inFlight: make(map[string]int),
 	}
 }
@@ -94,7 +96,11 @@ func (s *FIFO) OnRequest(req HandlerReq) {
 	state, ok := s.effects.ModelState(req.Model)
 	if !ok {
 		s.logger.Debugf("%s: model %s not handled by this router", s.name, req.Model)
-		s.effects.GrantError(req, ErrModelNotFound)
+		s.rejectAdmission(req, ErrModelNotFound)
+		return
+	}
+
+	if !s.admit(req) {
 		return
 	}
 
@@ -148,6 +154,7 @@ func (s *FIFO) OnCancel(req HandlerReq) {
 		for _, q := range s.queued {
 			if q.Respond == req.Respond {
 				removed = true
+				s.release(q.Model)
 				continue
 			}
 			kept = append(kept, q)
@@ -161,6 +168,7 @@ func (s *FIFO) OnCancel(req HandlerReq) {
 		for _, w := range sw.waiters {
 			if w.Respond == req.Respond {
 				removed = true
+				s.release(w.Model)
 				continue
 			}
 			filtered = append(filtered, w)
@@ -187,7 +195,7 @@ func (s *FIFO) OnSwapDone(ev SwapDone) {
 
 	for _, w := range sw.waiters {
 		if ev.Err != nil {
-			s.effects.GrantError(w, ev.Err)
+			s.grantError(w, ev.Err)
 		} else {
 			s.grantHandler(w, ev.ModelID)
 		}
@@ -201,6 +209,7 @@ func (s *FIFO) OnSwapDone(ev SwapDone) {
 // have evicted this (now-idle) process can now proceed.
 func (s *FIFO) OnServeDone(ev ServeDoneEvent) {
 	s.inFlight[ev.ModelID]--
+	s.release(ev.ModelID)
 	if s.inFlight[ev.ModelID] <= 0 {
 		delete(s.inFlight, ev.ModelID)
 		s.drainQueue()
@@ -227,7 +236,7 @@ func (s *FIFO) OnUnload(targets []string, timeout time.Duration) {
 			continue
 		}
 		for _, w := range sw.waiters {
-			s.effects.GrantError(w, unloadErr)
+			s.grantError(w, unloadErr)
 		}
 		delete(s.active, id)
 	}
@@ -238,7 +247,7 @@ func (s *FIFO) OnUnload(targets []string, timeout time.Duration) {
 		kept := s.queued[:0]
 		for _, w := range s.queued {
 			if targetSet[w.Model] {
-				s.effects.GrantError(w, unloadErr)
+				s.grantError(w, unloadErr)
 				continue
 			}
 			kept = append(kept, w)
@@ -261,31 +270,80 @@ func (s *FIFO) OnUnload(targets []string, timeout time.Duration) {
 func (s *FIFO) OnShutdown(err error) {
 	for _, sw := range s.active {
 		for _, w := range sw.waiters {
-			s.effects.GrantError(w, err)
+			s.grantError(w, err)
 		}
 	}
 	for _, w := range s.queued {
-		s.effects.GrantError(w, err)
+		s.grantError(w, err)
 	}
 }
 
 // grantHandler hands the caller a tracked handler for modelID and, only if the
 // caller was still there to receive it, bumps the in-flight count. Incrementing
 // when the grant failed would strand the counter and block future evictions.
-// Requests that would exceed the model's concurrency limit are rejected with a
-// shared.NewConcurrencyLimitError (HTTP 429 with Retry-After).
+// Concurrency-limit rejection happens earlier in admit, before a request can
+// start the loading stream.
 func (s *FIFO) grantHandler(req HandlerReq, modelID string) {
-	if s.inFlight[modelID] >= s.limit(modelID) {
-		s.effects.GrantError(req, shared.ConcurrencyLimitError{})
-		return
-	}
-
 	if err := shared.SetReqData(req.Ctx, "fifo_priority", strconv.Itoa(s.cfg.Priority[req.Model])); err != nil {
 		s.logger.Debugf("failed to set fifo_priority metadata: %v", err)
 	}
 
 	if s.effects.GrantServe(req, modelID) {
 		s.inFlight[modelID]++
+	} else {
+		s.release(modelID)
+	}
+}
+
+// grantError reports a post-admission error to the caller and releases the
+// request's reserved concurrency slot.
+func (s *FIFO) grantError(req HandlerReq, err error) {
+	s.release(req.Model)
+	s.effects.GrantError(req, err)
+}
+
+// admit performs the pre-stream admission handshake. Accepted requests reserve
+// one future serving slot until they serve, cancel while waiting, or receive a
+// post-admission error.
+func (s *FIFO) admit(req HandlerReq) bool {
+	if s.reserved[req.Model] >= s.limit(req.Model) {
+		s.rejectAdmission(req, shared.ConcurrencyLimitError{})
+		return false
+	}
+	if !sendAdmission(req, nil) {
+		return false
+	}
+	s.reserved[req.Model]++
+	return true
+}
+
+func (s *FIFO) rejectAdmission(req HandlerReq, err error) {
+	sendAdmission(req, err)
+}
+
+func sendAdmission(req HandlerReq, err error) bool {
+	if req.Admit == nil {
+		return true
+	}
+	select {
+	case req.Admit <- err:
+		return true
+	case <-reqDone(req):
+		return false
+	}
+}
+
+func reqDone(req HandlerReq) <-chan struct{} {
+	if req.Ctx == nil {
+		return nil
+	}
+	return req.Ctx.Done()
+}
+
+func (s *FIFO) release(modelID string) {
+	s.reserved[modelID]--
+	if s.reserved[modelID] <= 0 {
+		delete(s.reserved, modelID)
 	}
 }
 
@@ -343,7 +401,7 @@ func (s *FIFO) drainQueue() {
 	for _, req := range pending {
 		state, ok := s.effects.ModelState(req.Model)
 		if !ok {
-			s.effects.GrantError(req, ErrModelNotFound)
+			s.grantError(req, ErrModelNotFound)
 			continue
 		}
 		if sw, ok := s.active[req.Model]; ok {

--- a/internal/router/scheduler/fifo_test.go
+++ b/internal/router/scheduler/fifo_test.go
@@ -195,6 +195,44 @@ func assertAdmission429(t *testing.T, req HandlerReq) {
 	}
 }
 
+func TestFIFO_SendAdmission_CancelledContextWins(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r := HandlerReq{
+		Ctx:   ctx,
+		Admit: make(chan error, 1),
+	}
+
+	if sendAdmission(r, nil) {
+		t.Fatal("sendAdmission returned true for cancelled request")
+	}
+	select {
+	case err := <-r.Admit:
+		t.Fatalf("admission sent after cancellation: %v", err)
+	default:
+	}
+}
+
+func TestFIFO_SendAdmission_NilAdmitPreservesExistingBehavior(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if !sendAdmission(HandlerReq{Ctx: ctx}, nil) {
+		t.Fatal("nil Admit should preserve existing accepted behavior")
+	}
+}
+
+func TestFIFO_ReleaseWithoutReservationPanics(t *testing.T) {
+	s := newFIFO(&stubPlanner{}, newFakeEffects())
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("release without reservation did not panic")
+		}
+	}()
+	s.release("a")
+}
+
 func TestFIFO_FastPath(t *testing.T) {
 	eff := newFakeEffects()
 	eff.states["a"] = process.StateReady

--- a/internal/router/scheduler/fifo_test.go
+++ b/internal/router/scheduler/fifo_test.go
@@ -146,14 +146,52 @@ func newFIFO(planner Swapper, eff Effects) *FIFO {
 	return NewFIFO("test", logmon.NewWriter(io.Discard), planner, config.FifoConfig{}, nil, eff)
 }
 
-func req(model string) HandlerReq { return HandlerReq{Model: model} }
+func req(model string) HandlerReq {
+	return HandlerReq{
+		Model: model,
+		Ctx:   context.Background(),
+		Admit: make(chan error, 1),
+	}
+}
 
 // reqCh creates a HandlerReq with a unique Respond channel so OnCancel can
 // identify it among queued requests and swap waiters.
 func reqCh(model string) HandlerReq {
-	return HandlerReq{
-		Model:   model,
-		Respond: make(chan HandlerResp, 1),
+	r := req(model)
+	r.Respond = make(chan HandlerResp, 1)
+	return r
+}
+
+func admitErr(t *testing.T, req HandlerReq) error {
+	t.Helper()
+	select {
+	case err := <-req.Admit:
+		return err
+	default:
+		t.Fatal("admission result not sent")
+		return nil
+	}
+}
+
+func assertAdmitted(t *testing.T, req HandlerReq) {
+	t.Helper()
+	if err := admitErr(t, req); err != nil {
+		t.Fatalf("admission err=%v want nil", err)
+	}
+}
+
+func assertAdmission429(t *testing.T, req HandlerReq) {
+	t.Helper()
+	var httpErr shared.HTTPError
+	err := admitErr(t, req)
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("admission err=%v want HTTPError", err)
+	}
+	if httpErr.StatusCode() != http.StatusTooManyRequests {
+		t.Fatalf("StatusCode()=%d want 429", httpErr.StatusCode())
+	}
+	if httpErr.Header().Get("Retry-After") == "" {
+		t.Fatal("missing Retry-After header")
 	}
 }
 
@@ -197,16 +235,17 @@ func TestFIFO_ModelNotFound(t *testing.T) {
 	eff := newFakeEffects() // no states => model unknown
 	s := newFIFO(&stubPlanner{}, eff)
 
-	s.OnRequest(req("ghost"))
+	r := req("ghost")
+	s.OnRequest(r)
 
 	if got := len(eff.starts); got != 0 {
 		t.Errorf("StartSwap calls=%d want 0", got)
 	}
-	if eff.errored("ghost") != 1 {
-		t.Fatalf("want 1 error grant for ghost, grants=%+v", eff.grants)
+	if got := eff.errored("ghost"); got != 0 {
+		t.Fatalf("error grants=%d want 0 for admission rejection", got)
 	}
-	if !errors.Is(eff.grants[0].err, ErrModelNotFound) {
-		t.Errorf("err=%v want ErrModelNotFound", eff.grants[0].err)
+	if err := admitErr(t, r); !errors.Is(err, ErrModelNotFound) {
+		t.Errorf("admission err=%v want ErrModelNotFound", err)
 	}
 }
 
@@ -672,36 +711,32 @@ func newFIFOWithLimit(t *testing.T, model string, limit int) (*FIFO, *fakeEffect
 }
 
 // TestFIFO_ConcurrencyLimit_RejectsOverLimit verifies that a request arriving
-// while the model is at capacity gets an error grant instead of being served,
-// and that a new request succeeds once an in-flight one completes.
+// while the model is at capacity gets rejected during admission, before it can
+// be queued or served, and that a new request succeeds once capacity returns.
 func TestFIFO_ConcurrencyLimit_RejectsOverLimit(t *testing.T) {
 	s, eff := newFIFOWithLimit(t, "a", 1)
 
 	// First request: served (inFlight 0 → 1).
-	s.OnRequest(req("a"))
+	r1 := req("a")
+	s.OnRequest(r1)
+	assertAdmitted(t, r1)
 	if got := eff.served("a"); got != 1 {
 		t.Fatalf("served(a)=%d want 1", got)
 	}
 
-	// Second request while slot is occupied: rejected with HTTPError 429.
-	s.OnRequest(req("a"))
-	if got := eff.errored("a"); got != 1 {
-		t.Fatalf("errored(a)=%d want 1 (over-limit)", got)
-	}
-	var httpErr shared.HTTPError
-	if !errors.As(eff.grants[len(eff.grants)-1].err, &httpErr) {
-		t.Fatalf("err=%v want HTTPError", eff.grants[len(eff.grants)-1].err)
-	}
-	if httpErr.StatusCode() != http.StatusTooManyRequests {
-		t.Fatalf("StatusCode()=%d want 429", httpErr.StatusCode())
-	}
-	if httpErr.Header().Get("Retry-After") == "" {
-		t.Fatal("missing Retry-After header")
+	// Second request while slot is occupied: rejected at admission with 429.
+	r2 := req("a")
+	s.OnRequest(r2)
+	assertAdmission429(t, r2)
+	if got := eff.errored("a"); got != 0 {
+		t.Fatalf("errored(a)=%d want 0 (over-limit rejects before grant)", got)
 	}
 
 	// After the in-flight request finishes, a new request succeeds.
 	s.OnServeDone(ServeDoneEvent{ModelID: "a"})
-	s.OnRequest(req("a"))
+	r3 := req("a")
+	s.OnRequest(r3)
+	assertAdmitted(t, r3)
 	if got := eff.served("a"); got != 2 {
 		t.Fatalf("served(a)=%d want 2 after drain", got)
 	}
@@ -716,16 +751,20 @@ func TestFIFO_ConcurrencyLimit_DefaultIsTen(t *testing.T) {
 	s := newFIFO(&stubPlanner{}, eff)
 
 	for i := 0; i < 10; i++ {
-		s.OnRequest(req("a"))
+		r := req("a")
+		s.OnRequest(r)
+		assertAdmitted(t, r)
 	}
 	if got := eff.served("a"); got != 10 {
 		t.Fatalf("served(a)=%d want 10 (default limit)", got)
 	}
 
 	// 11th request is rejected.
-	s.OnRequest(req("a"))
-	if got := eff.errored("a"); got != 1 {
-		t.Fatalf("errored(a)=%d want 1 (over default limit)", got)
+	r := req("a")
+	s.OnRequest(r)
+	assertAdmission429(t, r)
+	if got := eff.errored("a"); got != 0 {
+		t.Fatalf("errored(a)=%d want 0 (over default limit rejects before grant)", got)
 	}
 }
 
@@ -734,21 +773,27 @@ func TestFIFO_ConcurrencyLimit_DefaultIsTen(t *testing.T) {
 func TestFIFO_ConcurrencyLimit_CustomLimit(t *testing.T) {
 	s, eff := newFIFOWithLimit(t, "a", 2)
 
-	s.OnRequest(req("a"))
-	s.OnRequest(req("a"))
-	s.OnRequest(req("a"))
+	r1 := req("a")
+	r2 := req("a")
+	r3 := req("a")
+	s.OnRequest(r1)
+	s.OnRequest(r2)
+	s.OnRequest(r3)
+	assertAdmitted(t, r1)
+	assertAdmitted(t, r2)
+	assertAdmission429(t, r3)
 
 	if got := eff.served("a"); got != 2 {
 		t.Fatalf("served(a)=%d want 2 (custom limit)", got)
 	}
-	if got := eff.errored("a"); got != 1 {
-		t.Fatalf("errored(a)=%d want 1 (over custom limit)", got)
+	if got := eff.errored("a"); got != 0 {
+		t.Fatalf("errored(a)=%d want 0 (over custom limit rejects before grant)", got)
 	}
 }
 
 // TestFIFO_ConcurrencyLimit_SwapWaiters verifies that when more swap waiters
-// exist than the concurrency limit, excess waiters are rejected on swap
-// completion rather than exceeding the limit.
+// exist than the concurrency limit, excess waiters are rejected during
+// admission rather than after the loading stream has started.
 func TestFIFO_ConcurrencyLimit_SwapWaiters(t *testing.T) {
 	eff := newFakeEffects()
 	eff.states["a"] = process.StateStopped
@@ -758,22 +803,108 @@ func TestFIFO_ConcurrencyLimit_SwapWaiters(t *testing.T) {
 	s := NewFIFO("test", logmon.NewWriter(io.Discard), &stubPlanner{}, config.FifoConfig{}, models, eff)
 
 	// Three requests arrive while model is loading: one starts swap, two join.
-	s.OnRequest(req("a"))
-	s.OnRequest(req("a"))
-	s.OnRequest(req("a"))
+	r1 := req("a")
+	r2 := req("a")
+	r3 := req("a")
+	s.OnRequest(r1)
+	s.OnRequest(r2)
+	s.OnRequest(r3)
+	assertAdmitted(t, r1)
+	assertAdmitted(t, r2)
+	assertAdmission429(t, r3)
 
 	if got := eff.startsFor("a"); got != 1 {
 		t.Fatalf("StartSwap(a)=%d want 1", got)
 	}
+	if sw := s.active["a"]; len(sw.waiters) != 2 {
+		t.Fatalf("waiters=%d want 2 (third request must not join)", len(sw.waiters))
+	}
 
-	// Swap completes: two served (limit), one rejected.
+	// Swap completes: only the two admitted requests are served.
 	eff.states["a"] = process.StateReady
 	s.OnSwapDone(SwapDone{ModelID: "a"})
 
 	if got := eff.served("a"); got != 2 {
-		t.Fatalf("served(a)=%d want 2 (limit on swap completion)", got)
+		t.Fatalf("served(a)=%d want 2", got)
 	}
-	if got := eff.errored("a"); got != 1 {
-		t.Fatalf("errored(a)=%d want 1 (excess waiter rejected)", got)
+	if got := eff.errored("a"); got != 0 {
+		t.Fatalf("errored(a)=%d want 0 (excess waiter rejected at admission)", got)
+	}
+}
+
+func TestFIFO_ConcurrencyLimit_QueuedWaitersReserveCapacity(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateStopped
+	eff.states["b"] = process.StateStopped
+	models := map[string]config.ModelConfig{
+		"a": {ConcurrencyLimit: 2},
+		"b": {},
+	}
+	s := NewFIFO("test", logmon.NewWriter(io.Discard), &stubPlanner{evict: map[string][]string{"a": {"b"}}}, config.FifoConfig{}, models, eff)
+
+	bReq := req("b")
+	aReq1 := req("a")
+	aReq2 := req("a")
+	aReq3 := req("a")
+
+	s.OnRequest(bReq)  // StartSwap(b)
+	s.OnRequest(aReq1) // queued behind b
+	s.OnRequest(aReq2) // queued behind b
+	s.OnRequest(aReq3) // rejected before queueing
+
+	assertAdmitted(t, bReq)
+	assertAdmitted(t, aReq1)
+	assertAdmitted(t, aReq2)
+	assertAdmission429(t, aReq3)
+
+	if got := len(s.queued); got != 2 {
+		t.Fatalf("queue len=%d want 2", got)
+	}
+	if got := eff.startsFor("a"); got != 0 {
+		t.Fatalf("StartSwap(a)=%d want 0 while b is loading", got)
+	}
+
+	eff.states["b"] = process.StateReady
+	s.OnSwapDone(SwapDone{ModelID: "b"})
+	s.OnServeDone(ServeDoneEvent{ModelID: "b"})
+	if got := eff.startsFor("a"); got != 1 {
+		t.Fatalf("StartSwap(a)=%d want 1 after b drains", got)
+	}
+
+	eff.states["a"] = process.StateReady
+	s.OnSwapDone(SwapDone{ModelID: "a"})
+	if got := eff.served("a"); got != 2 {
+		t.Fatalf("served(a)=%d want 2", got)
+	}
+}
+
+func TestFIFO_ConcurrencyLimit_CancelledQueuedWaiterReleasesReservation(t *testing.T) {
+	eff := newFakeEffects()
+	eff.states["a"] = process.StateStopped
+	eff.states["b"] = process.StateStopped
+	models := map[string]config.ModelConfig{
+		"a": {ConcurrencyLimit: 1},
+		"b": {},
+	}
+	s := NewFIFO("test", logmon.NewWriter(io.Discard), &stubPlanner{evict: map[string][]string{"a": {"b"}}}, config.FifoConfig{}, models, eff)
+
+	bReq := req("b")
+	cancelledReq := reqCh("a")
+	rejectedReq := req("a")
+	retryReq := req("a")
+
+	s.OnRequest(bReq)
+	s.OnRequest(cancelledReq)
+	s.OnRequest(rejectedReq)
+	assertAdmitted(t, bReq)
+	assertAdmitted(t, cancelledReq)
+	assertAdmission429(t, rejectedReq)
+
+	s.OnCancel(cancelledReq)
+	s.OnRequest(retryReq)
+	assertAdmitted(t, retryReq)
+
+	if got := len(s.queued); got != 1 {
+		t.Fatalf("queue len=%d want 1 after cancel and retry", got)
 	}
 }

--- a/internal/router/scheduler/scheduler.go
+++ b/internal/router/scheduler/scheduler.go
@@ -112,6 +112,7 @@ func New(conf config.Config, name string, logger *logmon.Monitor, planner Swappe
 type HandlerReq struct {
 	Model      string
 	Ctx        context.Context
+	Admit      chan error
 	Respond    chan HandlerResp
 	PositionCh chan int
 }


### PR DESCRIPTION
Reject over-limit requests during scheduler admission so loading SSE output is not started before a 429 can be returned.

- add admission handshake before loading stream setup
- reserve concurrency slots for queued and swap-waiting requests
- cover queued waiter rejection and streaming 429 regression

fixes #887