### PR TITLE
Makefile: set version from git tag (fixes #857)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 APP_NAME = llama-swap
 BUILD_DIR = build
 
+# Get closest tag or if that fails (no git repo or no tags) then devel
+GIT_VERSION := $(shell git describe --abbrev=6 --tags 2>/dev/null || echo devel)
 # Get the current Git hash
 GIT_HASH := $(shell git rev-parse --short HEAD)
 ifneq ($(shell git status --porcelain),)
@@ -42,23 +44,23 @@ ui: ui/node_modules
 # Build OSX binary
 mac: ui
 	@echo "Building Mac binary..."
-	GOOS=darwin GOARCH=arm64 go build -tags embed_ui -ldflags="-X main.commit=${GIT_HASH} -X main.version=local_${GIT_HASH} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-darwin-arm64
+	GOOS=darwin GOARCH=arm64 go build -tags embed_ui -ldflags="-X main.commit=${GIT_HASH} -X main.version=${GIT_VERSION} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-darwin-arm64
 
 # Build Linux binary
 linux: linux-arm64 linux-amd64
 
 linux-amd64: ui
 	@echo "Building Linux AMD64 binary..."
-	GOOS=linux GOARCH=amd64 go build -tags embed_ui -ldflags="-X main.commit=${GIT_HASH} -X main.version=local_${GIT_HASH} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-linux-amd64
+	GOOS=linux GOARCH=amd64 go build -tags embed_ui -ldflags="-X main.commit=${GIT_HASH} -X main.version=${GIT_VERSION} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-linux-amd64
 
 linux-arm64: ui
 	@echo "Building Linux ARM64 binary..."
-	GOOS=linux GOARCH=arm64 go build -tags embed_ui -ldflags="-X main.commit=${GIT_HASH} -X main.version=local_${GIT_HASH} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-linux-arm64
+	GOOS=linux GOARCH=arm64 go build -tags embed_ui -ldflags="-X main.commit=${GIT_HASH} -X main.version=${GIT_VERSION} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-linux-arm64
 
 # Build Windows binary
 windows: ui
 	@echo "Building Windows binary..."
-	GOOS=windows GOARCH=amd64 go build -tags embed_ui -ldflags="-X main.commit=${GIT_HASH} -X main.version=local_${GIT_HASH} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-windows-amd64.exe
+	GOOS=windows GOARCH=amd64 go build -tags embed_ui -ldflags="-X main.commit=${GIT_HASH} -X main.version=${GIT_VERSION} -X main.date=${BUILD_DATE}" -o $(BUILD_DIR)/$(APP_NAME)-windows-amd64.exe
 
 # for testing with real external processes
 simple-responder:


### PR DESCRIPTION
Hello

This PR fixes #857. It adds `GIT_VERSION` variable to Makefile which is set to closest tag or `devel` as fallback (instead of previous `local`).

It allows downstream packagers (like MacPorts) building with make from source code only (no git) to pass correct version and match the version in prebuilt binaries.

Tested:
source | build command | version
-- | -- | --
GIT repo with tags | make mac |  `version: v233 (083e421)`
GIT repo with tags <br> + uncomitted changes | make mac   | `version: v233 (083e421+)`
GIT repo with only main branch | make mac |  `version: devel (701a571)`
GIT repo with only main branch <br> + uncomitted changes | make mac | `version: devel (701a571+)`
source code only | make mac \ <br> GIT_VERSION=v223 \ <br> GIT_HASH=083e421 |  `version: v223 (083e421)`
source code only | make mac |  `version: devel ()`

