### PR TITLE
Add llama-tts binary

### DIFF
--- a/docker/unified/Dockerfile
+++ b/docker/unified/Dockerfile
@@ -176,6 +176,7 @@ COPY --from=sd-build /install/lib/ /usr/local/lib/
 # Copy llama.cpp binaries (statically linked)
 COPY --from=llama-build /install/bin/llama-server /usr/local/bin/
 COPY --from=llama-build /install/bin/llama-cli /usr/local/bin/
+COPY --from=llama-build /install/bin/llama-tts /usr/local/bin/
 
 # Copy ik-llama-server (CUDA only; empty copy for vulkan)
 COPY --from=ik-llama-build /install/bin/ /usr/local/bin/

--- a/docker/unified/install-llama.sh
+++ b/docker/unified/install-llama.sh
@@ -44,7 +44,7 @@ elif [ "$BACKEND" = "vulkan" ]; then
     )
 fi
 
-TARGETS=(llama-cli llama-server)
+TARGETS=(llama-cli llama-server llama-tts)
 
 rm -rf build/CMakeCache.txt build/CMakeFiles 2>/dev/null || true
 


### PR DESCRIPTION
Adds `llama-tts` binary to the unified docker that exists by default in the [llama.cpp](https://github.com/ggml-org/llama.cpp/tree/master/tools/tts) repo.