### PR TITLE
internal/server: show inflight activity requests

### DIFF
--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -149,7 +149,7 @@ func upstreamMetricsServer(response string) *Server {
 		muxlog:      logmon.NewWriter(io.Discard),
 		proxylog:    proxylog,
 		upstreamlog: logmon.NewWriter(io.Discard),
-		inflight:    &inflightCounter{},
+		inflight:    newInflightTracker(),
 		metrics:     newMetricsMonitor(proxylog, 10, 0),
 		local:       newStubRouter([]string{"m1"}, response),
 		peer:        newStubRouter(nil, ""),
@@ -298,6 +298,94 @@ func TestServer_HandleUpstream_MetricsSkipsGET(t *testing.T) {
 	if len(s.metrics.getMetrics()) != 0 {
 		t.Errorf("want no metrics entries for GET upstream, got %d", len(s.metrics.getMetrics()))
 	}
+}
+
+func TestServer_HandleUpstream_InflightTracksSupportedPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		method   string
+		path     string
+		wantPath string
+	}{
+		{
+			name:     "post inference",
+			method:   http.MethodPost,
+			path:     "/upstream/m1/v1/chat/completions",
+			wantPath: "/v1/chat/completions",
+		},
+		{
+			name:     "get model endpoint",
+			method:   http.MethodGet,
+			path:     "/upstream/m1/props",
+			wantPath: "/props",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			local := newStubRouter([]string{"m1"}, "ok")
+			var s *Server
+			var during shared.InFlightRequestsEvent
+			local.serveHTTP = func(w http.ResponseWriter, r *http.Request) {
+				during = s.inflight.Current()
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("ok"))
+			}
+			s = upstreamInflightServer(local)
+
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, httptest.NewRequest(tc.method, tc.path, strings.NewReader(`{}`)))
+			if w.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+			}
+			if during.Total != 1 || len(during.Requests) != 1 {
+				t.Fatalf("inflight during request = %+v, want 1 request", during)
+			}
+			entry := during.Requests[0]
+			if entry.Model != "m1" || entry.Method != tc.method || entry.ReqPath != tc.wantPath {
+				t.Errorf("inflight entry = %+v, want model=m1 method=%s path=%s", entry, tc.method, tc.wantPath)
+			}
+			if got := s.inflight.Current(); got.Total != 0 {
+				t.Errorf("inflight after request = %d, want 0", got.Total)
+			}
+		})
+	}
+}
+
+func TestServer_HandleUpstream_InflightSkipsUnsupportedPath(t *testing.T) {
+	local := newStubRouter([]string{"m1"}, "ok")
+	var s *Server
+	var during shared.InFlightRequestsEvent
+	local.serveHTTP = func(w http.ResponseWriter, r *http.Request) {
+		during = s.inflight.Current()
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	}
+	s = upstreamInflightServer(local)
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/upstream/m1/probe", strings.NewReader(`{}`)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	if during.Total != 0 || len(during.Requests) != 0 {
+		t.Fatalf("inflight during unsupported path = %+v, want empty", during)
+	}
+}
+
+func upstreamInflightServer(local *stubRouter) *Server {
+	cfg := config.Config{Models: map[string]config.ModelConfig{"m1": {}}}
+	proxylog := logmon.NewWriter(io.Discard)
+	s := &Server{
+		cfg:         cfg,
+		muxlog:      logmon.NewWriter(io.Discard),
+		proxylog:    proxylog,
+		upstreamlog: logmon.NewWriter(io.Discard),
+		inflight:    newInflightTracker(),
+		metrics:     newMetricsMonitor(proxylog, 10, 0),
+		local:       local,
+		peer:        newStubRouter(nil, ""),
+	}
+	s.routes()
+	return s
 }
 
 func TestServer_HandleMetrics_Unavailable(t *testing.T) {

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -336,15 +336,15 @@ func TestServer_HandleUpstream_InflightTracksSupportedPaths(t *testing.T) {
 			if w.Code != http.StatusOK {
 				t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
 			}
-			if during.Total != 1 || len(during.Requests) != 1 {
+			if len(during.Requests) != 1 {
 				t.Fatalf("inflight during request = %+v, want 1 request", during)
 			}
 			entry := during.Requests[0]
 			if entry.Model != "m1" || entry.Method != tc.method || entry.ReqPath != tc.wantPath {
 				t.Errorf("inflight entry = %+v, want model=m1 method=%s path=%s", entry, tc.method, tc.wantPath)
 			}
-			if got := s.inflight.Current(); got.Total != 0 {
-				t.Errorf("inflight after request = %d, want 0", got.Total)
+			if got := s.inflight.Current(); len(got.Requests) != 0 {
+				t.Errorf("inflight after request = %d, want 0", len(got.Requests))
 			}
 		})
 	}
@@ -366,7 +366,7 @@ func TestServer_HandleUpstream_InflightSkipsUnsupportedPath(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
 	}
-	if during.Total != 0 || len(during.Requests) != 0 {
+	if len(during.Requests) != 0 {
 		t.Fatalf("inflight during unsupported path = %+v, want empty", during)
 	}
 }

--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -177,6 +177,19 @@ func (s *Server) handleAPICapture(w http.ResponseWriter, r *http.Request) {
 	w.Write(jsonBytes)
 }
 
+// handleAPICancelInflight cancels an active model-dispatched request by its
+// inflight ID. Normal request cleanup removes the row and emits the update.
+func (s *Server) handleAPICancelInflight(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" || !s.inflight.Cancel(id) {
+		shared.SendResponse(w, r, http.StatusNotFound, "inflight request not found")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"msg": "ok"})
+}
+
 type messageType string
 
 const (
@@ -237,8 +250,11 @@ func (s *Server) handleAPIEvents(w http.ResponseWriter, r *http.Request) {
 			send(messageEnvelope{Type: msgTypeMetrics, Data: string(j)})
 		}
 	}
-	sendInFlight := func(total int) {
-		if j, err := json.Marshal(map[string]int{"total": total}); err == nil {
+	sendInFlight := func(stats shared.InFlightRequestsEvent) {
+		if stats.Requests == nil {
+			stats.Requests = []shared.InflightRequestEntry{}
+		}
+		if j, err := json.Marshal(stats); err == nil {
 			send(messageEnvelope{Type: msgTypeInFlight, Data: string(j)})
 		}
 	}
@@ -248,14 +264,14 @@ func (s *Server) handleAPIEvents(w http.ResponseWriter, r *http.Request) {
 	defer s.proxylog.OnLogData(func(data []byte) { sendLogData("proxy", data) })()
 	defer s.upstreamlog.OnLogData(func(data []byte) { sendLogData("upstream", data) })()
 	defer event.On(func(e ActivityLogEvent) { sendMetrics([]ActivityLogEntry{e.Metrics}) })()
-	defer event.On(func(e shared.InFlightRequestsEvent) { sendInFlight(e.Total) })()
+	defer event.On(func(e shared.InFlightRequestsEvent) { sendInFlight(e) })()
 
 	// initial payload
 	sendLogData("proxy", s.proxylog.GetHistory())
 	sendLogData("upstream", s.upstreamlog.GetHistory())
 	sendModels()
 	sendMetrics(s.metrics.getMetrics())
-	sendInFlight(int(s.inflight.Current()))
+	sendInFlight(s.inflight.Current())
 
 	for {
 		select {

--- a/internal/server/apigroup_test.go
+++ b/internal/server/apigroup_test.go
@@ -8,24 +8,142 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/event"
+	"github.com/mostlygeek/llama-swap/internal/shared"
 )
 
-func TestServer_InflightMiddleware(t *testing.T) {
-	c := &inflightCounter{}
-	mw := CreateInflightMiddleware(c)
+func TestServer_InflightMiddleware_AddsAndRemovesEntriesAroundRequestHandling(t *testing.T) {
+	tracker := newInflightTracker()
+	mw := CreateInflightMiddleware(tracker)
 
-	var duringRequest int64
+	var duringRequest shared.InFlightRequestsEvent
 	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		duringRequest = c.Current()
+		duringRequest = tracker.Current()
 	}))
 
-	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil))
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req = req.WithContext(shared.SetContext(req.Context(), shared.ReqContextData{
+		Model:    "requested-model",
+		ModelID:  "resolved-model",
+		Metadata: map[string]string{"source": "test"},
+	}))
 
-	if duringRequest != 1 {
-		t.Errorf("counter during request = %d, want 1", duringRequest)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if duringRequest.Total != 1 {
+		t.Fatalf("inflight total during request = %d, want 1", duringRequest.Total)
 	}
-	if got := c.Current(); got != 0 {
-		t.Errorf("counter after request = %d, want 0", got)
+	if len(duringRequest.Requests) != 1 {
+		t.Fatalf("inflight requests during request = %d, want 1", len(duringRequest.Requests))
+	}
+	entry := duringRequest.Requests[0]
+	if entry.ID == "" || entry.Model != "resolved-model" || entry.Method != http.MethodPost || entry.ReqPath != "/v1/chat/completions" {
+		t.Errorf("inflight entry = %+v", entry)
+	}
+	if entry.Metadata["source"] != "test" {
+		t.Errorf("metadata = %v, want source=test", entry.Metadata)
+	}
+	if got := tracker.Current(); got.Total != 0 || len(got.Requests) != 0 {
+		t.Errorf("inflight after request = %+v, want empty", got)
+	}
+}
+
+func TestServer_InflightEventPayloadIncludesRequestEntries(t *testing.T) {
+	tracker := newInflightTracker()
+	events := make(chan shared.InFlightRequestsEvent, 4)
+	cancelEvents := event.On(func(e shared.InFlightRequestsEvent) { events <- e })
+	defer cancelEvents()
+
+	release := make(chan struct{})
+	done := make(chan struct{})
+	handler := CreateInflightMiddleware(tracker)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+	}))
+
+	go func() {
+		defer close(done)
+		req := httptest.NewRequest(http.MethodGet, "/props?model=m1", nil)
+		req = req.WithContext(shared.SetContext(req.Context(), shared.ReqContextData{
+			Model:   "m1",
+			ModelID: "m1",
+		}))
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	}()
+
+	added := waitInflightEvent(t, events, 1)
+	if len(added.Requests) != 1 {
+		t.Fatalf("added requests = %d, want 1", len(added.Requests))
+	}
+	if added.Requests[0].Model != "m1" || added.Requests[0].ReqPath != "/props" {
+		t.Errorf("added request = %+v", added.Requests[0])
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not return")
+	}
+	removed := waitInflightEvent(t, events, 0)
+	if len(removed.Requests) != 0 {
+		t.Errorf("removed requests = %d, want 0", len(removed.Requests))
+	}
+}
+
+func TestServer_InflightCancelByIDCancelsRequestContext(t *testing.T) {
+	tracker := newInflightTracker()
+	idCh := make(chan string, 1)
+	done := make(chan struct{})
+	handler := CreateInflightMiddleware(tracker)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		current := tracker.Current()
+		if len(current.Requests) != 1 {
+			t.Errorf("inflight requests = %d, want 1", len(current.Requests))
+			return
+		}
+		idCh <- current.Requests[0].ID
+		<-r.Context().Done()
+		close(done)
+	}))
+
+	go func() {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+		req = req.WithContext(shared.SetContext(req.Context(), shared.ReqContextData{ModelID: "m1"}))
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	}()
+
+	var id string
+	select {
+	case id = <-idCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for inflight id")
+	}
+	if !tracker.Cancel(id) {
+		t.Fatalf("Cancel(%q) = false, want true", id)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("request context was not canceled")
+	}
+	if got := tracker.Current(); got.Total != 0 {
+		t.Errorf("inflight after cancel cleanup = %d, want 0", got.Total)
+	}
+}
+
+func waitInflightEvent(t *testing.T, events <-chan shared.InFlightRequestsEvent, total int) shared.InFlightRequestsEvent {
+	t.Helper()
+	timer := time.After(2 * time.Second)
+	for {
+		select {
+		case got := <-events:
+			if got.Total == total {
+				return got
+			}
+		case <-timer:
+			t.Fatalf("timed out waiting for inflight total %d", total)
+		}
 	}
 }
 
@@ -60,6 +178,60 @@ func TestServer_APIMetrics_Empty(t *testing.T) {
 	if body := strings.TrimSpace(w.Body.String()); body != "[]" {
 		t.Errorf("body = %q, want []", body)
 	}
+}
+
+func TestServer_APICancelInflight(t *testing.T) {
+	s := newTestServer(newStubRouter(nil, ""), newStubRouter(nil, ""))
+	ctx, cancel := context.WithCancel(context.Background())
+	id := s.inflight.Add(httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx), cancel)
+	defer s.inflight.Remove(id)
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/inflight/"+id+"/cancel", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 body=%q", w.Code, w.Body.String())
+	}
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancel endpoint did not cancel request context")
+	}
+
+	w = httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/inflight/missing/cancel", nil))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("missing status = %d, want 404", w.Code)
+	}
+}
+
+func TestServer_InflightMetricsRecordsCompletedOnce(t *testing.T) {
+	local := newStubRouter([]string{"m1"}, `{"usage":{"prompt_tokens":1,"completion_tokens":2}}`)
+	s := newTestServer(local, newStubRouter(nil, ""))
+	s.cfg = configWithModels("m1")
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, chatRequest("m1"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%q", w.Code, w.Body.String())
+	}
+	if got := s.inflight.Current(); got.Total != 0 {
+		t.Fatalf("inflight total after request = %d, want 0", got.Total)
+	}
+	gotMetrics := s.metrics.getMetrics()
+	if len(gotMetrics) != 1 {
+		t.Fatalf("metrics len = %d, want 1", len(gotMetrics))
+	}
+	if gotMetrics[0].Model != "m1" || gotMetrics[0].Tokens.InputTokens != 1 || gotMetrics[0].Tokens.OutputTokens != 2 {
+		t.Errorf("metric = %+v", gotMetrics[0])
+	}
+}
+
+func configWithModels(models ...string) config.Config {
+	cfg := config.Config{Models: make(map[string]config.ModelConfig, len(models))}
+	for _, model := range models {
+		cfg.Models[model] = config.ModelConfig{}
+	}
+	return cfg
 }
 
 func TestServer_APIPerformance_Unavailable(t *testing.T) {

--- a/internal/server/apigroup_test.go
+++ b/internal/server/apigroup_test.go
@@ -32,9 +32,6 @@ func TestServer_InflightMiddleware_AddsAndRemovesEntriesAroundRequestHandling(t 
 
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 
-	if duringRequest.Total != 1 {
-		t.Fatalf("inflight total during request = %d, want 1", duringRequest.Total)
-	}
 	if len(duringRequest.Requests) != 1 {
 		t.Fatalf("inflight requests during request = %d, want 1", len(duringRequest.Requests))
 	}
@@ -45,7 +42,7 @@ func TestServer_InflightMiddleware_AddsAndRemovesEntriesAroundRequestHandling(t 
 	if entry.Metadata["source"] != "test" {
 		t.Errorf("metadata = %v, want source=test", entry.Metadata)
 	}
-	if got := tracker.Current(); got.Total != 0 || len(got.Requests) != 0 {
+	if got := tracker.Current(); len(got.Requests) != 0 {
 		t.Errorf("inflight after request = %+v, want empty", got)
 	}
 }
@@ -127,8 +124,8 @@ func TestServer_InflightCancelByIDCancelsRequestContext(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("request context was not canceled")
 	}
-	if got := tracker.Current(); got.Total != 0 {
-		t.Errorf("inflight after cancel cleanup = %d, want 0", got.Total)
+	if got := tracker.Current(); len(got.Requests) != 0 {
+		t.Errorf("inflight after cancel cleanup = %d, want 0", len(got.Requests))
 	}
 }
 
@@ -138,7 +135,7 @@ func waitInflightEvent(t *testing.T, events <-chan shared.InFlightRequestsEvent,
 	for {
 		select {
 		case got := <-events:
-			if got.Total == total {
+			if len(got.Requests) == total {
 				return got
 			}
 		case <-timer:
@@ -214,8 +211,8 @@ func TestServer_InflightMetricsRecordsCompletedOnce(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d body=%q", w.Code, w.Body.String())
 	}
-	if got := s.inflight.Current(); got.Total != 0 {
-		t.Fatalf("inflight total after request = %d, want 0", got.Total)
+	if got := s.inflight.Current(); len(got.Requests) != 0 {
+		t.Fatalf("inflight total after request = %d, want 0", len(got.Requests))
 	}
 	gotMetrics := s.metrics.getMetrics()
 	if len(gotMetrics) != 1 {

--- a/internal/server/inflight.go
+++ b/internal/server/inflight.go
@@ -1,33 +1,184 @@
 package server
 
 import (
+	"context"
 	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/mostlygeek/llama-swap/internal/chain"
+	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/event"
 	"github.com/mostlygeek/llama-swap/internal/shared"
 )
 
-// inflightCounter tracks the number of in-flight model-dispatched requests.
-type inflightCounter struct {
-	total atomic.Int64
+// inflightTracker tracks in-flight model-dispatched requests and their
+// cancellable contexts.
+type inflightTracker struct {
+	nextID atomic.Uint64
+
+	mu       sync.RWMutex
+	requests map[string]inflightRequest
 }
 
-func (c *inflightCounter) Increment() int64 { return c.total.Add(1) }
-func (c *inflightCounter) Decrement() int64 { return c.total.Add(-1) }
-func (c *inflightCounter) Current() int64   { return c.total.Load() }
+type inflightRequest struct {
+	entry  shared.InflightRequestEntry
+	cancel context.CancelFunc
+}
 
-// CreateInflightMiddleware returns middleware that increments the counter on
-// entry and decrements on exit, emitting an InFlightRequestsEvent for each.
-func CreateInflightMiddleware(c *inflightCounter) chain.Middleware {
+func newInflightTracker() *inflightTracker {
+	return &inflightTracker{requests: make(map[string]inflightRequest)}
+}
+
+func (t *inflightTracker) Add(r *http.Request, cancel context.CancelFunc) string {
+	id := strconv.FormatUint(t.nextID.Add(1), 10)
+	entry := shared.InflightRequestEntry{
+		ID:        id,
+		Timestamp: time.Now(),
+		ReqPath:   r.URL.Path,
+		Method:    r.Method,
+	}
+	if data, ok := shared.ReadContext(r.Context()); ok {
+		entry.Model = data.ModelID
+		entry.Metadata = copyMetadata(data.Metadata)
+	}
+
+	t.mu.Lock()
+	t.requests[id] = inflightRequest{entry: entry, cancel: cancel}
+	snapshot := t.snapshotLocked()
+	t.mu.Unlock()
+
+	event.Emit(snapshot)
+	return id
+}
+
+func (t *inflightTracker) Remove(id string) {
+	t.mu.Lock()
+	delete(t.requests, id)
+	snapshot := t.snapshotLocked()
+	t.mu.Unlock()
+
+	event.Emit(snapshot)
+}
+
+func (t *inflightTracker) Cancel(id string) bool {
+	t.mu.RLock()
+	req, ok := t.requests[id]
+	t.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	req.cancel()
+	return true
+}
+
+func (t *inflightTracker) Current() shared.InFlightRequestsEvent {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.snapshotLocked()
+}
+
+func (t *inflightTracker) snapshotLocked() shared.InFlightRequestsEvent {
+	requests := make([]shared.InflightRequestEntry, 0, len(t.requests))
+	for _, req := range t.requests {
+		requests = append(requests, req.entry)
+	}
+	sort.Slice(requests, func(i, j int) bool {
+		if requests[i].Timestamp.Equal(requests[j].Timestamp) {
+			return requests[i].ID < requests[j].ID
+		}
+		return requests[i].Timestamp.Before(requests[j].Timestamp)
+	})
+	return shared.InFlightRequestsEvent{Total: len(requests), Requests: requests}
+}
+
+func copyMetadata(metadata map[string]string) map[string]string {
+	if len(metadata) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(metadata))
+	for k, v := range metadata {
+		out[k] = v
+	}
+	return out
+}
+
+// CreateInflightMiddleware returns middleware that tracks model-dispatched
+// requests until downstream handling completes.
+func CreateInflightMiddleware(t *inflightTracker) chain.Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			event.Emit(shared.InFlightRequestsEvent{Total: int(c.Increment())})
-			defer func() {
-				event.Emit(shared.InFlightRequestsEvent{Total: int(c.Decrement())})
-			}()
+			ctx, cancel := context.WithCancel(r.Context())
+			defer cancel()
+
+			r = r.WithContext(ctx)
+			id := t.Add(r, cancel)
+			defer t.Remove(id)
+
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// CreateUpstreamInflightMiddleware tracks /upstream/<model>/<path> requests
+// only when the stripped upstream path is one of the model-dispatched
+// inference endpoints.
+func CreateUpstreamInflightMiddleware(t *inflightTracker, cfg config.Config) chain.Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !strings.HasPrefix(r.URL.Path, "/upstream/") {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			_, _, remainingPath, found := shared.FindModelInPath(cfg, strings.TrimPrefix(r.URL.Path, "/upstream"))
+			if !found || !isModelDispatchedRequest(r.Method, remainingPath) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if _, err := shared.FetchContext(r, cfg); err != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			ctx, cancel := context.WithCancel(r.Context())
+			defer cancel()
+
+			r = r.WithContext(ctx)
+			tracked := r.Clone(ctx)
+			tracked.URL.Path = remainingPath
+			id := t.Add(tracked, cancel)
+			defer t.Remove(id)
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func isModelDispatchedRequest(method, path string) bool {
+	switch method {
+	case http.MethodPost:
+		for _, p := range modelPostJSONRoutes {
+			if p == path {
+				return true
+			}
+		}
+		for _, p := range modelPostFormRoutes {
+			if p == path {
+				return true
+			}
+		}
+	case http.MethodGet:
+		for _, p := range modelGetRoutes {
+			if p == path {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/server/inflight.go
+++ b/internal/server/inflight.go
@@ -93,7 +93,7 @@ func (t *inflightTracker) snapshotLocked() shared.InFlightRequestsEvent {
 		}
 		return requests[i].Timestamp.Before(requests[j].Timestamp)
 	})
-	return shared.InFlightRequestsEvent{Total: len(requests), Requests: requests}
+	return shared.InFlightRequestsEvent{Requests: requests}
 }
 
 func copyMetadata(metadata map[string]string) map[string]string {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,7 +29,7 @@ type Server struct {
 	upstreamlog *logmon.Monitor
 
 	perf     *perf.Monitor
-	inflight *inflightCounter
+	inflight *inflightTracker
 	metrics  *metricsMonitor
 	build    BuildInfo
 
@@ -147,7 +147,7 @@ func New(cfg config.Config, muxlog *logmon.Monitor, proxylog *logmon.Monitor, up
 		proxylog:    proxylog,
 		upstreamlog: upstreamlog,
 		perf:        perfMon,
-		inflight:    &inflightCounter{},
+		inflight:    newInflightTracker(),
 		metrics:     newMetricsMonitor(proxylog, cfg.MetricsMaxInMemory, cfg.CaptureBuffer),
 		build:       build,
 		local:       local,
@@ -243,13 +243,17 @@ func (s *Server) routes() {
 
 	// Upstream passthrough. Meter only the model-dispatched endpoints that can
 	// produce token usage/timings.
-	upstreamChain := apiChain.Append(CreateMetricsMiddleware(s.metrics, s.cfg))
+	upstreamChain := apiChain.Append(
+		CreateUpstreamInflightMiddleware(s.inflight, s.cfg),
+		CreateMetricsMiddleware(s.metrics, s.cfg),
+	)
 	mux.HandleFunc("GET /upstream", handleUpstreamRedirect)
 	mux.Handle("/upstream/{upstreamPath...}", upstreamChain.ThenFunc(s.handleUpstream))
 
 	// API group (API-key protected) consumed by the UI.
 	mux.Handle("POST /api/models/unload", apiChain.ThenFunc(s.handleAPIUnloadAll))
 	mux.Handle("POST /api/models/unload/{model...}", apiChain.ThenFunc(s.handleAPIUnloadModel))
+	mux.Handle("POST /api/inflight/{id}/cancel", apiChain.ThenFunc(s.handleAPICancelInflight))
 	mux.Handle("GET /api/events", apiChain.ThenFunc(s.handleAPIEvents))
 	mux.Handle("GET /api/metrics", apiChain.ThenFunc(s.handleAPIMetrics))
 	mux.Handle("GET /api/performance", apiChain.ThenFunc(s.handleAPIPerformance))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -23,6 +23,7 @@ import (
 type stubRouter struct {
 	models        map[string]bool
 	response      string
+	serveHTTP     func(http.ResponseWriter, *http.Request)
 	shutdownCalls atomic.Int32
 	running       map[string]process.ProcessState
 	unloadCalls   atomic.Int32
@@ -39,7 +40,11 @@ func newStubRouter(models []string, response string) *stubRouter {
 
 func (s *stubRouter) Handles(model string) bool      { return s.models[model] }
 func (s *stubRouter) Shutdown(_ time.Duration) error { s.shutdownCalls.Add(1); return nil }
-func (s *stubRouter) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+func (s *stubRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.serveHTTP != nil {
+		s.serveHTTP(w, r)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(s.response))
 }
@@ -64,7 +69,7 @@ func newTestServer(local router.LocalRouter, peer router.Router) *Server {
 		muxlog:      logmon.NewWriter(io.Discard),
 		proxylog:    proxylog,
 		upstreamlog: logmon.NewWriter(io.Discard),
-		inflight:    &inflightCounter{},
+		inflight:    newInflightTracker(),
 		metrics:     newMetricsMonitor(proxylog, 0, 0),
 		local:       local,
 		peer:        peer,

--- a/internal/shared/events.go
+++ b/internal/shared/events.go
@@ -46,7 +46,6 @@ func (e ModelPreloadedEvent) Type() uint32 {
 }
 
 type InFlightRequestsEvent struct {
-	Total    int                    `json:"total"`
 	Requests []InflightRequestEntry `json:"requests"`
 }
 

--- a/internal/shared/events.go
+++ b/internal/shared/events.go
@@ -1,5 +1,7 @@
 package shared
 
+import "time"
+
 const ProcessStateChangeEventID = 0x01
 const ConfigFileChangedEventID = 0x03
 const ActivityLogEventID = 0x05
@@ -44,9 +46,19 @@ func (e ModelPreloadedEvent) Type() uint32 {
 }
 
 type InFlightRequestsEvent struct {
-	Total int
+	Total    int                    `json:"total"`
+	Requests []InflightRequestEntry `json:"requests"`
 }
 
 func (e InFlightRequestsEvent) Type() uint32 {
 	return InFlightRequestsEventID
+}
+
+type InflightRequestEntry struct {
+	ID        string            `json:"id"`
+	Timestamp time.Time         `json:"timestamp"`
+	Model     string            `json:"model"`
+	ReqPath   string            `json:"req_path"`
+	Method    string            `json:"method"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
 }

--- a/ui-svelte/src/components/ActivityStats.svelte
+++ b/ui-svelte/src/components/ActivityStats.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { inFlightRequests, metrics } from "../stores/api";
+  import { metrics } from "../stores/api";
   import { persistentStore } from "../stores/persistent";
   import { calculateHistogramData } from "../lib/histogram";
   import TokenHistogram from "./TokenHistogram.svelte";
@@ -31,7 +31,6 @@
       totalInputTokens,
       totalOutputTokens,
       totalCacheTokens,
-      inFlightRequests: $inFlightRequests,
       promptHistogramData,
       genHistogramData,
     };
@@ -82,8 +81,7 @@
     <div class="text-muted-foreground text-xs uppercase tracking-wider">Processed</div>
     <div class="text-muted-foreground text-xs uppercase tracking-wider">Generated</div>
     <div class="text-sm">
-      <span class="font-semibold">{nf.format(stats.totalRequests)}</span> completed,
-      <span class="font-semibold">{nf.format(stats.inFlightRequests)}</span> waiting
+      <span class="font-semibold">{nf.format(stats.totalRequests)}</span> completed
     </div>
     <div class="text-sm">
       <span class="font-semibold">{nf.format(stats.totalCacheTokens)}</span> tokens

--- a/ui-svelte/src/components/ActivityTable.svelte
+++ b/ui-svelte/src/components/ActivityTable.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { untrack } from "svelte";
-  import type { ActivityLogEntry, ReqRespCapture } from "../lib/types";
-  import { getCapture } from "../stores/api";
+  import type { ActivityLogEntry, InflightRequestEntry, ReqRespCapture } from "../lib/types";
+  import { cancelInflightRequest, getCapture } from "../stores/api";
   import { persistentStore } from "../stores/persistent";
   import CaptureDialog from "./CaptureDialog.svelte";
   import {
@@ -25,6 +25,7 @@
   import { Button } from "$lib/components/ui/button/index.js";
   import {
     Columns3,
+    ChevronDown,
     ChevronLeft,
     ChevronRight,
     ChevronsLeft,
@@ -32,7 +33,9 @@
     ArrowUp,
     ArrowDown,
     ArrowUpDown,
+    CircleX,
     GripVertical,
+    X,
   } from "@lucide/svelte";
   import HeaderLabel from "./activity-table/HeaderLabel.svelte";
   import ViewCaptureButton from "./activity-table/ViewCaptureButton.svelte";
@@ -41,6 +44,7 @@
 
   interface Props {
     metrics: ActivityLogEntry[];
+    inflightRequests?: InflightRequestEntry[];
     storagePrefix: string;
     showModelColumn?: boolean;
     showPagination?: boolean;
@@ -52,6 +56,7 @@
 
   let {
     metrics,
+    inflightRequests = [],
     storagePrefix,
     showModelColumn = true,
     showPagination = false,
@@ -145,6 +150,8 @@
 
   // svelte-ignore state_referenced_locally
   const storedPageSize = persistentStore<number>(`${storagePrefix}-page-size`, 10);
+  // svelte-ignore state_referenced_locally
+  const storedInflightOpen = persistentStore<boolean>(`${storagePrefix}-inflight-open`, true);
 
   // When not paginating, use a large page size so all rows render in one page.
   // svelte-ignore state_referenced_locally
@@ -155,6 +162,7 @@
 
   // svelte-ignore state_referenced_locally
   let sorting = $state<SortingState>([]);
+  let inflightOpen = $state($storedInflightOpen);
 
   // Reset to the first page when the data source changes. We deliberately do
   // NOT track pagination here — page-size changes reset pageIndex inside
@@ -169,6 +177,21 @@
   let selectedCapture = $state<ReqRespCapture | null>(null);
   let dialogOpen = $state(false);
   let loadingCaptureId = $state<number | null>(null);
+  let cancelingInflightIds = $state<string[]>([]);
+  let inflightNowMs = $state(Date.now());
+
+  $effect(() => {
+    if (inflightRequests.length === 0) return;
+
+    let frame = 0;
+    const tick = () => {
+      inflightNowMs = Date.now();
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+
+    return () => cancelAnimationFrame(frame);
+  });
 
   async function viewCapture(id: number) {
     loadingCaptureId = id;
@@ -181,6 +204,21 @@
   function closeDialog() {
     dialogOpen = false;
     selectedCapture = null;
+  }
+
+  function setInflightOpen(open: boolean) {
+    inflightOpen = open;
+    storedInflightOpen.set(open);
+  }
+
+  async function cancelInflight(id: string) {
+    if (cancelingInflightIds.includes(id)) return;
+    cancelingInflightIds = [...cancelingInflightIds, id];
+    try {
+      await cancelInflightRequest(id);
+    } finally {
+      cancelingInflightIds = cancelingInflightIds.filter((current) => current !== id);
+    }
   }
 
   function buildColumns(withModel: boolean): ColumnDef<ActivityLogEntry>[] {
@@ -352,6 +390,8 @@
 
   let thClass = $derived(compact ? "px-4 py-2 h-9" : "px-6 py-3 h-12");
   let tdClass = $derived(compact ? "px-4 py-2" : "px-6 py-4");
+  let visibleColumnCount = $derived(table.getVisibleLeafColumns().length);
+  let pageCount = $derived(Math.max(table.getPageCount(), 1));
 
   function sortIcon(state: false | "asc" | "desc") {
     if (state === "asc") return ArrowUp;
@@ -397,9 +437,93 @@
     dragColId = null;
     dragOverColId = null;
   }
+
+  function formatInflightElapsed(timestamp: string): string {
+    const started = Date.parse(timestamp);
+    if (!Number.isFinite(started)) return "0.00s";
+    return `${(Math.max(0, inflightNowMs - started) / 1000).toFixed(2)}s`;
+  }
 </script>
 
-<Card.Root class="shrink-0 gap-0 overflow-hidden py-0 {cardClass}">
+<Card.Root class="relative p-3">
+  <div class="flex items-center gap-2 pr-7 text-sm">
+    <span class="text-muted-foreground text-xs uppercase tracking-wider">In-flight Requests</span>
+    <span>
+      <span class="font-semibold">{inflightRequests.length}</span> active
+    </span>
+  </div>
+
+  <Button
+    variant="ghost"
+    size="icon-xs"
+    class="text-muted-foreground absolute right-2 top-2 rounded-full"
+    onclick={() => setInflightOpen(!inflightOpen)}
+    title={inflightOpen ? "Hide in-flight requests" : "Show in-flight requests"}
+  >
+    {#if inflightOpen}
+      <X />
+    {:else}
+      <ChevronDown />
+    {/if}
+  </Button>
+
+  {#if inflightOpen}
+    <div class="mt-3 overflow-x-auto">
+      <Table.Root class="min-w-full">
+        <Table.Header>
+          <Table.Row>
+            <Table.Head class={thClass}>Cancel</Table.Head>
+            <Table.Head class={thClass}>Elapsed</Table.Head>
+            <Table.Head class={thClass}>Model</Table.Head>
+            <Table.Head class={thClass}>Method</Table.Head>
+            <Table.Head class={thClass}>Path</Table.Head>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {#each inflightRequests as request (request.id)}
+            <Table.Row>
+              <Table.Cell class={tdClass}>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  class="text-muted-foreground hover:text-destructive size-6"
+                  onclick={() => cancelInflight(request.id)}
+                  disabled={cancelingInflightIds.includes(request.id)}
+                  title="Cancel request"
+                  aria-label="Cancel inflight request"
+                >
+                  <CircleX class="size-4" />
+                </Button>
+              </Table.Cell>
+              <Table.Cell class="{tdClass} font-mono text-xs tabular-nums">
+                {formatInflightElapsed(request.timestamp)}
+              </Table.Cell>
+              <Table.Cell class={tdClass}>
+                <span class="block max-w-[16rem] truncate" title={request.model}>
+                  {request.model || "-"}
+                </span>
+              </Table.Cell>
+              <Table.Cell class="{tdClass} font-mono text-xs">{request.method || "-"}</Table.Cell>
+              <Table.Cell class="{tdClass} font-mono text-xs">
+                <span class="block max-w-[22rem] truncate" title={request.req_path}>
+                  {request.req_path || "-"}
+                </span>
+              </Table.Cell>
+            </Table.Row>
+          {:else}
+            <Table.Row>
+              <Table.Cell colspan={5} class="text-muted-foreground py-6 text-center text-sm">
+                No in-flight requests
+              </Table.Cell>
+            </Table.Row>
+          {/each}
+        </Table.Body>
+      </Table.Root>
+    </div>
+  {/if}
+</Card.Root>
+
+<Card.Root class="mt-3 shrink-0 gap-0 overflow-hidden py-0 {cardClass}">
   <Card.Header class="flex items-center justify-between border-b px-4 py-2">
     <div class="flex items-center gap-2">
       {#if title}
@@ -498,20 +622,21 @@
               </Table.Cell>
             {/each}
           </Table.Row>
-        {:else}
+        {/each}
+        {#if table.getRowModel().rows.length === 0}
           <Table.Row>
-            <Table.Cell colspan={columns.length} class="text-muted-foreground py-6 text-center text-sm">
+            <Table.Cell colspan={visibleColumnCount} class="text-muted-foreground py-6 text-center text-sm">
               {emptyMessage}
             </Table.Cell>
           </Table.Row>
-        {/each}
+        {/if}
       </Table.Body>
     </Table.Root>
 
     {#if showPagination && metrics.length > 0}
       <div class="flex items-center justify-between gap-2 border-t px-4 py-2 text-sm">
         <span class="text-muted-foreground text-xs">
-          Page {pagination.pageIndex + 1} of {table.getPageCount()} · {metrics.length} total
+          Page {pagination.pageIndex + 1} of {pageCount} · {metrics.length} total
         </span>
         <div class="flex items-center gap-1">
           <Button
@@ -544,7 +669,7 @@
           <Button
             variant="ghost"
             size="icon-sm"
-            onclick={() => table.setPageIndex(table.getPageCount() - 1)}
+            onclick={() => table.setPageIndex(pageCount - 1)}
             disabled={!table.getCanNextPage()}
             title="Last page"
           >

--- a/ui-svelte/src/components/model/ModelActivityTab.svelte
+++ b/ui-svelte/src/components/model/ModelActivityTab.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { metrics } from "../../stores/api";
+  import { inflightRequestEntries, metrics } from "../../stores/api";
   import ActivityTable from "../ActivityTable.svelte";
 
   interface Props {
@@ -11,10 +11,14 @@
   let modelMetrics = $derived(
     [...$metrics].filter((m) => m.model === modelId).sort((a, b) => b.id - a.id)
   );
+  let modelInflightRequests = $derived(
+    $inflightRequestEntries.filter((request) => request.model === modelId)
+  );
 </script>
 
 <ActivityTable
   metrics={modelMetrics}
+  inflightRequests={modelInflightRequests}
   storagePrefix="model-detail"
   showModelColumn={false}
   showPagination={true}

--- a/ui-svelte/src/lib/types.ts
+++ b/ui-svelte/src/lib/types.ts
@@ -61,8 +61,18 @@ export interface LogData {
   data: string;
 }
 
+export interface InflightRequestEntry {
+  id: string;
+  timestamp: string;
+  model: string;
+  req_path: string;
+  method: string;
+  metadata?: Record<string, string>;
+}
+
 export interface InFlightStats {
   total: number;
+  requests?: InflightRequestEntry[];
 }
 
 export interface NetIOStat {

--- a/ui-svelte/src/lib/types.ts
+++ b/ui-svelte/src/lib/types.ts
@@ -71,7 +71,6 @@ export interface InflightRequestEntry {
 }
 
 export interface InFlightStats {
-  total: number;
   requests?: InflightRequestEntry[];
 }
 

--- a/ui-svelte/src/routes/Activity.svelte
+++ b/ui-svelte/src/routes/Activity.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { metrics } from "../stores/api";
+  import { inflightRequestEntries, metrics } from "../stores/api";
   import ActivityStats from "../components/ActivityStats.svelte";
   import ActivityTable from "../components/ActivityTable.svelte";
 
@@ -13,6 +13,7 @@
 
   <ActivityTable
     metrics={sortedMetrics}
+    inflightRequests={$inflightRequestEntries}
     storagePrefix="activity"
     showModelColumn={true}
     showPagination={true}

--- a/ui-svelte/src/stores/api.test.ts
+++ b/ui-svelte/src/stores/api.test.ts
@@ -1,0 +1,45 @@
+import { get } from "svelte/store";
+import { describe, expect, it } from "vitest";
+import {
+  handleAPIEventMessage,
+  inFlightRequests,
+  inflightRequestEntries,
+} from "./api";
+
+describe("api store event handling", () => {
+  it("parses inflight request entries", () => {
+    inFlightRequests.set(0);
+    inflightRequestEntries.set([]);
+
+    handleAPIEventMessage(
+      JSON.stringify({
+        type: "inflight",
+        data: JSON.stringify({
+          total: 1,
+          requests: [
+            {
+              id: "7",
+              timestamp: "2026-07-03T00:00:00Z",
+              model: "m1",
+              req_path: "/v1/chat/completions",
+              method: "POST",
+              metadata: { source: "test" },
+            },
+          ],
+        }),
+      })
+    );
+
+    expect(get(inFlightRequests)).toBe(1);
+    expect(get(inflightRequestEntries)).toEqual([
+      {
+        id: "7",
+        timestamp: "2026-07-03T00:00:00Z",
+        model: "m1",
+        req_path: "/v1/chat/completions",
+        method: "POST",
+        metadata: { source: "test" },
+      },
+    ]);
+  });
+});

--- a/ui-svelte/src/stores/api.test.ts
+++ b/ui-svelte/src/stores/api.test.ts
@@ -15,7 +15,6 @@ describe("api store event handling", () => {
       JSON.stringify({
         type: "inflight",
         data: JSON.stringify({
-          total: 1,
           requests: [
             {
               id: "7",

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -7,6 +7,7 @@ import type {
   APIEventEnvelope,
   ReqRespCapture,
   InFlightStats,
+  InflightRequestEntry,
   PerformanceResponse,
 } from "../lib/types";
 import { connectionState } from "./theme";
@@ -22,6 +23,7 @@ export const proxyLogs = writable<string>("");
 export const upstreamLogs = writable<string>("");
 export const metrics = writable<ActivityLogEntry[]>([]);
 export const inFlightRequests = writable<number>(0);
+export const inflightRequestEntries = writable<InflightRequestEntry[]>([]);
 export const performanceEnabled = writable<boolean>(false);
 export const versionInfo = writable<VersionInfo>({
   build_date: "unknown",
@@ -44,6 +46,7 @@ export function enableAPIEvents(enabled: boolean): void {
     apiEventSource = null;
     metrics.set([]);
     inFlightRequests.set(0);
+    inflightRequestEntries.set([]);
     return;
   }
 
@@ -62,6 +65,7 @@ export function enableAPIEvents(enabled: boolean): void {
       upstreamLogs.set("");
       metrics.set([]);
       inFlightRequests.set(0);
+      inflightRequestEntries.set([]);
       models.set([]);
       retryCount = 0;
       connectionState.set("connected");
@@ -69,42 +73,7 @@ export function enableAPIEvents(enabled: boolean): void {
 
     apiEventSource.onmessage = (e: MessageEvent) => {
       try {
-        const message = JSON.parse(e.data) as APIEventEnvelope;
-        switch (message.type) {
-          case "modelStatus": {
-            const newModels = JSON.parse(message.data) as Model[];
-            // Sort models by name and id
-            newModels.sort((a, b) => {
-              return (a.name + a.id).localeCompare(b.name + b.id, undefined, { numeric: true });
-            });
-            models.set(newModels);
-            break;
-          }
-
-          case "logData": {
-            const logData = JSON.parse(message.data) as LogData;
-            switch (logData.source) {
-              case "proxy":
-                appendLog(logData.data, proxyLogs);
-                break;
-              case "upstream":
-                appendLog(logData.data, upstreamLogs);
-                break;
-            }
-            break;
-          }
-
-          case "metrics": {
-            const newMetrics = JSON.parse(message.data) as ActivityLogEntry[];
-            metrics.update((prevMetrics) => [...newMetrics, ...prevMetrics]);
-            break;
-          }
-          case "inflight": {
-            const stats = JSON.parse(message.data) as InFlightStats;
-            inFlightRequests.set(stats.total ?? 0);
-            break;
-          }
-        }
+        handleAPIEventMessage(e.data);
       } catch (err) {
         console.error(e.data, err);
       }
@@ -120,6 +89,47 @@ export function enableAPIEvents(enabled: boolean): void {
   };
 
   connect();
+}
+
+export function handleAPIEventMessage(data: string): void {
+  const message = JSON.parse(data) as APIEventEnvelope;
+  switch (message.type) {
+    case "modelStatus": {
+      const newModels = JSON.parse(message.data) as Model[];
+      // Sort models by name and id
+      newModels.sort((a, b) => {
+        return (a.name + a.id).localeCompare(b.name + b.id, undefined, { numeric: true });
+      });
+      models.set(newModels);
+      break;
+    }
+
+    case "logData": {
+      const logData = JSON.parse(message.data) as LogData;
+      switch (logData.source) {
+        case "proxy":
+          appendLog(logData.data, proxyLogs);
+          break;
+        case "upstream":
+          appendLog(logData.data, upstreamLogs);
+          break;
+      }
+      break;
+    }
+
+    case "metrics": {
+      const newMetrics = JSON.parse(message.data) as ActivityLogEntry[];
+      metrics.update((prevMetrics) => [...newMetrics, ...prevMetrics]);
+      break;
+    }
+
+    case "inflight": {
+      const stats = JSON.parse(message.data) as InFlightStats;
+      inFlightRequests.set(stats.total ?? 0);
+      inflightRequestEntries.set(stats.requests ?? []);
+      break;
+    }
+  }
 }
 
 // Fetch version info when connected
@@ -176,6 +186,20 @@ export async function unloadSingleModel(model: string): Promise<void> {
     }
   } catch (error) {
     console.error("Failed to unload model", model, error);
+    throw error;
+  }
+}
+
+export async function cancelInflightRequest(id: string): Promise<void> {
+  try {
+    const response = await fetch(`/api/inflight/${encodeURIComponent(id)}/cancel`, {
+      method: "POST",
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to cancel request: ${response.status}`);
+    }
+  } catch (error) {
+    console.error("Failed to cancel inflight request", id, error);
     throw error;
   }
 }

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -125,8 +125,9 @@ export function handleAPIEventMessage(data: string): void {
 
     case "inflight": {
       const stats = JSON.parse(message.data) as InFlightStats;
-      inFlightRequests.set(stats.total ?? 0);
-      inflightRequestEntries.set(stats.requests ?? []);
+      const requests = stats.requests ?? [];
+      inFlightRequests.set(requests.length);
+      inflightRequestEntries.set(requests);
       break;
     }
   }


### PR DESCRIPTION
Track active model-dispatched requests with cancellable contexts and stream request details to the UI.

- add inflight request snapshots and cancel endpoint
- include supported /upstream inference requests
- render a collapsible inflight table above completed activity


Expanded: 

<img width="1287" height="989" alt="image" src="https://github.com/user-attachments/assets/6d879606-330f-4cc6-bd04-3d3e3fed04bc" />

Collapsed: 

<img width="1132" height="203" alt="image" src="https://github.com/user-attachments/assets/150271e7-4fbf-4020-9f8f-d11df4c1ed36" />


Fixes #893 