### PR TITLE
internal/process: surface upstream output on premature exit

### DIFF
--- a/internal/process/process_command.go
+++ b/internal/process/process_command.go
@@ -425,6 +425,9 @@ func (p *ProcessCommand) doStart(startCtx context.Context, healthCheckTimeout ti
 	p.proxyLogger.Debugf("<%s> Executing start command: %s, env: %s", p.id, strings.Join(args, " "), strings.Join(p.config.Env, ", "))
 
 	cmdDone := make(chan struct{})
+	// Reset the process log so a premature exit surfaces only output from
+	// the current launch, not accumulated history from earlier attempts.
+	p.processLogger.Clear()
 	if err := cmd.Start(); err != nil {
 		cmdCancel()
 		return startResult{err: fmt.Errorf("failed to start command '%s': %w", strings.Join(args, " "), err)}
@@ -456,6 +459,9 @@ func (p *ProcessCommand) doStart(startCtx context.Context, healthCheckTimeout ti
 	}
 	prematureExit := func() startResult {
 		cmdCancel()
+		if output := p.processLogger.GetHistory(); len(output) > 0 {
+			return startResult{err: fmt.Errorf("upstream command exited prematurely:\n%s", strings.TrimSpace(string(output)))}
+		}
 		return startResult{err: fmt.Errorf("upstream command exited prematurely")}
 	}
 

--- a/internal/process/process_command_test.go
+++ b/internal/process/process_command_test.go
@@ -644,3 +644,31 @@ func TestProcessCommand_ConcurrentRunStop(t *testing.T) {
 		}
 	}
 }
+
+func TestProcessCommand_PrematureExitSurfacesOutput(t *testing.T) {
+	skipIfNoSimpleResponder(t)
+
+	// An undefined flag makes simple-responder (a Go flag program) print an error
+	// to stderr and exit before it becomes ready, mirroring a real upstream server
+	// rejecting a bad argument.
+	cmd, port := simpleResponderCmd(t, "-nonexistent-flag")
+	p := newProcessCommand(t, config.ModelConfig{
+		Cmd:                cmd,
+		Proxy:              fmt.Sprintf("http://127.0.0.1:%d", port),
+		CheckEndpoint:      "/health",
+		HealthCheckTimeout: 10,
+	})
+	t.Cleanup(func() { p.Stop(testStopTimeout) })
+
+	err := p.Run(testStartTimeout)
+	if err == nil {
+		t.Fatal("expected Run() to fail for a process that exits prematurely")
+	}
+	if !strings.Contains(err.Error(), "exited prematurely") {
+		t.Errorf("expected a premature-exit error, got: %v", err)
+	}
+	// The captured upstream output must be surfaced so the real cause is visible.
+	if !strings.Contains(err.Error(), "nonexistent-flag") {
+		t.Errorf("expected error to include upstream output, got: %v", err)
+	}
+}


### PR DESCRIPTION
When a model's process exits before becoming ready, clients received the
opaque "upstream command exited prematurely" with none of the upstream
server's output, so a bad launch (for example an invalid argument) could not
be diagnosed from the client. Include the captured process log so the real
cause reaches the caller; because WaitReady subscribers share the start
result, every waiting request benefits too.

- prematureExit now appends processLogger.GetHistory() when non-empty
- clear the process log before each launch so only the current attempt's
  output is surfaced, not accumulated history from earlier launches

fixes #896
