### PR TITLE
internal/server: add load-balanced model pools with dynamic spillover

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,6 +156,11 @@ type Config struct {
 	// support remote peers, see issue #433, #296
 	Peers PeerDictionaryConfig `yaml:"peers"`
 
+	// load-balanced pools: one externally-visible name backed by N member
+	// model instances on different GPUs. Requests addressed to the pool's
+	// name are fanned out across the members.
+	Pools map[string]PoolConfig `yaml:"pools"`
+
 	// upstream controls behaviour of the /upstream passthrough endpoint
 	Upstream UpstreamConfig `yaml:"upstream"`
 }
@@ -197,6 +202,15 @@ func (c *Config) RealModelName(search string) (string, bool) {
 	} else {
 		return "", false
 	}
+}
+
+// PoolMembers returns the configured members of a pool. ok is false when
+// search is not a pool name.
+func (c *Config) PoolMembers(search string) ([]string, bool) {
+	if pool, found := c.Pools[search]; found {
+		return pool.Members, true
+	}
+	return nil, false
 }
 
 func (c *Config) FindConfig(modelName string) (ModelConfig, string, bool) {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -485,7 +485,15 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 	// one routing group with swap disabled. Otherwise spilling to a cold
 	// member evicts the warm sibling (the default group is swap:true) and the
 	// pool silently degrades to serial evict/reload thrashing.
-	if config.Matrix == nil && len(config.Pools) > 0 {
+	//
+	// Matrix routing has no group with a swap flag to check, and the matrix
+	// solver may evict a running set member to load another, which breaks the
+	// coexistence a pool needs. Reject the combination rather than accept a
+	// pool that cannot actually keep its members warm together.
+	if config.Matrix != nil && len(config.Pools) > 0 {
+		return Config{}, fmt.Errorf("pools are not supported with matrix routing; use group routing and place each pool's members in one group with swap: false")
+	}
+	if len(config.Pools) > 0 {
 		groupOf := make(map[string]string, len(config.Models))
 		for groupID, groupConfig := range config.Groups {
 			for _, member := range groupConfig.Members {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -376,7 +376,9 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		}
 	}
 
-	// Clean up hooks preload
+	// Clean up hooks preload. A pool name expands to its first member so the
+	// pool starts with one warm instance; further members are warmed by
+	// spillover on demand.
 	if len(config.Hooks.OnStartup.Preload) > 0 {
 		var toPreload []string
 		for _, modelID := range config.Hooks.OnStartup.Preload {
@@ -386,6 +388,8 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 			}
 			if real, found := config.RealModelName(modelID); found {
 				toPreload = append(toPreload, real)
+			} else if pool, found := config.Pools[modelID]; found && len(pool.Members) > 0 {
+				toPreload = append(toPreload, pool.Members[0])
 			}
 		}
 		config.Hooks.OnStartup.Preload = toPreload
@@ -436,6 +440,75 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 			}
 		}
 		config.Peers[peerName] = peerConfig
+	}
+
+	// Validate pools: name must not collide with a model ID or an alias, every
+	// member must reference a real (non-pool) model ID, and a member must
+	// belong to at most one pool. Pool-to-pool nesting is rejected.
+	for poolID, poolCfg := range config.Pools {
+		if err := poolCfg.Validate(poolID); err != nil {
+			return Config{}, err
+		}
+		if _, exists := config.Models[poolID]; exists {
+			return Config{}, fmt.Errorf("pool %q: name conflicts with an existing model ID", poolID)
+		}
+		if _, exists := config.aliases[poolID]; exists {
+			return Config{}, fmt.Errorf("pool %q: name conflicts with an existing model alias", poolID)
+		}
+		for _, member := range poolCfg.Members {
+			if _, exists := config.Models[member]; !exists {
+				return Config{}, fmt.Errorf("pool %q: member %q is not a configured model", poolID, member)
+			}
+			if _, exists := config.Pools[member]; exists {
+				return Config{}, fmt.Errorf("pool %q: member %q is itself a pool (nesting not supported)", poolID, member)
+			}
+			// Request filters resolve against the requested model name, which
+			// on the pool path is the pool name - a member's filters would be
+			// silently bypassed. Reject rather than surprise.
+			mc := config.Models[member]
+			if mc.Filters.StripParams != "" || len(mc.Filters.SetParams) > 0 || len(mc.Filters.SetParamsByID) > 0 || mc.UseModelName != "" {
+				return Config{}, fmt.Errorf("pool %q: member %q defines filters/useModelName, which are not applied to requests addressed to the pool name; remove them or use the member directly", poolID, member)
+			}
+		}
+	}
+	memberOwner := make(map[string]string)
+	for poolID, poolCfg := range config.Pools {
+		for _, member := range poolCfg.Members {
+			if owner, taken := memberOwner[member]; taken {
+				return Config{}, fmt.Errorf("model %q is a member of multiple pools: %q and %q", member, owner, poolID)
+			}
+			memberOwner[member] = poolID
+		}
+	}
+
+	// Pool members must be able to coexist: all members of a pool must share
+	// one routing group with swap disabled. Otherwise spilling to a cold
+	// member evicts the warm sibling (the default group is swap:true) and the
+	// pool silently degrades to serial evict/reload thrashing.
+	if config.Matrix == nil && len(config.Pools) > 0 {
+		groupOf := make(map[string]string, len(config.Models))
+		for groupID, groupConfig := range config.Groups {
+			for _, member := range groupConfig.Members {
+				groupOf[member] = groupID
+			}
+		}
+		for poolID, poolCfg := range config.Pools {
+			firstGroup := ""
+			for i, member := range poolCfg.Members {
+				gid, found := groupOf[member]
+				if !found {
+					return Config{}, fmt.Errorf("pool %q: member %q is not in any group", poolID, member)
+				}
+				if config.Groups[gid].Swap {
+					return Config{}, fmt.Errorf("pool %q: member %q is in group %q which has swap: true; pool members must share a group with swap: false so they can run concurrently", poolID, member, gid)
+				}
+				if i == 0 {
+					firstGroup = gid
+				} else if gid != firstGroup {
+					return Config{}, fmt.Errorf("pool %q: members span groups %q and %q; all members of a pool must share one group", poolID, firstGroup, gid)
+				}
+			}
+		}
 	}
 
 	return config, nil

--- a/internal/config/pool.go
+++ b/internal/config/pool.go
@@ -1,0 +1,55 @@
+package config
+
+import "fmt"
+
+// PoolConfig declares a load-balanced pool of identical-purpose model
+// instances. When a request arrives addressed to the pool's name, the server
+// picks the least-busy member (ties broken round-robin) and forwards to that
+// instance. Members must be regular model IDs declared under top-level
+// `models:`, and all members of a pool must live in one shared routing group
+// with `swap: false` so they can coexist (validated at load time).
+//
+// Spillover is the per-member in-flight threshold: while the least-busy warm
+// member has fewer than Spillover requests running it keeps receiving
+// traffic; at or above it, the picker warms an additional (cold) member.
+// Set it to the member's slot count (llama-server -np). Default 1.
+type PoolConfig struct {
+	Members   []string `yaml:"members"`
+	Spillover int      `yaml:"spillover"`
+}
+
+func (c *PoolConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type rawPoolConfig PoolConfig
+	defaults := rawPoolConfig{
+		Members:   []string{},
+		Spillover: 1,
+	}
+	if err := unmarshal(&defaults); err != nil {
+		return err
+	}
+	if defaults.Spillover == 0 {
+		defaults.Spillover = 1
+	}
+	*c = PoolConfig(defaults)
+	return nil
+}
+
+// Validate checks the pool is internally consistent. It does not validate
+// that members reference existing model IDs or group placement - that is
+// done by load.go after the models map and groups are populated.
+func (c *PoolConfig) Validate(poolID string) error {
+	if len(c.Members) == 0 {
+		return fmt.Errorf("pool %q: members must not be empty", poolID)
+	}
+	if c.Spillover < 1 {
+		return fmt.Errorf("pool %q: spillover must be >= 1, got %d", poolID, c.Spillover)
+	}
+	seen := make(map[string]bool, len(c.Members))
+	for _, m := range c.Members {
+		if seen[m] {
+			return fmt.Errorf("pool %q: duplicate member %q", poolID, m)
+		}
+		seen[m] = true
+	}
+	return nil
+}

--- a/internal/config/pool_test.go
+++ b/internal/config/pool_test.go
@@ -1,0 +1,259 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestPoolConfig_Defaults(t *testing.T) {
+	var got PoolConfig
+	if err := yaml.Unmarshal([]byte("members: [a, b]\n"), &got); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if got.Spillover != 1 {
+		t.Fatalf("spillover default: got %d, want 1", got.Spillover)
+	}
+	if len(got.Members) != 2 {
+		t.Fatalf("members: got %v, want [a, b]", got.Members)
+	}
+}
+
+func TestPoolConfig_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     PoolConfig
+		wantErr string
+	}{
+		{
+			name:    "empty members",
+			cfg:     PoolConfig{Spillover: 1},
+			wantErr: "must not be empty",
+		},
+		{
+			name:    "duplicate members",
+			cfg:     PoolConfig{Members: []string{"a", "b", "a"}, Spillover: 1},
+			wantErr: "duplicate member",
+		},
+		{
+			name:    "spillover zero",
+			cfg:     PoolConfig{Members: []string{"a"}},
+			wantErr: "spillover must be >= 1",
+		},
+		{
+			name: "valid",
+			cfg:  PoolConfig{Members: []string{"a", "b", "c"}, Spillover: 2},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate("test")
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate: unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Validate: want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_PoolsValid(t *testing.T) {
+	const y = `
+models:
+  a:
+    cmd: echo a ${PORT}
+    unlisted: true
+  b:
+    cmd: echo b ${PORT}
+    unlisted: true
+  c:
+    cmd: echo c ${PORT}
+    unlisted: true
+pools:
+  pool-a:
+    members: [a, b, c]
+    spillover: 2
+groups:
+  g:
+    swap: false
+    persistent: true
+    members: [a, b, c]
+`
+	cfg, err := LoadConfigFromReader(strings.NewReader(y))
+	if err != nil {
+		t.Fatalf("LoadConfigFromReader: %v", err)
+	}
+	pool, ok := cfg.Pools["pool-a"]
+	if !ok {
+		t.Fatal("pool-a missing from cfg.Pools")
+	}
+	if pool.Spillover != 2 {
+		t.Fatalf("spillover: got %d, want 2", pool.Spillover)
+	}
+	members, ok := cfg.PoolMembers("pool-a")
+	if !ok || len(members) != 3 {
+		t.Fatalf("PoolMembers(pool-a): ok=%v members=%v", ok, members)
+	}
+}
+
+func TestLoadConfig_PoolPreloadExpandsToFirstMember(t *testing.T) {
+	const y = `
+models:
+  a:
+    cmd: echo a ${PORT}
+  b:
+    cmd: echo b ${PORT}
+pools:
+  pool-a:
+    members: [a, b]
+groups:
+  g: {swap: false, members: [a, b]}
+hooks:
+  on_startup:
+    preload: [pool-a]
+`
+	cfg, err := LoadConfigFromReader(strings.NewReader(y))
+	if err != nil {
+		t.Fatalf("LoadConfigFromReader: %v", err)
+	}
+	got := cfg.Hooks.OnStartup.Preload
+	if len(got) != 1 || got[0] != "a" {
+		t.Fatalf("preload: got %v, want [a] (first pool member)", got)
+	}
+}
+
+func TestLoadConfig_PoolErrors(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "member missing",
+			yaml: `
+models:
+  a:
+    cmd: echo a ${PORT}
+pools:
+  pool:
+    members: [a, nope]
+groups:
+  g: {swap: false, persistent: true, members: [a]}
+`,
+			wantErr: `member "nope" is not a configured model`,
+		},
+		{
+			name: "name collides with model",
+			yaml: `
+models:
+  a:
+    cmd: echo a ${PORT}
+  b:
+    cmd: echo b ${PORT}
+pools:
+  a:
+    members: [b]
+groups:
+  g: {swap: false, persistent: true, members: [a, b]}
+`,
+			wantErr: `conflicts with an existing model ID`,
+		},
+		{
+			name: "name collides with alias",
+			yaml: `
+models:
+  a:
+    cmd: echo a ${PORT}
+    aliases: [poolname]
+  b:
+    cmd: echo b ${PORT}
+pools:
+  poolname:
+    members: [b]
+groups:
+  g: {swap: false, persistent: true, members: [a, b]}
+`,
+			wantErr: `conflicts with an existing model alias`,
+		},
+		{
+			name: "member in multiple pools",
+			yaml: `
+models:
+  a:
+    cmd: echo a ${PORT}
+  b:
+    cmd: echo b ${PORT}
+pools:
+  p1:
+    members: [a, b]
+  p2:
+    members: [b]
+groups:
+  g: {swap: false, persistent: true, members: [a, b]}
+`,
+			wantErr: `member of multiple pools`,
+		},
+		{
+			name: "members in default swap group",
+			yaml: `
+models:
+  a:
+    cmd: echo a ${PORT}
+  b:
+    cmd: echo b ${PORT}
+pools:
+  pool:
+    members: [a, b]
+`,
+			wantErr: `swap: true`,
+		},
+		{
+			name: "members span groups",
+			yaml: `
+models:
+  a:
+    cmd: echo a ${PORT}
+  b:
+    cmd: echo b ${PORT}
+pools:
+  pool:
+    members: [a, b]
+groups:
+  g1: {swap: false, members: [a]}
+  g2: {swap: false, members: [b]}
+`,
+			wantErr: `span groups`,
+		},
+		{
+			name: "member with filters",
+			yaml: `
+models:
+  a:
+    cmd: echo a ${PORT}
+    filters:
+      stripParams: "temperature"
+  b:
+    cmd: echo b ${PORT}
+pools:
+  pool:
+    members: [a, b]
+groups:
+  g: {swap: false, members: [a, b]}
+`,
+			wantErr: `defines filters/useModelName`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := LoadConfigFromReader(strings.NewReader(tc.yaml))
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/internal/config/pool_test.go
+++ b/internal/config/pool_test.go
@@ -230,6 +230,26 @@ groups:
 			wantErr: `span groups`,
 		},
 		{
+			name: "matrix routing rejected with pools",
+			yaml: `
+models:
+  a:
+    cmd: echo a ${PORT}
+  b:
+    cmd: echo b ${PORT}
+pools:
+  pool:
+    members: [a, b]
+matrix:
+  vars:
+    x: a
+    y: b
+  sets:
+    combo: "x | y"
+`,
+			wantErr: `not supported with matrix routing`,
+		},
+		{
 			name: "member with filters",
 			yaml: `
 models:

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -190,6 +190,39 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Pools surface as one entry per pool name. The display metadata is taken
+	// from the first member that has it set, so the user sees a coherent
+	// listing without having to repeat name/description on every member.
+	for poolID, poolCfg := range s.cfg.Pools {
+		var name, desc string
+		var meta map[string]any
+		var caps config.ModelCapConfig
+		poolStatus := "unloaded"
+		for _, member := range poolCfg.Members {
+			mc, ok := s.cfg.Models[member]
+			if !ok {
+				continue
+			}
+			if name == "" {
+				name = mc.Name
+			}
+			if desc == "" {
+				desc = mc.Description
+			}
+			if meta == nil && len(mc.Metadata) > 0 {
+				meta = mc.Metadata
+			}
+			if caps.Empty() {
+				caps = mc.Capabilities
+			}
+			// the pool counts as loaded when any member is
+			if modelStatus(member) == "loaded" {
+				poolStatus = "loaded"
+			}
+		}
+		data = append(data, newRecord(poolID, name, desc, meta, caps, poolStatus))
+	}
+
 	sort.Slice(data, func(i, j int) bool { return data[i].ID < data[j].ID })
 
 	// Echo the Origin so browser clients can read the listing.

--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -74,9 +74,16 @@ func (s *Server) handleAPIUnloadAll(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{"msg": "ok"})
 }
 
-// handleAPIUnloadModel stops a single named local process.
+// handleAPIUnloadModel stops a single named local process. A pool name
+// unloads every member of the pool.
 func (s *Server) handleAPIUnloadModel(w http.ResponseWriter, r *http.Request) {
 	requested := strings.TrimPrefix(r.PathValue("model"), "/")
+	if members, ok := s.cfg.PoolMembers(requested); ok {
+		s.local.Unload(apiUnloadTimeout, members...)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+		return
+	}
 	realName, found := s.cfg.RealModelName(requested)
 	if !found {
 		shared.SendResponse(w, r, http.StatusNotFound, "model not found")

--- a/internal/server/poolpicker.go
+++ b/internal/server/poolpicker.go
@@ -1,0 +1,207 @@
+package server
+
+import (
+	"sync"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/process"
+)
+
+// failureQuarantine is how long a member whose pick ended in a server error
+// is excluded from cold-spill candidates (as long as alternatives exist).
+// Protects against a broken member (e.g. its pinned GPU is occupied) turning
+// into a spill blackhole of immediate 500s.
+const failureQuarantine = 15 * time.Second
+
+// poolPicker resolves a pool name to one of its member model IDs.
+//
+// Selection is least-busy with round-robin tie-breaking, plus dynamic
+// scale-out: while the least-busy READY member is below the pool's spillover
+// threshold it receives the request; otherwise a cold or starting member is
+// picked so it gets warmed (scale-in is the members' ttl). Members in
+// StateStopping are never picked: dispatching into the stop window would
+// wedge the upstream swap (Stop does not notify WaitReady waiters).
+//
+// Pick RESERVES the returned member (in-flight++) under the same mutex hold
+// that inspected the counters, so concurrent bursts cannot all pick the same
+// member off a stale snapshot. Callers must pair every successful Pick with
+// Release. Direct requests addressed to a member's own model ID are counted
+// via Acquire/Release so pool balancing sees them too.
+type poolPicker struct {
+	pools    map[string]*poolState
+	memberOf map[string]string // member model ID -> pool name
+}
+
+type poolState struct {
+	cfg config.PoolConfig
+
+	mu          sync.Mutex
+	rr          uint64
+	inflight    map[string]int
+	lastFailure map[string]time.Time
+}
+
+// newPoolPicker initialises the picker from the parsed config. It assumes
+// pools have already been validated by config.LoadConfigFromReader.
+func newPoolPicker(cfg config.Config) *poolPicker {
+	pools := make(map[string]*poolState, len(cfg.Pools))
+	memberOf := make(map[string]string)
+	for poolID, poolCfg := range cfg.Pools {
+		pools[poolID] = &poolState{
+			cfg:         poolCfg,
+			inflight:    make(map[string]int, len(poolCfg.Members)),
+			lastFailure: make(map[string]time.Time, len(poolCfg.Members)),
+		}
+		for _, m := range poolCfg.Members {
+			memberOf[m] = poolID
+		}
+	}
+	return &poolPicker{pools: pools, memberOf: memberOf}
+}
+
+// IsPool reports whether name is a configured pool.
+func (p *poolPicker) IsPool(name string) bool {
+	if p == nil {
+		return false
+	}
+	_, ok := p.pools[name]
+	return ok
+}
+
+// MemberPool returns the pool that modelID is a member of, if any.
+func (p *poolPicker) MemberPool(modelID string) (string, bool) {
+	if p == nil {
+		return "", false
+	}
+	pool, ok := p.memberOf[modelID]
+	return pool, ok
+}
+
+// Acquire counts a request dispatched to member outside Pick (direct requests
+// addressed to the member's own model ID). Pair with Release.
+func (p *poolPicker) Acquire(name, member string) {
+	if ps := p.state(name); ps != nil {
+		ps.mu.Lock()
+		ps.inflight[member]++
+		ps.mu.Unlock()
+	}
+}
+
+// Release records the completion of a request counted by Pick or Acquire.
+func (p *poolPicker) Release(name, member string) {
+	if ps := p.state(name); ps != nil {
+		ps.mu.Lock()
+		if ps.inflight[member] > 0 {
+			ps.inflight[member]--
+		}
+		ps.mu.Unlock()
+	}
+}
+
+// NoteFailure quarantines member as a cold-spill target for
+// failureQuarantine. Called when a pool-picked request ends in a server
+// error; only cold members are affected by quarantine, so a ready member
+// returning errors keeps serving (and draining) normally.
+func (p *poolPicker) NoteFailure(name, member string) {
+	if ps := p.state(name); ps != nil {
+		ps.mu.Lock()
+		ps.lastFailure[member] = time.Now()
+		ps.mu.Unlock()
+	}
+}
+
+func (p *poolPicker) state(name string) *poolState {
+	if p == nil {
+		return nil
+	}
+	return p.pools[name]
+}
+
+// Pick returns one member of the named pool and reserves one in-flight slot
+// on it. ok is false when name is not a pool. Callers must call Release with
+// the returned member when the request completes.
+func (p *poolPicker) Pick(name string, running map[string]process.ProcessState) (string, bool) {
+	ps := p.state(name)
+	if ps == nil || len(ps.cfg.Members) == 0 {
+		return "", false
+	}
+
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	ready, spill := ps.classify(running)
+
+	if len(ready) > 0 {
+		if ps.minInflight(ready) < ps.cfg.Spillover || len(spill) == 0 {
+			return ps.take(ready), true
+		}
+	}
+	if len(spill) > 0 {
+		return ps.take(spill), true
+	}
+	if len(ready) > 0 {
+		return ps.take(ready), true
+	}
+	// Last resort (e.g. every member mid-stop): route to the least-busy
+	// member anyway rather than failing the request.
+	return ps.take(ps.cfg.Members), true
+}
+
+// classify splits members into ready and spill candidates. Stopping members
+// are excluded entirely; cold members under failure quarantine are used only
+// when no other spill candidate exists. Caller holds ps.mu.
+func (ps *poolState) classify(running map[string]process.ProcessState) (ready, spill []string) {
+	now := time.Now()
+	var quarantined []string
+	for _, m := range ps.cfg.Members {
+		st, exists := running[m]
+		switch {
+		case exists && st == process.StateReady:
+			ready = append(ready, m)
+		case exists && (st == process.StateStopping || st == process.StateShutdown):
+			// draining: never route new work into the stop window
+		case exists && st == process.StateStarting:
+			spill = append(spill, m)
+		default: // stopped or unknown = cold
+			if t, ok := ps.lastFailure[m]; ok && now.Sub(t) < failureQuarantine {
+				quarantined = append(quarantined, m)
+			} else {
+				spill = append(spill, m)
+			}
+		}
+	}
+	if len(spill) == 0 {
+		spill = quarantined
+	}
+	return ready, spill
+}
+
+// take picks the least-busy candidate (ties broken round-robin), reserves
+// one in-flight slot on it and returns it. Caller holds ps.mu.
+func (ps *poolState) take(candidates []string) string {
+	min := ps.minInflight(candidates)
+	tied := make([]string, 0, len(candidates))
+	for _, m := range candidates {
+		if ps.inflight[m] == min {
+			tied = append(tied, m)
+		}
+	}
+	idx := ps.rr
+	ps.rr++
+	m := tied[idx%uint64(len(tied))]
+	ps.inflight[m]++
+	return m
+}
+
+// minInflight returns the smallest in-flight count among candidates. It does
+// not advance the round-robin counter. Caller holds ps.mu.
+func (ps *poolState) minInflight(candidates []string) int {
+	min := -1
+	for _, m := range candidates {
+		if n := ps.inflight[m]; min < 0 || n < min {
+			min = n
+		}
+	}
+	return min
+}

--- a/internal/server/poolpicker_test.go
+++ b/internal/server/poolpicker_test.go
@@ -144,8 +144,8 @@ func TestPoolPicker_QueueBalancesOnStarting(t *testing.T) {
 		"a": process.StateReady,
 		"b": process.StateStarting,
 	}
-	p.Pick("pool", running)    // a (ready, idle)
-	p.Acquire("pool", "b")     // b warming with one queued
+	p.Pick("pool", running) // a (ready, idle)
+	p.Acquire("pool", "b")  // b warming with one queued
 	m, _ := p.Pick("pool", running)
 	if m != "c" {
 		t.Fatalf("got %q, want c (least busy non-ready)", m)
@@ -190,8 +190,8 @@ func TestPoolPicker_FailureQuarantine(t *testing.T) {
 	}
 	// when every cold candidate is quarantined, fall back to them anyway
 	p.NoteFailure("pool", "c")
-	p.Release("pool", m)      // free the reservation on c from above
-	p.Pick("pool", running)   // re-saturate... a is still at 1; this pick:
+	p.Release("pool", m)    // free the reservation on c from above
+	p.Pick("pool", running) // re-saturate... a is still at 1; this pick:
 	// ready a saturated, spill = quarantined fallback {b, c}
 	m2, _ := p.Pick("pool", running)
 	if m2 == "a" {

--- a/internal/server/poolpicker_test.go
+++ b/internal/server/poolpicker_test.go
@@ -1,0 +1,260 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/process"
+)
+
+func newTestPickerN(members []string, spillover int) *poolPicker {
+	return newPoolPicker(config.Config{
+		Pools: map[string]config.PoolConfig{
+			"pool": {Members: members, Spillover: spillover},
+		},
+	})
+}
+
+func newTestPicker(members []string) *poolPicker {
+	return newTestPickerN(members, 1)
+}
+
+func TestPoolPicker_NotAPool(t *testing.T) {
+	p := newTestPicker([]string{"a", "b"})
+	if _, ok := p.Pick("not-a-pool", nil); ok {
+		t.Fatal("expected ok=false for non-pool name")
+	}
+	if _, ok := p.Pick("a", nil); ok {
+		t.Fatal("expected ok=false for a member's own name")
+	}
+}
+
+func TestPoolPicker_ColdBurstDistributes(t *testing.T) {
+	p := newTestPicker([]string{"a", "b", "c"})
+	// 6 concurrent picks with no releases (a burst): reservation must spread
+	// them evenly - exactly 2 per member.
+	seen := map[string]int{}
+	for i := 0; i < 6; i++ {
+		m, ok := p.Pick("pool", nil)
+		if !ok {
+			t.Fatal("Pick: ok=false")
+		}
+		seen[m]++
+	}
+	for _, m := range []string{"a", "b", "c"} {
+		if seen[m] != 2 {
+			t.Fatalf("burst distribution uneven: %v", seen)
+		}
+	}
+}
+
+func TestPoolPicker_BurstOnSingleReadySpills(t *testing.T) {
+	// THE race that motivated reserve-on-pick: one warm member, burst of 3.
+	// Request 1 takes the warm member; requests 2+3 must go to DIFFERENT cold
+	// members (not herd onto the warm one, not both onto one cold member).
+	p := newTestPicker([]string{"a", "b", "c"})
+	running := map[string]process.ProcessState{"a": process.StateReady}
+
+	m1, _ := p.Pick("pool", running)
+	if m1 != "a" {
+		t.Fatalf("pick 1: got %q, want a", m1)
+	}
+	m2, _ := p.Pick("pool", running)
+	m3, _ := p.Pick("pool", running)
+	if m2 == "a" || m3 == "a" {
+		t.Fatalf("burst herded onto warm member: m2=%q m3=%q", m2, m3)
+	}
+	if m2 == m3 {
+		t.Fatalf("burst stacked on one cold member: m2=%q m3=%q", m2, m3)
+	}
+}
+
+func TestPoolPicker_PreferReadyWhenIdle(t *testing.T) {
+	p := newTestPicker([]string{"a", "b", "c"})
+	running := map[string]process.ProcessState{
+		"b": process.StateReady,
+		"c": process.StateReady,
+	}
+	seen := map[string]int{}
+	for i := 0; i < 10; i++ {
+		m, ok := p.Pick("pool", running)
+		if !ok {
+			t.Fatal("Pick: ok=false")
+		}
+		if m == "a" {
+			t.Fatalf("picked cold member while idle ready members existed")
+		}
+		seen[m]++
+		p.Release("pool", m)
+	}
+	if seen["b"] == 0 || seen["c"] == 0 {
+		t.Fatalf("ready members not both used: seen=%v", seen)
+	}
+}
+
+func TestPoolPicker_SpilloverThreshold2(t *testing.T) {
+	p := newTestPickerN([]string{"a", "b"}, 2)
+	running := map[string]process.ProcessState{"a": process.StateReady}
+
+	m, _ := p.Pick("pool", running)
+	if m != "a" {
+		t.Fatalf("pick 1: got %q, want a", m)
+	}
+	m, _ = p.Pick("pool", running)
+	if m != "a" {
+		t.Fatalf("pick 2: got %q, want a (below spillover=2)", m)
+	}
+	m, _ = p.Pick("pool", running)
+	if m != "b" {
+		t.Fatalf("pick 3: got %q, want b (a saturated)", m)
+	}
+}
+
+func TestPoolPicker_ReleaseReturnsTrafficToWarm(t *testing.T) {
+	p := newTestPicker([]string{"a", "b", "c"})
+	running := map[string]process.ProcessState{"a": process.StateReady}
+
+	m1, _ := p.Pick("pool", running) // a
+	p.Release("pool", m1)
+	m2, _ := p.Pick("pool", running)
+	if m2 != "a" {
+		t.Fatalf("after release: got %q, want a", m2)
+	}
+}
+
+func TestPoolPicker_SaturatedNoColdFallsBackToReady(t *testing.T) {
+	p := newTestPicker([]string{"a", "b"})
+	running := map[string]process.ProcessState{
+		"a": process.StateReady,
+		"b": process.StateReady,
+	}
+	p.Pick("pool", running)
+	p.Pick("pool", running)
+	// everything ready and saturated, no cold members -> least busy ready
+	m, ok := p.Pick("pool", running)
+	if !ok || (m != "a" && m != "b") {
+		t.Fatalf("saturated pick: got %q ok=%v", m, ok)
+	}
+}
+
+func TestPoolPicker_QueueBalancesOnStarting(t *testing.T) {
+	p := newTestPicker([]string{"a", "b", "c"})
+	running := map[string]process.ProcessState{
+		"a": process.StateReady,
+		"b": process.StateStarting,
+	}
+	p.Pick("pool", running)    // a (ready, idle)
+	p.Acquire("pool", "b")     // b warming with one queued
+	m, _ := p.Pick("pool", running)
+	if m != "c" {
+		t.Fatalf("got %q, want c (least busy non-ready)", m)
+	}
+}
+
+func TestPoolPicker_StoppingNeverPicked(t *testing.T) {
+	p := newTestPicker([]string{"a", "b", "c"})
+	running := map[string]process.ProcessState{
+		"a": process.StateReady,
+		"b": process.StateStopping,
+	}
+	p.Pick("pool", running) // a, now saturated
+	// spill must skip b (stopping) and take c (cold)
+	m, _ := p.Pick("pool", running)
+	if m != "c" {
+		t.Fatalf("got %q, want c (stopping member must never be picked)", m)
+	}
+}
+
+func TestPoolPicker_AllStoppingLastResort(t *testing.T) {
+	p := newTestPicker([]string{"a", "b"})
+	running := map[string]process.ProcessState{
+		"a": process.StateStopping,
+		"b": process.StateStopping,
+	}
+	// degenerate case: still return something rather than failing
+	if _, ok := p.Pick("pool", running); !ok {
+		t.Fatal("expected a last-resort pick")
+	}
+}
+
+func TestPoolPicker_FailureQuarantine(t *testing.T) {
+	p := newTestPicker([]string{"a", "b", "c"})
+	running := map[string]process.ProcessState{"a": process.StateReady}
+	p.Pick("pool", running) // a saturated
+
+	p.NoteFailure("pool", "b")
+	m, _ := p.Pick("pool", running)
+	if m != "c" {
+		t.Fatalf("got %q, want c (b is quarantined)", m)
+	}
+	// when every cold candidate is quarantined, fall back to them anyway
+	p.NoteFailure("pool", "c")
+	p.Release("pool", m)      // free the reservation on c from above
+	p.Pick("pool", running)   // re-saturate... a is still at 1; this pick:
+	// ready a saturated, spill = quarantined fallback {b, c}
+	m2, _ := p.Pick("pool", running)
+	if m2 == "a" {
+		t.Fatalf("got %q, want a quarantined cold member as last spill resort", m2)
+	}
+}
+
+func TestPoolPicker_QuarantineExpires(t *testing.T) {
+	p := newTestPicker([]string{"a", "b"})
+	running := map[string]process.ProcessState{"a": process.StateReady}
+	ps := p.pools["pool"]
+	ps.lastFailure["b"] = time.Now().Add(-failureQuarantine - time.Second)
+	p.Pick("pool", running) // a saturated
+	m, _ := p.Pick("pool", running)
+	if m != "b" {
+		t.Fatalf("got %q, want b (quarantine expired)", m)
+	}
+}
+
+func TestPoolPicker_MemberPoolAndDirectAccounting(t *testing.T) {
+	p := newTestPicker([]string{"a", "b"})
+	pool, ok := p.MemberPool("a")
+	if !ok || pool != "pool" {
+		t.Fatalf("MemberPool(a): got %q ok=%v", pool, ok)
+	}
+	if _, ok := p.MemberPool("x"); ok {
+		t.Fatal("MemberPool(x): want ok=false")
+	}
+	// direct traffic on a must steer pool traffic to b
+	running := map[string]process.ProcessState{
+		"a": process.StateReady,
+		"b": process.StateReady,
+	}
+	p.Acquire("pool", "a")
+	m, _ := p.Pick("pool", running)
+	if m != "b" {
+		t.Fatalf("got %q, want b (a carries direct load)", m)
+	}
+}
+
+func TestPoolPicker_ReleaseNeverGoesNegative(t *testing.T) {
+	p := newTestPicker([]string{"a"})
+	p.Release("pool", "a")
+	p.Release("pool", "a")
+	running := map[string]process.ProcessState{"a": process.StateReady}
+	m, ok := p.Pick("pool", running)
+	if !ok || m != "a" {
+		t.Fatalf("got %q ok=%v, want a/true", m, ok)
+	}
+}
+
+func TestPoolPicker_NilSafe(t *testing.T) {
+	var p *poolPicker
+	if p.IsPool("anything") {
+		t.Fatal("nil picker IsPool: want false")
+	}
+	if _, ok := p.Pick("anything", nil); ok {
+		t.Fatal("nil picker Pick: want ok=false")
+	}
+	if _, ok := p.MemberPool("a"); ok {
+		t.Fatal("nil picker MemberPool: want ok=false")
+	}
+	p.Acquire("anything", "a")
+	p.Release("anything", "a")
+	p.NoteFailure("anything", "a")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -38,6 +38,8 @@ type Server struct {
 	local router.LocalRouter
 	peer  router.Router
 
+	picker *poolPicker
+
 	mux     *http.ServeMux
 	handler http.Handler
 
@@ -159,6 +161,7 @@ func New(cfg config.Config, muxlog *logmon.Monitor, proxylog *logmon.Monitor, up
 		build:       build,
 		local:       local,
 		peer:        peer,
+		picker:      newPoolPicker(cfg),
 		shutdownCtx: shutdownCtx,
 		shutdownFn:  shutdownFn,
 	}
@@ -168,7 +171,11 @@ func New(cfg config.Config, muxlog *logmon.Monitor, proxylog *logmon.Monitor, up
 }
 
 // localPeerHandler dispatches a model-routed request to the local or peer
-// router. The model is resolved once via shared.FetchContext.
+// router. The model is resolved once via shared.FetchContext. When the
+// requested name is a load-balanced pool, this handler rewrites the routing
+// key (data.ModelID) to a picked member before dispatch; the original
+// data.Model is kept so downstream filters and the upstream response continue
+// to see the name the client asked for.
 func (s *Server) localPeerHandler(w http.ResponseWriter, r *http.Request) {
 	stripVersionPrefix(r)
 
@@ -176,6 +183,34 @@ func (s *Server) localPeerHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		shared.SendError(w, r, shared.ErrNoModelInContext)
 		return
+	}
+
+	if member, ok := s.picker.Pick(data.Model, s.local.RunningModels()); ok {
+		// Pick reserved an in-flight slot on member; release it when done.
+		s.proxylog.Debugf("dispatch: pool %s -> member %s", data.Model, member)
+		data.ModelID = member
+		// FetchContext could not resolve the pool name to a model config, so
+		// carry the picked member's loading-state setting into the context.
+		if mc, exists := s.cfg.Models[member]; exists {
+			data.SendLoadingState = mc.SendLoadingState != nil && *mc.SendLoadingState
+		}
+		*r = *r.WithContext(shared.SetContext(r.Context(), data))
+		defer s.picker.Release(data.Model, member)
+
+		// Watch the response status so a member that cannot start (e.g. its
+		// GPU is occupied) is quarantined instead of re-picked immediately.
+		sr := &statusRecorder{ResponseWriter: w}
+		w = sr
+		defer func() {
+			if sr.status >= http.StatusInternalServerError {
+				s.picker.NoteFailure(data.Model, member)
+			}
+		}()
+	} else if pool, isMember := s.picker.MemberPool(data.ModelID); isMember {
+		// Direct request to a member's own ID: count it so pool balancing
+		// sees the load.
+		s.picker.Acquire(pool, data.ModelID)
+		defer s.picker.Release(pool, data.ModelID)
 	}
 
 	switch {


### PR DESCRIPTION
Today llama-swap runs one process per model, so every request for a model queues on that single instance even when other GPUs sit idle. This PR adds pools: one public model name served by several identical instances, each pinned to its own GPU. Requests sent to the pool name are spread across the instances, so a single model can answer many requests in parallel and throughput grows with the number of instances (and GPUs) you put behind it.

The pool is dynamic. Under light load only one instance runs. When that instance fills up the next one is started automatically, and when the load drops the idle instances unload themselves through their normal ttl and hand the GPU back to other models. You never have to commit all GPUs to the pool in advance; it grows and shrinks with demand.

Why it is worth merging: llama-swap can already swap between different models, but it cannot run one model across several GPUs to absorb concurrent traffic. Pools close that gap. The feature is optional through a new pools section, and configs that do not use it behave exactly as before.

```yaml
models:
  llama-gpu0:
    cmd: llama-server --port ${PORT} --device Vulkan0 -m model.gguf -ngl 99
    unlisted: true
  llama-gpu1:
    cmd: llama-server --port ${PORT} --device Vulkan1 -m model.gguf -ngl 99
    unlisted: true
pools:
  llama:
    members: [llama-gpu0, llama-gpu1]
    spillover: 1
groups:
  pool-group:
    swap: false
    exclusive: false
    members: [llama-gpu0, llama-gpu1]
```

How the balancing works, in plain terms: a request goes to the instance that currently has the fewest requests in flight, and instances that are equally loaded take turns. The count is reserved the moment an instance is chosen, so a burst of requests that arrive at the same time spreads across instances instead of all landing on the instance that is already warm. The spillover number per pool decides how many requests one instance takes before the next instance is started, so you set it to match how many slots each instance has. Instances that are in the middle of shutting down are never given new work, and an instance whose process fails to start is set aside for 15 seconds instead of being retried into repeated errors.

Mistakes are caught when the config loads rather than failing quietly later: every member must exist, each member belongs to exactly one pool, all members of a pool share one group that does not swap so they can run at the same time, and a pool name cannot clash with a model name or alias. The pool name also works everywhere an ordinary model name does: it appears in /v1/models, can be preloaded at startup, and can be unloaded through the API.

Tested with unit tests for the config checks and the selection logic, and in production on a three GPU box running two pools at once (a reasoning model and a translation model). Load spreading across GPUs, automatic scale up under load, mutual exclusion between pools, and unloading were all verified on real hardware.

### For reviewers, where things live in the code

`internal/config/pool.go`: the pools config type and its validation when the config loads.
`internal/config/load.go`: the checks on group placement and name clashes, and expanding a pool name in preload.
`internal/config/config.go`: the Pools field on Config plus the PoolMembers lookup.
`internal/server/poolpicker.go`: the picker itself.
`internal/server/server.go`: the dispatch hook in localPeerHandler.
`internal/server/api.go` and `apigroup.go`: pool entries in /v1/models and unload by pool name.

### How the code works

The picker (`poolPicker`) holds, per pool: a map from each member to how many requests it has in flight, a rotating cursor for breaking ties, a map with the last time each member failed to start, and one mutex over all of it.

`Pick` takes a snapshot of the running models and sorts a pool's members into ready, cold or starting (can be warmed), and stopping (never chosen). A member that failed to start in the last 15 seconds is left out of the warm candidates unless nothing else is free. If a ready member is still below the pool's spillover limit, or there is nothing cold left to warm, the request goes to the ready member with the fewest requests in flight; otherwise the coldest member with the fewest in flight is chosen so it starts. The chosen member's counter is raised before the lock is released, so a burst of requests that arrive together cannot all read zero and pile onto one member.

`Release` lowers the counter when a request finishes; `NoteFailure` stamps the failure time that drives the 15 second hold.

The dispatch hook lives in `localPeerHandler` (`internal/server/server.go`). After the normal lookup, if the requested name is a pool it asks the picker for a member, rewrites the request's model id to that member, and defers the release. The response writer is wrapped so a 5xx from a member marks it failed. If the requested name is a member's own id instead, the request is still counted against the pool so direct traffic and pool traffic share one view of load. Everything below the hook (the group router, the process manager, the swap logic) is untouched; the pool only chooses which existing model id the request is sent to.

Scaling down needs no new code: members are ordinary models with their own ttl, so an idle member unloads itself and gives the GPU back.