### PR TITLE
internal/config: resolve macros in capabilities fields

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -190,6 +190,12 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 			}
 		}
 
+		// Resolve macros in capabilities (they couldn't be decoded properly
+		// during YAML unmarshal because e.g. "${default_ctx}" is not an int).
+		if err := modelConfig.Capabilities.ResolveMacros(mergedMacros); err != nil {
+			return Config{}, fmt.Errorf("model %s: %w", modelId, err)
+		}
+
 		// Handle PORT macro - only allocate if cmd uses it
 		cmdHasPort := strings.Contains(modelConfig.Cmd, "${PORT}")
 		proxyHasPort := strings.Contains(modelConfig.Proxy, "${PORT}")
@@ -247,10 +253,6 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 			if err := validateNestedForUnknownMacros(modelConfig.Metadata, fmt.Sprintf("model %s metadata", modelId)); err != nil {
 				return Config{}, err
 			}
-		}
-
-		if err = modelConfig.Capabilities.Validate(); err != nil {
-			return Config{}, fmt.Errorf("model %s: %w", modelId, err)
 		}
 
 		// Validate SetParamsByID keys and values

--- a/internal/config/model_config.go
+++ b/internal/config/model_config.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -19,12 +22,74 @@ var validModalities = map[string]struct{}{
 // ModelCapConfig defines what modalities and features a model supports.
 // Used in /v1/models to inform clients. An empty block (all zero values) is
 // treated as not configured.
+//
+// The custom UnmarshalYAML stores the raw YAML node so macro substitution
+// can be applied later via ResolveMacros. After ResolveMacros is called the
+// typed fields (In, Out, Tools, Reranker, Context) are populated.
 type ModelCapConfig struct {
 	In       []string `yaml:"in"`
 	Out      []string `yaml:"out"`
 	Tools    bool     `yaml:"tools"`
 	Reranker bool     `yaml:"reranker"`
 	Context  int      `yaml:"context"`
+
+	rawNode *yaml.Node
+}
+
+// UnmarshalYAML stores the raw YAML node so macro substitution via
+// ResolveMacros can apply before the typed fields are decoded.
+func (c *ModelCapConfig) UnmarshalYAML(value *yaml.Node) error {
+	c.rawNode = value
+	// Pre-populate typed fields for the common case (no macros).
+	// If this succeeds we have valid data; if not (e.g. string in int field
+	// because of a macro reference like "${default_ctx}"), we keep the raw
+	// node and resolve after macro substitution.
+	type rawCap ModelCapConfig
+	if err := value.Decode((*rawCap)(c)); err != nil {
+		// Reset fields to zero; macro resolution will re-decode.
+		c.In = nil
+		c.Out = nil
+		c.Tools = false
+		c.Reranker = false
+		c.Context = 0
+	}
+	return nil
+}
+
+// ResolveMacros marshals the raw YAML node back to YAML, substitutes all
+// macros (LIFO order matching LoadConfigFromReader), and re-decodes the
+// result into the typed fields.
+func (c *ModelCapConfig) ResolveMacros(macros MacroList) error {
+	if c.rawNode == nil {
+		return nil
+	}
+	if len(macros) == 0 {
+		return c.Validate()
+	}
+
+	rawYAML, err := yaml.Marshal(c.rawNode)
+	if err != nil {
+		return fmt.Errorf("capabilities: failed to marshal raw node: %w", err)
+	}
+
+	s := string(rawYAML)
+
+	// Substitute macros in LIFO order (same as LoadConfigFromReader).
+	for i := len(macros) - 1; i >= 0; i-- {
+		entry := macros[i]
+		macroSlug := fmt.Sprintf("${%s}", entry.Name)
+		macroStr := fmt.Sprintf("%v", entry.Value)
+		s = strings.ReplaceAll(s, macroSlug, macroStr)
+	}
+
+	// Decode the substituted YAML back into the typed struct.
+	*c = ModelCapConfig{}
+	type rawCap ModelCapConfig
+	if err := yaml.Unmarshal([]byte(s), (*rawCap)(c)); err != nil {
+		return fmt.Errorf("capabilities: failed to decode after macro substitution: %w", err)
+	}
+
+	return c.Validate()
 }
 
 // Empty returns true when all fields are at their zero values.

--- a/internal/config/model_config_test.go
+++ b/internal/config/model_config_test.go
@@ -334,3 +334,134 @@ models:
 		assert.Contains(t, err.Error(), "video")
 	})
 }
+
+func TestConfig_ModelCapabilities_MacroResolution(t *testing.T) {
+	t.Run("context from global macro", func(t *testing.T) {
+		content := `
+macros:
+  default_ctx: 98304
+models:
+  model1:
+    cmd: path/to/cmd --port ${PORT}
+    capabilities:
+      in:
+        - text
+        - image
+      out:
+        - text
+      tools: true
+      context: ${default_ctx}
+`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NoError(t, err)
+
+		mc := config.Models["model1"]
+		assert.False(t, mc.Capabilities.Empty())
+		assert.Equal(t, []string{"text", "image"}, mc.Capabilities.In)
+		assert.Equal(t, []string{"text"}, mc.Capabilities.Out)
+		assert.True(t, mc.Capabilities.Tools)
+		assert.Equal(t, 98304, mc.Capabilities.Context)
+	})
+
+	t.Run("context from model macro overrides global", func(t *testing.T) {
+		content := `
+macros:
+  default_ctx: 4096
+models:
+  model1:
+    cmd: path/to/cmd --port ${PORT}
+    macros:
+      default_ctx: 65536
+    capabilities:
+      context: ${default_ctx}
+`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NoError(t, err)
+
+		mc := config.Models["model1"]
+		assert.Equal(t, 65536, mc.Capabilities.Context)
+	})
+
+	t.Run("macro in modalities", func(t *testing.T) {
+		content := `
+macros:
+  img_modality: image
+models:
+  model1:
+    cmd: path/to/cmd --port ${PORT}
+    capabilities:
+      in:
+        - text
+        - ${img_modality}
+      out:
+        - text
+`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NoError(t, err)
+
+		mc := config.Models["model1"]
+		assert.Equal(t, []string{"text", "image"}, mc.Capabilities.In)
+	})
+
+	t.Run("macro in tools", func(t *testing.T) {
+		content := `
+macros:
+  has_tools: true
+models:
+  model1:
+    cmd: path/to/cmd --port ${PORT}
+    capabilities:
+      tools: ${has_tools}
+`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NoError(t, err)
+
+		mc := config.Models["model1"]
+		assert.True(t, mc.Capabilities.Tools)
+	})
+
+	t.Run("macro in reranker", func(t *testing.T) {
+		content := `
+macros:
+  is_reranker: true
+models:
+  model1:
+    cmd: path/to/cmd --port ${PORT}
+    capabilities:
+      reranker: ${is_reranker}
+`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NoError(t, err)
+
+		mc := config.Models["model1"]
+		assert.True(t, mc.Capabilities.Reranker)
+	})
+
+	t.Run("no capabilities block is unchanged", func(t *testing.T) {
+		content := `
+macros:
+  default_ctx: 98304
+models:
+  model1:
+    cmd: path/to/cmd --port ${PORT}
+`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NoError(t, err)
+
+		mc := config.Models["model1"]
+		assert.True(t, mc.Capabilities.Empty())
+	})
+
+	t.Run("unknown macro in capabilities errors", func(t *testing.T) {
+		content := `
+models:
+  model1:
+    cmd: path/to/cmd --port ${PORT}
+    capabilities:
+      context: ${undefined_macro}
+`
+		_, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to decode after macro substitution")
+	})
+}


### PR DESCRIPTION
Model macros (e.g. ${default_ctx}) were not resolved inside the capabilities block because ModelCapConfig has typed fields (int, bool) that YAML cannot parse macro reference strings into.

Add a custom UnmarshalYAML on ModelCapConfig that captures the raw yaml.Node, and a ResolveMacros method that marshals it back to YAML, substitutes all macros (LIFO order), and re-decodes into the typed struct. Existing Capabilities.Validate() call is subsumed by ResolveMacros.

- new ModelCapConfig.rawNode field (unexported)
- ModelCapConfig.UnmarshalYAML captures raw node; best-effort direct decode; resets fields to zero on failure (macro not yet known)
- ModelCapConfig.ResolveMacros: marshal -> LIFO substitute -> decode
- LoadConfigFromReader calls ResolveMacros after the main LIFO loop, before PORT allocation and unknown-macro validation
- Removes the now-redundant standalone Capabilities.Validate() call

Closes #900