### PR TITLE
internal/server: support vLLM metrics

### DIFF
--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -185,6 +185,7 @@ func (mp *metricsMonitor) record(modelID string, r *http.Request, recorder *resp
 		parsed := gjson.ParseBytes(body)
 		usage := parsed.Get("usage")
 		timings := parsed.Get("timings")
+		responseMetrics := parsed.Get("metrics")
 
 		// /infill responses are arrays; timings live in the last element (#463).
 		if strings.HasPrefix(r.URL.Path, "/infill") {
@@ -193,8 +194,8 @@ func (mp *metricsMonitor) record(modelID string, r *http.Request, recorder *resp
 			}
 		}
 
-		if usage.Exists() || timings.Exists() {
-			if parsedMetrics, err := parseMetrics(modelID, recorder.StartTime(), usage, timings); err != nil {
+		if usage.Exists() || timings.Exists() || responseMetrics.Exists() {
+			if parsedMetrics, err := parseMetrics(modelID, recorder.StartTime(), usage, timings, responseMetrics); err != nil {
 				mp.logger.Warnf("error parsing metrics: %v, path=%s, recording minimal metrics", err, r.URL.Path)
 			} else {
 				tm.Tokens = parsedMetrics.Tokens
@@ -351,6 +352,7 @@ func processStreamingResponse(modelID string, start time.Time, body []byte) (Act
 		cachedTokens              int64 = -1
 		hasAny                    bool
 		timings                   gjson.Result
+		responseMetrics           gjson.Result
 	)
 
 	prefix := []byte("data:")
@@ -402,23 +404,28 @@ func processStreamingResponse(modelID string, start time.Time, body []byte) (Act
 			timings = t
 			hasAny = true
 		}
+		if m := parsed.Get("metrics"); m.Exists() {
+			responseMetrics = m
+			hasAny = true
+		}
 	}
 
 	if !hasAny {
 		return ActivityLogEntry{}, fmt.Errorf("no valid JSON data found in stream")
 	}
 
-	return buildMetrics(modelID, start, inputTokens, outputTokens, cachedTokens, timings), nil
+	return buildMetrics(modelID, start, inputTokens, outputTokens, cachedTokens, timings, responseMetrics), nil
 }
 
-func parseMetrics(modelID string, start time.Time, usage, timings gjson.Result) (ActivityLogEntry, error) {
+func parseMetrics(modelID string, start time.Time, usage, timings, responseMetrics gjson.Result) (ActivityLogEntry, error) {
 	input, output, cached, _ := extractUsageTokens(usage)
-	return buildMetrics(modelID, start, input, output, cached, timings), nil
+	return buildMetrics(modelID, start, input, output, cached, timings, responseMetrics), nil
 }
 
 // buildMetrics composes an ActivityLogEntry from accumulated token counts and
-// optional llama-server timings (which override input/output and provide rates).
-func buildMetrics(modelID string, start time.Time, inputTokens, outputTokens, cachedTokens int64, timings gjson.Result) ActivityLogEntry {
+// optional llama-server timings (which override input/output and provide rates)
+// or vLLM response metrics.
+func buildMetrics(modelID string, start time.Time, inputTokens, outputTokens, cachedTokens int64, timings, responseMetrics gjson.Result) ActivityLogEntry {
 	wallDurationMs := int(time.Since(start).Milliseconds())
 	durationMs := wallDurationMs
 	tokensPerSecond := -1.0
@@ -442,6 +449,9 @@ func buildMetrics(modelID string, start time.Time, inputTokens, outputTokens, ca
 			draftTokens = int(timings.Get("draft_n").Int())
 			draftAccTokens = int(timings.Get("draft_n_accepted").Int())
 		}
+	}
+	if tokensPerSecondValue := responseMetrics.Get("tokens_per_second"); tokensPerSecondValue.Exists() {
+		tokensPerSecond = tokensPerSecondValue.Float()
 	}
 
 	return ActivityLogEntry{

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -17,7 +17,7 @@ import (
 func TestServer_ParseMetrics_ChatCompletions(t *testing.T) {
 	body := `{"usage":{"prompt_tokens":12,"completion_tokens":7,"prompt_tokens_details":{"cached_tokens":4}}}`
 	parsed := gjson.Parse(body)
-	entry, err := parseMetrics("m", time.Now(), parsed.Get("usage"), parsed.Get("timings"))
+	entry, err := parseMetrics("m", time.Now(), parsed.Get("usage"), parsed.Get("timings"), parsed.Get("metrics"))
 	if err != nil {
 		t.Fatalf("parseMetrics: %v", err)
 	}
@@ -29,7 +29,7 @@ func TestServer_ParseMetrics_ChatCompletions(t *testing.T) {
 func TestServer_ParseMetrics_Timings(t *testing.T) {
 	body := `{"timings":{"prompt_n":20,"predicted_n":50,"prompt_per_second":100.0,"predicted_per_second":40.0,"prompt_ms":200,"predicted_ms":1250,"cache_n":8}}`
 	parsed := gjson.Parse(body)
-	entry, err := parseMetrics("m", time.Now(), parsed.Get("usage"), parsed.Get("timings"))
+	entry, err := parseMetrics("m", time.Now(), parsed.Get("usage"), parsed.Get("timings"), parsed.Get("metrics"))
 	if err != nil {
 		t.Fatalf("parseMetrics: %v", err)
 	}
@@ -54,6 +54,38 @@ func TestServer_ProcessStreamingResponse(t *testing.T) {
 	}
 	if entry.Tokens.InputTokens != 15 || entry.Tokens.OutputTokens != 33 {
 		t.Fatalf("tokens = %+v", entry.Tokens)
+	}
+}
+
+func TestServer_ProcessStreamingResponse_VLLMMetrics(t *testing.T) {
+	body := []byte(`data: {"id":"chatcmpl-b7a832cea986aea4","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":14,"total_tokens":166,"completion_tokens":152},"metrics":{"tokens_per_second":24.116032676555495}}
+
+data: [DONE]
+`)
+	entry, err := processStreamingResponse("m", time.Now(), body)
+	if err != nil {
+		t.Fatalf("processStreamingResponse: %v", err)
+	}
+	if entry.Tokens.InputTokens != 14 || entry.Tokens.OutputTokens != 152 {
+		t.Fatalf("tokens = %+v", entry.Tokens)
+	}
+	if entry.Tokens.TokensPerSecond != 24.116032676555495 {
+		t.Errorf("TokensPerSecond = %v, want 24.116032676555495", entry.Tokens.TokensPerSecond)
+	}
+}
+
+func TestServer_ParseMetrics_VLLMMetrics(t *testing.T) {
+	body := `{"id":"chatcmpl-ad324a51921b2e7f","object":"chat.completion","usage":{"prompt_tokens":14,"total_tokens":260,"completion_tokens":246,"prompt_tokens_details":null},"metrics":{"tokens_per_second":24.298537778478494}}`
+	parsed := gjson.Parse(body)
+	entry, err := parseMetrics("m", time.Now(), parsed.Get("usage"), parsed.Get("timings"), parsed.Get("metrics"))
+	if err != nil {
+		t.Fatalf("parseMetrics: %v", err)
+	}
+	if entry.Tokens.InputTokens != 14 || entry.Tokens.OutputTokens != 246 {
+		t.Fatalf("tokens = %+v", entry.Tokens)
+	}
+	if entry.Tokens.TokensPerSecond != 24.298537778478494 {
+		t.Errorf("TokensPerSecond = %v, want 24.298537778478494", entry.Tokens.TokensPerSecond)
 	}
 }
 
@@ -264,7 +296,7 @@ func TestServer_ParseMetrics_Infill(t *testing.T) {
 	if arr := parsed.Array(); len(arr) > 0 {
 		timings = arr[len(arr)-1].Get("timings")
 	}
-	entry, err := parseMetrics("m", time.Now(), parsed.Get("usage"), timings)
+	entry, err := parseMetrics("m", time.Now(), parsed.Get("usage"), timings, parsed.Get("metrics"))
 	if err != nil {
 		t.Fatalf("parseMetrics: %v", err)
 	}


### PR DESCRIPTION
Read vLLM usage token counts and response generation speed from completion responses.

- parse tokens_per_second from non-streaming metrics
- retain streaming metrics from final events
- cover both vLLM response modes

Fixes #906 