### PR TITLE
feat: add per-model output caps and dynamic reasoning effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,9 @@ Almost all configuration settings are optional and can be added one step at a ti
   - `env` to pass custom environment variables to inference servers
   - `cmdStop` gracefully stop Docker/Podman containers
   - `useModelName` to override model names sent to upstream servers
-  - `${PORT}` automatic port variables for dynamic port assignment
-  - `filters` rewrite parts of requests before sending to the upstream server
+   - `${PORT}` automatic port variables for dynamic port assignment
+   - `filters` rewrite parts of requests before sending to the upstream server
+   - `capabilities` advertise model features, set output-token limits, and configure reasoning-effort budgets
 
 See the [configuration documentation](docs/configuration.md) for all options.
 

--- a/README.md
+++ b/README.md
@@ -220,9 +220,9 @@ Almost all configuration settings are optional and can be added one step at a ti
   - `env` to pass custom environment variables to inference servers
   - `cmdStop` gracefully stop Docker/Podman containers
   - `useModelName` to override model names sent to upstream servers
-   - `${PORT}` automatic port variables for dynamic port assignment
-   - `filters` rewrite parts of requests before sending to the upstream server
-   - `capabilities` advertise model features, set output-token limits, and configure reasoning-effort budgets
+  - `${PORT}` automatic port variables for dynamic port assignment
+  - `filters` rewrite parts of requests before sending to the upstream server
+  - `capabilities` advertise model features, set output-token limits, and configure reasoning-effort budgets
 
 See the [configuration documentation](docs/configuration.md) for all options.
 

--- a/config-schema.json
+++ b/config-schema.json
@@ -442,6 +442,12 @@
                                 "minimum": 0,
                                 "default": 0,
                                 "description": "Maximum token context length supported by the model."
+                            },
+                            "max_output_tokens": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "default": 0,
+                                "description": "Maximum output tokens for a generation request. 0 does not enforce a limit."
                             }
                         },
                         "additionalProperties": false,

--- a/config-schema.json
+++ b/config-schema.json
@@ -499,6 +499,25 @@
                                 "description": "Optional reasoning-effort support and per-effort token budgets."
                             }
                         },
+                        "allOf": [
+                            {
+                                "if": {
+                                    "required": [
+                                        "reasoning"
+                                    ]
+                                },
+                                "then": {
+                                    "required": [
+                                        "max_output_tokens"
+                                    ],
+                                    "properties": {
+                                        "max_output_tokens": {
+                                            "minimum": 1
+                                        }
+                                    }
+                                }
+                            }
+                        ],
                         "additionalProperties": false,
                         "description": "Defines what the model accepts for input, output and other metadata. Used in v1/models to inform clients what the model can do. An empty capabilities block (all zero values) is treated as not configured."
                     }

--- a/config-schema.json
+++ b/config-schema.json
@@ -448,6 +448,55 @@
                                 "minimum": 0,
                                 "default": 0,
                                 "description": "Maximum output tokens for a generation request. 0 does not enforce a limit."
+                            },
+                            "reasoning": {
+                                "type": "object",
+                                "required": [
+                                    "default",
+                                    "efforts"
+                                ],
+                                "properties": {
+                                    "default": {
+                                        "type": "string",
+                                        "enum": [
+                                            "none",
+                                            "low",
+                                            "medium",
+                                            "high",
+                                            "xhigh"
+                                        ],
+                                        "description": "Default reasoning effort for requests that do not specify one."
+                                    },
+                                    "efforts": {
+                                        "type": "object",
+                                        "minProperties": 1,
+                                        "properties": {
+                                            "none": {
+                                                "const": 0
+                                            },
+                                            "low": {
+                                                "type": "integer",
+                                                "minimum": 1
+                                            },
+                                            "medium": {
+                                                "type": "integer",
+                                                "minimum": 1
+                                            },
+                                            "high": {
+                                                "type": "integer",
+                                                "minimum": 1
+                                            },
+                                            "xhigh": {
+                                                "type": "integer",
+                                                "minimum": 1
+                                            }
+                                        },
+                                        "additionalProperties": false,
+                                        "description": "Token budget for each supported reasoning effort. Enabled effort budgets must be less than max_output_tokens."
+                                    }
+                                },
+                                "additionalProperties": false,
+                                "description": "Optional reasoning-effort support and per-effort token budgets."
                             }
                         },
                         "additionalProperties": false,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -363,6 +363,13 @@ models:
       # - must be an integer > 0
       context: 32000
 
+      # max_output_tokens: maximum generated tokens allowed per request
+      # - default: 0 (no limit)
+      # - caps max_tokens and max_completion_tokens for chat completions,
+      #   max_tokens for completions, and max_output_tokens for responses
+      # - lower client-provided values are preserved
+      max_output_tokens: 4096
+
   # Unlisted model example:
   "qwen-unlisted":
     # unlisted: boolean, true or false

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -370,6 +370,19 @@ models:
       # - lower client-provided values are preserved
       max_output_tokens: 4096
 
+      # reasoning: optional reasoning effort selection and token budgets
+      # - default must be configured in efforts
+      # - valid efforts: none, low, medium, high, xhigh
+      # - none must have budget 0; all other budgets must be greater than 0
+      #   and less than max_output_tokens
+      reasoning:
+        default: medium
+        efforts:
+          none: 0
+          low: 512
+          medium: 1024
+          high: 2048
+
   # Unlisted model example:
   "qwen-unlisted":
     # unlisted: boolean, true or false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -423,6 +423,19 @@ models:
       # - context is not used as an output-token limit
       max_output_tokens: 4096
 
+      # reasoning: optional reasoning effort selection and token budgets
+      # - default must be configured in efforts
+      # - valid efforts: none, low, medium, high, xhigh
+      # - none must have budget 0; all other budgets must be greater than 0
+      #   and less than max_output_tokens
+      reasoning:
+        default: medium
+        efforts:
+          none: 0
+          low: 512
+          medium: 1024
+          high: 2048
+
   # Unlisted model example:
   "qwen-unlisted":
     # unlisted: boolean, true or false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -410,6 +410,23 @@ models:
       tlsHandshake: 10
       idleConn: 90
 
+```
+
+### Output caps and reasoning effort
+
+`max_output_tokens` is the per-model generated-token limit. llama-swap caps or
+injects `max_tokens` and `max_completion_tokens` for Chat Completions,
+`max_tokens` for Completions, and `max_output_tokens` for Responses. Chat
+Completions accepts `reasoning_effort`; Responses accepts `reasoning.effort`,
+while top-level `reasoning_effort` remains a compatibility alias.
+
+Dynamic effort selection requires official llama.cpp build `b8605` or newer and
+cannot be used with `--reasoning-budget` or `LLAMA_ARG_THINK_BUDGET`.
+Omitted or `default` effort does not add thinking overrides. The extended
+`/v1/models` fields are llama-swap metadata extensions; the OpenAI-compatible
+core is `id`, `object`, `created`, and `owned_by`.
+
+```yaml
     # Output caps and reasoning effort
     # - max_output_tokens caps max_tokens and max_completion_tokens for Chat
     #   Completions, max_tokens for Completions, and max_output_tokens for Responses

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -410,6 +410,19 @@ models:
       tlsHandshake: 10
       idleConn: 90
 
+    # Output caps and reasoning effort
+    # - max_output_tokens caps max_tokens and max_completion_tokens for Chat
+    #   Completions, max_tokens for Completions, and max_output_tokens for Responses
+    # - Chat Completions accepts reasoning_effort; Responses accepts reasoning.effort
+    #   (top-level reasoning_effort remains a compatibility alias for Responses)
+    # - dynamic effort selection requires llama.cpp build b8605 or newer and no
+    #   --reasoning-budget or LLAMA_ARG_THINK_BUDGET startup override
+    # - omitted or default effort preserves upstream startup behavior
+    # - llama-swap metadata extensions in /v1/models: architecture, capabilities,
+    #   supported_parameters, context_length, max_input_tokens, max_output_tokens,
+    #   reasoning_supported, reasoning_default, reasoning_efforts, reasoning_budgets
+    # - OpenAI's compatible core fields are id, object, created, and owned_by
+
     # capabilities: model metadata and optional generation limits
     capabilities:
       # context: maximum token context length supported by the model

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -410,6 +410,19 @@ models:
       tlsHandshake: 10
       idleConn: 90
 
+    # capabilities: model metadata and optional generation limits
+    capabilities:
+      # context: maximum token context length supported by the model
+      context: 32000
+
+      # max_output_tokens: maximum generated tokens allowed per request
+      # - default: 0 (no limit)
+      # - caps max_tokens and max_completion_tokens for /v1/chat/completions,
+      #   max_tokens for /v1/completions, and max_output_tokens for /v1/responses
+      # - a lower client-provided value is preserved; higher values are capped
+      # - context is not used as an output-token limit
+      max_output_tokens: 4096
+
   # Unlisted model example:
   "qwen-unlisted":
     # unlisted: boolean, true or false

--- a/internal/config/commands.go
+++ b/internal/config/commands.go
@@ -55,3 +55,22 @@ func StripComments(cmdStr string) string {
 	}
 	return strings.Join(cleanedLines, "\n")
 }
+
+// HasFixedReasoningBudget reports whether the upstream command or environment
+// overrides llama.cpp's request-level thinking budget.
+func HasFixedReasoningBudget(args, env []string) bool {
+	for i, arg := range args {
+		if arg == "--reasoning-budget" && i+1 < len(args) {
+			return true
+		}
+		if strings.HasPrefix(arg, "--reasoning-budget=") {
+			return true
+		}
+	}
+	for _, value := range env {
+		if strings.HasPrefix(value, "LLAMA_ARG_THINK_BUDGET=") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/config_schema_test.go
+++ b/internal/config/config_schema_test.go
@@ -9,17 +9,11 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// TestConfig_ExampleMatchesSchema validates that config.example.yaml conforms to
-// config-schema.json. Both files live at the repository root.
-func TestConfig_ExampleMatchesSchema(t *testing.T) {
-	const (
-		schemaPath  = "../../config-schema.json"
-		examplePath = "../../config.example.yaml"
-	)
-
-	schemaBytes, err := os.ReadFile(schemaPath)
+func resolveConfigSchema(t *testing.T) *jsonschema.Resolved {
+	t.Helper()
+	schemaBytes, err := os.ReadFile("../../config-schema.json")
 	if err != nil {
-		t.Fatalf("reading %s: %v", schemaPath, err)
+		t.Fatalf("reading config-schema.json: %v", err)
 	}
 
 	var schema jsonschema.Schema
@@ -33,6 +27,15 @@ func TestConfig_ExampleMatchesSchema(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolving schema: %v", err)
 	}
+	return resolved
+}
+
+// TestConfig_ExampleMatchesSchema validates that config.example.yaml conforms to
+// config-schema.json. Both files live at the repository root.
+func TestConfig_ExampleMatchesSchema(t *testing.T) {
+	const examplePath = "../../config.example.yaml"
+
+	resolved := resolveConfigSchema(t)
 
 	exampleBytes, err := os.ReadFile(examplePath)
 	if err != nil {
@@ -56,5 +59,44 @@ func TestConfig_ExampleMatchesSchema(t *testing.T) {
 
 	if err := resolved.Validate(instance); err != nil {
 		t.Fatalf("config.example.yaml does not match config-schema.json:\n%v", err)
+	}
+}
+
+func TestConfig_SchemaReasoningRequiresOutputLimit(t *testing.T) {
+	resolved := resolveConfigSchema(t)
+
+	withoutLimit := map[string]any{
+		"models": map[string]any{
+			"m": map[string]any{
+				"cmd": "llama-server",
+				"capabilities": map[string]any{
+					"reasoning": map[string]any{
+						"default": "low",
+						"efforts": map[string]any{"low": 1},
+					},
+				},
+			},
+		},
+	}
+	if err := resolved.Validate(withoutLimit); err == nil {
+		t.Fatal("reasoning without max_output_tokens passed schema validation")
+	}
+
+	withLimit := map[string]any{
+		"models": map[string]any{
+			"m": map[string]any{
+				"cmd": "llama-server",
+				"capabilities": map[string]any{
+					"max_output_tokens": 2,
+					"reasoning": map[string]any{
+						"default": "low",
+						"efforts": map[string]any{"low": 1},
+					},
+				},
+			},
+		},
+	}
+	if err := resolved.Validate(withLimit); err != nil {
+		t.Fatalf("reasoning with max_output_tokens failed schema validation: %v", err)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -44,6 +44,27 @@ groups:
 	assert.Contains(t, err.Error(), "model member model2 is used in multiple groups:")
 }
 
+func TestConfig_HasFixedReasoningBudget(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		env  []string
+		want bool
+	}{
+		{"no override", []string{"llama-server", "--port", "8080"}, nil, false},
+		{"separate command argument", []string{"llama-server", "--reasoning-budget", "8192"}, nil, true},
+		{"equals command argument", []string{"llama-server", "--reasoning-budget=8192"}, nil, true},
+		{"environment override", []string{"llama-server"}, []string{"LLAMA_ARG_THINK_BUDGET=8192"}, true},
+		{"unrelated environment", []string{"llama-server"}, []string{"OTHER_REASONING_BUDGET=8192"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasFixedReasoningBudget(tc.args, tc.env); got != tc.want {
+				t.Errorf("HasFixedReasoningBudget() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestConfig_ModelAliasesAreUnique(t *testing.T) {
 	content := `
 models:

--- a/internal/config/model_config.go
+++ b/internal/config/model_config.go
@@ -19,20 +19,40 @@ var validModalities = map[string]struct{}{
 	"image": {},
 }
 
+var validReasoningEfforts = map[string]struct{}{
+	"none":   {},
+	"low":    {},
+	"medium": {},
+	"high":   {},
+	"xhigh":  {},
+}
+
+// ModelReasoningConfig defines the reasoning modes and their token budgets.
+// A non-empty Efforts map marks a model as supporting reasoning selection.
+type ModelReasoningConfig struct {
+	Default string         `yaml:"default"`
+	Efforts map[string]int `yaml:"efforts"`
+}
+
+func (c ModelReasoningConfig) Enabled() bool {
+	return len(c.Efforts) > 0
+}
+
 // ModelCapConfig defines what modalities and features a model supports.
 // Used in /v1/models to inform clients. An empty block (all zero values) is
 // treated as not configured.
 //
 // The custom UnmarshalYAML stores the raw YAML node so macro substitution
 // can be applied later via ResolveMacros. After ResolveMacros is called the
-// typed fields (In, Out, Tools, Reranker, Context, MaxOutputTokens) are populated.
+// typed fields (In, Out, Tools, Reranker, Context, MaxOutputTokens, Reasoning) are populated.
 type ModelCapConfig struct {
-	In              []string `yaml:"in"`
-	Out             []string `yaml:"out"`
-	Tools           bool     `yaml:"tools"`
-	Reranker        bool     `yaml:"reranker"`
-	Context         int      `yaml:"context"`
-	MaxOutputTokens int      `yaml:"max_output_tokens"`
+	In              []string             `yaml:"in"`
+	Out             []string             `yaml:"out"`
+	Tools           bool                 `yaml:"tools"`
+	Reranker        bool                 `yaml:"reranker"`
+	Context         int                  `yaml:"context"`
+	MaxOutputTokens int                  `yaml:"max_output_tokens"`
+	Reasoning       ModelReasoningConfig `yaml:"reasoning"`
 
 	rawNode *yaml.Node
 }
@@ -54,6 +74,7 @@ func (c *ModelCapConfig) UnmarshalYAML(value *yaml.Node) error {
 		c.Reranker = false
 		c.Context = 0
 		c.MaxOutputTokens = 0
+		c.Reasoning = ModelReasoningConfig{}
 	}
 	return nil
 }
@@ -96,7 +117,7 @@ func (c *ModelCapConfig) ResolveMacros(macros MacroList) error {
 
 // Empty returns true when all fields are at their zero values.
 func (c ModelCapConfig) Empty() bool {
-	return len(c.In) == 0 && len(c.Out) == 0 && !c.Tools && !c.Reranker && c.Context == 0 && c.MaxOutputTokens == 0
+	return len(c.In) == 0 && len(c.Out) == 0 && !c.Tools && !c.Reranker && c.Context == 0 && c.MaxOutputTokens == 0 && !c.Reasoning.Enabled() && c.Reasoning.Default == ""
 }
 
 // Validate checks that all modality values are recognized and context is
@@ -117,6 +138,41 @@ func (c ModelCapConfig) Validate() error {
 	}
 	if c.MaxOutputTokens < 0 {
 		return errors.New("capabilities.max_output_tokens: must be >= 0")
+	}
+	if c.Context > 0 && c.MaxOutputTokens > c.Context {
+		return errors.New("capabilities.max_output_tokens: must be <= capabilities.context")
+	}
+	if !c.Reasoning.Enabled() {
+		if c.Reasoning.Default != "" {
+			return errors.New("capabilities.reasoning.default: requires capabilities.reasoning.efforts")
+		}
+		return nil
+	}
+	if c.MaxOutputTokens == 0 {
+		return errors.New("capabilities.reasoning: requires capabilities.max_output_tokens > 0")
+	}
+	if _, ok := validReasoningEfforts[c.Reasoning.Default]; !ok {
+		return fmt.Errorf("capabilities.reasoning.default: invalid effort %q", c.Reasoning.Default)
+	}
+	if _, ok := c.Reasoning.Efforts[c.Reasoning.Default]; !ok {
+		return fmt.Errorf("capabilities.reasoning.default: %q is not configured in capabilities.reasoning.efforts", c.Reasoning.Default)
+	}
+	for effort, budget := range c.Reasoning.Efforts {
+		if _, ok := validReasoningEfforts[effort]; !ok {
+			return fmt.Errorf("capabilities.reasoning.efforts: invalid effort %q", effort)
+		}
+		if effort == "none" {
+			if budget != 0 {
+				return errors.New("capabilities.reasoning.efforts.none: must be 0")
+			}
+			continue
+		}
+		if budget <= 0 {
+			return fmt.Errorf("capabilities.reasoning.efforts.%s: must be > 0", effort)
+		}
+		if budget >= c.MaxOutputTokens {
+			return fmt.Errorf("capabilities.reasoning.efforts.%s: must be less than capabilities.max_output_tokens", effort)
+		}
 	}
 	return nil
 }

--- a/internal/config/model_config.go
+++ b/internal/config/model_config.go
@@ -25,13 +25,14 @@ var validModalities = map[string]struct{}{
 //
 // The custom UnmarshalYAML stores the raw YAML node so macro substitution
 // can be applied later via ResolveMacros. After ResolveMacros is called the
-// typed fields (In, Out, Tools, Reranker, Context) are populated.
+// typed fields (In, Out, Tools, Reranker, Context, MaxOutputTokens) are populated.
 type ModelCapConfig struct {
-	In       []string `yaml:"in"`
-	Out      []string `yaml:"out"`
-	Tools    bool     `yaml:"tools"`
-	Reranker bool     `yaml:"reranker"`
-	Context  int      `yaml:"context"`
+	In              []string `yaml:"in"`
+	Out             []string `yaml:"out"`
+	Tools           bool     `yaml:"tools"`
+	Reranker        bool     `yaml:"reranker"`
+	Context         int      `yaml:"context"`
+	MaxOutputTokens int      `yaml:"max_output_tokens"`
 
 	rawNode *yaml.Node
 }
@@ -52,6 +53,7 @@ func (c *ModelCapConfig) UnmarshalYAML(value *yaml.Node) error {
 		c.Tools = false
 		c.Reranker = false
 		c.Context = 0
+		c.MaxOutputTokens = 0
 	}
 	return nil
 }
@@ -94,7 +96,7 @@ func (c *ModelCapConfig) ResolveMacros(macros MacroList) error {
 
 // Empty returns true when all fields are at their zero values.
 func (c ModelCapConfig) Empty() bool {
-	return len(c.In) == 0 && len(c.Out) == 0 && !c.Tools && !c.Reranker && c.Context == 0
+	return len(c.In) == 0 && len(c.Out) == 0 && !c.Tools && !c.Reranker && c.Context == 0 && c.MaxOutputTokens == 0
 }
 
 // Validate checks that all modality values are recognized and context is
@@ -112,6 +114,9 @@ func (c ModelCapConfig) Validate() error {
 	}
 	if c.Context < 0 {
 		return errors.New("capabilities.context: must be >= 0")
+	}
+	if c.MaxOutputTokens < 0 {
+		return errors.New("capabilities.max_output_tokens: must be >= 0")
 	}
 	return nil
 }

--- a/internal/config/model_config_test.go
+++ b/internal/config/model_config_test.go
@@ -330,6 +330,37 @@ func TestConfig_ModelCapabilities_Validate(t *testing.T) {
 		assert.Contains(t, err.Error(), "capabilities.max_output_tokens")
 	})
 
+	t.Run("reasoning", func(t *testing.T) {
+		valid := ModelCapConfig{
+			Context:         32000,
+			MaxOutputTokens: 4096,
+			Reasoning: ModelReasoningConfig{
+				Default: "medium",
+				Efforts: map[string]int{"none": 0, "low": 512, "medium": 1024, "high": 2048},
+			},
+		}
+		assert.NoError(t, valid.Validate())
+
+		for _, tc := range []struct {
+			name string
+			caps ModelCapConfig
+		}{
+			{"default_without_efforts", ModelCapConfig{Reasoning: ModelReasoningConfig{Default: "low"}}},
+			{"invalid_default", ModelCapConfig{MaxOutputTokens: 10, Reasoning: ModelReasoningConfig{Default: "invalid", Efforts: map[string]int{"low": 1}}}},
+			{"default_not_configured", ModelCapConfig{MaxOutputTokens: 10, Reasoning: ModelReasoningConfig{Default: "high", Efforts: map[string]int{"low": 1}}}},
+			{"unknown_effort", ModelCapConfig{MaxOutputTokens: 10, Reasoning: ModelReasoningConfig{Default: "low", Efforts: map[string]int{"low": 1, "max": 2}}}},
+			{"none_with_budget", ModelCapConfig{MaxOutputTokens: 10, Reasoning: ModelReasoningConfig{Default: "none", Efforts: map[string]int{"none": 1}}}},
+			{"enabled_effort_without_budget", ModelCapConfig{MaxOutputTokens: 10, Reasoning: ModelReasoningConfig{Default: "low", Efforts: map[string]int{"low": 0}}}},
+			{"budget_at_output_limit", ModelCapConfig{MaxOutputTokens: 10, Reasoning: ModelReasoningConfig{Default: "low", Efforts: map[string]int{"low": 10}}}},
+			{"reasoning_without_output_limit", ModelCapConfig{Reasoning: ModelReasoningConfig{Default: "low", Efforts: map[string]int{"low": 1}}}},
+			{"output_exceeds_context", ModelCapConfig{Context: 10, MaxOutputTokens: 11}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.Error(t, tc.caps.Validate())
+			})
+		}
+	})
+
 	t.Run("rejects_invalid_at_load", func(t *testing.T) {
 		content := `
 models:
@@ -347,6 +378,27 @@ models:
 }
 
 func TestConfig_ModelCapabilities_MacroResolution(t *testing.T) {
+	t.Run("reasoning budgets from macros", func(t *testing.T) {
+		content := `
+macros:
+  output_tokens: 4096
+  medium_budget: 1024
+models:
+  model1:
+    cmd: path/to/cmd --port ${PORT}
+    capabilities:
+      max_output_tokens: ${output_tokens}
+      reasoning:
+        default: medium
+        efforts:
+          none: 0
+          medium: ${medium_budget}
+`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NoError(t, err)
+		assert.Equal(t, 1024, config.Models["model1"].Capabilities.Reasoning.Efforts["medium"])
+	})
+
 	t.Run("max output tokens from macro", func(t *testing.T) {
 		content := `
 macros:

--- a/internal/config/model_config_test.go
+++ b/internal/config/model_config_test.go
@@ -188,6 +188,7 @@ models:
         - image
       tools: true
       context: 32000
+      max_output_tokens: 4096
 `
 		config, err := LoadConfigFromReader(strings.NewReader(content))
 		assert.NoError(t, err)
@@ -198,6 +199,7 @@ models:
 		assert.Equal(t, []string{"text", "audio", "image"}, mc.Capabilities.Out)
 		assert.True(t, mc.Capabilities.Tools)
 		assert.Equal(t, 32000, mc.Capabilities.Context)
+		assert.Equal(t, 4096, mc.Capabilities.MaxOutputTokens)
 	})
 
 	t.Run("partial fields", func(t *testing.T) {
@@ -208,6 +210,7 @@ models:
     capabilities:
       tools: true
       context: 8192
+      max_output_tokens: 1024
 `
 		config, err := LoadConfigFromReader(strings.NewReader(content))
 		assert.NoError(t, err)
@@ -218,6 +221,7 @@ models:
 		assert.Nil(t, mc.Capabilities.Out)
 		assert.True(t, mc.Capabilities.Tools)
 		assert.Equal(t, 8192, mc.Capabilities.Context)
+		assert.Equal(t, 1024, mc.Capabilities.MaxOutputTokens)
 	})
 
 	t.Run("not set", func(t *testing.T) {
@@ -319,6 +323,13 @@ func TestConfig_ModelCapabilities_Validate(t *testing.T) {
 		assert.Contains(t, err.Error(), "capabilities.context")
 	})
 
+	t.Run("negative_max_output_tokens", func(t *testing.T) {
+		caps := ModelCapConfig{MaxOutputTokens: -1}
+		err := caps.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "capabilities.max_output_tokens")
+	})
+
 	t.Run("rejects_invalid_at_load", func(t *testing.T) {
 		content := `
 models:
@@ -336,6 +347,21 @@ models:
 }
 
 func TestConfig_ModelCapabilities_MacroResolution(t *testing.T) {
+	t.Run("max output tokens from macro", func(t *testing.T) {
+		content := `
+macros:
+  max_output: 4096
+models:
+  model1:
+    cmd: path/to/cmd --port ${PORT}
+    capabilities:
+      max_output_tokens: ${max_output}
+`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NoError(t, err)
+		assert.Equal(t, 4096, config.Models["model1"].Capabilities.MaxOutputTokens)
+	})
+
 	t.Run("context from global macro", func(t *testing.T) {
 		content := `
 macros:

--- a/internal/process/process_command.go
+++ b/internal/process/process_command.go
@@ -573,23 +573,25 @@ func applyReasoningEffort(w http.ResponseWriter, r *http.Request, modelID string
 		shared.SendResponse(w, r, http.StatusBadRequest, "could not read request body")
 		return false
 	}
-	effortValue := gjson.GetBytes(body, "reasoning_effort")
-	if !effortValue.Exists() {
+	effort, hasEffort, nested, err := requestReasoningEffort(body, r.URL.Path)
+	if err != nil {
+		shared.SendResponse(w, r, http.StatusBadRequest, err.Error())
+		return false
+	}
+	if !hasEffort {
 		r.Body = io.NopCloser(bytes.NewReader(body))
 		return true
 	}
-	effort := effortValue.String()
+	body, err = removeReasoningSelector(body, nested)
+	if err != nil {
+		shared.SendResponse(w, r, http.StatusInternalServerError, "could not remove reasoning effort")
+		return false
+	}
 	if !reasoning.Enabled() {
 		shared.SendResponse(w, r, http.StatusBadRequest, fmt.Sprintf("reasoning_effort is not supported for model %q", modelID))
 		return false
 	}
-	if effort == "default" {
-		body, err = sjson.DeleteBytes(body, "reasoning_effort")
-		if err != nil {
-			shared.SendResponse(w, r, http.StatusInternalServerError, "could not remove reasoning_effort")
-			return false
-		}
-	} else {
+	if effort != "default" {
 		budget, ok := reasoning.Efforts[effort]
 		if !ok {
 			shared.SendResponse(w, r, http.StatusBadRequest, "reasoning_effort must be one of: default, none, low, medium, high, xhigh")
@@ -599,10 +601,7 @@ func applyReasoningEffort(w http.ResponseWriter, r *http.Request, modelID string
 			shared.SendResponse(w, r, http.StatusBadRequest, fmt.Sprintf("reasoning_effort is unavailable for model %q: %s", modelID, unavailableReason))
 			return false
 		}
-		body, err = sjson.DeleteBytes(body, "reasoning_effort")
-		if err == nil {
-			body, err = sjson.SetBytes(body, "thinking_budget_tokens", budget)
-		}
+		body, err = sjson.SetBytes(body, "thinking_budget_tokens", budget)
 		if err == nil {
 			body, err = sjson.SetBytes(body, "chat_template_kwargs.enable_thinking", effort != "none")
 		}
@@ -618,6 +617,38 @@ func applyReasoningEffort(w http.ResponseWriter, r *http.Request, modelID string
 	return true
 }
 
+func requestReasoningEffort(body []byte, path string) (effort string, exists, nested bool, err error) {
+	topLevel := gjson.GetBytes(body, "reasoning_effort")
+	if !isResponsesPath(path) {
+		return topLevel.String(), topLevel.Exists(), false, nil
+	}
+
+	nestedValue := gjson.GetBytes(body, "reasoning.effort")
+	if nestedValue.Exists() && topLevel.Exists() {
+		return "", false, false, fmt.Errorf("reasoning.effort and reasoning_effort cannot both be supplied")
+	}
+	if nestedValue.Exists() {
+		return nestedValue.String(), true, true, nil
+	}
+	return topLevel.String(), topLevel.Exists(), false, nil
+}
+
+func removeReasoningSelector(body []byte, nested bool) ([]byte, error) {
+	if !nested {
+		return sjson.DeleteBytes(body, "reasoning_effort")
+	}
+
+	updated, err := sjson.DeleteBytes(body, "reasoning.effort")
+	if err != nil {
+		return nil, err
+	}
+	reasoning := gjson.GetBytes(updated, "reasoning")
+	if reasoning.IsObject() && len(reasoning.Map()) == 0 {
+		return sjson.DeleteBytes(updated, "reasoning")
+	}
+	return updated, nil
+}
+
 func isReasoningPath(path string) bool {
 	switch path {
 	case "/v1/chat/completions", "/chat/completions", "/v1/responses", "/responses":
@@ -625,6 +656,10 @@ func isReasoningPath(path string) bool {
 	default:
 		return false
 	}
+}
+
+func isResponsesPath(path string) bool {
+	return path == "/v1/responses" || path == "/responses"
 }
 
 // sendStopSignal runs the configured CmdStop (if any) or sends SIGTERM to

--- a/internal/process/process_command.go
+++ b/internal/process/process_command.go
@@ -1,14 +1,18 @@
 package process
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
 	"net/url"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -17,6 +21,8 @@ import (
 	"github.com/mostlygeek/llama-swap/internal/event"
 	"github.com/mostlygeek/llama-swap/internal/logmon"
 	"github.com/mostlygeek/llama-swap/internal/shared"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 var ErrStartAborted = fmt.Errorf("aborted")
@@ -36,6 +42,10 @@ const cmdWaitDelay = 10 * time.Second
 // Stop() by this point, so killProcess is a no-op kill; the short grace just
 // bounds the rare case where a process is still alive when its context is cut.
 const parentCancelGraceTimeout = time.Second
+
+const minimumThinkingBudgetBuild = 8605
+
+var buildInfoPattern = regexp.MustCompile(`^b(\d+)-[0-9a-f]+$`)
 
 type runReq struct {
 	timeout time.Duration
@@ -363,6 +373,12 @@ func (p *ProcessCommand) doStart(startCtx context.Context, healthCheckTimeout ti
 	if err != nil {
 		return startResult{err: fmt.Errorf("unable to get sanitized command: %w", err)}
 	}
+	fixedReasoningBudget := config.HasFixedReasoningBudget(args, p.config.Env)
+	reasoningDynamic := false
+	reasoningUnavailableReason := "llama.cpp does not support per-request reasoning budgets"
+	if fixedReasoningBudget {
+		reasoningUnavailableReason = "llama.cpp was started with a fixed reasoning budget"
+	}
 
 	proxyURL, err := url.Parse(p.config.Proxy)
 	if err != nil {
@@ -404,6 +420,9 @@ func (p *ProcessCommand) doStart(startCtx context.Context, healthCheckTimeout ti
 				}
 			}
 		}()
+		if !applyReasoningEffort(w, r, p.id, p.config.Capabilities.Reasoning, reasoningDynamic, reasoningUnavailableReason) {
+			return
+		}
 		reverseProxy.ServeHTTP(w, r)
 	})
 
@@ -465,6 +484,9 @@ func (p *ProcessCommand) doStart(startCtx context.Context, healthCheckTimeout ti
 
 	checkEndpoint := strings.TrimSpace(p.config.CheckEndpoint)
 	if checkEndpoint == "none" {
+		if !fixedReasoningBudget {
+			reasoningDynamic = upstreamSupportsThinkingBudget(reverseProxy, startCtx)
+		}
 		return startResult{cmd: cmd, cmdDone: cmdDone, cancel: cmdCancel, handlerFn: handlerFn}
 	}
 
@@ -509,8 +531,100 @@ func (p *ProcessCommand) doStart(startCtx context.Context, healthCheckTimeout ti
 		case <-time.After(time.Second):
 		}
 	}
+	if !fixedReasoningBudget {
+		reasoningDynamic = upstreamSupportsThinkingBudget(reverseProxy, startCtx)
+	}
 
 	return startResult{cmd: cmd, cmdDone: cmdDone, cancel: cmdCancel, handlerFn: handlerFn}
+}
+
+// upstreamSupportsThinkingBudget accepts official llama.cpp builds at or after
+// the commit that introduced the request-level field. Unknown/forked builds are
+// deliberately rejected rather than silently ignoring a selected effort.
+func upstreamSupportsThinkingBudget(proxy *httputil.ReverseProxy, ctx context.Context) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "/props", nil)
+	if err != nil {
+		return false
+	}
+	rr := httptest.NewRecorder()
+	proxy.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		return false
+	}
+	buildInfo := gjson.GetBytes(rr.Body.Bytes(), "build_info").String()
+	return supportsThinkingBudgetBuildInfo(buildInfo)
+}
+
+func supportsThinkingBudgetBuildInfo(buildInfo string) bool {
+	match := buildInfoPattern.FindStringSubmatch(buildInfo)
+	if len(match) != 2 {
+		return false
+	}
+	build, err := strconv.Atoi(match[1])
+	return err == nil && build >= minimumThinkingBudgetBuild
+}
+
+func applyReasoningEffort(w http.ResponseWriter, r *http.Request, modelID string, reasoning config.ModelReasoningConfig, dynamic bool, unavailableReason string) bool {
+	if r.Method != http.MethodPost || !isReasoningPath(r.URL.Path) || !strings.Contains(r.Header.Get("Content-Type"), "application/json") {
+		return true
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		shared.SendResponse(w, r, http.StatusBadRequest, "could not read request body")
+		return false
+	}
+	effortValue := gjson.GetBytes(body, "reasoning_effort")
+	if !effortValue.Exists() {
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		return true
+	}
+	effort := effortValue.String()
+	if !reasoning.Enabled() {
+		shared.SendResponse(w, r, http.StatusBadRequest, fmt.Sprintf("reasoning_effort is not supported for model %q", modelID))
+		return false
+	}
+	if effort == "default" {
+		body, err = sjson.DeleteBytes(body, "reasoning_effort")
+		if err != nil {
+			shared.SendResponse(w, r, http.StatusInternalServerError, "could not remove reasoning_effort")
+			return false
+		}
+	} else {
+		budget, ok := reasoning.Efforts[effort]
+		if !ok {
+			shared.SendResponse(w, r, http.StatusBadRequest, "reasoning_effort must be one of: default, none, low, medium, high, xhigh")
+			return false
+		}
+		if !dynamic {
+			shared.SendResponse(w, r, http.StatusBadRequest, fmt.Sprintf("reasoning_effort is unavailable for model %q: %s", modelID, unavailableReason))
+			return false
+		}
+		body, err = sjson.DeleteBytes(body, "reasoning_effort")
+		if err == nil {
+			body, err = sjson.SetBytes(body, "thinking_budget_tokens", budget)
+		}
+		if err == nil {
+			body, err = sjson.SetBytes(body, "chat_template_kwargs.enable_thinking", effort != "none")
+		}
+		if err != nil {
+			shared.SendResponse(w, r, http.StatusInternalServerError, "could not apply reasoning_effort")
+			return false
+		}
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.Header.Del("Transfer-Encoding")
+	r.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	r.ContentLength = int64(len(body))
+	return true
+}
+
+func isReasoningPath(path string) bool {
+	switch path {
+	case "/v1/chat/completions", "/chat/completions", "/v1/responses", "/responses":
+		return true
+	default:
+		return false
+	}
 }
 
 // sendStopSignal runs the configured CmdStop (if any) or sends SIGTERM to

--- a/internal/process/process_command_test.go
+++ b/internal/process/process_command_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/shared"
 	"github.com/tidwall/gjson"
 )
 
@@ -197,6 +198,61 @@ func TestProcess_ApplyReasoningEffort(t *testing.T) {
 				t.Errorf("status = %d, want 400", w.Code)
 			}
 		})
+	}
+}
+
+func TestProcessCommand_ResponsesReasoningAlias(t *testing.T) {
+	cfg, err := config.LoadConfigFromReader(strings.NewReader(`
+models:
+  canonical:
+    cmd: llama-server --port ${PORT}
+    aliases: [MODEL_ALIAS]
+    capabilities:
+      max_output_tokens: 4096
+      reasoning:
+        default: medium
+        efforts:
+          none: 0
+          low: 1024
+          medium: 2048
+`))
+	if err != nil {
+		t.Fatalf("LoadConfigFromReader: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{
+"model":"MODEL_ALIAS","input":"test","reasoning":{"effort":"low"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	data, err := shared.FetchContext(req, cfg)
+	if err != nil {
+		t.Fatalf("FetchContext: %v", err)
+	}
+	if data.ModelID != "canonical" {
+		t.Fatalf("ModelID = %q, want canonical", data.ModelID)
+	}
+
+	var upstreamBody []byte
+	p := &ProcessCommand{id: data.ModelID, config: cfg.Models[data.ModelID]}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !applyReasoningEffort(w, r, p.id, p.config.Capabilities.Reasoning, true, "") {
+			return
+		}
+		upstreamBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	})
+	p.handler.Store(&handler)
+	p.ServeHTTP(httptest.NewRecorder(), req)
+
+	if gjson.GetBytes(upstreamBody, "model").String() != "MODEL_ALIAS" {
+		t.Errorf("upstream model = %s, want MODEL_ALIAS", upstreamBody)
+	}
+	if gjson.GetBytes(upstreamBody, "reasoning.effort").Exists() || gjson.GetBytes(upstreamBody, "reasoning_effort").Exists() {
+		t.Errorf("reasoning selector was forwarded: %s", upstreamBody)
+	}
+	if got := gjson.GetBytes(upstreamBody, "thinking_budget_tokens").Int(); got != 1024 {
+		t.Errorf("thinking_budget_tokens = %d, want 1024", got)
+	}
+	if !gjson.GetBytes(upstreamBody, "chat_template_kwargs.enable_thinking").Bool() {
+		t.Errorf("enable_thinking = false, want true")
 	}
 }
 

--- a/internal/process/process_command_test.go
+++ b/internal/process/process_command_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/tidwall/gjson"
 )
 
 const (
@@ -25,6 +26,100 @@ const (
 	testPollInterval    = 20 * time.Millisecond
 	testLogPollInterval = 10 * time.Millisecond
 )
+
+func TestProcess_ApplyReasoningEffort(t *testing.T) {
+	reasoning := config.ModelReasoningConfig{
+		Default: "medium",
+		Efforts: map[string]int{"none": 0, "low": 1024, "medium": 2048, "high": 4096, "xhigh": 8192},
+	}
+
+	request := func(body string) *http.Request {
+		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+		r.Header.Set("Content-Type", "application/json")
+		return r
+	}
+
+	t.Run("selected effort forwards dynamic controls", func(t *testing.T) {
+		r := request(`{"reasoning_effort":"high"}`)
+		if ok := applyReasoningEffort(httptest.NewRecorder(), r, "qwopus", reasoning, true, ""); !ok {
+			t.Fatal("applyReasoningEffort returned false")
+		}
+		body, _ := io.ReadAll(r.Body)
+		if got := gjson.GetBytes(body, "thinking_budget_tokens").Int(); got != 4096 {
+			t.Errorf("thinking_budget_tokens = %d, want 4096", got)
+		}
+		if !gjson.GetBytes(body, "chat_template_kwargs.enable_thinking").Bool() {
+			t.Error("enable_thinking = false, want true")
+		}
+		if gjson.GetBytes(body, "reasoning_effort").Exists() {
+			t.Error("reasoning_effort was forwarded")
+		}
+	})
+
+	t.Run("none disables thinking", func(t *testing.T) {
+		r := request(`{"reasoning_effort":"none"}`)
+		if ok := applyReasoningEffort(httptest.NewRecorder(), r, "qwopus", reasoning, true, ""); !ok {
+			t.Fatal("applyReasoningEffort returned false")
+		}
+		body, _ := io.ReadAll(r.Body)
+		if got := gjson.GetBytes(body, "thinking_budget_tokens").Int(); got != 0 {
+			t.Errorf("thinking_budget_tokens = %d, want 0", got)
+		}
+		if gjson.GetBytes(body, "chat_template_kwargs.enable_thinking").Bool() {
+			t.Error("enable_thinking = true, want false")
+		}
+	})
+
+	t.Run("default preserves startup behavior", func(t *testing.T) {
+		r := request(`{"reasoning_effort":"default"}`)
+		if ok := applyReasoningEffort(httptest.NewRecorder(), r, "qwopus", reasoning, false, ""); !ok {
+			t.Fatal("applyReasoningEffort returned false")
+		}
+		body, _ := io.ReadAll(r.Body)
+		if gjson.GetBytes(body, "thinking_budget_tokens").Exists() || gjson.GetBytes(body, "reasoning_effort").Exists() {
+			t.Errorf("default body = %s, want no overrides", body)
+		}
+	})
+
+	t.Run("fixed upstream rejects explicit effort", func(t *testing.T) {
+		r := request(`{"reasoning_effort":"low"}`)
+		w := httptest.NewRecorder()
+		if ok := applyReasoningEffort(w, r, "qwopus", reasoning, false, "llama.cpp was started with a fixed reasoning budget"); ok {
+			t.Fatal("applyReasoningEffort returned true")
+		}
+		if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "fixed reasoning budget") {
+			t.Errorf("status=%d body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("unsupported model rejects effort", func(t *testing.T) {
+		r := request(`{"reasoning_effort":"low"}`)
+		w := httptest.NewRecorder()
+		if ok := applyReasoningEffort(w, r, "plain", config.ModelReasoningConfig{}, true, ""); ok {
+			t.Fatal("applyReasoningEffort returned true")
+		}
+		if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "not supported") {
+			t.Errorf("status=%d body=%s", w.Code, w.Body.String())
+		}
+	})
+}
+
+func TestProcess_SupportsThinkingBudgetBuildInfo(t *testing.T) {
+	for _, tc := range []struct {
+		buildInfo string
+		want      bool
+	}{
+		{"b8604-deadbee", false},
+		{"b8605-0fcb376", true},
+		{"b9000-deadbee", true},
+		{"unknown", false},
+		{"b9000-custom", false},
+	} {
+		if got := supportsThinkingBudgetBuildInfo(tc.buildInfo); got != tc.want {
+			t.Errorf("supportsThinkingBudgetBuildInfo(%q) = %v, want %v", tc.buildInfo, got, tc.want)
+		}
+	}
+}
 
 func newProcessCommand(t *testing.T, conf config.ModelConfig) *ProcessCommand {
 	t.Helper()

--- a/internal/process/process_command_test.go
+++ b/internal/process/process_command_test.go
@@ -33,14 +33,14 @@ func TestProcess_ApplyReasoningEffort(t *testing.T) {
 		Efforts: map[string]int{"none": 0, "low": 1024, "medium": 2048, "high": 4096, "xhigh": 8192},
 	}
 
-	request := func(body string) *http.Request {
-		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	request := func(path, body string) *http.Request {
+		r := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
 		r.Header.Set("Content-Type", "application/json")
 		return r
 	}
 
 	t.Run("selected effort forwards dynamic controls", func(t *testing.T) {
-		r := request(`{"reasoning_effort":"high"}`)
+		r := request("/v1/chat/completions", `{"reasoning_effort":"high"}`)
 		if ok := applyReasoningEffort(httptest.NewRecorder(), r, "qwopus", reasoning, true, ""); !ok {
 			t.Fatal("applyReasoningEffort returned false")
 		}
@@ -57,7 +57,7 @@ func TestProcess_ApplyReasoningEffort(t *testing.T) {
 	})
 
 	t.Run("none disables thinking", func(t *testing.T) {
-		r := request(`{"reasoning_effort":"none"}`)
+		r := request("/v1/chat/completions", `{"reasoning_effort":"none"}`)
 		if ok := applyReasoningEffort(httptest.NewRecorder(), r, "qwopus", reasoning, true, ""); !ok {
 			t.Fatal("applyReasoningEffort returned false")
 		}
@@ -71,7 +71,7 @@ func TestProcess_ApplyReasoningEffort(t *testing.T) {
 	})
 
 	t.Run("default preserves startup behavior", func(t *testing.T) {
-		r := request(`{"reasoning_effort":"default"}`)
+		r := request("/v1/chat/completions", `{"reasoning_effort":"default"}`)
 		if ok := applyReasoningEffort(httptest.NewRecorder(), r, "qwopus", reasoning, false, ""); !ok {
 			t.Fatal("applyReasoningEffort returned false")
 		}
@@ -82,7 +82,7 @@ func TestProcess_ApplyReasoningEffort(t *testing.T) {
 	})
 
 	t.Run("fixed upstream rejects explicit effort", func(t *testing.T) {
-		r := request(`{"reasoning_effort":"low"}`)
+		r := request("/v1/chat/completions", `{"reasoning_effort":"low"}`)
 		w := httptest.NewRecorder()
 		if ok := applyReasoningEffort(w, r, "qwopus", reasoning, false, "llama.cpp was started with a fixed reasoning budget"); ok {
 			t.Fatal("applyReasoningEffort returned true")
@@ -93,7 +93,7 @@ func TestProcess_ApplyReasoningEffort(t *testing.T) {
 	})
 
 	t.Run("unsupported model rejects effort", func(t *testing.T) {
-		r := request(`{"reasoning_effort":"low"}`)
+		r := request("/v1/chat/completions", `{"reasoning_effort":"low"}`)
 		w := httptest.NewRecorder()
 		if ok := applyReasoningEffort(w, r, "plain", config.ModelReasoningConfig{}, true, ""); ok {
 			t.Fatal("applyReasoningEffort returned true")
@@ -102,6 +102,102 @@ func TestProcess_ApplyReasoningEffort(t *testing.T) {
 			t.Errorf("status=%d body=%s", w.Code, w.Body.String())
 		}
 	})
+
+	for _, tc := range []struct {
+		effort string
+		budget int64
+		enable bool
+	}{
+		{"none", 0, false},
+		{"low", 1024, true},
+		{"medium", 2048, true},
+		{"high", 4096, true},
+		{"xhigh", 8192, true},
+	} {
+		t.Run("responses nested "+tc.effort, func(t *testing.T) {
+			r := request("/v1/responses", `{"reasoning":{"effort":"`+tc.effort+`"}}`)
+			if ok := applyReasoningEffort(httptest.NewRecorder(), r, "qwopus-test", reasoning, true, ""); !ok {
+				t.Fatal("applyReasoningEffort returned false")
+			}
+			body, _ := io.ReadAll(r.Body)
+			if got := gjson.GetBytes(body, "thinking_budget_tokens").Int(); got != tc.budget {
+				t.Errorf("thinking_budget_tokens = %d, want %d", got, tc.budget)
+			}
+			if got := gjson.GetBytes(body, "chat_template_kwargs.enable_thinking").Bool(); got != tc.enable {
+				t.Errorf("enable_thinking = %v, want %v", got, tc.enable)
+			}
+			if gjson.GetBytes(body, "reasoning").Exists() {
+				t.Errorf("nested reasoning selector was forwarded: %s", body)
+			}
+		})
+	}
+
+	t.Run("responses nested default preserves startup behavior", func(t *testing.T) {
+		r := request("/v1/responses", `{"reasoning":{"effort":"default"}}`)
+		if ok := applyReasoningEffort(httptest.NewRecorder(), r, "qwopus", reasoning, false, ""); !ok {
+			t.Fatal("applyReasoningEffort returned false")
+		}
+		body, _ := io.ReadAll(r.Body)
+		if gjson.GetBytes(body, "reasoning").Exists() || gjson.GetBytes(body, "thinking_budget_tokens").Exists() {
+			t.Errorf("default body = %s, want no overrides", body)
+		}
+	})
+
+	t.Run("responses omitted effort preserves request", func(t *testing.T) {
+		r := request("/v1/responses", `{"input":"hello"}`)
+		if ok := applyReasoningEffort(httptest.NewRecorder(), r, "qwopus", reasoning, false, ""); !ok {
+			t.Fatal("applyReasoningEffort returned false")
+		}
+		body, _ := io.ReadAll(r.Body)
+		if string(body) != `{"input":"hello"}` {
+			t.Errorf("body = %s", body)
+		}
+	})
+
+	t.Run("responses top level compatibility alias", func(t *testing.T) {
+		r := request("/v1/responses", `{"reasoning_effort":"low"}`)
+		if ok := applyReasoningEffort(httptest.NewRecorder(), r, "qwopus", reasoning, true, ""); !ok {
+			t.Fatal("applyReasoningEffort returned false")
+		}
+		body, _ := io.ReadAll(r.Body)
+		if got := gjson.GetBytes(body, "thinking_budget_tokens").Int(); got != 1024 || gjson.GetBytes(body, "reasoning_effort").Exists() {
+			t.Errorf("compatibility body = %s", body)
+		}
+	})
+
+	t.Run("responses rejects both selector forms", func(t *testing.T) {
+		r := request("/v1/responses", `{"reasoning_effort":"low","reasoning":{"effort":"high"}}`)
+		w := httptest.NewRecorder()
+		if ok := applyReasoningEffort(w, r, "qwopus", reasoning, true, ""); ok {
+			t.Fatal("applyReasoningEffort returned true")
+		}
+		if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), "cannot both") {
+			t.Errorf("status=%d body=%s", w.Code, w.Body.String())
+		}
+	})
+
+	for _, tc := range []struct {
+		name      string
+		reasoning config.ModelReasoningConfig
+		dynamic   bool
+		reason    string
+	}{
+		{"unsupported model", config.ModelReasoningConfig{}, true, ""},
+		{"fixed budget", reasoning, false, "llama.cpp was started with a fixed reasoning budget"},
+		{"old build", reasoning, false, "llama.cpp does not support per-request reasoning budgets"},
+		{"unknown build", reasoning, false, "llama.cpp does not support per-request reasoning budgets"},
+	} {
+		t.Run("responses nested "+tc.name+" rejects", func(t *testing.T) {
+			r := request("/v1/responses", `{"reasoning":{"effort":"low"}}`)
+			w := httptest.NewRecorder()
+			if ok := applyReasoningEffort(w, r, "qwopus", tc.reasoning, tc.dynamic, tc.reason); ok {
+				t.Fatal("applyReasoningEffort returned true")
+			}
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", w.Code)
+			}
+		})
+	}
 }
 
 func TestProcess_SupportsThinkingBudgetBuildInfo(t *testing.T) {

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -29,6 +29,7 @@ type modelRecord struct {
 	Capabilities        map[string]any `json:"capabilities,omitempty"`
 	SupportedParameters []string       `json:"supported_parameters,omitempty"`
 	ContextLength       int            `json:"context_length,omitempty"`
+	MaxOutputTokens     int            `json:"max_output_tokens,omitempty"`
 	Meta                map[string]any `json:"meta,omitempty"`
 	Status              map[string]any `json:"status"`
 }
@@ -41,11 +42,12 @@ var cappedMetadataKeys = map[string]struct{}{
 	"capabilities":         {},
 	"supported_parameters": {},
 	"context_length":       {},
+	"max_output_tokens":    {},
 }
 
 // renderCapabilities converts a model's capabilities config into additional
 // /v1/models fields. Returns zero values when caps.Empty() is true.
-func renderCapabilities(caps config.ModelCapConfig) (arch map[string]any, capsMap map[string]any, params []string, ctxLen int) {
+func renderCapabilities(caps config.ModelCapConfig) (arch map[string]any, capsMap map[string]any, params []string, ctxLen, maxOutputTokens int) {
 	if caps.Empty() {
 		return
 	}
@@ -103,6 +105,9 @@ func renderCapabilities(caps config.ModelCapConfig) (arch map[string]any, capsMa
 	if caps.Context > 0 {
 		ctxLen = caps.Context
 	}
+	if caps.MaxOutputTokens > 0 {
+		maxOutputTokens = caps.MaxOutputTokens
+	}
 
 	return
 }
@@ -158,7 +163,7 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 			Description: strings.TrimSpace(description),
 			Status:      map[string]any{"value": status},
 		}
-		rec.Architecture, rec.Capabilities, rec.SupportedParameters, rec.ContextLength = renderCapabilities(caps)
+		rec.Architecture, rec.Capabilities, rec.SupportedParameters, rec.ContextLength, rec.MaxOutputTokens = renderCapabilities(caps)
 		if !caps.Empty() {
 			metadata = filterCappedMetadata(metadata)
 		}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -17,7 +17,10 @@ import (
 // apiUnloadTimeout is used by the API endpoints to stop processes
 const apiUnloadTimeout = 10 * time.Second
 
-// modelRecord is one entry in the OpenAI-compatible /v1/models listing.
+// modelRecord is one entry in the OpenAI-compatible /v1/models listing. The
+// OpenAI core fields are ID, Object, Created, and OwnedBy. Architecture,
+// Capabilities, SupportedParameters, ContextLength, MaxInputTokens,
+// MaxOutputTokens, and Reasoning* are llama-swap model metadata extensions.
 type modelRecord struct {
 	ID                  string         `json:"id"`
 	Object              string         `json:"object"`

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -29,7 +29,12 @@ type modelRecord struct {
 	Capabilities        map[string]any `json:"capabilities,omitempty"`
 	SupportedParameters []string       `json:"supported_parameters,omitempty"`
 	ContextLength       int            `json:"context_length,omitempty"`
+	MaxInputTokens      int            `json:"max_input_tokens,omitempty"`
 	MaxOutputTokens     int            `json:"max_output_tokens,omitempty"`
+	ReasoningSupported  bool           `json:"reasoning_supported,omitempty"`
+	ReasoningDefault    string         `json:"reasoning_default,omitempty"`
+	ReasoningEfforts    []string       `json:"reasoning_efforts,omitempty"`
+	ReasoningBudgets    map[string]int `json:"reasoning_budgets,omitempty"`
 	Meta                map[string]any `json:"meta,omitempty"`
 	Status              map[string]any `json:"status"`
 }
@@ -42,12 +47,17 @@ var cappedMetadataKeys = map[string]struct{}{
 	"capabilities":         {},
 	"supported_parameters": {},
 	"context_length":       {},
+	"max_input_tokens":     {},
 	"max_output_tokens":    {},
+	"reasoning_supported":  {},
+	"reasoning_default":    {},
+	"reasoning_efforts":    {},
+	"reasoning_budgets":    {},
 }
 
 // renderCapabilities converts a model's capabilities config into additional
 // /v1/models fields. Returns zero values when caps.Empty() is true.
-func renderCapabilities(caps config.ModelCapConfig) (arch map[string]any, capsMap map[string]any, params []string, ctxLen, maxOutputTokens int) {
+func renderCapabilities(caps config.ModelCapConfig) (arch map[string]any, capsMap map[string]any, params []string, ctxLen, maxInputTokens, maxOutputTokens int, reasoningSupported bool, reasoningDefault string, reasoningEfforts []string, reasoningBudgets map[string]int) {
 	if caps.Empty() {
 		return
 	}
@@ -107,6 +117,21 @@ func renderCapabilities(caps config.ModelCapConfig) (arch map[string]any, capsMa
 	}
 	if caps.MaxOutputTokens > 0 {
 		maxOutputTokens = caps.MaxOutputTokens
+		if caps.Context > 0 {
+			maxInputTokens = caps.Context - caps.MaxOutputTokens
+		}
+	}
+	if caps.Reasoning.Enabled() {
+		reasoningSupported = true
+		reasoningDefault = caps.Reasoning.Default
+		reasoningEfforts = make([]string, 0, len(caps.Reasoning.Efforts))
+		reasoningBudgets = make(map[string]int, len(caps.Reasoning.Efforts))
+		for effort, budget := range caps.Reasoning.Efforts {
+			reasoningEfforts = append(reasoningEfforts, effort)
+			reasoningBudgets[effort] = budget
+		}
+		sort.Strings(reasoningEfforts)
+		params = append(params, "reasoning_effort")
 	}
 
 	return
@@ -163,7 +188,7 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 			Description: strings.TrimSpace(description),
 			Status:      map[string]any{"value": status},
 		}
-		rec.Architecture, rec.Capabilities, rec.SupportedParameters, rec.ContextLength, rec.MaxOutputTokens = renderCapabilities(caps)
+		rec.Architecture, rec.Capabilities, rec.SupportedParameters, rec.ContextLength, rec.MaxInputTokens, rec.MaxOutputTokens, rec.ReasoningSupported, rec.ReasoningDefault, rec.ReasoningEfforts, rec.ReasoningBudgets = renderCapabilities(caps)
 		if !caps.Empty() {
 			metadata = filterCappedMetadata(metadata)
 		}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -62,7 +62,14 @@ func TestServer_HandleListModels_Aliases(t *testing.T) {
 	s.cfg = config.Config{
 		IncludeAliasesInList: true,
 		Models: map[string]config.ModelConfig{
-			"real": {Aliases: []string{"nick"}, Capabilities: config.ModelCapConfig{MaxOutputTokens: 1024}},
+			"real": {Aliases: []string{"nick"}, Capabilities: config.ModelCapConfig{
+				Context:         8192,
+				MaxOutputTokens: 1024,
+				Reasoning: config.ModelReasoningConfig{
+					Default: "low",
+					Efforts: map[string]int{"none": 0, "low": 256},
+				},
+			}},
 		},
 	}
 
@@ -85,6 +92,12 @@ func TestServer_HandleListModels_Aliases(t *testing.T) {
 	}
 	if ids["real"].MaxOutputTokens != 1024 || ids["nick"].MaxOutputTokens != 1024 {
 		t.Errorf("alias max_output_tokens = %d, real = %d, want 1024", ids["nick"].MaxOutputTokens, ids["real"].MaxOutputTokens)
+	}
+	if ids["real"].MaxInputTokens != 7168 || ids["nick"].MaxInputTokens != 7168 {
+		t.Errorf("alias max_input_tokens = %d, real = %d, want 7168", ids["nick"].MaxInputTokens, ids["real"].MaxInputTokens)
+	}
+	if !ids["real"].ReasoningSupported || !ids["nick"].ReasoningSupported || ids["real"].ReasoningDefault != "low" || ids["nick"].ReasoningDefault != "low" {
+		t.Errorf("alias reasoning metadata = real:%+v nick:%+v", ids["real"], ids["nick"])
 	}
 }
 
@@ -524,6 +537,9 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 		if m.ContextLength != 100000 {
 			t.Errorf("context_length = %d", m.ContextLength)
 		}
+		if m.MaxInputTokens != 91808 {
+			t.Errorf("max_input_tokens = %d", m.MaxInputTokens)
+		}
 		if m.MaxOutputTokens != 8192 {
 			t.Errorf("max_output_tokens = %d", m.MaxOutputTokens)
 		}
@@ -619,6 +635,31 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 		}
 	})
 
+	t.Run("reasoning", func(t *testing.T) {
+		m := getModel(t, newServer(config.ModelConfig{
+			Capabilities: config.ModelCapConfig{
+				Context:         32000,
+				MaxOutputTokens: 4096,
+				Reasoning: config.ModelReasoningConfig{
+					Default: "medium",
+					Efforts: map[string]int{"none": 0, "low": 512, "medium": 1024, "high": 2048},
+				},
+			},
+		}))
+		if !m.ReasoningSupported || m.ReasoningDefault != "medium" {
+			t.Errorf("reasoning support/default = %v/%q", m.ReasoningSupported, m.ReasoningDefault)
+		}
+		if !stringSliceEqual(m.ReasoningEfforts, []string{"high", "low", "medium", "none"}) {
+			t.Errorf("reasoning_efforts = %v", m.ReasoningEfforts)
+		}
+		if m.ReasoningBudgets["medium"] != 1024 || m.ReasoningBudgets["none"] != 0 {
+			t.Errorf("reasoning_budgets = %v", m.ReasoningBudgets)
+		}
+		if !stringSliceEqual(m.SupportedParameters, []string{"reasoning_effort"}) {
+			t.Errorf("supported_parameters = %v", m.SupportedParameters)
+		}
+	})
+
 	t.Run("audio_transcriptions", func(t *testing.T) {
 		m := getModel(t, newServer(config.ModelConfig{
 			Capabilities: config.ModelCapConfig{In: []string{"audio"}, Out: []string{"text"}},
@@ -667,7 +708,9 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 			Capabilities: config.ModelCapConfig{In: []string{"text"}},
 			Metadata: map[string]any{
 				"architecture":      "should-be-dropped",
+				"max_input_tokens":  "should-be-dropped",
 				"max_output_tokens": "should-be-dropped",
+				"reasoning_budgets": "should-be-dropped",
 				"custom_field":      "should-remain",
 				"capabilities":      "also-dropped",
 				"other_metadata":    "also-remain",
@@ -685,6 +728,12 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 		}
 		if _, ok := meta["max_output_tokens"]; ok {
 			t.Error("max_output_tokens should be filtered from metadata")
+		}
+		if _, ok := meta["max_input_tokens"]; ok {
+			t.Error("max_input_tokens should be filtered from metadata")
+		}
+		if _, ok := meta["reasoning_budgets"]; ok {
+			t.Error("reasoning_budgets should be filtered from metadata")
 		}
 		if _, ok := meta["custom_field"]; !ok {
 			t.Error("custom_field should remain in metadata")

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -62,7 +62,7 @@ func TestServer_HandleListModels_Aliases(t *testing.T) {
 	s.cfg = config.Config{
 		IncludeAliasesInList: true,
 		Models: map[string]config.ModelConfig{
-			"real": {Aliases: []string{"nick"}},
+			"real": {Aliases: []string{"nick"}, Capabilities: config.ModelCapConfig{MaxOutputTokens: 1024}},
 		},
 	}
 
@@ -73,12 +73,18 @@ func TestServer_HandleListModels_Aliases(t *testing.T) {
 		Data []modelRecord `json:"data"`
 	}
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	ids := map[string]bool{}
+	ids := map[string]modelRecord{}
 	for _, m := range resp.Data {
-		ids[m.ID] = true
+		ids[m.ID] = m
 	}
-	if !ids["real"] || !ids["nick"] {
+	if _, ok := ids["real"]; !ok {
+		t.Errorf("expected real entry; got %v", ids)
+	}
+	if _, ok := ids["nick"]; !ok {
 		t.Errorf("expected alias entry; got %v", ids)
+	}
+	if ids["real"].MaxOutputTokens != 1024 || ids["nick"].MaxOutputTokens != 1024 {
+		t.Errorf("alias max_output_tokens = %d, real = %d, want 1024", ids["nick"].MaxOutputTokens, ids["real"].MaxOutputTokens)
 	}
 }
 
@@ -484,10 +490,11 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 	t.Run("all_fields", func(t *testing.T) {
 		m := getModel(t, newServer(config.ModelConfig{
 			Capabilities: config.ModelCapConfig{
-				In:      []string{"text", "image"},
-				Out:     []string{"text", "audio"},
-				Tools:   true,
-				Context: 100000,
+				In:              []string{"text", "image"},
+				Out:             []string{"text", "audio"},
+				Tools:           true,
+				Context:         100000,
+				MaxOutputTokens: 8192,
 			},
 		}))
 		if m.Architecture == nil {
@@ -516,6 +523,9 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 		}
 		if m.ContextLength != 100000 {
 			t.Errorf("context_length = %d", m.ContextLength)
+		}
+		if m.MaxOutputTokens != 8192 {
+			t.Errorf("max_output_tokens = %d", m.MaxOutputTokens)
 		}
 	})
 
@@ -597,6 +607,18 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 		}
 	})
 
+	t.Run("max_output_tokens", func(t *testing.T) {
+		m := getModel(t, newServer(config.ModelConfig{
+			Capabilities: config.ModelCapConfig{MaxOutputTokens: 4096},
+		}))
+		if m.MaxOutputTokens != 4096 {
+			t.Errorf("max_output_tokens = %d", m.MaxOutputTokens)
+		}
+		if m.ContextLength != 0 {
+			t.Errorf("context_length = %d, want 0", m.ContextLength)
+		}
+	})
+
 	t.Run("audio_transcriptions", func(t *testing.T) {
 		m := getModel(t, newServer(config.ModelConfig{
 			Capabilities: config.ModelCapConfig{In: []string{"audio"}, Out: []string{"text"}},
@@ -644,10 +666,11 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 		m := getModel(t, newServer(config.ModelConfig{
 			Capabilities: config.ModelCapConfig{In: []string{"text"}},
 			Metadata: map[string]any{
-				"architecture":   "should-be-dropped",
-				"custom_field":   "should-remain",
-				"capabilities":   "also-dropped",
-				"other_metadata": "also-remain",
+				"architecture":      "should-be-dropped",
+				"max_output_tokens": "should-be-dropped",
+				"custom_field":      "should-remain",
+				"capabilities":      "also-dropped",
+				"other_metadata":    "also-remain",
 			},
 		}))
 		if m.Architecture == nil || m.Architecture["input_modalities"] == nil {
@@ -659,6 +682,9 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 		meta := m.Meta["llamaswap"].(map[string]any)
 		if _, ok := meta["architecture"]; ok {
 			t.Error("architecture should be filtered from metadata")
+		}
+		if _, ok := meta["max_output_tokens"]; ok {
+			t.Error("max_output_tokens should be filtered from metadata")
 		}
 		if _, ok := meta["custom_field"]; !ok {
 			t.Error("custom_field should remain in metadata")

--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -46,7 +46,7 @@ func (s *Server) modelStatus() []apiModel {
 		if st, ok := running[id]; ok {
 			state = string(st)
 		}
-		_, capsMap, _, _, _ := renderCapabilities(mc.Capabilities)
+		_, capsMap, _, _, _, _, _, _, _, _ := renderCapabilities(mc.Capabilities)
 		models = append(models, apiModel{
 			Id:           id,
 			Name:         mc.Name,

--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -46,7 +46,7 @@ func (s *Server) modelStatus() []apiModel {
 		if st, ok := running[id]; ok {
 			state = string(st)
 		}
-		_, capsMap, _, _ := renderCapabilities(mc.Capabilities)
+		_, capsMap, _, _, _ := renderCapabilities(mc.Capabilities)
 		models = append(models, apiModel{
 			Id:           id,
 			Name:         mc.Name,

--- a/internal/server/filters.go
+++ b/internal/server/filters.go
@@ -111,7 +111,7 @@ func applyMaxOutputTokens(body []byte, path string, max int) ([]byte, error) {
 			continue
 		}
 		configured = true
-		if value.Type == gjson.Number && value.Float() >= 0 && value.Float() <= float64(max) && value.Float() == math.Trunc(value.Float()) {
+		if value.Type == gjson.Number && value.Float() > 0 && value.Float() <= float64(max) && value.Float() == math.Trunc(value.Float()) {
 			continue
 		}
 		var err error

--- a/internal/server/filters.go
+++ b/internal/server/filters.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"strconv"
@@ -12,6 +13,7 @@ import (
 	"github.com/mostlygeek/llama-swap/internal/chain"
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/shared"
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
@@ -57,6 +59,11 @@ func CreateFilterMiddleware(cfg config.Config) chain.Middleware {
 				shared.SendResponse(w, r, http.StatusInternalServerError, err.Error())
 				return
 			}
+			body, err = applyMaxOutputTokens(body, r.URL.Path, maxOutputTokens(cfg, data.Model))
+			if err != nil {
+				shared.SendResponse(w, r, http.StatusInternalServerError, err.Error())
+				return
+			}
 
 			r.Body = io.NopCloser(bytes.NewReader(body))
 			r.Header.Del("Transfer-Encoding")
@@ -66,6 +73,62 @@ func CreateFilterMiddleware(cfg config.Config) chain.Middleware {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// maxOutputTokens returns the configured cap for a model or alias. A zero value
+// leaves requests unchanged for backwards compatibility.
+func maxOutputTokens(cfg config.Config, requested string) int {
+	realName, ok := cfg.RealModelName(requested)
+	if !ok {
+		return 0
+	}
+	return cfg.Models[realName].Capabilities.MaxOutputTokens
+}
+
+// applyMaxOutputTokens caps OpenAI-compatible generation parameters. It runs
+// after user filters so filters cannot raise a model's configured limit.
+func applyMaxOutputTokens(body []byte, path string, max int) ([]byte, error) {
+	if max == 0 {
+		return body, nil
+	}
+
+	var fields []string
+	switch path {
+	case "/v1/chat/completions", "/v/chat/completions":
+		fields = []string{"max_tokens", "max_completion_tokens"}
+	case "/v1/completions", "/v/completions":
+		fields = []string{"max_tokens"}
+	case "/v1/responses", "/v/responses":
+		fields = []string{"max_output_tokens"}
+	default:
+		return body, nil
+	}
+
+	configured := false
+	for _, field := range fields {
+		value := gjson.GetBytes(body, field)
+		if !value.Exists() {
+			continue
+		}
+		configured = true
+		if value.Type == gjson.Number && value.Float() >= 0 && value.Float() <= float64(max) && value.Float() == math.Trunc(value.Float()) {
+			continue
+		}
+		var err error
+		body, err = sjson.SetBytes(body, field, max)
+		if err != nil {
+			return nil, fmt.Errorf("error capping parameter %s in request: %w", field, err)
+		}
+	}
+
+	if !configured {
+		var err error
+		body, err = sjson.SetBytes(body, fields[0], max)
+		if err != nil {
+			return nil, fmt.Errorf("error setting parameter %s in request: %w", fields[0], err)
+		}
+	}
+	return body, nil
 }
 
 // CreateFormFilterMiddleware returns middleware that applies the UseModelName

--- a/internal/server/filters_test.go
+++ b/internal/server/filters_test.go
@@ -13,6 +13,77 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+func TestServer_ApplyMaxOutputTokens(t *testing.T) {
+	tests := []struct {
+		name  string
+		path  string
+		body  string
+		field string
+		want  int64
+	}{
+		{"chat caps max_tokens", "/v1/chat/completions", `{"max_tokens":512}`, "max_tokens", 128},
+		{"chat preserves lower max_tokens", "/v1/chat/completions", `{"max_tokens":64}`, "max_tokens", 64},
+		{"chat caps negative max_tokens", "/v1/chat/completions", `{"max_tokens":-1}`, "max_tokens", 128},
+		{"chat caps fractional max_tokens", "/v1/chat/completions", `{"max_tokens":128.5}`, "max_tokens", 128},
+		{"chat caps max_completion_tokens", "/v1/chat/completions", `{"max_completion_tokens":512}`, "max_completion_tokens", 128},
+		{"completions injects default", "/v1/completions", `{}`, "max_tokens", 128},
+		{"responses caps max_output_tokens", "/v1/responses", `{"max_output_tokens":512}`, "max_output_tokens", 128},
+		{"versionless responses injects default", "/v/responses", `{}`, "max_output_tokens", 128},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := applyMaxOutputTokens([]byte(tt.body), tt.path, 128)
+			if err != nil {
+				t.Fatalf("applyMaxOutputTokens: %v", err)
+			}
+			if got := gjson.GetBytes(out, tt.field).Int(); got != tt.want {
+				t.Errorf("%s = %d, want %d", tt.field, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("zero configuration leaves request unchanged", func(t *testing.T) {
+		body := []byte(`{"max_tokens":512}`)
+		out, err := applyMaxOutputTokens(body, "/v1/chat/completions", 0)
+		if err != nil {
+			t.Fatalf("applyMaxOutputTokens: %v", err)
+		}
+		if string(out) != string(body) {
+			t.Errorf("body = %s, want %s", out, body)
+		}
+	})
+}
+
+func TestServer_MaxOutputTokens_Alias(t *testing.T) {
+	cfg, err := config.LoadConfigFromReader(strings.NewReader(`
+models:
+  real:
+    cmd: llama-server --port ${PORT}
+    aliases: [alias]
+    filters:
+      setParams:
+        max_tokens: 512
+    capabilities:
+      max_output_tokens: 128
+`))
+	if err != nil {
+		t.Fatalf("LoadConfigFromReader: %v", err)
+	}
+
+	var got []byte
+	handler := CreateFilterMiddleware(cfg)(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got, _ = io.ReadAll(r.Body)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"alias"}`))
+	req.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	if tokens := gjson.GetBytes(got, "max_tokens").Int(); tokens != 128 {
+		t.Errorf("max_tokens = %d, want 128", tokens)
+	}
+}
+
 func TestServer_ApplyFilters(t *testing.T) {
 	t.Run("useModelName rewrite", func(t *testing.T) {
 		out, err := applyFilters([]byte(`{"model":"alias","temp":1}`), "alias", "real-model", config.Filters{})

--- a/internal/server/filters_test.go
+++ b/internal/server/filters_test.go
@@ -24,6 +24,7 @@ func TestServer_ApplyMaxOutputTokens(t *testing.T) {
 		{"chat caps max_tokens", "/v1/chat/completions", `{"max_tokens":512}`, "max_tokens", 128},
 		{"chat preserves lower max_tokens", "/v1/chat/completions", `{"max_tokens":64}`, "max_tokens", 64},
 		{"chat caps negative max_tokens", "/v1/chat/completions", `{"max_tokens":-1}`, "max_tokens", 128},
+		{"chat caps zero max_tokens", "/v1/chat/completions", `{"max_tokens":0}`, "max_tokens", 128},
 		{"chat caps fractional max_tokens", "/v1/chat/completions", `{"max_tokens":128.5}`, "max_tokens", 128},
 		{"chat caps max_completion_tokens", "/v1/chat/completions", `{"max_completion_tokens":512}`, "max_completion_tokens", 128},
 		{"completions injects default", "/v1/completions", `{}`, "max_tokens", 128},


### PR DESCRIPTION
## Summary

Adds configurable per-model output-token caps and dynamic reasoning-effort handling for llama.cpp-backed models.

- Applies configured output caps across Chat Completions, Completions, and Responses.
- Adds per-model reasoning-effort budgets: `none`, `low`, `medium`, `high`, and `xhigh`.
- Supports Chat Completions `reasoning_effort` and Responses `reasoning.effort`; top-level Responses `reasoning_effort` remains a compatibility alias.
- Exposes configured limits and reasoning metadata through llama-swap `/v1/models` extension fields.
- Documents endpoint mappings, llama.cpp dynamic-reasoning requirements, fixed-budget incompatibility, and extension-field status.
- Adds Responses alias-pipeline coverage for upstream reasoning transformation.

## Compatibility

Dynamic reasoning selection requires official llama.cpp build `b8605` or newer. Explicit effort is rejected when the model uses fixed `--reasoning-budget` or `LLAMA_ARG_THINK_BUDGET`.

When effort is omitted or `default`, llama-swap sends no thinking overrides, preserving upstream/default behavior.

## Validation

- `go test -count=1 ./internal/config ./internal/process ./internal/server`
- `git diff --check main...HEAD`
- Manual validation against official llama.cpp covered Chat and Responses mappings, aliases, unsupported-upstream errors, and fixed-budget handling.