### PR TITLE
internal/config: preserve yaml anchors in capabilities

### DIFF
--- a/internal/config/model_config.go
+++ b/internal/config/model_config.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -23,9 +22,9 @@ var validModalities = map[string]struct{}{
 // Used in /v1/models to inform clients. An empty block (all zero values) is
 // treated as not configured.
 //
-// The custom UnmarshalYAML stores the raw YAML node so macro substitution
-// can be applied later via ResolveMacros. After ResolveMacros is called the
-// typed fields (In, Out, Tools, Reranker, Context) are populated.
+// The custom UnmarshalYAML stores an untyped representation so YAML anchors
+// can be resolved before macro substitution. After ResolveMacros is called
+// the typed fields (In, Out, Tools, Reranker, Context) are populated.
 type ModelCapConfig struct {
 	In       []string `yaml:"in"`
 	Out      []string `yaml:"out"`
@@ -33,59 +32,44 @@ type ModelCapConfig struct {
 	Reranker bool     `yaml:"reranker"`
 	Context  int      `yaml:"context"`
 
-	rawNode *yaml.Node
+	raw map[string]any
 }
 
-// UnmarshalYAML stores the raw YAML node so macro substitution via
-// ResolveMacros can apply before the typed fields are decoded.
+// UnmarshalYAML decodes capabilities into an untyped map. This materializes
+// YAML aliases and merge keys while allowing macro placeholders in fields
+// that will ultimately be decoded as ints or bools.
 func (c *ModelCapConfig) UnmarshalYAML(value *yaml.Node) error {
-	c.rawNode = value
-	// Pre-populate typed fields for the common case (no macros).
-	// If this succeeds we have valid data; if not (e.g. string in int field
-	// because of a macro reference like "${default_ctx}"), we keep the raw
-	// node and resolve after macro substitution.
-	type rawCap ModelCapConfig
-	if err := value.Decode((*rawCap)(c)); err != nil {
-		// Reset fields to zero; macro resolution will re-decode.
-		c.In = nil
-		c.Out = nil
-		c.Tools = false
-		c.Reranker = false
-		c.Context = 0
-	}
-	return nil
+	return value.Decode(&c.raw)
 }
 
-// ResolveMacros marshals the raw YAML node back to YAML, substitutes all
-// macros (LIFO order matching LoadConfigFromReader), and re-decodes the
-// result into the typed fields.
+// ResolveMacros substitutes all macros in the untyped representation (LIFO
+// order matching LoadConfigFromReader), then decodes the resolved values into
+// the typed fields.
 func (c *ModelCapConfig) ResolveMacros(macros MacroList) error {
-	if c.rawNode == nil {
-		return nil
-	}
-	if len(macros) == 0 {
+	if c.raw == nil {
 		return c.Validate()
 	}
 
-	rawYAML, err := yaml.Marshal(c.rawNode)
-	if err != nil {
-		return fmt.Errorf("capabilities: failed to marshal raw node: %w", err)
-	}
-
-	s := string(rawYAML)
-
-	// Substitute macros in LIFO order (same as LoadConfigFromReader).
+	var resolved any = c.raw
 	for i := len(macros) - 1; i >= 0; i-- {
 		entry := macros[i]
-		macroSlug := fmt.Sprintf("${%s}", entry.Name)
-		macroStr := fmt.Sprintf("%v", entry.Value)
-		s = strings.ReplaceAll(s, macroSlug, macroStr)
+		var err error
+		resolved, err = substituteMacroInValue(resolved, entry.Name, entry.Value)
+		if err != nil {
+			return fmt.Errorf("capabilities: failed macro substitution: %w", err)
+		}
+	}
+	if err := validateNestedForUnknownMacros(resolved, "capabilities"); err != nil {
+		return err
 	}
 
-	// Decode the substituted YAML back into the typed struct.
+	var node yaml.Node
+	if err := node.Encode(resolved); err != nil {
+		return fmt.Errorf("capabilities: failed to encode after macro substitution: %w", err)
+	}
 	*c = ModelCapConfig{}
 	type rawCap ModelCapConfig
-	if err := yaml.Unmarshal([]byte(s), (*rawCap)(c)); err != nil {
+	if err := node.Decode((*rawCap)(c)); err != nil {
 		return fmt.Errorf("capabilities: failed to decode after macro substitution: %w", err)
 	}
 

--- a/internal/config/model_config_anchor_test.go
+++ b/internal/config/model_config_anchor_test.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_ModelCapabilities_YAMLAnchors(t *testing.T) {
+	content := `
+defs:
+  vlm-capabilities: &vlm-capabilities
+    in:
+      - text
+      - image
+    out: [text]
+    tools: true
+  llm-capabilities: &llm-capabilities
+    in: [text]
+    out: [text]
+    tools: true
+models:
+  GLM-4.7-Flash-Q8_0-ik:
+    capabilities:
+      <<: [*llm-capabilities]
+      context: 202752
+    cmd: |
+      ./llama-server
+      # .... some other parameters using macros
+      --port ${PORT}
+      --model ./bartowski/zai-org_GLM-4.7-Flash-GGUF/zai-org_GLM-4.7-Flash-Q8_0.gguf
+      --ubatch-size 4096
+      --batch-size 4096
+      --ctx-size 202752
+`
+
+	config, err := LoadConfigFromReader(strings.NewReader(content))
+	if assert.NoError(t, err) {
+		capabilities := config.Models["GLM-4.7-Flash-Q8_0-ik"].Capabilities
+		assert.Equal(t, []string{"text"}, capabilities.In)
+		assert.Equal(t, []string{"text"}, capabilities.Out)
+		assert.True(t, capabilities.Tools)
+		assert.Equal(t, 202752, capabilities.Context)
+	}
+}
+
+func TestConfig_ModelCapabilities_YAMLAnchorsWithMacros(t *testing.T) {
+	content := `
+macros:
+  default_ctx: 98304
+defs:
+  llm-capabilities: &llm-capabilities
+    in: [text]
+    out: [text]
+    tools: true
+    context: ${default_ctx}
+models:
+  model1:
+    cmd: path/to/cmd --port ${PORT}
+    macros:
+      default_ctx: 4096
+    capabilities:
+      <<: [*llm-capabilities]
+  model2:
+    cmd: path/to/cmd --port ${PORT}
+    macros:
+      default_ctx: 8192
+    capabilities:
+      <<: [*llm-capabilities]
+`
+
+	config, err := LoadConfigFromReader(strings.NewReader(content))
+	if assert.NoError(t, err) {
+		for modelID, expectedContext := range map[string]int{"model1": 4096, "model2": 8192} {
+			capabilities := config.Models[modelID].Capabilities
+			assert.Equal(t, []string{"text"}, capabilities.In)
+			assert.Equal(t, []string{"text"}, capabilities.Out)
+			assert.True(t, capabilities.Tools)
+			assert.Equal(t, expectedContext, capabilities.Context)
+		}
+	}
+}

--- a/internal/config/model_config_test.go
+++ b/internal/config/model_config_test.go
@@ -437,6 +437,26 @@ models:
 		assert.True(t, mc.Capabilities.Reranker)
 	})
 
+	t.Run("quoted direct macros preserve scalar types", func(t *testing.T) {
+		content := `
+macros:
+  default_ctx: 32768
+  has_tools: true
+models:
+  model1:
+    cmd: path/to/cmd --port ${PORT}
+    capabilities:
+      context: "${default_ctx}"
+      tools: "${has_tools}"
+`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NoError(t, err)
+
+		mc := config.Models["model1"]
+		assert.Equal(t, 32768, mc.Capabilities.Context)
+		assert.True(t, mc.Capabilities.Tools)
+	})
+
 	t.Run("no capabilities block is unchanged", func(t *testing.T) {
 		content := `
 macros:
@@ -462,6 +482,6 @@ models:
 `
 		_, err := LoadConfigFromReader(strings.NewReader(content))
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to decode after macro substitution")
+		assert.Contains(t, err.Error(), "capabilities: unknown macro '${undefined_macro}'")
 	})
 }


### PR DESCRIPTION
Resolve capability macros from an untyped representation so YAML anchors are materialized before typed values are decoded.

- preserve macro value types for capability fields
- support anchors shared across model configurations
- reject unresolved capability macros

fixes #917