### PR TITLE
internal/server: expand inflight request details

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -235,6 +235,32 @@
             "additionalProperties": false,
             "description": "Store configuration for durable llama-swap state."
         },
+        "ui": {
+            "type": "object",
+            "properties": {
+                "activity": {
+                    "type": "object",
+                    "properties": {
+                        "session_id": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "default": [
+                                "X-Session-ID",
+                                "X-Litellm-Session-Id"
+                            ],
+                            "description": "Ordered request headers used to identify sessions in the Activity page."
+                        }
+                    },
+                    "additionalProperties": false,
+                    "default": {}
+                }
+            },
+            "additionalProperties": false,
+            "default": {},
+            "description": "Embedded UI configuration."
+        },
         "performance": {
             "type": "object",
             "properties": {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -63,6 +63,15 @@ metricsMaxInMemory: 1000
 # - set to 0 to disable
 captureBuffer: 15
 
+# ui.activity.session_id: ordered request headers used to identify sessions in
+# the Activity page's in-flight request table.
+# - optional, default: ["X-Session-ID", "X-Litellm-Session-Id"]
+# - matching is case-insensitive; the first non-empty matching header is shown
+# - set to [] to disable session ID lookup
+ui:
+  activity:
+    session_id: ["X-Session-ID", "X-Litellm-Session-Id"]
+
 # performance: configuration for system monitoring statistics
 # - timing values are duration strings like 1s, 1h30m, 90m, 2h10s, etc.
 performance:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,15 @@ metricsMaxInMemory: 1000
 # - set to 0 to disable
 captureBuffer: 15
 
+# ui.activity.session_id: ordered request headers used to identify sessions in
+# the Activity page's in-flight request table.
+# - optional, default: ["X-Session-ID", "X-Litellm-Session-Id"]
+# - matching is case-insensitive; the first non-empty matching header is shown
+# - set to [] to disable session ID lookup
+ui:
+  activity:
+    session_id: ["X-Session-ID", "X-Litellm-Session-Id"]
+
 # store: persistent storage for llama-swap state
 # - optional, default: in-memory sqlite database capped by metricsMaxInMemory
 # - path is a sqlite database file path

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,6 +109,14 @@ type Store struct {
 	Path string `yaml:"path"`
 }
 
+type UIConfig struct {
+	Activity UIActivityConfig `yaml:"activity" json:"activity"`
+}
+
+type UIActivityConfig struct {
+	SessionID []string `yaml:"session_id" json:"session_id"`
+}
+
 type Config struct {
 	HealthCheckTimeout int                    `yaml:"healthCheckTimeout"`
 	LogRequests        bool                   `yaml:"logRequests"`
@@ -118,6 +126,7 @@ type Config struct {
 	MetricsMaxInMemory int                    `yaml:"metricsMaxInMemory"`
 	CaptureBuffer      int                    `yaml:"captureBuffer"`
 	Store              *Store                 `yaml:"store"`
+	UI                 UIConfig               `yaml:"ui"`
 	Performance        PerformanceConfig      `yaml:"performance"`
 	GlobalTTL          int                    `yaml:"globalTTL"`
 	UnloadTimeout      int                    `yaml:"unloadTimeout"`

--- a/internal/config/config_posix_test.go
+++ b/internal/config/config_posix_test.go
@@ -260,6 +260,10 @@ groups:
 		HealthCheckTimeout: 15,
 		MetricsMaxInMemory: 1000,
 		CaptureBuffer:      5,
+		UI: UIConfig{Activity: UIActivityConfig{SessionID: []string{
+			"X-Session-ID",
+			"X-Litellm-Session-Id",
+		}}},
 		Performance: PerformanceConfig{
 			Every: 5 * time.Second,
 		},

--- a/internal/config/config_windows_test.go
+++ b/internal/config/config_windows_test.go
@@ -249,6 +249,10 @@ groups:
 		HealthCheckTimeout: 15,
 		MetricsMaxInMemory: 1000,
 		CaptureBuffer:      5,
+		UI: UIConfig{Activity: UIActivityConfig{SessionID: []string{
+			"X-Session-ID",
+			"X-Litellm-Session-Id",
+		}}},
 		Performance: PerformanceConfig{
 			Every: 5 * time.Second,
 		},

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -36,6 +36,10 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		CaptureBuffer:      5,
 		GlobalTTL:          0,
 		UnloadTimeout:      DEFAULT_UNLOAD_TIMEOUT,
+		UI: UIConfig{Activity: UIActivityConfig{SessionID: []string{
+			"X-Session-ID",
+			"X-Litellm-Session-Id",
+		}}},
 	}
 	if err = yaml.Unmarshal([]byte(yamlStr), &config); err != nil {
 		return Config{}, err
@@ -67,6 +71,8 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 	if config.UnloadTimeout == 0 {
 		config.UnloadTimeout = DEFAULT_UNLOAD_TIMEOUT
 	}
+
+	config.UI.Activity.SessionID = normalizeHeaderNames(config.UI.Activity.SessionID)
 
 	if config.Store != nil {
 		if err := validateStorePath(config.Store.Path); err != nil {
@@ -457,4 +463,22 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 	}
 
 	return config, nil
+}
+
+func normalizeHeaderNames(names []string) []string {
+	normalized := make([]string, 0, len(names))
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		key := strings.ToLower(name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		normalized = append(normalized, name)
+	}
+	return normalized
 }

--- a/internal/config/ui_test.go
+++ b/internal/config/ui_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestConfig_UIActivitySessionID(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want []string
+	}{
+		{
+			name: "defaults",
+			want: []string{"X-Session-ID", "X-Litellm-Session-Id"},
+		},
+		{
+			name: "normalizes configured headers",
+			yaml: "ui:\n  activity:\n    session_id: [' X-Trace-ID ', '', x-trace-id, X-Session-ID]\n",
+			want: []string{"X-Trace-ID", "X-Session-ID"},
+		},
+		{
+			name: "explicit empty list disables lookup",
+			yaml: "ui:\n  activity:\n    session_id: []\n",
+			want: []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := LoadConfigFromReader(strings.NewReader(tc.yaml))
+			if err != nil {
+				t.Fatalf("LoadConfigFromReader: %v", err)
+			}
+			if !reflect.DeepEqual(cfg.UI.Activity.SessionID, tc.want) {
+				t.Errorf("session id headers = %#v, want %#v", cfg.UI.Activity.SessionID, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -271,6 +271,7 @@ const (
 	msgTypeLogData     messageType = "logData"
 	msgTypeActivity    messageType = "activity"
 	msgTypeInFlight    messageType = "inflight"
+	msgTypeUIConfig    messageType = "uiConfig"
 )
 
 type messageEnvelope struct {
@@ -324,12 +325,17 @@ func (s *Server) handleAPIEvents(w http.ResponseWriter, r *http.Request) {
 			send(messageEnvelope{Type: msgTypeActivity, Data: string(j)})
 		}
 	}
-	sendInFlight := func(stats shared.InFlightRequestsEvent) {
-		if stats.Requests == nil {
-			stats.Requests = []shared.InflightRequestEntry{}
+	sendInFlight := func(update shared.InFlightRequestsEvent) {
+		if update.Operation == inflightOperationSnapshot && update.Requests == nil {
+			update.Requests = []shared.InflightRequestEntry{}
 		}
-		if j, err := json.Marshal(stats); err == nil {
+		if j, err := json.Marshal(update); err == nil {
 			send(messageEnvelope{Type: msgTypeInFlight, Data: string(j)})
+		}
+	}
+	sendUIConfig := func() {
+		if j, err := json.Marshal(s.cfg.UI); err == nil {
+			send(messageEnvelope{Type: msgTypeUIConfig, Data: string(j)})
 		}
 	}
 
@@ -344,6 +350,7 @@ func (s *Server) handleAPIEvents(w http.ResponseWriter, r *http.Request) {
 	sendLogData("proxy", s.proxylog.GetHistory())
 	sendLogData("upstream", s.upstreamlog.GetHistory())
 	sendModels()
+	sendUIConfig()
 	sendInFlight(s.inflight.Current())
 
 	for {

--- a/internal/server/apigroup_test.go
+++ b/internal/server/apigroup_test.go
@@ -6,12 +6,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/mostlygeek/llama-swap/internal/cache"
 	"github.com/mostlygeek/llama-swap/internal/config"
-	"github.com/mostlygeek/llama-swap/internal/event"
 	"github.com/mostlygeek/llama-swap/internal/shared"
 	"github.com/mostlygeek/llama-swap/internal/store"
 )
@@ -26,6 +26,11 @@ func TestServer_InflightMiddleware_AddsAndRemovesEntriesAroundRequestHandling(t 
 	}))
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	started := time.Now().Add(-time.Second)
+	req = req.WithContext(context.WithValue(req.Context(), inflightStartContextKey{}, started))
+	req.Header.Set("User-Agent", "test-agent")
+	req.Header.Set("Authorization", "Bearer secret")
+	req.Header.Set("X-Forwarded-For", "203.0.113.9, 10.0.0.1")
 	req = req.WithContext(shared.SetContext(req.Context(), shared.ReqContextData{
 		Model:    "requested-model",
 		ModelID:  "resolved-model",
@@ -41,19 +46,81 @@ func TestServer_InflightMiddleware_AddsAndRemovesEntriesAroundRequestHandling(t 
 	if entry.ID == "" || entry.Model != "resolved-model" || entry.Method != http.MethodPost || entry.ReqPath != "/v1/chat/completions" {
 		t.Errorf("inflight entry = %+v", entry)
 	}
+	if !entry.Timestamp.Equal(started) {
+		t.Errorf("timestamp = %v, want request start %v", entry.Timestamp, started)
+	}
+	if entry.ElapsedMs < 1000 {
+		t.Errorf("elapsed ms = %d, want at least 1000", entry.ElapsedMs)
+	}
 	if entry.Metadata["source"] != "test" {
 		t.Errorf("metadata = %v, want source=test", entry.Metadata)
+	}
+	if entry.RemoteIP != "203.0.113.9" {
+		t.Errorf("remote ip = %q, want 203.0.113.9", entry.RemoteIP)
+	}
+	if entry.ReqHeaders["User-Agent"] != "test-agent" || entry.ReqHeaders["Authorization"] != "[REDACTED]" {
+		t.Errorf("request headers = %v", entry.ReqHeaders)
 	}
 	if got := tracker.Current(); len(got.Requests) != 0 {
 		t.Errorf("inflight after request = %+v, want empty", got)
 	}
 }
 
+func TestServer_InflightMiddleware_StreamsResponseUpdates(t *testing.T) {
+	events := make(chan shared.InFlightRequestsEvent, 8)
+	tracker := newInflightTrackerWithPublisher(8, func(update shared.InFlightRequestsEvent) {
+		events <- update
+	})
+
+	release := make(chan struct{})
+	done := make(chan struct{})
+	handler := CreateInflightMiddleware(tracker)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Set-Cookie", "secret=value")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello"))
+		w.(http.Flusher).Flush()
+		<-release
+	}))
+
+	go func() {
+		defer close(done)
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+		req = req.WithContext(shared.SetContext(req.Context(), shared.ReqContextData{ModelID: "m1"}))
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	}()
+
+	_ = waitInflightEvent(t, events, inflightOperationUpsert)
+	headers := waitInflightEvent(t, events, inflightOperationUpsert)
+	if headers.Request == nil || headers.Request.RespHeaders["Content-Type"] != "text/event-stream" {
+		t.Fatalf("response headers event = %+v", headers)
+	}
+	if headers.Request.RespHeaders["Set-Cookie"] != "[REDACTED]" {
+		t.Errorf("response headers = %v", headers.Request.RespHeaders)
+	}
+
+	bytesUpdate := waitInflightEvent(t, events, inflightOperationUpsert)
+	if bytesUpdate.Request == nil || bytesUpdate.Request.RespBytes != 5 {
+		t.Errorf("response bytes event = %+v, want 5", bytesUpdate.Request)
+	}
+
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not return")
+	}
+	removed := waitInflightEvent(t, events, inflightOperationRemove)
+	if removed.ID == "" {
+		t.Error("remove event missing id")
+	}
+}
+
 func TestServer_InflightEventPayloadIncludesRequestEntries(t *testing.T) {
-	tracker := newInflightTracker()
 	events := make(chan shared.InFlightRequestsEvent, 4)
-	cancelEvents := event.On(func(e shared.InFlightRequestsEvent) { events <- e })
-	defer cancelEvents()
+	tracker := newInflightTrackerWithPublisher(4, func(update shared.InFlightRequestsEvent) {
+		events <- update
+	})
 
 	release := make(chan struct{})
 	done := make(chan struct{})
@@ -71,12 +138,12 @@ func TestServer_InflightEventPayloadIncludesRequestEntries(t *testing.T) {
 		handler.ServeHTTP(httptest.NewRecorder(), req)
 	}()
 
-	added := waitInflightEvent(t, events, 1)
-	if len(added.Requests) != 1 {
-		t.Fatalf("added requests = %d, want 1", len(added.Requests))
+	added := waitInflightEvent(t, events, inflightOperationUpsert)
+	if added.Request == nil {
+		t.Fatal("added request is nil")
 	}
-	if added.Requests[0].Model != "m1" || added.Requests[0].ReqPath != "/props" {
-		t.Errorf("added request = %+v", added.Requests[0])
+	if added.Request.Model != "m1" || added.Request.ReqPath != "/props" {
+		t.Errorf("added request = %+v", added.Request)
 	}
 
 	close(release)
@@ -85,9 +152,53 @@ func TestServer_InflightEventPayloadIncludesRequestEntries(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("handler did not return")
 	}
-	removed := waitInflightEvent(t, events, 0)
-	if len(removed.Requests) != 0 {
-		t.Errorf("removed requests = %d, want 0", len(removed.Requests))
+	removed := waitInflightEvent(t, events, inflightOperationRemove)
+	if removed.ID != added.Request.ID {
+		t.Errorf("removed id = %q, want %q", removed.ID, added.Request.ID)
+	}
+}
+
+func TestServer_InflightTracker_OutboxDoesNotBlockRequests(t *testing.T) {
+	publishStarted := make(chan struct{})
+	releasePublisher := make(chan struct{})
+	published := make(chan shared.InFlightRequestsEvent, 4)
+	var blockFirst sync.Once
+
+	tracker := newInflightTrackerWithPublisher(1, func(update shared.InFlightRequestsEvent) {
+		blockFirst.Do(func() {
+			close(publishStarted)
+			<-releasePublisher
+		})
+		published <- update
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	id := tracker.Add(req, func() {})
+	select {
+	case <-publishStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("publisher did not start")
+	}
+
+	// Fill the one-item outbox while the publisher is blocked, then overflow
+	// it with the removal. The request path must still return immediately.
+	tracker.SetResponseHeaders(id, http.Header{"Content-Type": {"text/event-stream"}})
+	removed := make(chan struct{})
+	go func() {
+		tracker.Remove(id)
+		close(removed)
+	}()
+	select {
+	case <-removed:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Remove blocked on a busy publisher")
+	}
+
+	close(releasePublisher)
+	_ = waitInflightEvent(t, published, inflightOperationUpsert)
+	recovered := waitInflightEvent(t, published, inflightOperationSnapshot)
+	if len(recovered.Requests) != 0 {
+		t.Errorf("recovery snapshot = %+v, want no requests", recovered.Requests)
 	}
 }
 
@@ -147,17 +258,17 @@ func waitInflightTrackerCount(t *testing.T, tracker *inflightTracker, total int)
 	}
 }
 
-func waitInflightEvent(t *testing.T, events <-chan shared.InFlightRequestsEvent, total int) shared.InFlightRequestsEvent {
+func waitInflightEvent(t *testing.T, events <-chan shared.InFlightRequestsEvent, operation string) shared.InFlightRequestsEvent {
 	t.Helper()
 	timer := time.After(2 * time.Second)
 	for {
 		select {
 		case got := <-events:
-			if len(got.Requests) == total {
+			if got.Operation == operation {
 				return got
 			}
 		case <-timer:
-			t.Fatalf("timed out waiting for inflight total %d", total)
+			t.Fatalf("timed out waiting for inflight operation %q", operation)
 		}
 	}
 }
@@ -338,6 +449,7 @@ func TestServer_APIPerformance_Unavailable(t *testing.T) {
 
 func TestServer_APIEvents_InitialPayload(t *testing.T) {
 	s := newTestServer(newStubRouter(nil, ""), newStubRouter(nil, ""))
+	s.cfg.UI.Activity.SessionID = []string{"X-Trace-ID"}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	req := httptest.NewRequest(http.MethodGet, "/api/events", nil).WithContext(ctx)
@@ -358,7 +470,7 @@ func TestServer_APIEvents_InitialPayload(t *testing.T) {
 	}
 
 	body := w.Body.String()
-	for _, want := range []string{`"type":"modelStatus"`, `"type":"inflight"`, `"type":"logData"`} {
+	for _, want := range []string{`"type":"modelStatus"`, `"type":"inflight"`, `"type":"uiConfig"`, `"type":"logData"`, `X-Trace-ID`} {
 		if !strings.Contains(body, want) {
 			t.Errorf("initial SSE payload missing %s; body=%q", want, body)
 		}

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -46,6 +46,7 @@ func CreateAuthMiddleware(cfg config.Config) chain.Middleware {
 func CreateRequestContextMiddleware(cfg config.Config) chain.Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r = markInflightStart(r)
 			data, err := shared.FetchContext(r, cfg)
 			if err != nil {
 				shared.SendError(w, r, shared.ErrNoModelInContext)

--- a/internal/server/inflight.go
+++ b/internal/server/inflight.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"bufio"
 	"context"
+	"fmt"
+	"net"
 	"net/http"
 	"sort"
 	"strconv"
@@ -16,53 +19,215 @@ import (
 	"github.com/mostlygeek/llama-swap/internal/shared"
 )
 
+const inflightUpdateInterval = 250 * time.Millisecond
+const inflightOutboxSize = 128
+
+const (
+	inflightOperationSnapshot = "snapshot"
+	inflightOperationUpsert   = "upsert"
+	inflightOperationRemove   = "remove"
+)
+
+type inflightStartContextKey struct{}
+
+func markInflightStart(r *http.Request) *http.Request {
+	if _, ok := r.Context().Value(inflightStartContextKey{}).(time.Time); ok {
+		return r
+	}
+	return r.WithContext(context.WithValue(r.Context(), inflightStartContextKey{}, time.Now()))
+}
+
+func inflightStart(r *http.Request) time.Time {
+	if started, ok := r.Context().Value(inflightStartContextKey{}).(time.Time); ok {
+		return started
+	}
+	return time.Now()
+}
+
 // inflightTracker tracks in-flight model-dispatched requests and their
 // cancellable contexts.
 type inflightTracker struct {
 	nextID atomic.Uint64
 
+	// mu serializes state mutations and their corresponding outbox writes so
+	// request updates keep the same order in which they were applied.
 	mu       sync.RWMutex
-	requests map[string]inflightRequest
+	requests map[string]*inflightRequest
+
+	updates          chan shared.InFlightRequestsEvent
+	needsSnapshot    atomic.Bool
+	publisherRunning atomic.Bool
+	publish          func(shared.InFlightRequestsEvent)
 }
 
 type inflightRequest struct {
-	entry  shared.InflightRequestEntry
-	cancel context.CancelFunc
+	entry       shared.InflightRequestEntry
+	cancel      context.CancelFunc
+	lastEmitted time.Time
+	timer       *time.Timer
 }
 
 func newInflightTracker() *inflightTracker {
-	return &inflightTracker{requests: make(map[string]inflightRequest)}
+	return newInflightTrackerWithPublisher(inflightOutboxSize, func(update shared.InFlightRequestsEvent) {
+		event.Emit(update)
+	})
+}
+
+func newInflightTrackerWithPublisher(size int, publish func(shared.InFlightRequestsEvent)) *inflightTracker {
+	t := &inflightTracker{
+		requests: make(map[string]*inflightRequest),
+		updates:  make(chan shared.InFlightRequestsEvent, size),
+		publish:  publish,
+	}
+	return t
 }
 
 func (t *inflightTracker) Add(r *http.Request, cancel context.CancelFunc) string {
 	id := strconv.FormatUint(t.nextID.Add(1), 10)
 	entry := shared.InflightRequestEntry{
-		ID:        id,
-		Timestamp: time.Now(),
-		ReqPath:   r.URL.Path,
-		Method:    r.Method,
+		ID:          id,
+		Timestamp:   inflightStart(r),
+		ReqPath:     r.URL.Path,
+		Method:      r.Method,
+		ReqHeaders:  headerMap(r.Header),
+		RemoteIP:    clientIP(r),
+		RespHeaders: map[string]string{},
 	}
+	redactHeaders(entry.ReqHeaders)
 	if data, ok := shared.ReadContext(r.Context()); ok {
 		entry.Model = data.ModelID
 		entry.Metadata = copyMetadata(data.Metadata)
 	}
 
 	t.mu.Lock()
-	t.requests[id] = inflightRequest{entry: entry, cancel: cancel}
-	snapshot := t.snapshotLocked()
+	req := &inflightRequest{entry: entry, cancel: cancel, lastEmitted: time.Now()}
+	t.requests[id] = req
+	t.enqueueLocked(upsertInflightEvent(req.entry))
 	t.mu.Unlock()
-
-	event.Emit(snapshot)
 	return id
 }
 
 func (t *inflightTracker) Remove(id string) {
 	t.mu.Lock()
-	delete(t.requests, id)
-	snapshot := t.snapshotLocked()
+	req, ok := t.requests[id]
+	if ok {
+		delete(t.requests, id)
+		if req.timer != nil {
+			req.timer.Stop()
+		}
+		t.enqueueLocked(shared.InFlightRequestsEvent{Operation: inflightOperationRemove, ID: id})
+	}
 	t.mu.Unlock()
+}
 
-	event.Emit(snapshot)
+func (t *inflightTracker) SetResponseHeaders(id string, headers http.Header) {
+	values := headerMap(headers)
+	redactHeaders(values)
+
+	t.mu.Lock()
+	req, ok := t.requests[id]
+	if ok {
+		req.entry.RespHeaders = values
+		req.lastEmitted = time.Now()
+		t.enqueueLocked(upsertInflightEvent(req.entry))
+	}
+	t.mu.Unlock()
+}
+
+func (t *inflightTracker) AddResponseBytes(id string, total int) {
+	if total <= 0 {
+		return
+	}
+
+	t.mu.Lock()
+	req, ok := t.requests[id]
+	if !ok {
+		t.mu.Unlock()
+		return
+	}
+	req.entry.RespBytes += int64(total)
+
+	now := time.Now()
+	remaining := inflightUpdateInterval - now.Sub(req.lastEmitted)
+	if remaining <= 0 && req.timer == nil {
+		req.lastEmitted = now
+		t.enqueueLocked(upsertInflightEvent(req.entry))
+		t.mu.Unlock()
+		return
+	}
+	if req.timer == nil {
+		if remaining < 0 {
+			remaining = 0
+		}
+		req.timer = time.AfterFunc(remaining, func() { t.emitPending(id) })
+	}
+	t.mu.Unlock()
+}
+
+func (t *inflightTracker) emitPending(id string) {
+	t.mu.Lock()
+	req, ok := t.requests[id]
+	if !ok {
+		t.mu.Unlock()
+		return
+	}
+	req.timer = nil
+	req.lastEmitted = time.Now()
+	t.enqueueLocked(upsertInflightEvent(req.entry))
+	t.mu.Unlock()
+}
+
+// enqueueLocked adds an update without allowing event-bus backpressure to
+// block the request path. On overflow, a later snapshot replaces any dropped
+// incremental updates with the tracker's authoritative state.
+func (t *inflightTracker) enqueueLocked(update shared.InFlightRequestsEvent) {
+	select {
+	case t.updates <- update:
+	default:
+		t.needsSnapshot.Store(true)
+	}
+	t.startPublisher()
+}
+
+func (t *inflightTracker) startPublisher() {
+	if t.publisherRunning.CompareAndSwap(false, true) {
+		go t.publishUpdates()
+	}
+}
+
+func (t *inflightTracker) publishUpdates() {
+	for {
+		select {
+		case update := <-t.updates:
+			t.publish(refreshInflightElapsed(update))
+			t.publishRecoverySnapshots()
+		default:
+			t.publisherRunning.Store(false)
+			// An enqueue racing with the transition to idle either starts a new
+			// publisher or leaves work here for this publisher to reclaim.
+			if len(t.updates) > 0 && t.publisherRunning.CompareAndSwap(false, true) {
+				continue
+			}
+			return
+		}
+	}
+}
+
+func (t *inflightTracker) publishRecoverySnapshots() {
+	for t.needsSnapshot.Swap(false) {
+		t.discardQueuedUpdates()
+		t.publish(t.Current())
+	}
+}
+
+func (t *inflightTracker) discardQueuedUpdates() {
+	for {
+		select {
+		case <-t.updates:
+		default:
+			return
+		}
+	}
 }
 
 func (t *inflightTracker) Cancel(id string) bool {
@@ -79,13 +244,16 @@ func (t *inflightTracker) Cancel(id string) bool {
 func (t *inflightTracker) Current() shared.InFlightRequestsEvent {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	return t.snapshotLocked()
+	return shared.InFlightRequestsEvent{
+		Operation: inflightOperationSnapshot,
+		Requests:  t.snapshotLocked(),
+	}
 }
 
-func (t *inflightTracker) snapshotLocked() shared.InFlightRequestsEvent {
+func (t *inflightTracker) snapshotLocked() []shared.InflightRequestEntry {
 	requests := make([]shared.InflightRequestEntry, 0, len(t.requests))
 	for _, req := range t.requests {
-		requests = append(requests, req.entry)
+		requests = append(requests, copyInflightEntry(req.entry))
 	}
 	sort.Slice(requests, func(i, j int) bool {
 		if requests[i].Timestamp.Equal(requests[j].Timestamp) {
@@ -93,7 +261,51 @@ func (t *inflightTracker) snapshotLocked() shared.InFlightRequestsEvent {
 		}
 		return requests[i].Timestamp.Before(requests[j].Timestamp)
 	})
-	return shared.InFlightRequestsEvent{Requests: requests}
+	return requests
+}
+
+func upsertInflightEvent(entry shared.InflightRequestEntry) shared.InFlightRequestsEvent {
+	entry = copyInflightEntry(entry)
+	return shared.InFlightRequestsEvent{Operation: inflightOperationUpsert, Request: &entry}
+}
+
+func copyInflightEntry(entry shared.InflightRequestEntry) shared.InflightRequestEntry {
+	entry.Metadata = copyMetadata(entry.Metadata)
+	entry.ReqHeaders = copyStringMap(entry.ReqHeaders)
+	entry.RespHeaders = copyStringMap(entry.RespHeaders)
+	setInflightElapsed(&entry)
+	return entry
+}
+
+func refreshInflightElapsed(update shared.InFlightRequestsEvent) shared.InFlightRequestsEvent {
+	if update.Request != nil {
+		entry := *update.Request
+		setInflightElapsed(&entry)
+		update.Request = &entry
+	}
+	for i := range update.Requests {
+		setInflightElapsed(&update.Requests[i])
+	}
+	return update
+}
+
+func setInflightElapsed(entry *shared.InflightRequestEntry) {
+	elapsed := time.Since(entry.Timestamp)
+	if elapsed < 0 {
+		elapsed = 0
+	}
+	entry.ElapsedMs = elapsed.Milliseconds()
+}
+
+func copyStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
 }
 
 func copyMetadata(metadata map[string]string) map[string]string {
@@ -105,6 +317,47 @@ func copyMetadata(metadata map[string]string) map[string]string {
 		out[k] = v
 	}
 	return out
+}
+
+type inflightResponseWriter struct {
+	http.ResponseWriter
+	tracker     *inflightTracker
+	id          string
+	wroteHeader bool
+}
+
+func (w *inflightResponseWriter) WriteHeader(statusCode int) {
+	if w.wroteHeader {
+		return
+	}
+	w.wroteHeader = true
+	w.tracker.SetResponseHeaders(w.id, w.Header())
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *inflightResponseWriter) Write(data []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	n, err := w.ResponseWriter.Write(data)
+	w.tracker.AddResponseBytes(w.id, n)
+	return n, err
+}
+
+func (w *inflightResponseWriter) Flush() {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (w *inflightResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hijacker, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hijacker.Hijack()
+	}
+	return nil, nil, fmt.Errorf("underlying ResponseWriter does not support hijacking")
 }
 
 // CreateInflightMiddleware returns middleware that tracks model-dispatched
@@ -119,7 +372,7 @@ func CreateInflightMiddleware(t *inflightTracker) chain.Middleware {
 			id := t.Add(r, cancel)
 			defer t.Remove(id)
 
-			next.ServeHTTP(w, r)
+			next.ServeHTTP(&inflightResponseWriter{ResponseWriter: w, tracker: t, id: id}, r)
 		})
 	}
 }
@@ -134,6 +387,7 @@ func CreateUpstreamInflightMiddleware(t *inflightTracker, cfg config.Config) cha
 				next.ServeHTTP(w, r)
 				return
 			}
+			r = markInflightStart(r)
 
 			_, _, remainingPath, found := shared.FindModelInPath(cfg, strings.TrimPrefix(r.URL.Path, "/upstream"))
 			if !found || !isModelDispatchedRequest(r.Method, remainingPath) {
@@ -155,7 +409,7 @@ func CreateUpstreamInflightMiddleware(t *inflightTracker, cfg config.Config) cha
 			id := t.Add(tracked, cancel)
 			defer t.Remove(id)
 
-			next.ServeHTTP(w, r)
+			next.ServeHTTP(&inflightResponseWriter{ResponseWriter: w, tracker: t, id: id}, r)
 		})
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -206,9 +206,9 @@ func (s *Server) routes() {
 	modelChain := chain.New(
 		authMW,
 		CreateRequestContextMiddleware(s.cfg),
+		CreateInflightMiddleware(s.inflight),
 		CreateFilterMiddleware(s.cfg),
 		CreateFormFilterMiddleware(s.cfg),
-		CreateInflightMiddleware(s.inflight),
 		CreateMetricsMiddleware(s.metrics, s.cfg),
 	)
 	// Custom endpoints only need auth.

--- a/internal/shared/events.go
+++ b/internal/shared/events.go
@@ -46,7 +46,10 @@ func (e ModelPreloadedEvent) Type() uint32 {
 }
 
 type InFlightRequestsEvent struct {
-	Requests []InflightRequestEntry `json:"requests"`
+	Operation string                 `json:"operation"`
+	Requests  []InflightRequestEntry `json:"requests,omitempty"`
+	Request   *InflightRequestEntry  `json:"request,omitempty"`
+	ID        string                 `json:"id,omitempty"`
 }
 
 func (e InFlightRequestsEvent) Type() uint32 {
@@ -54,10 +57,15 @@ func (e InFlightRequestsEvent) Type() uint32 {
 }
 
 type InflightRequestEntry struct {
-	ID        string            `json:"id"`
-	Timestamp time.Time         `json:"timestamp"`
-	Model     string            `json:"model"`
-	ReqPath   string            `json:"req_path"`
-	Method    string            `json:"method"`
-	Metadata  map[string]string `json:"metadata,omitempty"`
+	ID          string            `json:"id"`
+	Timestamp   time.Time         `json:"timestamp"`
+	Model       string            `json:"model"`
+	ReqPath     string            `json:"req_path"`
+	Method      string            `json:"method"`
+	ReqHeaders  map[string]string `json:"req_headers"`
+	RemoteIP    string            `json:"remote_ip"`
+	RespHeaders map[string]string `json:"resp_headers"`
+	RespBytes   int64             `json:"resp_bytes"`
+	ElapsedMs   int64             `json:"elapsed_ms"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
 }

--- a/ui-svelte/src/components/ActivityTable.svelte
+++ b/ui-svelte/src/components/ActivityTable.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { ActivityLogEntry, InflightRequestEntry, ReqRespCapture } from "../lib/types";
-  import { cancelInflightRequest, getCapture } from "../stores/api";
+  import { cancelInflightRequest, getCapture, uiConfig } from "../stores/api";
   import { persistentStore } from "../stores/persistent";
   import CaptureDialog from "./CaptureDialog.svelte";
   import {
@@ -38,7 +38,9 @@
   import ViewCaptureButton from "./activity-table/ViewCaptureButton.svelte";
   import MetaCell from "./activity-table/MetaCell.svelte";
   import ModelLink from "./activity-table/ModelLink.svelte";
+  import MiddleEllipsis from "./activity-table/MiddleEllipsis.svelte";
   import { formatDuration, formatSpeed, formatRelativeTime } from "../lib/format";
+  import { formatBytes, liveElapsedMs, requestHeader, sessionID } from "../lib/inflight";
 
   interface Props {
     metrics: ActivityLogEntry[];
@@ -167,6 +169,74 @@
   // svelte-ignore state_referenced_locally
   const storedInflightOpen = persistentStore<boolean>(`${storagePrefix}-inflight-open`, true);
 
+  function buildInflightColumnMeta(withModel: boolean): ColMeta[] {
+    const cols: ColMeta[] = [
+      { id: "cancel", label: "Cancel", defaultVisible: true },
+      { id: "elapsed", label: "Elapsed", defaultVisible: true },
+    ];
+    if (withModel) cols.push({ id: "model", label: "Model", defaultVisible: true });
+    cols.push(
+      { id: "request", label: "Request", defaultVisible: true },
+      { id: "identity", label: "Address", defaultVisible: true },
+      { id: "user_agent", label: "User Agent", defaultVisible: true },
+      { id: "session_id", label: "Session ID", defaultVisible: true },
+      { id: "bytes_received", label: "Bytes Received", defaultVisible: true }
+    );
+    return cols;
+  }
+
+  let inflightColumnMeta = $derived(buildInflightColumnMeta(showModelColumn));
+  let inflightColumnLabelMap = $derived(
+    Object.fromEntries(inflightColumnMeta.map((column) => [column.id, column.label])) as Record<string, string>
+  );
+  let inflightDefaultVisibility = $derived.by(() => {
+    const visibility: VisibilityState = {};
+    for (const column of inflightColumnMeta) visibility[column.id] = column.defaultVisible;
+    return visibility;
+  });
+
+  // svelte-ignore state_referenced_locally
+  const storedInflightVisibility = persistentStore<VisibilityState>(
+    `${storagePrefix}-inflight-columns`,
+    {}
+  );
+  // svelte-ignore state_referenced_locally
+  let inflightColumnVisibility = $state<VisibilityState>(
+    Object.keys($storedInflightVisibility).length > 0
+      ? $storedInflightVisibility
+      : inflightDefaultVisibility
+  );
+  // svelte-ignore state_referenced_locally
+  const storedInflightColumnOrder = persistentStore<string[]>(
+    `${storagePrefix}-inflight-column-order`,
+    []
+  );
+  let inflightDefaultColumnOrder = $derived(inflightColumnMeta.map((column) => column.id));
+  // svelte-ignore state_referenced_locally
+  let inflightColumnOrder = $state<string[]>(
+    $storedInflightColumnOrder.length > 0
+      ? $storedInflightColumnOrder
+      : inflightDefaultColumnOrder
+  );
+  let visibleInflightColumns = $derived(
+    inflightColumnOrder.filter((id) => inflightColumnVisibility[id] !== false)
+  );
+
+  $effect(() => {
+    const known = new Set(inflightColumnMeta.map((column) => column.id));
+    const hasStale = inflightColumnOrder.some((id) => !known.has(id));
+    const missing = inflightColumnMeta
+      .filter((column) => !inflightColumnOrder.includes(column.id))
+      .map((column) => column.id);
+    if (hasStale || missing.length > 0) {
+      inflightColumnOrder = [
+        ...inflightColumnOrder.filter((id) => known.has(id)),
+        ...missing,
+      ];
+      storedInflightColumnOrder.set(inflightColumnOrder);
+    }
+  });
+
   // When onSortChange is provided the table sorts on the server: the sort
   // state is driven by the sort/order props and toggles are forwarded to the
   // parent. Otherwise it falls back to client-side sorting of the current page.
@@ -180,14 +250,18 @@
   let dialogOpen = $state(false);
   let loadingCaptureId = $state<number | null>(null);
   let cancelingInflightIds = $state<string[]>([]);
-  let inflightNowMs = $state(Date.now());
+  let inflightNowMs = $state(performance.now());
 
   $effect(() => {
     if (inflightRequests.length === 0) return;
 
+    // Refresh synchronously when the first request appears so the initial
+    // render does not use the timestamp from when this component mounted.
+    inflightNowMs = performance.now();
+
     let frame = 0;
     const tick = () => {
-      inflightNowMs = Date.now();
+      inflightNowMs = performance.now();
       frame = requestAnimationFrame(tick);
     };
     frame = requestAnimationFrame(tick);
@@ -381,8 +455,10 @@
     getSortedRowModel: getSortedRowModel(),
   });
 
-  let thClass = $derived(compact ? "px-4 py-2 h-9" : "px-6 py-3 h-12");
-  let tdClass = $derived(compact ? "px-4 py-2" : "px-6 py-4");
+  let thClass = $derived(compact ? "px-2 py-2 h-9" : "px-3 py-3 h-12");
+  let tdClass = $derived(compact ? "px-2 py-2" : "px-3 py-4");
+  let inflightThClass = $derived(compact ? "h-7 px-2 py-1" : "h-8 px-3 py-1.5");
+  let inflightTdClass = $derived(compact ? "px-2 py-1" : "px-3 py-1.5");
   let visibleColumnCount = $derived(table.getVisibleLeafColumns().length);
   let pageCount = $derived(Math.max(totalPages, 1));
   let visiblePages = $derived.by(() => {
@@ -450,81 +526,163 @@
     dragOverColId = null;
   }
 
-  function formatInflightElapsed(timestamp: string): string {
-    const started = Date.parse(timestamp);
-    if (!Number.isFinite(started)) return "0.00s";
-    return `${(Math.max(0, inflightNowMs - started) / 1000).toFixed(2)}s`;
+  function formatInflightElapsed(request: InflightRequestEntry, nowMs: number): string {
+    return `${(liveElapsedMs(request.elapsed_ms, request.client_received_at_ms, nowMs) / 1000).toFixed(2)}s`;
+  }
+
+  function toggleInflightColumn(id: string, visible: boolean) {
+    inflightColumnVisibility = { ...inflightColumnVisibility, [id]: visible };
+    storedInflightVisibility.set(inflightColumnVisibility);
+  }
+
+  let inflightDragColId: string | null = $state(null);
+  let inflightDragOverColId: string | null = $state(null);
+
+  function handleInflightColDragStart(e: DragEvent, id: string) {
+    inflightDragColId = id;
+    if (e.dataTransfer) {
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", id);
+    }
+  }
+
+  function handleInflightColDragOver(e: DragEvent, id: string) {
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "move";
+    inflightDragOverColId = id;
+  }
+
+  function handleInflightColDrop(e: DragEvent, targetId: string) {
+    e.preventDefault();
+    const sourceId = inflightDragColId;
+    inflightDragColId = null;
+    inflightDragOverColId = null;
+    if (!sourceId || sourceId === targetId) return;
+    const next = [...inflightColumnOrder];
+    const from = next.indexOf(sourceId);
+    let to = next.indexOf(targetId);
+    if (from === -1 || to === -1) return;
+    next.splice(from, 1);
+    if (from < to) to -= 1;
+    next.splice(to, 0, sourceId);
+    inflightColumnOrder = next;
+    storedInflightColumnOrder.set(next);
+  }
+
+  function clearInflightColumnDrag() {
+    inflightDragColId = null;
+    inflightDragOverColId = null;
   }
 </script>
 
 <Card.Root class="relative p-3">
-  <div class="flex items-center gap-2 pr-7 text-sm">
+  <div class="flex items-center gap-2 pr-16 text-sm">
     <span class="text-muted-foreground text-xs uppercase tracking-wider">In-flight Requests</span>
     <span>
       <span class="font-semibold">{inflightRequests.length}</span> active
     </span>
   </div>
 
-  <Button
-    variant="ghost"
-    size="icon-xs"
-    class="text-muted-foreground absolute right-2 top-2 rounded-full"
-    onclick={() => setInflightOpen(!inflightOpen)}
-    title={inflightOpen ? "Hide in-flight requests" : "Show in-flight requests"}
-  >
-    {#if inflightOpen}
-      <X />
-    {:else}
-      <ChevronDown />
-    {/if}
-  </Button>
+  <div class="absolute right-2 top-2 flex items-center gap-1">
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger
+        class="text-muted-foreground hover:bg-muted inline-flex size-6 items-center justify-center rounded-full"
+        title="Select in-flight columns"
+      >
+        <Columns3 class="size-4" />
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content align="end" class="min-w-[18rem] max-h-[60vh] overflow-y-auto p-0">
+        <DropdownMenu.Label class="text-muted-foreground border-b px-3 py-2 text-xs font-medium uppercase tracking-wider">
+          Columns <span class="text-[10px] normal-case tracking-normal">(drag to reorder)</span>
+        </DropdownMenu.Label>
+        {#each inflightColumnOrder as columnId (columnId)}
+          {@const isDragOver = inflightDragOverColId === columnId && inflightDragColId !== columnId}
+          <DropdownMenu.CheckboxItem
+            checked={inflightColumnVisibility[columnId] !== false}
+            onCheckedChange={(visible) => toggleInflightColumn(columnId, !!visible)}
+            closeOnSelect={false}
+            draggable="true"
+            ondragstart={(event) => handleInflightColDragStart(event, columnId)}
+            ondragover={(event) => handleInflightColDragOver(event, columnId)}
+            ondrop={(event) => handleInflightColDrop(event, columnId)}
+            ondragend={clearInflightColumnDrag}
+            class={isDragOver ? "bg-accent" : ""}
+          >
+            <GripVertical class="text-muted-foreground/50 size-4 cursor-grab active:cursor-grabbing" />
+            <span class="flex-1">{inflightColumnLabelMap[columnId] ?? columnId}</span>
+          </DropdownMenu.CheckboxItem>
+        {/each}
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+
+    <Button
+      variant="ghost"
+      size="icon-xs"
+      class="text-muted-foreground rounded-full"
+      onclick={() => setInflightOpen(!inflightOpen)}
+      title={inflightOpen ? "Hide in-flight requests" : "Show in-flight requests"}
+    >
+      {#if inflightOpen}
+        <X />
+      {:else}
+        <ChevronDown />
+      {/if}
+    </Button>
+  </div>
 
   {#if inflightOpen}
-    <div class="mt-3 overflow-x-auto">
+    <div class="mt-2 overflow-x-auto">
       <Table.Root class="min-w-full">
         <Table.Header>
           <Table.Row>
-            <Table.Head class={thClass}>Cancel</Table.Head>
-            <Table.Head class={thClass}>Elapsed</Table.Head>
-            <Table.Head class={thClass}>Model</Table.Head>
-            <Table.Head class={thClass}>Method</Table.Head>
-            <Table.Head class={thClass}>Path</Table.Head>
+            {#each visibleInflightColumns as columnId (columnId)}
+              <Table.Head class={inflightThClass}>{inflightColumnLabelMap[columnId] ?? columnId}</Table.Head>
+            {/each}
           </Table.Row>
         </Table.Header>
         <Table.Body>
           {#each inflightRequests as request (request.id)}
             <Table.Row>
-              <Table.Cell class={tdClass}>
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  class="text-muted-foreground hover:text-destructive size-6"
-                  onclick={() => cancelInflight(request.id)}
-                  disabled={cancelingInflightIds.includes(request.id)}
-                  title="Cancel request"
-                  aria-label="Cancel inflight request"
-                >
-                  <CircleX class="size-4" />
-                </Button>
-              </Table.Cell>
-              <Table.Cell class="{tdClass} font-mono text-xs tabular-nums">
-                {formatInflightElapsed(request.timestamp)}
-              </Table.Cell>
-              <Table.Cell class={tdClass}>
-                <span class="block max-w-[16rem] truncate" title={request.model}>
-                  {request.model || "-"}
-                </span>
-              </Table.Cell>
-              <Table.Cell class="{tdClass} font-mono text-xs">{request.method || "-"}</Table.Cell>
-              <Table.Cell class="{tdClass} font-mono text-xs">
-                <span class="block max-w-[22rem] truncate" title={request.req_path}>
-                  {request.req_path || "-"}
-                </span>
-              </Table.Cell>
+              {#each visibleInflightColumns as columnId (columnId)}
+                <Table.Cell class={inflightTdClass}>
+                  {#if columnId === "cancel"}
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      class="text-muted-foreground hover:text-destructive size-6"
+                      onclick={() => cancelInflight(request.id)}
+                      disabled={cancelingInflightIds.includes(request.id)}
+                      title="Cancel request"
+                      aria-label="Cancel inflight request"
+                    >
+                      <CircleX class="size-4" />
+                    </Button>
+                  {:else if columnId === "elapsed"}
+                    <span class="font-mono text-xs tabular-nums">
+                      {formatInflightElapsed(request, inflightNowMs)}
+                    </span>
+                  {:else if columnId === "model"}
+                    <MiddleEllipsis value={request.model} tailLength={10} className="max-w-[14rem]" />
+                  {:else if columnId === "request"}
+                    {@const requestLabel = `${request.method || "-"} ${request.req_path || "-"}`}
+                    <MiddleEllipsis value={requestLabel} tailLength={14} className="max-w-[20rem] font-mono text-xs" />
+                  {:else if columnId === "identity"}
+                    <MiddleEllipsis value={request.remote_ip} tailLength={8} className="max-w-[12rem] font-mono text-xs" />
+                  {:else if columnId === "user_agent"}
+                    {@const userAgent = requestHeader(request.req_headers, "User-Agent")}
+                    <MiddleEllipsis value={userAgent} tailLength={18} className="max-w-[20rem] text-xs" />
+                  {:else if columnId === "session_id"}
+                    {@const session = sessionID(request.req_headers, $uiConfig.activity.session_id)}
+                    <MiddleEllipsis value={session} tailLength={8} className="max-w-[14rem] font-mono text-xs" />
+                  {:else if columnId === "bytes_received"}
+                    <span class="font-mono text-xs tabular-nums">{formatBytes(request.resp_bytes)}</span>
+                  {/if}
+                </Table.Cell>
+              {/each}
             </Table.Row>
           {:else}
             <Table.Row>
-              <Table.Cell colspan={5} class="text-muted-foreground py-6 text-center text-sm">
+              <Table.Cell colspan={Math.max(visibleInflightColumns.length, 1)} class="text-muted-foreground py-4 text-center text-sm">
                 No in-flight requests
               </Table.Cell>
             </Table.Row>

--- a/ui-svelte/src/components/activity-table/MiddleEllipsis.svelte
+++ b/ui-svelte/src/components/activity-table/MiddleEllipsis.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  interface Props {
+    value: string;
+    tailLength?: number;
+    className?: string;
+  }
+
+  let { value, tailLength = 10, className = "" }: Props = $props();
+
+  let displayValue = $derived(value || "-");
+  let head = $derived(
+    displayValue.length > tailLength ? displayValue.slice(0, -tailLength) : displayValue
+  );
+  let tail = $derived(
+    displayValue.length > tailLength ? displayValue.slice(-tailLength) : ""
+  );
+</script>
+
+<span class="flex min-w-0 items-baseline {className}" title={displayValue}>
+  <span class="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{head}</span>
+  {#if tail}
+    <span class="shrink-0 whitespace-nowrap">{tail}</span>
+  {/if}
+</span>

--- a/ui-svelte/src/components/playground/SpeechInterface.svelte
+++ b/ui-svelte/src/components/playground/SpeechInterface.svelte
@@ -10,6 +10,7 @@
   import { Button } from "$lib/components/ui/button/index.js";
   import * as Select from "$lib/components/ui/select/index.js";
   import { RefreshCw, Download } from "@lucide/svelte";
+  import { playgroundSessionHeaders } from "../../lib/playgroundSession";
 
   const iface = createPlaygroundInterface("playground-speech-model", playgroundStores.speechGenerating);
   const selectedModelStore = iface.selectedModel;
@@ -74,7 +75,9 @@
     isLoadingVoices = true;
 
     try {
-      const response = await fetch(`/v1/audio/voices?model=${encodeURIComponent(model)}`);
+      const response = await fetch(`/v1/audio/voices?model=${encodeURIComponent(model)}`, {
+        headers: playgroundSessionHeaders,
+      });
       if (!response.ok) {
         // Fall back to default voices if API call fails
         availableVoices = defaultVoices;

--- a/ui-svelte/src/lib/audioApi.ts
+++ b/ui-svelte/src/lib/audioApi.ts
@@ -1,4 +1,5 @@
 import type { AudioTranscriptionResponse } from "./types";
+import { playgroundSessionHeaders } from "./playgroundSession";
 
 export async function transcribeAudio(
   model: string,
@@ -11,6 +12,7 @@ export async function transcribeAudio(
 
   const response = await fetch("/v1/audio/transcriptions", {
     method: "POST",
+    headers: playgroundSessionHeaders,
     body: formData,
     signal,
   });

--- a/ui-svelte/src/lib/chatApi.ts
+++ b/ui-svelte/src/lib/chatApi.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage, ContentPart } from "./types";
+import { playgroundSessionHeaders } from "./playgroundSession";
 
 export type Endpoint = "v1/chat/completions" | "v1/messages" | "v1/responses";
 
@@ -305,6 +306,7 @@ export async function* streamChatCompletion(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      ...playgroundSessionHeaders,
     },
     body: JSON.stringify(body),
     signal,

--- a/ui-svelte/src/lib/imageApi.ts
+++ b/ui-svelte/src/lib/imageApi.ts
@@ -1,4 +1,5 @@
 import type { ImageGenerationRequest, ImageGenerationResponse } from "./types";
+import { playgroundSessionHeaders } from "./playgroundSession";
 
 export async function generateImage(
   model: string,
@@ -17,6 +18,7 @@ export async function generateImage(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      ...playgroundSessionHeaders,
     },
     body: JSON.stringify(request),
     signal,

--- a/ui-svelte/src/lib/inflight.test.ts
+++ b/ui-svelte/src/lib/inflight.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatBytes, liveElapsedMs, requestHeader, sessionID } from "./inflight";
+
+describe("inflight helpers", () => {
+  it("looks up headers case-insensitively", () => {
+    expect(requestHeader({ "User-Agent": "agent" }, "user-agent")).toBe("agent");
+  });
+
+  it("uses configured session header precedence", () => {
+    const headers = { "X-Litellm-Session-Id": "second", "X-Session-Id": "first" };
+    expect(sessionID(headers, ["x-session-id", "x-litellm-session-id"])).toBe("first");
+  });
+
+  it("formats byte counts", () => {
+    expect(formatBytes(42)).toBe("42 B");
+    expect(formatBytes(2048)).toBe("2.00 KB");
+  });
+
+  it("advances server elapsed time from a client-local receipt time", () => {
+    expect(liveElapsedMs(250, 1_000, 2_500)).toBe(1_750);
+  });
+});

--- a/ui-svelte/src/lib/inflight.ts
+++ b/ui-svelte/src/lib/inflight.ts
@@ -1,0 +1,42 @@
+export function requestHeader(
+  headers: Record<string, string> | undefined,
+  name: string
+): string {
+  if (!headers) return "";
+  const wanted = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === wanted) return value;
+  }
+  return "";
+}
+
+export function sessionID(
+  headers: Record<string, string> | undefined,
+  sessionHeaders: string[]
+): string {
+  for (const name of sessionHeaders) {
+    const value = requestHeader(headers, name);
+    if (value) return value;
+  }
+  return "";
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = units[0];
+  for (let i = 1; i < units.length && value >= 1024; i++) {
+    value /= 1024;
+    unit = units[i];
+  }
+  return `${value.toFixed(value >= 10 ? 1 : 2)} ${unit}`;
+}
+
+export function liveElapsedMs(
+  serverElapsedMs: number,
+  receivedAtMs: number | undefined,
+  nowMs: number
+): number {
+  return serverElapsedMs + Math.max(0, nowMs - (receivedAtMs ?? nowMs));
+}

--- a/ui-svelte/src/lib/playgroundSession.test.ts
+++ b/ui-svelte/src/lib/playgroundSession.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { playgroundSessionHeaders, playgroundSessionID } from "./playgroundSession";
+
+describe("playground session", () => {
+  it("creates one five-character Playground session id", () => {
+    expect(playgroundSessionID).toMatch(/^lspg-[a-z0-9]{5}$/);
+    expect(playgroundSessionHeaders["X-Session-ID"]).toBe(playgroundSessionID);
+  });
+});

--- a/ui-svelte/src/lib/playgroundSession.ts
+++ b/ui-svelte/src/lib/playgroundSession.ts
@@ -1,0 +1,19 @@
+const SESSION_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
+const SESSION_SUFFIX_LENGTH = 5;
+
+function createPlaygroundSessionID(): string {
+  const random = crypto.getRandomValues(new Uint8Array(SESSION_SUFFIX_LENGTH));
+  let suffix = "";
+  for (const value of random) {
+    suffix += SESSION_ALPHABET[value % SESSION_ALPHABET.length];
+  }
+  return `lspg-${suffix}`;
+}
+
+// Module initialization runs once per UI load, so every Playground request
+// made by this page shares one session identifier.
+export const playgroundSessionID = createPlaygroundSessionID();
+
+export const playgroundSessionHeaders = {
+  "X-Session-ID": playgroundSessionID,
+} as const;

--- a/ui-svelte/src/lib/rerankApi.ts
+++ b/ui-svelte/src/lib/rerankApi.ts
@@ -1,3 +1,5 @@
+import { playgroundSessionHeaders } from "./playgroundSession";
+
 export interface RerankResult {
   index: number;
   relevance_score: number;
@@ -18,7 +20,7 @@ export async function rerank(
 ): Promise<RerankResponse> {
   const response = await fetch("/v1/rerank", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...playgroundSessionHeaders },
     body: JSON.stringify({ model, query, documents }),
     signal,
   });

--- a/ui-svelte/src/lib/sdApi.ts
+++ b/ui-svelte/src/lib/sdApi.ts
@@ -1,4 +1,5 @@
 import type { SdApiTxt2ImgRequest, SdApiResponse, SdApiLora } from "./types";
+import { playgroundSessionHeaders } from "./playgroundSession";
 
 export async function generateSdImage(
   request: SdApiTxt2ImgRequest,
@@ -8,6 +9,7 @@ export async function generateSdImage(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      ...playgroundSessionHeaders,
     },
     body: JSON.stringify(request),
     signal,
@@ -27,7 +29,7 @@ export async function fetchSdLoras(
 ): Promise<SdApiLora[]> {
   const response = await fetch(
     `/sdapi/v1/loras?model=${encodeURIComponent(model)}`,
-    { signal }
+    { headers: playgroundSessionHeaders, signal }
   );
 
   if (!response.ok) {

--- a/ui-svelte/src/lib/speechApi.ts
+++ b/ui-svelte/src/lib/speechApi.ts
@@ -1,4 +1,5 @@
 import type { SpeechGenerationRequest } from "./types";
+import { playgroundSessionHeaders } from "./playgroundSession";
 
 export async function generateSpeech(
   model: string,
@@ -16,6 +17,7 @@ export async function generateSpeech(
     method: "POST",
     headers: {
       "Content-Type": "application/json",
+      ...playgroundSessionHeaders,
     },
     body: JSON.stringify(request),
     signal,

--- a/ui-svelte/src/lib/types.ts
+++ b/ui-svelte/src/lib/types.ts
@@ -75,11 +75,26 @@ export interface InflightRequestEntry {
   model: string;
   req_path: string;
   method: string;
+  req_headers: Record<string, string>;
+  remote_ip: string;
+  resp_headers: Record<string, string>;
+  resp_bytes: number;
+  elapsed_ms: number;
+  client_received_at_ms?: number;
   metadata?: Record<string, string>;
 }
 
 export interface InFlightStats {
+  operation: "snapshot" | "upsert" | "remove";
   requests?: InflightRequestEntry[];
+  request?: InflightRequestEntry;
+  id?: string;
+}
+
+export interface UIConfig {
+  activity: {
+    session_id: string[];
+  };
 }
 
 export interface NetIOStat {
@@ -123,7 +138,7 @@ export interface PerformanceResponse {
 }
 
 export interface APIEventEnvelope {
-  type: "modelStatus" | "logData" | "activity" | "inflight" | "perfsys" | "perfgpu";
+  type: "modelStatus" | "logData" | "activity" | "inflight" | "uiConfig" | "perfsys" | "perfgpu";
   data: string;
 }
 

--- a/ui-svelte/src/stores/api.test.ts
+++ b/ui-svelte/src/stores/api.test.ts
@@ -5,6 +5,7 @@ import {
   handleAPIEventMessage,
   inFlightRequests,
   inflightRequestEntries,
+  uiConfig,
 } from "./api";
 
 describe("api store event handling", () => {
@@ -16,6 +17,7 @@ describe("api store event handling", () => {
       JSON.stringify({
         type: "inflight",
         data: JSON.stringify({
+          operation: "snapshot",
           requests: [
             {
               id: "7",
@@ -23,6 +25,11 @@ describe("api store event handling", () => {
               model: "m1",
               req_path: "/v1/chat/completions",
               method: "POST",
+              req_headers: { "User-Agent": "test-agent" },
+              remote_ip: "203.0.113.9",
+              resp_headers: {},
+              resp_bytes: 0,
+              elapsed_ms: 125,
               metadata: { source: "test" },
             },
           ],
@@ -38,9 +45,54 @@ describe("api store event handling", () => {
         model: "m1",
         req_path: "/v1/chat/completions",
         method: "POST",
+        req_headers: { "User-Agent": "test-agent" },
+        remote_ip: "203.0.113.9",
+        resp_headers: {},
+        resp_bytes: 0,
+        elapsed_ms: 125,
+        client_received_at_ms: expect.any(Number),
         metadata: { source: "test" },
       },
     ]);
+  });
+
+  it("upserts and removes inflight entries by id", () => {
+    handleAPIEventMessage(JSON.stringify({
+      type: "inflight",
+      data: JSON.stringify({
+        operation: "upsert",
+        request: {
+          id: "7",
+          timestamp: "2026-07-03T00:00:00Z",
+          model: "m1",
+          req_path: "/v1/chat/completions",
+          method: "POST",
+          req_headers: {},
+          remote_ip: "203.0.113.9",
+          resp_headers: { "Content-Type": "text/event-stream" },
+          resp_bytes: 42,
+          elapsed_ms: 250,
+        },
+      }),
+    }));
+
+    expect(get(inflightRequestEntries)).toHaveLength(1);
+    expect(get(inflightRequestEntries)[0].resp_bytes).toBe(42);
+
+    handleAPIEventMessage(JSON.stringify({
+      type: "inflight",
+      data: JSON.stringify({ operation: "remove", id: "7" }),
+    }));
+    expect(get(inflightRequestEntries)).toEqual([]);
+    expect(get(inFlightRequests)).toBe(0);
+  });
+
+  it("parses UI activity configuration", () => {
+    handleAPIEventMessage(JSON.stringify({
+      type: "uiConfig",
+      data: JSON.stringify({ activity: { session_id: ["X-Trace-ID"] } }),
+    }));
+    expect(get(uiConfig).activity.session_id).toEqual(["X-Trace-ID"]);
   });
 
   it("increments activity revision for activity events", () => {

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -10,6 +10,7 @@ import type {
   InFlightStats,
   InflightRequestEntry,
   PerformanceResponse,
+  UIConfig,
 } from "../lib/types";
 import { connectionState } from "./theme";
 
@@ -25,6 +26,10 @@ export const upstreamLogs = writable<string>("");
 export const activityRevision = writable<number>(0);
 export const inFlightRequests = writable<number>(0);
 export const inflightRequestEntries = writable<InflightRequestEntry[]>([]);
+const defaultUIConfig = (): UIConfig => ({
+  activity: { session_id: ["X-Session-ID", "X-Litellm-Session-Id"] },
+});
+export const uiConfig = writable<UIConfig>(defaultUIConfig());
 export const performanceEnabled = writable<boolean>(false);
 export const versionInfo = writable<VersionInfo>({
   build_date: "unknown",
@@ -48,6 +53,7 @@ export function enableAPIEvents(enabled: boolean): void {
     activityRevision.set(0);
     inFlightRequests.set(0);
     inflightRequestEntries.set([]);
+    uiConfig.set(defaultUIConfig());
     return;
   }
 
@@ -67,6 +73,7 @@ export function enableAPIEvents(enabled: boolean): void {
       activityRevision.update((n) => n + 1);
       inFlightRequests.set(0);
       inflightRequestEntries.set([]);
+      uiConfig.set(defaultUIConfig());
       models.set([]);
       retryCount = 0;
       connectionState.set("connected");
@@ -125,9 +132,41 @@ export function handleAPIEventMessage(data: string): void {
 
     case "inflight": {
       const stats = JSON.parse(message.data) as InFlightStats;
-      const requests = stats.requests ?? [];
-      inFlightRequests.set(requests.length);
-      inflightRequestEntries.set(requests);
+      const withReceiptTime = (request: InflightRequestEntry): InflightRequestEntry => ({
+        ...request,
+        client_received_at_ms: performance.now(),
+      });
+      inflightRequestEntries.update((current) => {
+        let requests = current;
+        switch (stats.operation) {
+          case "snapshot":
+            requests = (stats.requests ?? []).map(withReceiptTime);
+            break;
+          case "upsert": {
+            if (!stats.request) break;
+            const received = withReceiptTime(stats.request);
+            const index = current.findIndex((request) => request.id === received.id);
+            requests = index === -1
+              ? [...current, received]
+              : current.map((request, i) => i === index ? received : request);
+            break;
+          }
+          case "remove":
+            requests = current.filter((request) => request.id !== stats.id);
+            break;
+        }
+        requests.sort((a, b) => {
+          const byTime = Date.parse(a.timestamp) - Date.parse(b.timestamp);
+          return byTime || a.id.localeCompare(b.id, undefined, { numeric: true });
+        });
+        inFlightRequests.set(requests.length);
+        return requests;
+      });
+      break;
+    }
+
+    case "uiConfig": {
+      uiConfig.set(JSON.parse(message.data) as UIConfig);
       break;
     }
   }


### PR DESCRIPTION
Track request and streamed response metadata for active model requests.

- publish keyed updates through a non-blocking recoverable outbox
- add compact configurable activity columns and clock-safe elapsed time
- tag playground requests with a page-scoped session ID

Fixes #912