### PR TITLE
internal/server: support Open WebUI model unload

### DIFF
--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"sort"
 	"strconv"
@@ -77,18 +78,56 @@ func (s *Server) handleAPIUnloadAll(w http.ResponseWriter, r *http.Request) {
 // handleAPIUnloadModel stops a single named local process.
 func (s *Server) handleAPIUnloadModel(w http.ResponseWriter, r *http.Request) {
 	requested := strings.TrimPrefix(r.PathValue("model"), "/")
-	realName, found := s.cfg.RealModelName(requested)
-	if !found {
-		shared.SendResponse(w, r, http.StatusNotFound, "model not found")
+	if status, message := s.unloadLocalModel(requested); status != 0 {
+		shared.SendResponse(w, r, status, message)
 		return
 	}
-	if !s.local.Handles(realName) {
-		shared.SendResponse(w, r, http.StatusNotFound, "no local server found for requested model")
-		return
-	}
-	s.local.Unload(apiUnloadTimeout, realName)
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("OK"))
+}
+
+// unloadLocalModel resolves a configured model or alias and stops only its
+// canonical local process. It returns an HTTP status and message on failure.
+func (s *Server) unloadLocalModel(requested string) (int, string) {
+	realName, found := s.cfg.RealModelName(requested)
+	if !found {
+		return http.StatusNotFound, "model not found"
+	}
+	if !s.local.Handles(realName) {
+		return http.StatusNotFound, "no local server found for requested model"
+	}
+	s.local.Unload(apiUnloadTimeout, realName)
+	return 0, ""
+}
+
+// handleOpenWebUIUnload provides llama.cpp's named-model unload endpoint for
+// Open WebUI while keeping llama-swap's management API unchanged.
+func (s *Server) handleOpenWebUIUnload(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Model string `json:"model"`
+	}
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&body); err != nil {
+		shared.SendResponse(w, r, http.StatusBadRequest, "invalid unload request")
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		shared.SendResponse(w, r, http.StatusBadRequest, "invalid unload request")
+		return
+	}
+
+	requested := strings.TrimSpace(body.Model)
+	if requested == "" {
+		shared.SendResponse(w, r, http.StatusBadRequest, "model is required")
+		return
+	}
+	if status, message := s.unloadLocalModel(requested); status != 0 {
+		shared.SendResponse(w, r, status, message)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]bool{"status": true})
 }
 
 // handleAPIActivity serves paginated activity table rows.

--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -116,12 +116,11 @@ func (s *Server) handleOpenWebUIUnload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	requested := strings.TrimSpace(body.Model)
-	if requested == "" {
+	if strings.TrimSpace(body.Model) == "" {
 		shared.SendResponse(w, r, http.StatusBadRequest, "model is required")
 		return
 	}
-	if status, message := s.unloadLocalModel(requested); status != 0 {
+	if status, message := s.unloadLocalModel(body.Model); status != 0 {
 		shared.SendResponse(w, r, status, message)
 		return
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -247,6 +247,8 @@ func (s *Server) routes() {
 	// Operations endpoints.
 	mux.Handle("GET /unload", apiChain.ThenFunc(s.handleUnload))
 	mux.Handle("GET /running", apiChain.ThenFunc(s.handleRunning))
+	// llama.cpp-compatible endpoint used by Open WebUI's unload control.
+	mux.Handle("POST /models/unload", apiChain.ThenFunc(s.handleOpenWebUIUnload))
 
 	// Upstream passthrough. Meter only the model-dispatched endpoints that can
 	// produce token usage/timings.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,6 +29,8 @@ type stubRouter struct {
 	shutdownCalls atomic.Int32
 	running       map[string]process.ProcessState
 	unloadCalls   atomic.Int32
+	unloadMu      sync.Mutex
+	unloadModels  [][]string
 	loggers       map[string]*logmon.Monitor
 }
 
@@ -51,7 +54,12 @@ func (s *stubRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *stubRouter) RunningModels() map[string]process.ProcessState { return s.running }
-func (s *stubRouter) Unload(_ time.Duration, _ ...string)            { s.unloadCalls.Add(1) }
+func (s *stubRouter) Unload(_ time.Duration, models ...string) {
+	s.unloadCalls.Add(1)
+	s.unloadMu.Lock()
+	s.unloadModels = append(s.unloadModels, append([]string(nil), models...))
+	s.unloadMu.Unlock()
+}
 func (s *stubRouter) ProcessLogger(modelID string) (*logmon.Monitor, bool) {
 	if s.loggers != nil {
 		if lg, ok := s.loggers[modelID]; ok {

--- a/internal/server/unload_test.go
+++ b/internal/server/unload_test.go
@@ -1,0 +1,150 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+)
+
+func unloadTestConfig(t *testing.T) config.Config {
+	t.Helper()
+	cfg, err := config.LoadConfigFromReader(strings.NewReader(`
+apiKeys:
+  - secret
+models:
+  real:
+    cmd: path/to/server
+    proxy: http://localhost:8080
+    aliases:
+      - alias
+`))
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	return cfg
+}
+
+func newUnloadTestServer(t *testing.T) (*Server, *stubRouter) {
+	t.Helper()
+	local := newStubRouter([]string{"real"}, "served")
+	s := newTestServer(local, newStubRouter(nil, ""))
+	s.cfg = unloadTestConfig(t)
+	s.routes() // Rebuild so auth middleware captures the configured API key.
+	return s, local
+}
+
+func unloadRequest(body string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/models/unload", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Authorization", "Bearer secret")
+	return r
+}
+
+func TestServer_OpenWebUIUnload(t *testing.T) {
+	t.Run("canonical model", func(t *testing.T) {
+		s, local := newUnloadTestServer(t)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, unloadRequest(`{"model":"real"}`))
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 body=%q", w.Code, w.Body.String())
+		}
+		if got := w.Header().Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", got)
+		}
+		var response map[string]bool
+		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if !response["status"] {
+			t.Errorf("response = %s, want status=true", w.Body.String())
+		}
+		if local.unloadCalls.Load() != 1 || len(local.unloadModels) != 1 || strings.Join(local.unloadModels[0], ",") != "real" {
+			t.Errorf("unloads = %#v, want [[real]]", local.unloadModels)
+		}
+	})
+
+	t.Run("alias resolves to canonical model", func(t *testing.T) {
+		s, local := newUnloadTestServer(t)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, unloadRequest(`{"model":"alias"}`))
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 body=%q", w.Code, w.Body.String())
+		}
+		if len(local.unloadModels) != 1 || strings.Join(local.unloadModels[0], ",") != "real" {
+			t.Errorf("unloads = %#v, want [[real]]", local.unloadModels)
+		}
+	})
+}
+
+func TestServer_OpenWebUIUnload_InvalidRequest(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		body string
+		want int
+	}{
+		{name: "missing body", want: http.StatusBadRequest},
+		{name: "invalid JSON", body: `{`, want: http.StatusBadRequest},
+		{name: "missing model", body: `{}`, want: http.StatusBadRequest},
+		{name: "non-string model", body: `{"model":1}`, want: http.StatusBadRequest},
+		{name: "empty model", body: `{"model":" "}`, want: http.StatusBadRequest},
+		{name: "unknown model", body: `{"model":"unknown"}`, want: http.StatusNotFound},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s, local := newUnloadTestServer(t)
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, unloadRequest(tt.body))
+
+			if w.Code != tt.want {
+				t.Errorf("status = %d, want %d body=%q", w.Code, tt.want, w.Body.String())
+			}
+			if local.unloadCalls.Load() != 0 {
+				t.Errorf("unload calls = %d, want 0", local.unloadCalls.Load())
+			}
+		})
+	}
+}
+
+func TestServer_OpenWebUIUnload_Regression(t *testing.T) {
+	s, local := newUnloadTestServer(t)
+
+	t.Run("management unload all remains authenticated", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/api/models/unload", nil)
+		r.Header.Set("Authorization", "Bearer secret")
+		s.ServeHTTP(w, r)
+		if w.Code != http.StatusOK || w.Body.String() != "{\"msg\":\"ok\"}\n" {
+			t.Errorf("response = %d %q, want 200 JSON success", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("management named unload remains authenticated", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/api/models/unload/real", nil)
+		r.Header.Set("Authorization", "Bearer secret")
+		s.ServeHTTP(w, r)
+		if w.Code != http.StatusOK || w.Body.String() != "OK" {
+			t.Errorf("response = %d %q, want 200 OK", w.Code, w.Body.String())
+		}
+	})
+
+	t.Run("normal model routing remains unchanged", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"alias"}`))
+		r.Header.Set("Content-Type", "application/json")
+		r.Header.Set("Authorization", "Bearer secret")
+		s.ServeHTTP(w, r)
+		if w.Code != http.StatusOK || w.Body.String() != "served" {
+			t.Errorf("response = %d %q, want 200 served", w.Code, w.Body.String())
+		}
+	})
+
+	if local.unloadCalls.Load() != 2 {
+		t.Errorf("unload calls = %d, want 2", local.unloadCalls.Load())
+	}
+}

--- a/internal/server/unload_test.go
+++ b/internal/server/unload_test.go
@@ -21,6 +21,7 @@ models:
     proxy: http://localhost:8080
     aliases:
       - alias
+      - " alias "
 `))
 	if err != nil {
 		t.Fatalf("load config: %v", err)
@@ -72,6 +73,19 @@ func TestServer_OpenWebUIUnload(t *testing.T) {
 		s, local := newUnloadTestServer(t)
 		w := httptest.NewRecorder()
 		s.ServeHTTP(w, unloadRequest(`{"model":"alias"}`))
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200 body=%q", w.Code, w.Body.String())
+		}
+		if len(local.unloadModels) != 1 || strings.Join(local.unloadModels[0], ",") != "real" {
+			t.Errorf("unloads = %#v, want [[real]]", local.unloadModels)
+		}
+	})
+
+	t.Run("whitespace alias resolves exactly", func(t *testing.T) {
+		s, local := newUnloadTestServer(t)
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, unloadRequest(`{"model":" alias "}`))
 
 		if w.Code != http.StatusOK {
 			t.Fatalf("status = %d, want 200 body=%q", w.Code, w.Body.String())


### PR DESCRIPTION
Add the llama.cpp-compatible named unload endpoint so Open WebUI can unload configured models and aliases without using the management API.

- validate named unload requests
- resolve aliases to canonical local models
- preserve management unload behavior with regression coverage