### PR TITLE
internal/config,server: add setParamsByMatch request filter

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -22,6 +22,13 @@
                     },
                     {
                         "type": "boolean"
+                    },
+                    {
+                        "type": "object",
+                        "additionalProperties": true
+                    },
+                    {
+                        "type": "array"
                     }
                 ]
             },
@@ -39,7 +46,7 @@
                 }
             },
             "default": {},
-            "description": "A dictionary of string substitutions. Global macros can be used in any configuration value; model macros are scoped to their model. Macro names must be <64 chars, match ^[a-zA-Z0-9_-]+$, and not be PID, PORT, or MODEL_ID. Values can be string, number, or boolean. Macros can reference other macros defined before them."
+            "description": "A dictionary of substitutions. Global macros can be used in any configuration value; model macros are scoped to their model. Macro names must be <64 chars, match ^[a-zA-Z0-9_-]+$, and not be PID, PORT, or MODEL_ID. Values can be a string, number, boolean, object, or array. Objects and arrays may only be substituted as a whole value (e.g. filters.setParamsByMatch: ${my_rules}); interpolating one into a string is a load-time error. Macros can reference other macros defined before them."
         },
         "timeouts": {
             "type": "object",
@@ -518,11 +525,42 @@
                                 },
                                 "default": {},
                                 "description": "Dictionary mapping requested model IDs (or aliases) to parameters to set/override in requests. Applied after setParams and can override those values. Useful with aliases to vary behaviour depending on which alias the client used (e.g. different reasoning_effort per alias). Keys support ${MODEL_ID} macro substitution. Protected params like 'model' cannot be overridden."
+                            },
+                            "setParamsByMatch": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "key": {
+                                            "type": "string",
+                                            "pattern": "^[A-Za-z0-9_-]+$",
+                                            "description": "Top-level request field to inspect (e.g. reasoning_effort). Must not be 'model' and may only contain letters, digits, underscores, and hyphens."
+                                        },
+                                        "match": {
+                                            "type": "string",
+                                            "description": "Value the key must equal for the rule to apply. Non-string JSON values are compared by their string form, so booleans and numbers must be quoted."
+                                        },
+                                        "set": {
+                                            "type": "object",
+                                            "additionalProperties": true,
+                                            "minProperties": 1,
+                                            "description": "Parameters to apply when the rule matches. Object values are merged into an existing request object rather than replacing it. Protected params like 'model' cannot be overridden."
+                                        }
+                                    },
+                                    "required": [
+                                        "key",
+                                        "match",
+                                        "set"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "default": [],
+                                "description": "List of rules that set parameters when a request field equals a value. Rules are evaluated in order and every matching rule applies, so a later rule overrides an earlier one. Applied after stripParams and before setParams/setParamsByID. Because rules match on the request body instead of the model ID, clients can vary parameters between requests without causing a model swap."
                             }
                         },
                         "additionalProperties": false,
                         "default": {},
-                        "description": "Dictionary of filter settings. Supports stripParams, setParams, and setParamsByID."
+                        "description": "Dictionary of filter settings. Supports stripParams, setParams, setParamsByID, and setParamsByMatch."
                     },
                     "metadata": {
                         "type": "object",
@@ -693,11 +731,42 @@
                                 "additionalProperties": true,
                                 "default": {},
                                 "description": "Dictionary of parameters to set/override in requests to this peer. Useful for injecting provider-specific settings. Protected params like 'model' cannot be overridden. Values can be strings, numbers, booleans, arrays, or objects."
+                            },
+                            "setParamsByMatch": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "key": {
+                                            "type": "string",
+                                            "pattern": "^[A-Za-z0-9_-]+$",
+                                            "description": "Top-level request field to inspect (e.g. reasoning_effort). Must not be 'model' and may only contain letters, digits, underscores, and hyphens."
+                                        },
+                                        "match": {
+                                            "type": "string",
+                                            "description": "Value the key must equal for the rule to apply. Non-string JSON values are compared by their string form, so booleans and numbers must be quoted."
+                                        },
+                                        "set": {
+                                            "type": "object",
+                                            "additionalProperties": true,
+                                            "minProperties": 1,
+                                            "description": "Parameters to apply when the rule matches. Object values are merged into an existing request object rather than replacing it. Protected params like 'model' cannot be overridden."
+                                        }
+                                    },
+                                    "required": [
+                                        "key",
+                                        "match",
+                                        "set"
+                                    ],
+                                    "additionalProperties": false
+                                },
+                                "default": [],
+                                "description": "List of rules that set parameters when a request field equals a value. Rules are evaluated in order and every matching rule applies, so a later rule overrides an earlier one. Applied after stripParams and before setParams."
                             }
                         },
                         "additionalProperties": false,
                         "default": {},
-                        "description": "Dictionary of filter settings for peer requests. Supports stripParams and setParams."
+                        "description": "Dictionary of filter settings for peer requests. Supports stripParams, setParams, and setParamsByMatch."
                     },
                     "timeouts": {
                         "type": "object",

--- a/config-schema.json
+++ b/config-schema.json
@@ -8,6 +8,11 @@
         "models"
     ],
     "definitions": {
+        "macroReference": {
+            "type": "string",
+            "pattern": "^\\$\\{[A-Za-z0-9_-]+\\}$",
+            "description": "A whole-value macro reference (e.g. ${my_rules}) that expands to the field's native type at load time."
+        },
         "macros": {
             "type": "object",
             "additionalProperties": {
@@ -527,35 +532,42 @@
                                 "description": "Dictionary mapping requested model IDs (or aliases) to parameters to set/override in requests. Applied after setParams and can override those values. Useful with aliases to vary behaviour depending on which alias the client used (e.g. different reasoning_effort per alias). Keys support ${MODEL_ID} macro substitution. Protected params like 'model' cannot be overridden."
                             },
                             "setParamsByMatch": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "key": {
-                                            "type": "string",
-                                            "pattern": "^[A-Za-z0-9_-]+$",
-                                            "description": "Top-level request field to inspect (e.g. reasoning_effort). Must not be 'model' and may only contain letters, digits, underscores, and hyphens."
-                                        },
-                                        "match": {
-                                            "type": "string",
-                                            "description": "Value the key must equal for the rule to apply. Non-string JSON values are compared by their string form, so booleans and numbers must be quoted."
-                                        },
-                                        "set": {
+                                "oneOf": [
+                                    {
+                                        "type": "array",
+                                        "items": {
                                             "type": "object",
-                                            "additionalProperties": true,
-                                            "minProperties": 1,
-                                            "description": "Parameters to apply when the rule matches. Object values are merged into an existing request object rather than replacing it. Protected params like 'model' cannot be overridden."
+                                            "properties": {
+                                                "key": {
+                                                    "type": "string",
+                                                    "pattern": "^[A-Za-z0-9_-]+$",
+                                                    "description": "Top-level request field to inspect (e.g. reasoning_effort). Must not be 'model' and may only contain letters, digits, underscores, and hyphens."
+                                                },
+                                                "match": {
+                                                    "type": "string",
+                                                    "description": "Value the key must equal for the rule to apply. Non-string JSON values are compared by their string form, so booleans and numbers must be quoted."
+                                                },
+                                                "set": {
+                                                    "type": "object",
+                                                    "additionalProperties": true,
+                                                    "minProperties": 1,
+                                                    "description": "Parameters to apply when the rule matches. Object values are merged into an existing request object rather than replacing it. Protected params like 'model' cannot be overridden."
+                                                }
+                                            },
+                                            "required": [
+                                                "key",
+                                                "match",
+                                                "set"
+                                            ],
+                                            "additionalProperties": false
                                         }
                                     },
-                                    "required": [
-                                        "key",
-                                        "match",
-                                        "set"
-                                    ],
-                                    "additionalProperties": false
-                                },
+                                    {
+                                        "$ref": "#/definitions/macroReference"
+                                    }
+                                ],
                                 "default": [],
-                                "description": "List of rules that set parameters when a request field equals a value. Rules are evaluated in order and every matching rule applies, so a later rule overrides an earlier one. Applied after stripParams and before setParams/setParamsByID. Because rules match on the request body instead of the model ID, clients can vary parameters between requests without causing a model swap."
+                                "description": "List of rules that set parameters when a request field equals a value, or a whole-value macro reference (e.g. ${my_rules}) expanding to such a list. Rules are evaluated in order and every matching rule applies, so a later rule overrides an earlier one. Applied after stripParams and before setParams/setParamsByID. Because rules match on the request body instead of the model ID, clients can vary parameters between requests without causing a model swap."
                             }
                         },
                         "additionalProperties": false,
@@ -733,35 +745,42 @@
                                 "description": "Dictionary of parameters to set/override in requests to this peer. Useful for injecting provider-specific settings. Protected params like 'model' cannot be overridden. Values can be strings, numbers, booleans, arrays, or objects."
                             },
                             "setParamsByMatch": {
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "key": {
-                                            "type": "string",
-                                            "pattern": "^[A-Za-z0-9_-]+$",
-                                            "description": "Top-level request field to inspect (e.g. reasoning_effort). Must not be 'model' and may only contain letters, digits, underscores, and hyphens."
-                                        },
-                                        "match": {
-                                            "type": "string",
-                                            "description": "Value the key must equal for the rule to apply. Non-string JSON values are compared by their string form, so booleans and numbers must be quoted."
-                                        },
-                                        "set": {
+                                "oneOf": [
+                                    {
+                                        "type": "array",
+                                        "items": {
                                             "type": "object",
-                                            "additionalProperties": true,
-                                            "minProperties": 1,
-                                            "description": "Parameters to apply when the rule matches. Object values are merged into an existing request object rather than replacing it. Protected params like 'model' cannot be overridden."
+                                            "properties": {
+                                                "key": {
+                                                    "type": "string",
+                                                    "pattern": "^[A-Za-z0-9_-]+$",
+                                                    "description": "Top-level request field to inspect (e.g. reasoning_effort). Must not be 'model' and may only contain letters, digits, underscores, and hyphens."
+                                                },
+                                                "match": {
+                                                    "type": "string",
+                                                    "description": "Value the key must equal for the rule to apply. Non-string JSON values are compared by their string form, so booleans and numbers must be quoted."
+                                                },
+                                                "set": {
+                                                    "type": "object",
+                                                    "additionalProperties": true,
+                                                    "minProperties": 1,
+                                                    "description": "Parameters to apply when the rule matches. Object values are merged into an existing request object rather than replacing it. Protected params like 'model' cannot be overridden."
+                                                }
+                                            },
+                                            "required": [
+                                                "key",
+                                                "match",
+                                                "set"
+                                            ],
+                                            "additionalProperties": false
                                         }
                                     },
-                                    "required": [
-                                        "key",
-                                        "match",
-                                        "set"
-                                    ],
-                                    "additionalProperties": false
-                                },
+                                    {
+                                        "$ref": "#/definitions/macroReference"
+                                    }
+                                ],
                                 "default": [],
-                                "description": "List of rules that set parameters when a request field equals a value. Rules are evaluated in order and every matching rule applies, so a later rule overrides an earlier one. Applied after stripParams and before setParams."
+                                "description": "List of rules that set parameters when a request field equals a value, or a whole-value macro reference (e.g. ${my_rules}) expanding to such a list. Rules are evaluated in order and every matching rule applies, so a later rule overrides an earlier one. Applied after stripParams and before setParams."
                             }
                         },
                         "additionalProperties": false,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -125,7 +125,10 @@ unloadTimeout: 10
 # - macro names are strings and must be less than 64 characters
 # - macro names must match the regex ^[a-zA-Z0-9_-]+$
 # - macro names must not be a reserved name: PID, PORT, or MODEL_ID
-# - macro values can be numbers, bools, or strings
+# - macro values can be numbers, bools, strings, maps, or lists
+# - map and list macros can only be substituted as a whole value, for example
+#   `setParamsByMatch: ${reasoning_rules}`. Interpolating one into a string is
+#   a load-time error. Use them to share structured settings between models.
 # - macros can contain other macros, but they must be defined before they are used
 # - environment variables can be referenced with ${env.VAR_NAME} syntax
 #   - env macros are substituted first, before regular macros
@@ -142,6 +145,21 @@ macros:
   # Example of macro-in-macro usage. macros can contain other macros
   # but they must be previously declared.
   "default_args": "--ctx-size ${default_ctx}"
+
+  # Example of a list-valued macro. Structured macros let several models share
+  # one definition, and are used as a whole value: setParamsByMatch: ${reasoning_rules}
+  "reasoning_rules":
+    - key: reasoning_effort
+      match: none
+      set:
+        chat_template_kwargs:
+          enable_thinking: false
+    - key: reasoning_effort
+      match: high
+      set:
+        chat_template_kwargs:
+          enable_thinking: true
+        thinking_budget_tokens: 8192
 
   # Example of environment variable macros
   # - ${env.VAR_NAME} pulls the value from the system environment
@@ -310,7 +328,7 @@ models:
 
     # filters: a dictionary of filter settings
     # - optional, default: empty dictionary
-    # - same capabilities as peer filters (stripParams, setParams)
+    # - same capabilities as peer filters (stripParams, setParams, setParamsByMatch)
     filters:
       # stripParams: a comma separated list of parameters to remove from the request
       # - optional, default: ""
@@ -349,6 +367,33 @@ models:
         "${MODEL_ID}:low":
           chat_template_kwargs:
             reasoning_effort: low
+
+      # setParamsByMatch: a list of rules that set parameters when a request
+      # field equals a value
+      # - optional, default: empty list
+      # - matches on the request body, not the model ID, so clients that send a
+      #   fixed `model` and vary a separate field (e.g. Open WebUI or OpenCode
+      #   sending reasoning_effort) get variant behaviour with no model swap
+      # - `key` is a top-level request field, letters/digits/underscore/hyphen
+      #   only; the `model` key cannot be matched on
+      # - `match` is compared against the field's string form, so JSON booleans
+      #   and numbers must be quoted (e.g. match: "true")
+      # - rules run in order and every match applies, so a later rule wins
+      # - object values are merged into an existing request object instead of
+      #   replacing it, so other keys the client sent are preserved
+      # - runs after stripParams and before setParams/setParamsByID
+      setParamsByMatch:
+        - key: reasoning_effort
+          match: none
+          set:
+            chat_template_kwargs:
+              enable_thinking: false
+        - key: reasoning_effort
+          match: high
+          set:
+            chat_template_kwargs:
+              enable_thinking: true
+            thinking_budget_tokens: 8192
 
     # aliases: alternative model names that this model configuration is used for
     # - optional, default: empty array
@@ -708,7 +753,7 @@ peers:
 
     # filters: a dictionary of filter settings for peer requests
     # - optional, default: empty dictionary
-    # - same capabilities as model filters (stripParams, setParams)
+    # - same capabilities as model filters (stripParams, setParams, setParamsByMatch)
     filters:
       # stripParams: a comma separated list of parameters to remove from the request
       # - optional, default: ""
@@ -726,3 +771,14 @@ peers:
         provider:
           data_collection: "deny"
           zdr: true
+
+      # setParamsByMatch: a list of rules that set parameters when a request
+      # field equals a value
+      # - optional, default: empty list
+      # - same behaviour as model filters, see the models section above
+      setParamsByMatch:
+        - key: reasoning_effort
+          match: none
+          set:
+            reasoning:
+              enabled: false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -216,7 +216,10 @@ unloadTimeout: 10
 # - macro names are strings and must be less than 64 characters
 # - macro names must match the regex ^[a-zA-Z0-9_-]+$
 # - macro names must not be a reserved name: PID, PORT, or MODEL_ID
-# - macro values can be numbers, bools, or strings
+# - macro values can be numbers, bools, strings, maps, or lists
+# - map and list macros can only be substituted as a whole value, for example
+#   `setParamsByMatch: ${reasoning_rules}`. Interpolating one into a string is
+#   a load-time error. Use them to share structured settings between models.
 # - macros can contain other macros, but they must be defined before they are used
 # - environment variables can be referenced with ${env.VAR_NAME} syntax
 #   - env macros are substituted first, before regular macros
@@ -233,6 +236,21 @@ macros:
   # Example of macro-in-macro usage. macros can contain other macros
   # but they must be previously declared.
   "default_args": "--ctx-size ${default_ctx}"
+
+  # Example of a list-valued macro. Structured macros let several models share
+  # one definition, and are used as a whole value: setParamsByMatch: ${reasoning_rules}
+  "reasoning_rules":
+    - key: reasoning_effort
+      match: none
+      set:
+        chat_template_kwargs:
+          enable_thinking: false
+    - key: reasoning_effort
+      match: high
+      set:
+        chat_template_kwargs:
+          enable_thinking: true
+        thinking_budget_tokens: 8192
 
   # Example of environment variable macros
   # - ${env.VAR_NAME} pulls the value from the system environment
@@ -388,7 +406,7 @@ models:
 
     # filters: a dictionary of filter settings
     # - optional, default: empty dictionary
-    # - same capabilities as peer filters (stripParams, setParams)
+    # - same capabilities as peer filters (stripParams, setParams, setParamsByMatch)
     filters:
       # stripParams: a comma separated list of parameters to remove from the request
       # - optional, default: ""
@@ -427,6 +445,33 @@ models:
         "${MODEL_ID}:low":
           chat_template_kwargs:
             reasoning_effort: low
+
+      # setParamsByMatch: a list of rules that set parameters when a request
+      # field equals a value
+      # - optional, default: empty list
+      # - matches on the request body, not the model ID, so clients that send a
+      #   fixed `model` and vary a separate field (e.g. Open WebUI or OpenCode
+      #   sending reasoning_effort) get variant behaviour with no model swap
+      # - `key` is a top-level request field, letters/digits/underscore/hyphen
+      #   only; the `model` key cannot be matched on
+      # - `match` is compared against the field's string form, so JSON booleans
+      #   and numbers must be quoted (e.g. match: "true")
+      # - rules run in order and every match applies, so a later rule wins
+      # - object values are merged into an existing request object instead of
+      #   replacing it, so other keys the client sent are preserved
+      # - runs after stripParams and before setParams/setParamsByID
+      setParamsByMatch:
+        - key: reasoning_effort
+          match: none
+          set:
+            chat_template_kwargs:
+              enable_thinking: false
+        - key: reasoning_effort
+          match: high
+          set:
+            chat_template_kwargs:
+              enable_thinking: true
+            thinking_budget_tokens: 8192
 
     # aliases: alternative model names that this model configuration is used for
     # - optional, default: empty array
@@ -661,7 +706,7 @@ peers:
 
     # filters: a dictionary of filter settings for peer requests
     # - optional, default: empty dictionary
-    # - same capabilities as model filters (stripParams, setParams)
+    # - same capabilities as model filters (stripParams, setParams, setParamsByMatch)
     filters:
       # stripParams: a comma separated list of parameters to remove from the request
       # - optional, default: ""

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -709,6 +709,8 @@ models:
 }
 
 func TestConfig_InvalidMacroType(t *testing.T) {
+	// Maps and lists are valid macro values, but only as a whole value. Using
+	// one inside a string is what makes the type invalid for that position.
 	content := `
 startPort: 10000
 macros:
@@ -717,13 +719,13 @@ macros:
 
 models:
   test-model:
-    cmd: /path/to/server -p ${PORT}
+    cmd: /path/to/server -p ${PORT} ${INVALID}
 `
 
 	_, err := LoadConfigFromReader(strings.NewReader(content))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "INVALID")
-	assert.Contains(t, err.Error(), "must be a scalar type")
+	assert.Contains(t, err.Error(), "can only be used as a whole value")
 }
 
 func TestConfig_MacroTypeValidation(t *testing.T) {
@@ -781,7 +783,7 @@ models:
 			shouldErr: false,
 		},
 		{
-			name: "array macro (invalid)",
+			name: "array macro (valid as a whole value)",
 			yaml: `
 startPort: 10000
 macros:
@@ -790,10 +792,10 @@ models:
   test-model:
     cmd: /path/to/server -p ${PORT}
 `,
-			shouldErr: true,
+			shouldErr: false,
 		},
 		{
-			name: "map macro (invalid)",
+			name: "map macro (valid as a whole value)",
 			yaml: `
 startPort: 10000
 macros:
@@ -802,6 +804,18 @@ macros:
 models:
   test-model:
     cmd: /path/to/server -p ${PORT}
+`,
+			shouldErr: false,
+		},
+		{
+			name: "array macro interpolated into a string (invalid)",
+			yaml: `
+startPort: 10000
+macros:
+  ARR: [1, 2, 3]
+models:
+  test-model:
+    cmd: /path/to/server -p ${PORT} ${ARR}
 `,
 			shouldErr: true,
 		},
@@ -1856,4 +1870,219 @@ routing:
 	cfg, err := LoadConfigFromReader(strings.NewReader(yaml))
 	require.NoError(t, err)
 	assert.Equal(t, 5, cfg.Routing.Scheduler.Settings.Fifo.Priority["gemma"])
+}
+
+func TestConfig_SetParamsByMatchValidation(t *testing.T) {
+	t.Run("valid rules load", func(t *testing.T) {
+		cfg, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  m1:
+    cmd: server --port ${PORT}
+    filters:
+      setParamsByMatch:
+        - key: reasoning_effort
+          match: none
+          set:
+            chat_template_kwargs:
+              enable_thinking: false
+        - key: reasoning_effort
+          match: high
+          set:
+            chat_template_kwargs:
+              enable_thinking: true
+            thinking_budget_tokens: 8192
+`))
+		require.NoError(t, err)
+		rules := cfg.Models["m1"].Filters.SetParamsByMatch
+		require.Len(t, rules, 2)
+		assert.Equal(t, "reasoning_effort", rules[0].Key)
+		assert.Equal(t, "none", rules[0].Match)
+		assert.Equal(t, 8192, rules[1].Set["thinking_budget_tokens"])
+	})
+
+	t.Run("protected key rejected", func(t *testing.T) {
+		_, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  m1:
+    cmd: server --port ${PORT}
+    filters:
+      setParamsByMatch:
+        - key: model
+          match: x
+          set:
+            top_p: 0.9
+`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "model m1 filters.setParamsByMatch[0]")
+		assert.Contains(t, err.Error(), "protected parameter")
+	})
+
+	t.Run("empty set rejected", func(t *testing.T) {
+		_, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  m1:
+    cmd: server --port ${PORT}
+    filters:
+      setParamsByMatch:
+        - key: reasoning_effort
+          match: high
+`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "set must not be empty")
+	})
+
+	t.Run("dotted key rejected", func(t *testing.T) {
+		_, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  m1:
+    cmd: server --port ${PORT}
+    filters:
+      setParamsByMatch:
+        - key: a.b
+          match: x
+          set:
+            top_p: 0.9
+`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must contain only letters")
+	})
+
+	t.Run("peer rules validated", func(t *testing.T) {
+		_, err := LoadConfigFromReader(strings.NewReader(`
+peers:
+  p1:
+    proxy: http://localhost:9999
+    models: [remote-model]
+    filters:
+      setParamsByMatch:
+        - key: model
+          match: x
+          set:
+            top_p: 0.9
+`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "peers.p1.filters.setParamsByMatch[0]")
+	})
+
+	t.Run("macros expand inside set values", func(t *testing.T) {
+		cfg, err := LoadConfigFromReader(strings.NewReader(`
+macros:
+  budget: 4096
+models:
+  m1:
+    cmd: server --port ${PORT}
+    filters:
+      setParamsByMatch:
+        - key: reasoning_effort
+          match: high
+          set:
+            thinking_budget_tokens: ${budget}
+`))
+		require.NoError(t, err)
+		rules := cfg.Models["m1"].Filters.SetParamsByMatch
+		require.Len(t, rules, 1)
+		assert.Equal(t, 4096, rules[0].Set["thinking_budget_tokens"])
+	})
+}
+
+func TestConfig_StructuredMacros(t *testing.T) {
+	t.Run("list macro shared by multiple models", func(t *testing.T) {
+		cfg, err := LoadConfigFromReader(strings.NewReader(`
+macros:
+  reasoning_rules:
+    - key: reasoning_effort
+      match: none
+      set:
+        chat_template_kwargs:
+          enable_thinking: false
+    - key: reasoning_effort
+      match: high
+      set:
+        chat_template_kwargs:
+          enable_thinking: true
+        thinking_budget_tokens: 8192
+models:
+  m1:
+    cmd: server --port ${PORT}
+    filters:
+      setParamsByMatch: ${reasoning_rules}
+  m2:
+    cmd: server --port ${PORT}
+    filters:
+      setParamsByMatch: ${reasoning_rules}
+`))
+		require.NoError(t, err)
+		require.Len(t, cfg.Models["m1"].Filters.SetParamsByMatch, 2)
+		require.Len(t, cfg.Models["m2"].Filters.SetParamsByMatch, 2)
+		assert.Equal(t, "none", cfg.Models["m1"].Filters.SetParamsByMatch[0].Match)
+		assert.Equal(t, 8192, cfg.Models["m2"].Filters.SetParamsByMatch[1].Set["thinking_budget_tokens"])
+	})
+
+	t.Run("map macro used as a whole value", func(t *testing.T) {
+		cfg, err := LoadConfigFromReader(strings.NewReader(`
+macros:
+  shared_params:
+    temperature: 0.7
+    top_p: 0.9
+models:
+  m1:
+    cmd: server --port ${PORT}
+    filters:
+      setParams: ${shared_params}
+`))
+		require.NoError(t, err)
+		assert.Equal(t, 0.7, cfg.Models["m1"].Filters.SetParams["temperature"])
+	})
+
+	t.Run("non-scalar macro cannot be interpolated into a string", func(t *testing.T) {
+		_, err := LoadConfigFromReader(strings.NewReader(`
+macros:
+  reasoning_rules:
+    - key: reasoning_effort
+      match: none
+      set:
+        top_p: 0.9
+models:
+  m1:
+    cmd: server --port ${PORT} ${reasoning_rules}
+`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "can only be used as a whole value")
+	})
+
+	t.Run("self-reference in a list macro rejected", func(t *testing.T) {
+		_, err := LoadConfigFromReader(strings.NewReader(`
+macros:
+  loop:
+    - key: k
+      match: "${loop}"
+      set:
+        top_p: 0.9
+models:
+  m1:
+    cmd: server --port ${PORT}
+`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "self-reference")
+	})
+
+	t.Run("scalar macros still interpolate", func(t *testing.T) {
+		cfg, err := LoadConfigFromReader(strings.NewReader(`
+macros:
+  budget: 4096
+  flags: "--foo --bar"
+models:
+  m1:
+    cmd: server --port ${PORT} ${flags}
+    filters:
+      setParamsByMatch:
+        - key: reasoning_effort
+          match: high
+          set:
+            thinking_budget_tokens: ${budget}
+`))
+		require.NoError(t, err)
+		assert.Contains(t, cfg.Models["m1"].Cmd, "--foo --bar")
+		assert.Equal(t, 4096, cfg.Models["m1"].Filters.SetParamsByMatch[0].Set["thinking_budget_tokens"])
+	})
 }

--- a/internal/config/filters.go
+++ b/internal/config/filters.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+	"regexp"
 	"slices"
 	"sort"
 	"strings"
@@ -26,6 +28,80 @@ type Filters struct {
 	// which alias the client used. Applied after SetParams, so it can override those values.
 	// Protected params (like "model") cannot be set.
 	SetParamsByID map[string]map[string]any `yaml:"setParamsByID"`
+
+	// SetParamsByMatch applies parameters when a request field equals a value.
+	// Rules are evaluated in order and every matching rule applies, so a later
+	// rule overrides an earlier one. Applied after StripParams and before
+	// SetParams/SetParamsByID, which keep the final say.
+	SetParamsByMatch []MatchRule `yaml:"setParamsByMatch"`
+}
+
+// MatchRule sets request parameters when a request field equals a specific
+// value. Unlike SetParamsByID, which keys off the requested model ID, a rule
+// matches on the contents of the request body. Clients can therefore vary
+// parameters between requests without changing the model they ask for, so no
+// model swap is triggered and the loaded process is reused.
+type MatchRule struct {
+	// Key is the top-level request field to inspect (e.g. "reasoning_effort").
+	Key string `yaml:"key"`
+
+	// Match is the value Key must equal for the rule to apply. Non-string JSON
+	// values are compared by their string form, so YAML booleans and numbers
+	// must be quoted to match them.
+	Match string `yaml:"match"`
+
+	// Set holds the parameters applied when the rule matches. A value that is
+	// a map is merged into an existing request object rather than replacing it.
+	// Protected params (like "model") cannot be set.
+	Set map[string]any `yaml:"set"`
+}
+
+// matchRuleKeyRegex restricts a rule key to characters gjson treats literally,
+// so a lookup always targets the same top-level field.
+var matchRuleKeyRegex = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// Validate checks a single match rule at config load time.
+func (r MatchRule) Validate() error {
+	if r.Key == "" {
+		return fmt.Errorf("key must not be empty")
+	}
+	if slices.Contains(ProtectedParams, r.Key) {
+		return fmt.Errorf("key '%s' is a protected parameter", r.Key)
+	}
+	if !matchRuleKeyRegex.MatchString(r.Key) {
+		return fmt.Errorf("key '%s' must contain only letters, digits, underscores, or hyphens", r.Key)
+	}
+	if len(r.Set) == 0 {
+		return fmt.Errorf("set must not be empty")
+	}
+	return nil
+}
+
+// SanitizedSet returns the rule's params with protected params removed and keys
+// sorted for consistent iteration order. Mirrors SanitizedSetParams.
+func (r MatchRule) SanitizedSet() (map[string]any, []string) {
+	if len(r.Set) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[string]any, len(r.Set))
+	keys := make([]string, 0, len(r.Set))
+
+	for key, value := range r.Set {
+		if slices.Contains(ProtectedParams, key) {
+			continue
+		}
+		result[key] = value
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	if len(result) == 0 {
+		return nil, nil
+	}
+
+	return result, keys
 }
 
 // SanitizedStripParams returns a sorted list of parameters to strip,

--- a/internal/config/filters_test.go
+++ b/internal/config/filters_test.go
@@ -283,3 +283,80 @@ func TestProtectedParams(t *testing.T) {
 	// Verify that "model" is protected
 	assert.Contains(t, ProtectedParams, "model")
 }
+
+func TestFilters_MatchRuleValidate(t *testing.T) {
+	validSet := map[string]any{"top_p": 0.9}
+
+	tests := []struct {
+		name    string
+		rule    MatchRule
+		wantErr string
+	}{
+		{
+			name: "valid rule",
+			rule: MatchRule{Key: "reasoning_effort", Match: "high", Set: validSet},
+		},
+		{
+			name:    "empty key",
+			rule:    MatchRule{Match: "high", Set: validSet},
+			wantErr: "key must not be empty",
+		},
+		{
+			name:    "protected key",
+			rule:    MatchRule{Key: "model", Match: "x", Set: validSet},
+			wantErr: "is a protected parameter",
+		},
+		{
+			name:    "dotted key",
+			rule:    MatchRule{Key: "a.b", Match: "x", Set: validSet},
+			wantErr: "must contain only letters",
+		},
+		{
+			name:    "wildcard key",
+			rule:    MatchRule{Key: "a*", Match: "x", Set: validSet},
+			wantErr: "must contain only letters",
+		},
+		{
+			name:    "empty set",
+			rule:    MatchRule{Key: "reasoning_effort", Match: "high"},
+			wantErr: "set must not be empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.rule.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestFilters_MatchRuleSanitizedSet(t *testing.T) {
+	t.Run("empty set", func(t *testing.T) {
+		params, keys := MatchRule{Key: "k", Match: "v"}.SanitizedSet()
+		assert.Nil(t, params)
+		assert.Nil(t, keys)
+	})
+
+	t.Run("keys sorted and protected removed", func(t *testing.T) {
+		rule := MatchRule{Key: "k", Match: "v", Set: map[string]any{
+			"top_p": 0.9,
+			"model": "hijacked",
+			"temp":  0.1,
+		}}
+		params, keys := rule.SanitizedSet()
+		assert.Equal(t, []string{"temp", "top_p"}, keys)
+		assert.Equal(t, map[string]any{"temp": 0.1, "top_p": 0.9}, params)
+	})
+
+	t.Run("only protected params", func(t *testing.T) {
+		rule := MatchRule{Key: "k", Match: "v", Set: map[string]any{"model": "x"}}
+		params, keys := rule.SanitizedSet()
+		assert.Nil(t, params)
+		assert.Nil(t, keys)
+	})
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -291,6 +291,10 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		return Config{}, err
 	}
 
+	if err := validateSetParamsByMatch(config); err != nil {
+		return Config{}, err
+	}
+
 	if err := validateSelectors(config); err != nil {
 		return Config{}, err
 	}
@@ -300,6 +304,27 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 	}
 
 	return config, nil
+}
+
+// validateSetParamsByMatch checks every setParamsByMatch rule on models and
+// peers. Macros inside rule values are already expanded and validated before
+// the typed decode, so only the rule shape is checked here.
+func validateSetParamsByMatch(config Config) error {
+	for modelID, modelConfig := range config.Models {
+		for i, rule := range modelConfig.Filters.SetParamsByMatch {
+			if err := rule.Validate(); err != nil {
+				return fmt.Errorf("model %s filters.setParamsByMatch[%d]: %w", modelID, i, err)
+			}
+		}
+	}
+	for peerID, peerConfig := range config.Peers {
+		for i, rule := range peerConfig.Filters.SetParamsByMatch {
+			if err := rule.Validate(); err != nil {
+				return fmt.Errorf("peers.%s.filters.setParamsByMatch[%d]: %w", peerID, i, err)
+			}
+		}
+	}
+	return nil
 }
 
 func validateProfiles(config Config) error {

--- a/internal/config/macros.go
+++ b/internal/config/macros.go
@@ -26,6 +26,18 @@ type configMacroConfig struct {
 	Models map[string]modelMacroConfig `yaml:"models"`
 }
 
+// isScalarMacroValue reports whether a macro value is a scalar that can be
+// interpolated into a string. Maps and lists may only be substituted as a whole
+// value (e.g. filters.setParamsByMatch: ${my_rules}).
+func isScalarMacroValue(value any) bool {
+	switch value.(type) {
+	case string, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, bool:
+		return true
+	default:
+		return false
+	}
+}
+
 // validateMacro validates macro name and value constraints
 func validateMacro(name string, value any) error {
 	if len(name) >= 64 {
@@ -35,18 +47,24 @@ func validateMacro(name string, value any) error {
 		return fmt.Errorf("macro name '%s' contains invalid characters, must match pattern ^[a-zA-Z0-9_-]+$", name)
 	}
 
-	// Validate that value is a scalar type
+	// Scalars can be interpolated anywhere; maps and lists are only valid as a
+	// whole value, which lets structured settings be shared between models.
+	macroSlug := fmt.Sprintf("${%s}", name)
 	switch v := value.(type) {
 	case string:
 		// Check for self-reference
-		macroSlug := fmt.Sprintf("${%s}", name)
 		if strings.Contains(v, macroSlug) {
 			return fmt.Errorf("macro '%s' contains self-reference", name)
 		}
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, bool:
 		// These types are allowed
+	case map[string]any, []any:
+		// Scan nested values for a self-reference via the YAML rendering
+		if rendered, err := yaml.Marshal(v); err == nil && strings.Contains(string(rendered), macroSlug) {
+			return fmt.Errorf("macro '%s' contains self-reference", name)
+		}
 	default:
-		return fmt.Errorf("macro '%s' has invalid type %T, must be a scalar type (string, int, float, or bool)", name, value)
+		return fmt.Errorf("macro '%s' has invalid type %T, must be a scalar type (string, int, float, or bool), a map, or a list", name, value)
 	}
 
 	switch name {
@@ -136,7 +154,11 @@ func resolveConfigMacros(yamlStr string) (map[string]any, configMacroConfig, err
 		if key == "models" {
 			continue
 		}
-		raw[key] = substituteMacroList(value, declarations.Macros)
+		resolved, err := substituteMacroList(value, declarations.Macros)
+		if err != nil {
+			return nil, configMacroConfig{}, err
+		}
+		raw[key] = resolved
 	}
 
 	// startPort may itself contain a global macro, so read it only after the
@@ -165,7 +187,10 @@ func resolveConfigMacros(yamlStr string) (map[string]any, configMacroConfig, err
 		// covers every model value; setParamsByID keys are handled separately
 		// because ordinary mapping keys are intentionally not macro targets.
 		macros := mergeModelMacros(modelID, declarations.Macros, declarations.Models[modelID].Macros)
-		resolved := substituteMacroList(model, macros)
+		resolved, err := substituteMacroList(model, macros)
+		if err != nil {
+			return nil, configMacroConfig{}, fmt.Errorf("model %s: %w", modelID, err)
+		}
 		model = resolved.(map[string]any)
 		if err := substituteSetParamsByIDKeys(model, macros); err != nil {
 			return nil, configMacroConfig{}, fmt.Errorf("model %s filters.setParamsByID: %w", modelID, err)
@@ -184,7 +209,10 @@ func resolveConfigMacros(yamlStr string) (map[string]any, configMacroConfig, err
 			}
 
 			portMacro := MacroList{{Name: "PORT", Value: nextPort}}
-			resolved = substituteMacroList(model, portMacro)
+			resolved, err = substituteMacroList(model, portMacro)
+			if err != nil {
+				return nil, configMacroConfig{}, fmt.Errorf("model %s: %w", modelID, err)
+			}
 			model = resolved.(map[string]any)
 			if err := substituteSetParamsByIDKeys(model, portMacro); err != nil {
 				return nil, configMacroConfig{}, fmt.Errorf("model %s filters.setParamsByID: %w", modelID, err)
@@ -254,11 +282,15 @@ func mergeModelMacros(modelID string, global, model MacroList) MacroList {
 	return merged
 }
 
-func substituteMacroList(resolved any, macros MacroList) any {
+func substituteMacroList(resolved any, macros MacroList) (any, error) {
 	for i := len(macros) - 1; i >= 0; i-- {
-		resolved = substituteMacroInValue(resolved, macros[i].Name, macros[i].Value)
+		var err error
+		resolved, err = substituteMacroInValue(resolved, macros[i].Name, macros[i].Value)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return resolved
+	return resolved, nil
 }
 
 func substituteSetParamsByIDKeys(model map[string]any, macros MacroList) error {
@@ -411,41 +443,51 @@ func validateMacroUses(value any, path, modelID, fieldPath string, allowPID bool
 }
 
 // substituteMacroInValue recursively substitutes a single macro in a value structure
-func substituteMacroInValue(value any, macroName string, macroValue any) any {
+func substituteMacroInValue(value any, macroName string, macroValue any) (any, error) {
 	macroSlug := fmt.Sprintf("${%s}", macroName)
-	macroStr := fmt.Sprintf("%v", macroValue)
 
 	switch v := value.(type) {
 	case string:
 		// Check if this is a direct macro substitution
 		if v == macroSlug {
-			return macroValue
+			return macroValue, nil
 		}
 		// Handle string interpolation
 		if strings.Contains(v, macroSlug) {
-			return strings.ReplaceAll(v, macroSlug, macroStr)
+			if !isScalarMacroValue(macroValue) {
+				return nil, fmt.Errorf("macro '%s' has a non-scalar value and can only be used as a whole value, not interpolated into a string", macroName)
+			}
+			return strings.ReplaceAll(v, macroSlug, fmt.Sprintf("%v", macroValue)), nil
 		}
-		return v
+		return v, nil
 
 	case map[string]any:
 		// Recursively process map values
 		newMap := make(map[string]any)
 		for key, val := range v {
-			newMap[key] = substituteMacroInValue(val, macroName, macroValue)
+			newVal, err := substituteMacroInValue(val, macroName, macroValue)
+			if err != nil {
+				return nil, err
+			}
+			newMap[key] = newVal
 		}
-		return newMap
+		return newMap, nil
 
 	case []any:
 		// Recursively process slice elements
 		newSlice := make([]any, len(v))
 		for i, val := range v {
-			newSlice[i] = substituteMacroInValue(val, macroName, macroValue)
+			newVal, err := substituteMacroInValue(val, macroName, macroValue)
+			if err != nil {
+				return nil, err
+			}
+			newSlice[i] = newVal
 		}
-		return newSlice
+		return newSlice, nil
 
 	default:
 		// Return scalar types as-is
-		return value
+		return value, nil
 	}
 }
 

--- a/internal/server/filters.go
+++ b/internal/server/filters.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/mostlygeek/llama-swap/internal/chain"
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/shared"
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
@@ -19,6 +21,7 @@ import (
 //
 //   - UseModelName rewrite (issue #69)
 //   - StripParams removal (issue #174)
+//   - SetParamsByMatch request-field matching (issue #958)
 //   - SetParams injection (issue #453)
 //   - SetParamsByID per-alias overrides
 //
@@ -124,8 +127,8 @@ func resolveFilters(cfg config.Config, requested string) (useModelName string, f
 }
 
 // applyFilters rewrites the JSON body in place. Order matches the legacy
-// ProxyManager: useModelName, stripParams, setParams, then setParamsByID (which
-// can override setParams).
+// ProxyManager: useModelName, stripParams, setParamsByMatch, setParams, then
+// setParamsByID (which can override setParams).
 func applyFilters(body []byte, requested, useModelName string, f config.Filters) ([]byte, error) {
 	var err error
 
@@ -139,6 +142,10 @@ func applyFilters(body []byte, requested, useModelName string, f config.Filters)
 		if body, err = sjson.DeleteBytes(body, param); err != nil {
 			return nil, fmt.Errorf("error stripping parameter %s from request", param)
 		}
+	}
+
+	if body, err = applySetParamsByMatch(body, f); err != nil {
+		return nil, err
 	}
 
 	setParams, setKeys := f.SanitizedSetParams()
@@ -156,4 +163,74 @@ func applyFilters(body []byte, requested, useModelName string, f config.Filters)
 	}
 
 	return body, nil
+}
+
+// applySetParamsByMatch applies every rule whose key matches its configured
+// value. Rules run in configuration order, so a later rule overrides an earlier
+// one. Requests that do not carry the key, or carry a different value, are left
+// untouched. Because rules match on the request body and never on the model ID,
+// a client can change these params between requests without triggering a swap.
+func applySetParamsByMatch(body []byte, f config.Filters) ([]byte, error) {
+	var err error
+
+	for _, rule := range f.SetParamsByMatch {
+		value := gjson.GetBytes(body, rule.Key)
+		if !value.Exists() || value.String() != rule.Match {
+			continue
+		}
+
+		set, keys := rule.SanitizedSet()
+		for _, key := range keys {
+			if body, err = setMergedParam(body, key, set[key]); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return body, nil
+}
+
+// setMergedParam writes val at key. When the configured value and the value
+// already in the request are both objects, sub-keys are written individually so
+// keys the client sent survive (e.g. setting chat_template_kwargs.enable_thinking
+// keeps any other chat_template_kwargs the client provided). Anything else is a
+// plain overwrite.
+func setMergedParam(body []byte, key string, val any) ([]byte, error) {
+	sub, isMap := val.(map[string]any)
+	if !isMap || !gjson.GetBytes(body, key).IsObject() {
+		body, err := sjson.SetBytes(body, key, val)
+		if err != nil {
+			return nil, fmt.Errorf("error setting parameter %s in request", key)
+		}
+		return body, nil
+	}
+
+	subKeys := make([]string, 0, len(sub))
+	for subKey := range sub {
+		subKeys = append(subKeys, subKey)
+	}
+	sort.Strings(subKeys)
+
+	var err error
+	for _, subKey := range subKeys {
+		path := key + "." + escapePathSegment(subKey)
+		if body, err = sjson.SetBytes(body, path, sub[subKey]); err != nil {
+			return nil, fmt.Errorf("error setting parameter %s in request", path)
+		}
+	}
+	return body, nil
+}
+
+// escapePathSegment escapes the characters gjson/sjson treat as path syntax so
+// a sub-key is matched literally when joined into a composite path.
+func escapePathSegment(segment string) string {
+	var b strings.Builder
+	for _, r := range segment {
+		switch r {
+		case '.', '*', '?', '\\':
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }

--- a/internal/server/filters_test.go
+++ b/internal/server/filters_test.go
@@ -56,6 +56,197 @@ func TestServer_ApplyFilters(t *testing.T) {
 	})
 }
 
+func TestServer_ApplySetParamsByMatch(t *testing.T) {
+	// reasoningRules mirrors the documented reasoning-effort use case.
+	reasoningRules := []config.MatchRule{
+		{
+			Key:   "reasoning_effort",
+			Match: "none",
+			Set:   map[string]any{"chat_template_kwargs": map[string]any{"enable_thinking": false}},
+		},
+		{
+			Key:   "reasoning_effort",
+			Match: "high",
+			Set: map[string]any{
+				"chat_template_kwargs":   map[string]any{"enable_thinking": true},
+				"thinking_budget_tokens": 8192,
+			},
+		},
+	}
+
+	t.Run("no rules leaves body untouched", func(t *testing.T) {
+		in := []byte(`{"model":"m","reasoning_effort":"high"}`)
+		out, err := applySetParamsByMatch(in, config.Filters{})
+		if err != nil {
+			t.Fatalf("applySetParamsByMatch: %v", err)
+		}
+		if !bytes.Equal(in, out) {
+			t.Errorf("body = %s, want unchanged", out)
+		}
+	})
+
+	t.Run("key absent leaves body untouched", func(t *testing.T) {
+		f := config.Filters{SetParamsByMatch: reasoningRules}
+		out, err := applySetParamsByMatch([]byte(`{"model":"m"}`), f)
+		if err != nil {
+			t.Fatalf("applySetParamsByMatch: %v", err)
+		}
+		if gjson.GetBytes(out, "chat_template_kwargs").Exists() {
+			t.Errorf("chat_template_kwargs should not be injected, got %s", out)
+		}
+	})
+
+	t.Run("key present but no rule matches", func(t *testing.T) {
+		f := config.Filters{SetParamsByMatch: reasoningRules}
+		out, err := applySetParamsByMatch([]byte(`{"model":"m","reasoning_effort":"medium"}`), f)
+		if err != nil {
+			t.Fatalf("applySetParamsByMatch: %v", err)
+		}
+		if gjson.GetBytes(out, "chat_template_kwargs").Exists() {
+			t.Errorf("chat_template_kwargs should not be injected, got %s", out)
+		}
+	})
+
+	t.Run("match applies every key in set", func(t *testing.T) {
+		f := config.Filters{SetParamsByMatch: reasoningRules}
+		out, err := applySetParamsByMatch([]byte(`{"model":"m","reasoning_effort":"high"}`), f)
+		if err != nil {
+			t.Fatalf("applySetParamsByMatch: %v", err)
+		}
+		if got := gjson.GetBytes(out, "chat_template_kwargs.enable_thinking").Bool(); !got {
+			t.Errorf("enable_thinking = %v, want true", got)
+		}
+		if got := gjson.GetBytes(out, "thinking_budget_tokens").Int(); got != 8192 {
+			t.Errorf("thinking_budget_tokens = %d, want 8192", got)
+		}
+	})
+
+	t.Run("merge preserves client-sent sibling kwargs", func(t *testing.T) {
+		f := config.Filters{SetParamsByMatch: reasoningRules}
+		in := []byte(`{"model":"m","reasoning_effort":"none","chat_template_kwargs":{"custom_flag":true}}`)
+		out, err := applySetParamsByMatch(in, f)
+		if err != nil {
+			t.Fatalf("applySetParamsByMatch: %v", err)
+		}
+		if got := gjson.GetBytes(out, "chat_template_kwargs.custom_flag").Bool(); !got {
+			t.Errorf("custom_flag was dropped, body = %s", out)
+		}
+		if got := gjson.GetBytes(out, "chat_template_kwargs.enable_thinking").Bool(); got {
+			t.Errorf("enable_thinking = %v, want false", got)
+		}
+	})
+
+	t.Run("non-object value is overwritten wholesale", func(t *testing.T) {
+		f := config.Filters{SetParamsByMatch: reasoningRules}
+		in := []byte(`{"model":"m","reasoning_effort":"none","chat_template_kwargs":"bogus"}`)
+		out, err := applySetParamsByMatch(in, f)
+		if err != nil {
+			t.Fatalf("applySetParamsByMatch: %v", err)
+		}
+		if got := gjson.GetBytes(out, "chat_template_kwargs.enable_thinking").Bool(); got {
+			t.Errorf("enable_thinking = %v, want false", got)
+		}
+	})
+
+	t.Run("later matching rule wins", func(t *testing.T) {
+		f := config.Filters{SetParamsByMatch: []config.MatchRule{
+			{Key: "effort", Match: "x", Set: map[string]any{"top_p": 0.1}},
+			{Key: "effort", Match: "x", Set: map[string]any{"top_p": 0.9}},
+		}}
+		out, err := applySetParamsByMatch([]byte(`{"effort":"x"}`), f)
+		if err != nil {
+			t.Fatalf("applySetParamsByMatch: %v", err)
+		}
+		if got := gjson.GetBytes(out, "top_p").Float(); got != 0.9 {
+			t.Errorf("top_p = %v, want 0.9", got)
+		}
+	})
+
+	t.Run("non-string json values match by string form", func(t *testing.T) {
+		f := config.Filters{SetParamsByMatch: []config.MatchRule{
+			{Key: "depth", Match: "3", Set: map[string]any{"hit_number": true}},
+			{Key: "flag", Match: "true", Set: map[string]any{"hit_bool": true}},
+		}}
+		out, err := applySetParamsByMatch([]byte(`{"depth":3,"flag":true}`), f)
+		if err != nil {
+			t.Fatalf("applySetParamsByMatch: %v", err)
+		}
+		if !gjson.GetBytes(out, "hit_number").Bool() {
+			t.Errorf("numeric value did not match, body = %s", out)
+		}
+		if !gjson.GetBytes(out, "hit_bool").Bool() {
+			t.Errorf("bool value did not match, body = %s", out)
+		}
+	})
+
+	t.Run("protected params are ignored", func(t *testing.T) {
+		f := config.Filters{SetParamsByMatch: []config.MatchRule{
+			{Key: "effort", Match: "x", Set: map[string]any{"model": "hijacked", "top_p": 0.3}},
+		}}
+		out, err := applySetParamsByMatch([]byte(`{"model":"m","effort":"x"}`), f)
+		if err != nil {
+			t.Fatalf("applySetParamsByMatch: %v", err)
+		}
+		if got := gjson.GetBytes(out, "model").String(); got != "m" {
+			t.Errorf("model = %q, want m", got)
+		}
+		if got := gjson.GetBytes(out, "top_p").Float(); got != 0.3 {
+			t.Errorf("top_p = %v, want 0.3", got)
+		}
+	})
+
+	t.Run("sub-keys with dots are written literally", func(t *testing.T) {
+		f := config.Filters{SetParamsByMatch: []config.MatchRule{
+			{Key: "effort", Match: "x", Set: map[string]any{
+				"kwargs": map[string]any{"a.b": 1},
+			}},
+		}}
+		out, err := applySetParamsByMatch([]byte(`{"effort":"x","kwargs":{"keep":true}}`), f)
+		if err != nil {
+			t.Fatalf("applySetParamsByMatch: %v", err)
+		}
+		if got := gjson.GetBytes(out, `kwargs.a\.b`).Int(); got != 1 {
+			t.Errorf("kwargs['a.b'] = %d, want 1, body = %s", got, out)
+		}
+		if !gjson.GetBytes(out, "kwargs.keep").Bool() {
+			t.Errorf("sibling key dropped, body = %s", out)
+		}
+	})
+
+	t.Run("setParams overrides setParamsByMatch", func(t *testing.T) {
+		f := config.Filters{
+			SetParamsByMatch: []config.MatchRule{
+				{Key: "effort", Match: "x", Set: map[string]any{"top_p": 0.1}},
+			},
+			SetParams: map[string]any{"top_p": 0.9},
+		}
+		out, err := applyFilters([]byte(`{"model":"m","effort":"x"}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "top_p").Float(); got != 0.9 {
+			t.Errorf("top_p = %v, want 0.9", got)
+		}
+	})
+
+	t.Run("runs after stripParams", func(t *testing.T) {
+		// stripping the matched key means no rule can fire
+		f := config.Filters{
+			StripParams: "effort",
+			SetParamsByMatch: []config.MatchRule{
+				{Key: "effort", Match: "x", Set: map[string]any{"top_p": 0.1}},
+			},
+		}
+		out, err := applyFilters([]byte(`{"model":"m","effort":"x"}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if gjson.GetBytes(out, "top_p").Exists() {
+			t.Errorf("rule should not have matched after strip, body = %s", out)
+		}
+	})
+}
+
 func TestServer_ResolveFilters_QualifiedPeer(t *testing.T) {
 	want := config.Filters{StripParams: "temperature"}
 	cfg := config.Config{Peers: config.PeerDictionaryConfig{


### PR DESCRIPTION
Set request parameters when a request field matches a value. Rules match on the request body rather than the model ID, so clients that send a fixed `model` and vary a separate field can change behaviour between requests without triggering a model swap.

```yaml
macros:
  reasoning_rules:
    - key: reasoning_effort
      match: none
      set:
        chat_template_kwargs:
          enable_thinking: false
    - key: reasoning_effort
      match: high
      set:
        chat_template_kwargs:
          enable_thinking: true
        thinking_budget_tokens: 8192

models:
  my-model:
    filters:
      setParamsByMatch: ${reasoning_rules}
```

- rules run in order after `stripParams` and before `setParams`/`setParamsByID`, which keep the final say
- every matching rule applies, so a later rule overrides an earlier one
- object values merge into an existing request object, so `chat_template_kwargs` the client already sent are preserved rather than replaced
- `match` compares against the field's string form, so JSON booleans and numbers must be quoted
- protected params like `model` cannot be matched on or set
- supported in both model and peer filters, validated at config load

Macros can now hold maps and lists so several models can share one rule set. Without this a shared rule list needs a stray top-level YAML anchor key. Structured macros are only valid as a whole value; interpolating one into a string is a load-time error. This changes two existing tests that asserted macros were scalar-only.

Replaces the earlier reasoning-specific filter in this PR per the discussion in #958.

Fixes #958
