### PR TITLE
internal/server: add support for profiles 

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
   - `/running` - list currently running models ([#61](https://github.com/mostlygeek/llama-swap/issues/61))
   - `POST /api/models/unload` - manually unload all running models ([#58](https://github.com/mostlygeek/llama-swap/issues/58))
   - `POST /api/models/unload/:model_id` - unload a specific model
+  - `GET /api/profiles` - list configured profiles and the active selection
+  - `PUT /api/profiles/active` - activate a profile or select none
   - `/logs` - remote log monitoring
     - `GET /logs` returns buffered plain text logs.
       - If `Accept: text/html` is sent, `/logs` redirects to `/ui/`.
@@ -56,6 +58,7 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
   - `/metrics` - system and GPU metrics for prometheus
 - ✅ API Key support - define keys to restrict access to API endpoints
 - ✅ Customizable
+  - Switch model ID routing at runtime with profiles
   - Run concurrent models with a custom DSL swap matrix ([#643](https://github.com/mostlygeek/llama-swap/issues/643))
   - Automatic unloading of models after timeout by setting a `ttl`
   - Docker and Podman support using `cmd` and `cmdStop` together

--- a/config-schema.json
+++ b/config-schema.json
@@ -298,6 +298,48 @@
         "macros": {
             "$ref": "#/definitions/macros"
         },
+        "profiles": {
+            "type": "object",
+            "default": {},
+            "description": "Runtime-selectable model ID rewrites. One profile or none may be active at runtime.",
+            "propertyNames": {
+                "type": "string",
+                "minLength": 1
+            },
+            "additionalProperties": {
+                "type": "object",
+                "required": [
+                    "pins"
+                ],
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "default": "",
+                        "maxLength": 1024
+                    },
+                    "pins": {
+                        "type": "object",
+                        "minProperties": 1,
+                        "description": "Model IDs to rewrite while this profile is active. An empty string or null disables the model ID.",
+                        "propertyNames": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "additionalProperties": {
+                            "oneOf": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
         "models": {
             "type": "object",
             "description": "A dictionary of model configurations. Each key is a model's ID. Model settings have defaults if not defined. The model's ID is available as ${MODEL_ID}.",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -170,6 +170,21 @@ upstream:
   ignorePaths:
     - '.*\.(js|json|css|png|gif|jpg|jpeg|ico|txt)$'
 
+# profiles: named model ID replacements switched at runtime through the UI or API
+# - optional, default: empty dictionary
+# - one profile or none is active; startup and configuration reload select none
+# - pins are applied before aliases, filters, and routing
+# - targets may be a local model, peer model, alias, or setParamsByID alias
+# - an empty string or YAML null (~) disables the pin with a 404; it is not
+#   added to model listings, while existing local, alias, or peer IDs remain
+profiles:
+  "coding":
+    description: "Coding-focused model routing"
+    pins:
+      "llm-code": "gpt-oss-120b"
+      "llm-plan": "qwen-unlisted"
+      "image-gen": ~
+
 # models: a dictionary of model configurations
 # - required
 # - each key is the model's ID, used in API requests

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,7 @@ llama-swap supports many more features to customize how you want to manage your 
 | `env`     | define environment variables per model         |
 | `aliases` | serve a model with different names             |
 | `filters` | modify requests before sending to the upstream |
+| `profiles` | switch model ID replacements at runtime       |
 | `...`     | And many more tweaks                           |
 
 ## Full Configuration Example
@@ -247,6 +248,21 @@ apiKeys:
   # use environment variable macros to keep secrets out of the config
   - "${env.API_KEY_1}"
   - "${env.API_KEY_2}"
+
+# profiles: named model ID replacements switched at runtime through the UI or API
+# - optional, default: empty dictionary
+# - one profile or none is active; startup and configuration reload select none
+# - pins are applied before aliases, filters, and routing
+# - targets may be a local model, peer model, alias, or setParamsByID alias
+# - an empty string or YAML null (~) disables the pin with a 404; it is not
+#   added to model listings, while existing local, alias, or peer IDs remain
+profiles:
+  "coding":
+    description: "Coding-focused model routing"
+    pins:
+      "llm-code": "gpt-oss-120b"
+      "llm-plan": "qwen-unlisted"
+      "image-gen": ~
 
 # models: a dictionary of model configurations
 # - required

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,21 +117,44 @@ type UIActivityConfig struct {
 	SessionID []string `yaml:"session_id" json:"session_id"`
 }
 
+// ProfileConfig describes a runtime-selectable set of model ID rewrites.
+// Empty pin targets disable the corresponding model ID while the profile is
+// active. YAML null values decode to the same empty string representation.
+type ProfileConfig struct {
+	Description string            `yaml:"description" json:"description"`
+	Pins        map[string]string `yaml:"pins" json:"pins"`
+}
+
+// UnmarshalYAML rejects the removed list-shaped profile syntax with a useful
+// migration error while allowing null pin values to normalize to empty strings.
+func (c *ProfileConfig) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("profile must be a mapping with description and pins; the legacy list syntax is no longer supported")
+	}
+	type rawProfileConfig ProfileConfig
+	var raw rawProfileConfig
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	*c = ProfileConfig(raw)
+	return nil
+}
+
 type Config struct {
-	HealthCheckTimeout int                    `yaml:"healthCheckTimeout"`
-	LogRequests        bool                   `yaml:"logRequests"`
-	LogLevel           string                 `yaml:"logLevel"`
-	LogTimeFormat      string                 `yaml:"logTimeFormat"`
-	LogToStdout        string                 `yaml:"logToStdout"`
-	MetricsMaxInMemory int                    `yaml:"metricsMaxInMemory"`
-	CaptureBuffer      int                    `yaml:"captureBuffer"`
-	Store              *Store                 `yaml:"store"`
-	UI                 UIConfig               `yaml:"ui"`
-	Performance        PerformanceConfig      `yaml:"performance"`
-	GlobalTTL          int                    `yaml:"globalTTL"`
-	UnloadTimeout      int                    `yaml:"unloadTimeout"`
-	Models             map[string]ModelConfig `yaml:"models"` /* key is model ID */
-	Profiles           map[string][]string    `yaml:"profiles"`
+	HealthCheckTimeout int                      `yaml:"healthCheckTimeout"`
+	LogRequests        bool                     `yaml:"logRequests"`
+	LogLevel           string                   `yaml:"logLevel"`
+	LogTimeFormat      string                   `yaml:"logTimeFormat"`
+	LogToStdout        string                   `yaml:"logToStdout"`
+	MetricsMaxInMemory int                      `yaml:"metricsMaxInMemory"`
+	CaptureBuffer      int                      `yaml:"captureBuffer"`
+	Store              *Store                   `yaml:"store"`
+	UI                 UIConfig                 `yaml:"ui"`
+	Performance        PerformanceConfig        `yaml:"performance"`
+	GlobalTTL          int                      `yaml:"globalTTL"`
+	UnloadTimeout      int                      `yaml:"unloadTimeout"`
+	Models             map[string]ModelConfig   `yaml:"models"` /* key is model ID */
+	Profiles           map[string]ProfileConfig `yaml:"profiles"`
 
 	// routing is the canonical source for swap/scheduling configuration.
 	// New code must read Routing, never the backwards-compat fields below.
@@ -216,6 +239,22 @@ func (c *Config) FindConfig(modelName string) (ModelConfig, string, bool) {
 	} else {
 		return c.Models[realName], realName, true
 	}
+}
+
+// ResolveBaseModel resolves a name without applying profiles. Local model IDs
+// and aliases take precedence over peer model IDs, matching server dispatch.
+func (c *Config) ResolveBaseModel(search string) (string, bool) {
+	if realName, found := c.RealModelName(search); found {
+		return realName, true
+	}
+	for _, peer := range c.Peers {
+		for _, modelID := range peer.Models {
+			if modelID == search {
+				return search, true
+			}
+		}
+	}
+	return "", false
 }
 
 func LoadConfig(path string) (Config, error) {

--- a/internal/config/config_posix_test.go
+++ b/internal/config/config_posix_test.go
@@ -140,8 +140,10 @@ models:
 healthCheckTimeout: 15
 profiles:
   test:
-    - model1
-    - model2
+    description: Test profile
+    pins:
+      fast: model1
+      disabled: ~
 groups:
   group1:
     swap: true
@@ -267,8 +269,14 @@ groups:
 		Performance: PerformanceConfig{
 			Every: 5 * time.Second,
 		},
-		Profiles: map[string][]string{
-			"test": {"model1", "model2"},
+		Profiles: map[string]ProfileConfig{
+			"test": {
+				Description: "Test profile",
+				Pins: map[string]string{
+					"fast":     "model1",
+					"disabled": "",
+				},
+			},
 		},
 		aliases: map[string]string{
 			"m1":        "model1",

--- a/internal/config/config_windows_test.go
+++ b/internal/config/config_windows_test.go
@@ -132,8 +132,10 @@ models:
 healthCheckTimeout: 15
 profiles:
   test:
-    - model1
-    - model2
+    description: Test profile
+    pins:
+      fast: model1
+      disabled: ~
 groups:
   group1:
     swap: true
@@ -256,8 +258,14 @@ groups:
 		Performance: PerformanceConfig{
 			Every: 5 * time.Second,
 		},
-		Profiles: map[string][]string{
-			"test": {"model1", "model2"},
+		Profiles: map[string]ProfileConfig{
+			"test": {
+				Description: "Test profile",
+				Pins: map[string]string{
+					"fast":     "model1",
+					"disabled": "",
+				},
+			},
 		},
 		aliases: map[string]string{
 			"m1":        "model1",

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -462,7 +462,34 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		config.Peers[peerName] = peerConfig
 	}
 
+	if err := validateProfiles(config); err != nil {
+		return Config{}, err
+	}
+
 	return config, nil
+}
+
+func validateProfiles(config Config) error {
+	for profileName, profile := range config.Profiles {
+		if strings.TrimSpace(profileName) == "" {
+			return fmt.Errorf("profiles: profile names cannot be empty")
+		}
+		if len(profile.Pins) == 0 {
+			return fmt.Errorf("profiles.%s.pins must contain at least one entry", profileName)
+		}
+		for pin, target := range profile.Pins {
+			if strings.TrimSpace(pin) == "" {
+				return fmt.Errorf("profiles.%s.pins: pin names cannot be empty", profileName)
+			}
+			if target == "" {
+				continue
+			}
+			if _, found := config.ResolveBaseModel(target); !found {
+				return fmt.Errorf("profiles.%s.pins.%s references unknown model %q", profileName, pin, target)
+			}
+		}
+	}
+	return nil
 }
 
 func normalizeHeaderNames(names []string) []string {

--- a/internal/config/profile_test.go
+++ b/internal/config/profile_test.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Profiles_LoadAndResolve(t *testing.T) {
+	cfg, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  local:
+    cmd: echo ${PORT}
+    aliases: [local-fast]
+    filters:
+      setParamsByID:
+        local-thinking:
+          thinking: true
+peers:
+  remote:
+    proxy: http://example.com
+    models: [peer-model]
+profiles:
+  coding:
+    description: Coding profile
+    pins:
+      direct: local
+      alias: local-fast
+      variant: local-thinking
+      peer: peer-model
+      disabled-empty: ""
+      disabled-null: ~
+      local: peer-model
+`))
+	require.NoError(t, err)
+
+	profile := cfg.Profiles["coding"]
+	assert.Equal(t, "Coding profile", profile.Description)
+	assert.Equal(t, "", profile.Pins["disabled-empty"])
+	assert.Equal(t, "", profile.Pins["disabled-null"])
+
+	tests := []struct {
+		requested string
+		target    string
+		modelID   string
+		disabled  bool
+	}{
+		{"direct", "local", "local", false},
+		{"alias", "local-fast", "local", false},
+		{"variant", "local-thinking", "local", false},
+		{"peer", "peer-model", "peer-model", false},
+		{"local", "peer-model", "peer-model", false},
+		{"disabled-empty", "", "", true},
+		{"disabled-null", "", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.requested, func(t *testing.T) {
+			target, pinned := profile.Pins[tc.requested]
+			require.True(t, pinned)
+			assert.Equal(t, tc.target, target)
+			if tc.disabled {
+				assert.Empty(t, target)
+				return
+			}
+			modelID, found := cfg.ResolveBaseModel(target)
+			require.True(t, found)
+			assert.Equal(t, tc.modelID, modelID)
+		})
+	}
+
+	got, found := cfg.ResolveBaseModel("local-fast")
+	require.True(t, found)
+	assert.Equal(t, "local", got)
+}
+
+func TestConfig_Profiles_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile string
+		wantErr string
+	}{
+		{
+			name: "legacy list",
+			profile: `profiles:
+  old: [model]
+`,
+			wantErr: "legacy list syntax",
+		},
+		{
+			name: "empty pins",
+			profile: `profiles:
+  empty:
+    pins: {}
+`,
+			wantErr: "must contain at least one entry",
+		},
+		{
+			name: "unknown target",
+			profile: `profiles:
+  bad:
+    pins:
+      public: missing
+`,
+			wantErr: "references unknown model",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  model:
+    cmd: echo ${PORT}
+` + tc.profile))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestConfig_Profiles_DoNotChain(t *testing.T) {
+	cfg, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  base:
+    cmd: echo ${PORT}
+profiles:
+  test:
+    pins:
+      first: base
+      second: first
+`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `references unknown model "first"`)
+	assert.Empty(t, cfg.Profiles)
+}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -137,6 +137,7 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 	created := time.Now().Unix()
 	data := make([]modelRecord, 0, len(s.cfg.Models))
 	running := s.local.RunningModels()
+	modelIDs := make(map[string]struct{})
 
 	modelStatus := func(id string) string {
 		if _, ok := running[id]; ok {
@@ -166,6 +167,11 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for id, mc := range s.cfg.Models {
+		modelIDs[id] = struct{}{}
+		for _, alias := range mc.Aliases {
+			modelIDs[alias] = struct{}{}
+		}
+
 		if mc.Unlisted {
 			continue
 		}
@@ -183,7 +189,20 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 
 	for peerID, peer := range s.cfg.Peers {
 		for _, modelID := range peer.Models {
+			modelIDs[modelID] = struct{}{}
 			data = append(data, newRecord(modelID, peerID+": "+modelID, "", map[string]any{"peerID": peerID}, config.ModelCapConfig{}, "unloaded"))
+		}
+	}
+
+	if profile, ok := s.cfg.Profiles[s.ActiveProfile()]; ok {
+		for pin, target := range profile.Pins {
+			if target == "" {
+				continue
+			}
+			if _, shadowsModel := modelIDs[pin]; shadowsModel {
+				continue
+			}
+			data = append(data, newRecord(pin, "", "", nil, config.ModelCapConfig{}, "unloaded"))
 		}
 	}
 

--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -28,6 +28,70 @@ type apiModel struct {
 	Capabilities map[string]any `json:"capabilities,omitempty"`
 }
 
+type apiProfile struct {
+	ID          string            `json:"id"`
+	Description string            `json:"description"`
+	Pins        map[string]string `json:"pins"`
+}
+
+func nullableProfile(name string) any {
+	if name == "" {
+		return nil
+	}
+	return name
+}
+
+func (s *Server) handleAPIProfiles(w http.ResponseWriter, r *http.Request) {
+	ids := make([]string, 0, len(s.cfg.Profiles))
+	for id := range s.cfg.Profiles {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	profiles := make([]apiProfile, 0, len(ids))
+	for _, id := range ids {
+		profile := s.cfg.Profiles[id]
+		profiles = append(profiles, apiProfile{
+			ID:          id,
+			Description: profile.Description,
+			Pins:        profile.Pins,
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"active":   nullableProfile(s.ActiveProfile()),
+		"profiles": profiles,
+	})
+}
+
+func (s *Server) handleAPIActiveProfile(w http.ResponseWriter, r *http.Request) {
+	var body map[string]json.RawMessage
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&body); err != nil {
+		shared.SendResponse(w, r, http.StatusBadRequest, "invalid profile request")
+		return
+	}
+	raw, ok := body["name"]
+	if !ok {
+		shared.SendResponse(w, r, http.StatusBadRequest, "profile name is required")
+		return
+	}
+
+	var name string
+	if string(raw) != "null" {
+		if err := json.Unmarshal(raw, &name); err != nil {
+			shared.SendResponse(w, r, http.StatusBadRequest, "profile name must be a string or null")
+			return
+		}
+	}
+	if _, err := s.setActiveProfile(name); err != nil {
+		shared.SendResponse(w, r, http.StatusNotFound, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"active": nullableProfile(s.ActiveProfile())})
+}
+
 // modelStatus returns every configured model joined with its current process
 // state (defaulting to "stopped"), followed by peer models.
 func (s *Server) modelStatus() []apiModel {
@@ -272,6 +336,7 @@ const (
 	msgTypeActivity    messageType = "activity"
 	msgTypeInFlight    messageType = "inflight"
 	msgTypeUIConfig    messageType = "uiConfig"
+	msgTypeProfile     messageType = "profileChanged"
 )
 
 type messageEnvelope struct {
@@ -338,9 +403,18 @@ func (s *Server) handleAPIEvents(w http.ResponseWriter, r *http.Request) {
 			send(messageEnvelope{Type: msgTypeUIConfig, Data: string(j)})
 		}
 	}
+	sendProfile := func() {
+		if j, err := json.Marshal(map[string]any{"active": nullableProfile(s.ActiveProfile())}); err == nil {
+			send(messageEnvelope{Type: msgTypeProfile, Data: string(j)})
+		}
+	}
 
 	defer event.On(func(e shared.ProcessStateChangeEvent) { sendModels() })()
 	defer event.On(func(e shared.ConfigFileChangedEvent) { sendModels() })()
+	defer event.On(func(e shared.ProfileChangedEvent) {
+		sendProfile()
+		sendModels()
+	})()
 	defer s.proxylog.OnLogData(func(data []byte) { sendLogData("proxy", data) })()
 	defer s.upstreamlog.OnLogData(func(data []byte) { sendLogData("upstream", data) })()
 	defer event.On(func(e ActivityLogEvent) { sendActivity(e.Metrics.ID) })()
@@ -351,6 +425,7 @@ func (s *Server) handleAPIEvents(w http.ResponseWriter, r *http.Request) {
 	sendLogData("upstream", s.upstreamlog.GetHistory())
 	sendModels()
 	sendUIConfig()
+	sendProfile()
 	sendInFlight(s.inflight.Current())
 
 	for {

--- a/internal/server/apigroup_test.go
+++ b/internal/server/apigroup_test.go
@@ -470,7 +470,7 @@ func TestServer_APIEvents_InitialPayload(t *testing.T) {
 	}
 
 	body := w.Body.String()
-	for _, want := range []string{`"type":"modelStatus"`, `"type":"inflight"`, `"type":"uiConfig"`, `"type":"logData"`, `X-Trace-ID`} {
+	for _, want := range []string{`"type":"modelStatus"`, `"type":"inflight"`, `"type":"uiConfig"`, `"type":"profileChanged"`, `"type":"logData"`, `X-Trace-ID`} {
 		if !strings.Contains(body, want) {
 			t.Errorf("initial SSE payload missing %s; body=%q", want, body)
 		}

--- a/internal/server/profiles.go
+++ b/internal/server/profiles.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/mostlygeek/llama-swap/internal/chain"
+	"github.com/mostlygeek/llama-swap/internal/shared"
+)
+
+// CreateProfileMiddleware applies the request's active profile snapshot before
+// the normal request pipeline resolves the rewritten model.
+func CreateProfileMiddleware(s *Server) chain.Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			profile, ok := s.cfg.Profiles[s.ActiveProfile()]
+			if ok {
+				var model, replacement string
+				var pinned bool
+				if strings.HasPrefix(r.URL.Path, "/upstream/") {
+					model, replacement, pinned = upstreamProfilePin(r.PathValue("upstreamPath"), profile.Pins)
+				} else {
+					model, _ = shared.ExtractModel(r)
+					if model != "" {
+						replacement, pinned = profile.Pins[model]
+					}
+				}
+				if pinned {
+					updated, err := shared.ReplaceRequestModel(r, model, replacement)
+					if err != nil {
+						shared.SendResponse(w, r, http.StatusBadRequest, err.Error())
+						return
+					}
+					r = updated
+				}
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func upstreamProfilePin(upstreamPath string, pins map[string]string) (model, replacement string, found bool) {
+	upstreamPath = strings.TrimPrefix(upstreamPath, "/")
+	matchedPin := ""
+	for pin, candidate := range pins {
+		switch {
+		case upstreamPath == pin:
+			if len(pin) > len(matchedPin) {
+				matchedPin = pin
+				replacement = candidate
+			}
+		case strings.HasPrefix(upstreamPath, pin+"/"):
+			if len(pin) > len(matchedPin) {
+				matchedPin = pin
+				replacement = candidate
+			}
+		}
+	}
+	return matchedPin, replacement, matchedPin != ""
+}

--- a/internal/server/profiles_test.go
+++ b/internal/server/profiles_test.go
@@ -1,0 +1,311 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/shared"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func profileTestConfig(t *testing.T) config.Config {
+	t.Helper()
+	cfg, err := config.LoadConfigFromReader(strings.NewReader(`
+models:
+  real:
+    cmd: echo ${PORT}
+    name: Real Model
+    filters:
+      setParamsByID:
+        variant:
+          thinking: true
+  hidden:
+    cmd: echo hidden
+    proxy: http://localhost:1234
+    name: Hidden Model
+    unlisted: true
+peers:
+  remote:
+    proxy: http://example.com
+    models: [remote-model]
+profiles:
+  coding:
+    description: Coding profile
+    pins:
+      public: variant
+      disabled: ~
+      real: hidden
+      expose: hidden
+      remote-model: hidden
+`))
+	require.NoError(t, err)
+	return cfg
+}
+
+func profileTestServer(t *testing.T, cfg config.Config, local *stubRouter) *Server {
+	t.Helper()
+	s := newTestServer(local, newStubRouter(nil, ""))
+	s.cfg = cfg
+	s.routes()
+	t.Cleanup(func() { s.store.Close() })
+	return s
+}
+
+func TestServer_ProfileAPI(t *testing.T) {
+	s := profileTestServer(t, profileTestConfig(t), newStubRouter([]string{"real", "hidden"}, "ok"))
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/profiles", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+	var listed struct {
+		Active   *string      `json:"active"`
+		Profiles []apiProfile `json:"profiles"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listed))
+	require.Nil(t, listed.Active)
+	require.Len(t, listed.Profiles, 1)
+	assert.Equal(t, "", listed.Profiles[0].Pins["disabled"])
+
+	w = httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/api/profiles/active", strings.NewReader(`{"name":"coding"}`)))
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "coding", s.ActiveProfile())
+
+	w = httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/api/profiles/active", strings.NewReader(`{"name":"missing"}`)))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, "coding", s.ActiveProfile())
+
+	w = httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/api/profiles/active", strings.NewReader(`{"name":null}`)))
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, s.ActiveProfile())
+}
+
+func TestServer_ProfileMiddleware_JSONAndFilters(t *testing.T) {
+	cfg := profileTestConfig(t)
+	local := newStubRouter([]string{"real", "hidden"}, "")
+	var received shared.ReqContextData
+	var body []byte
+	local.serveHTTP = func(w http.ResponseWriter, r *http.Request) {
+		received, _ = shared.ReadContext(r.Context())
+		body, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":true}`))
+	}
+	s := profileTestServer(t, cfg, local)
+	_, err := s.setActiveProfile("coding")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"public"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	assert.Equal(t, "variant", received.Model)
+	assert.Equal(t, "real", received.ModelID)
+	assert.Empty(t, received.Metadata)
+	assert.Equal(t, "variant", gjson.GetBytes(body, "model").String())
+	assert.True(t, gjson.GetBytes(body, "thinking").Bool())
+
+	req = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"disabled"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestServer_Profile_UpstreamPreservesBody(t *testing.T) {
+	cfg := profileTestConfig(t)
+	local := newStubRouter([]string{"real", "hidden"}, "")
+	var gotBody string
+	var gotModel string
+	local.serveHTTP = func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		data, _ := shared.ReadContext(r.Context())
+		gotModel = data.ModelID
+		w.WriteHeader(http.StatusOK)
+	}
+	s := profileTestServer(t, cfg, local)
+	_, err := s.setActiveProfile("coding")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/upstream/public/custom", strings.NewReader(`{"model":"public"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, `{"model":"public"}`, gotBody)
+	assert.Equal(t, "real", gotModel)
+}
+
+func TestServer_ProfileMiddleware_RewriteUpstreamPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		pins map[string]string
+		want string
+	}{
+		{
+			name: "pin",
+			path: "public/v1/chat/completions",
+			pins: map[string]string{"public": "real"},
+			want: "real/v1/chat/completions",
+		},
+		{
+			name: "longest pin",
+			path: "author/public/v1/chat/completions",
+			pins: map[string]string{"author": "short", "author/public": "real"},
+			want: "real/v1/chat/completions",
+		},
+		{
+			name: "disabled",
+			path: "disabled/v1/chat/completions",
+			pins: map[string]string{"disabled": ""},
+			want: "",
+		},
+		{
+			name: "not pinned",
+			path: "real/v1/chat/completions",
+			pins: map[string]string{"public": "real"},
+			want: "real/v1/chat/completions",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/upstream/"+tc.path, nil)
+			req.SetPathValue("upstreamPath", tc.path)
+			model, replacement, found := upstreamProfilePin(tc.path, tc.pins)
+			if found {
+				var err error
+				req, err = shared.ReplaceRequestModel(req, model, replacement)
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tc.want, req.PathValue("upstreamPath"))
+			assert.Equal(t, "/upstream/"+tc.want, req.URL.Path)
+		})
+	}
+}
+
+func TestServer_Profile_UpstreamMetricsUseResolvedModel(t *testing.T) {
+	cfg, err := config.LoadConfigFromReader(strings.NewReader(`
+models:
+  m1:
+    cmd: echo ${PORT}
+profiles:
+  test:
+    pins:
+      public: m1
+`))
+	require.NoError(t, err)
+	s := upstreamMetricsServer(t, `{"usage":{"prompt_tokens":2,"completion_tokens":3}}`)
+	s.cfg = cfg
+	s.routes()
+	_, err = s.setActiveProfile("test")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/upstream/public/v1/chat/completions", strings.NewReader(`{"model":"public"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	entries := metricsEntries(t, s.metrics)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "m1", entries[0].Model)
+	assert.Empty(t, entries[0].Metadata)
+}
+
+func TestServer_Profile_ModelListings(t *testing.T) {
+	s := profileTestServer(t, profileTestConfig(t), newStubRouter([]string{"real", "hidden"}, ""))
+	_, err := s.setActiveProfile("coding")
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	var response struct {
+		Data []modelRecord `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	names := make(map[string]string)
+	for _, record := range response.Data {
+		names[record.ID] = record.Name
+	}
+	assert.Contains(t, names, "public")
+	assert.Empty(t, names["public"])
+	assert.Equal(t, "Real Model", names["real"])
+	assert.Equal(t, "remote: remote-model", names["remote-model"])
+	assert.Contains(t, names, "expose")
+	assert.Empty(t, names["expose"])
+	assert.NotContains(t, names, "disabled")
+	assert.NotContains(t, names, "hidden")
+
+	status := s.modelStatus()
+	byID := make(map[string]apiModel)
+	for _, model := range status {
+		byID[model.Id] = model
+	}
+	assert.Contains(t, byID, "real")
+	assert.Contains(t, byID, "hidden")
+	assert.Equal(t, "remote", byID["remote-model"].PeerID)
+	assert.NotContains(t, byID, "public")
+	assert.NotContains(t, byID, "expose")
+	assert.NotContains(t, byID, "disabled")
+}
+
+func TestServer_Profile_ManagementUsesConcreteModel(t *testing.T) {
+	cfg := profileTestConfig(t)
+	local := newStubRouter([]string{"real", "hidden"}, "")
+	realLog := logmon.NewWriter(io.Discard)
+	hiddenLog := logmon.NewWriter(io.Discard)
+	local.loggers = map[string]*logmon.Monitor{
+		"real":   realLog,
+		"hidden": hiddenLog,
+	}
+	s := profileTestServer(t, cfg, local)
+	_, err := s.setActiveProfile("coding")
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/models/unload/real", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, []string{"real"}, local.unloadModels)
+
+	logger, err := s.getLogger("real")
+	require.NoError(t, err)
+	assert.Same(t, realLog, logger)
+}
+
+func TestServer_Profile_ConcurrentSelectionAndListing(t *testing.T) {
+	s := profileTestServer(t, profileTestConfig(t), newStubRouter([]string{"real", "hidden"}, ""))
+	var wg sync.WaitGroup
+	for worker := 0; worker < 8; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				if worker%2 == 0 {
+					_, _ = s.setActiveProfile("coding")
+				} else {
+					_, _ = s.setActiveProfile("")
+				}
+				w := httptest.NewRecorder()
+				s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+				assert.Equal(t, http.StatusOK, w.Code)
+			}
+		}(worker)
+	}
+	wg.Wait()
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mostlygeek/llama-swap/internal/chain"
 	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/event"
 	"github.com/mostlygeek/llama-swap/internal/logmon"
 	"github.com/mostlygeek/llama-swap/internal/perf"
 	"github.com/mostlygeek/llama-swap/internal/router"
@@ -35,6 +36,9 @@ type Server struct {
 	store    *store.Store
 	build    BuildInfo
 
+	profileMu     sync.RWMutex
+	activeProfile string
+
 	local router.LocalRouter
 	peer  router.Router
 
@@ -44,6 +48,35 @@ type Server struct {
 	shutdownCtx  context.Context
 	shutdownFn   context.CancelFunc
 	shuttingDown atomic.Bool
+}
+
+// ActiveProfile returns the active runtime profile, or an empty string when no
+// profile is active.
+func (s *Server) ActiveProfile() string {
+	s.profileMu.RLock()
+	defer s.profileMu.RUnlock()
+	return s.activeProfile
+}
+
+// setActiveProfile updates the runtime selection. An empty name deactivates
+// profiles. It returns whether the selection changed.
+func (s *Server) setActiveProfile(name string) (bool, error) {
+	if name != "" {
+		if _, ok := s.cfg.Profiles[name]; !ok {
+			return false, fmt.Errorf("profile %q not found", name)
+		}
+	}
+	s.profileMu.Lock()
+	if s.activeProfile == name {
+		s.profileMu.Unlock()
+		return false, nil
+	}
+	s.activeProfile = name
+	s.profileMu.Unlock()
+
+	s.proxylog.Infof("active profile changed to %q", name)
+	event.Emit(shared.ProfileChangedEvent{Active: name})
+	return true, nil
 }
 
 // modelPostJSONRoutes are endpoints with a model id in the JSON request body.
@@ -205,6 +238,7 @@ func (s *Server) routes() {
 	authMW := CreateAuthMiddleware(s.cfg)
 	modelChain := chain.New(
 		authMW,
+		CreateProfileMiddleware(s),
 		CreateRequestContextMiddleware(s.cfg),
 		CreateInflightMiddleware(s.inflight),
 		CreateFilterMiddleware(s.cfg),
@@ -251,6 +285,7 @@ func (s *Server) routes() {
 	// Upstream passthrough. Meter only the model-dispatched endpoints that can
 	// produce token usage/timings.
 	upstreamChain := apiChain.Append(
+		CreateProfileMiddleware(s),
 		CreateUpstreamInflightMiddleware(s.inflight, s.cfg),
 		CreateMetricsMiddleware(s.metrics, s.cfg),
 	)
@@ -260,6 +295,8 @@ func (s *Server) routes() {
 	// API group (API-key protected) consumed by the UI.
 	mux.Handle("POST /api/models/unload", apiChain.ThenFunc(s.handleAPIUnloadAll))
 	mux.Handle("POST /api/models/unload/{model...}", apiChain.ThenFunc(s.handleAPIUnloadModel))
+	mux.Handle("GET /api/profiles", apiChain.ThenFunc(s.handleAPIProfiles))
+	mux.Handle("PUT /api/profiles/active", apiChain.ThenFunc(s.handleAPIActiveProfile))
 	mux.Handle("POST /api/inflight/{id}/cancel", apiChain.ThenFunc(s.handleAPICancelInflight))
 	mux.Handle("GET /api/events", apiChain.ThenFunc(s.handleAPIEvents))
 	mux.Handle("GET /api/metrics/activity", apiChain.ThenFunc(s.handleAPIActivity))

--- a/internal/shared/events.go
+++ b/internal/shared/events.go
@@ -7,6 +7,7 @@ const ConfigFileChangedEventID = 0x03
 const ActivityLogEventID = 0x05
 const ModelPreloadedEventID = 0x06
 const InFlightRequestsEventID = 0x07
+const ProfileChangedEventID = 0x08
 
 // ProcessStateChangeEvent is emitted whenever a process transitions between
 // lifecycle states. States are carried as strings so this package stays a leaf
@@ -68,4 +69,12 @@ type InflightRequestEntry struct {
 	RespBytes   int64             `json:"resp_bytes"`
 	ElapsedMs   int64             `json:"elapsed_ms"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+type ProfileChangedEvent struct {
+	Active string
+}
+
+func (e ProfileChangedEvent) Type() uint32 {
+	return ProfileChangedEventID
 }

--- a/internal/shared/http.go
+++ b/internal/shared/http.go
@@ -203,6 +203,12 @@ func ReplaceRequestModel(r *http.Request, model, replacement string) (*http.Requ
 		}
 		r.PostForm.Set("model", replacement)
 		replaceRequestBody(r, []byte(r.PostForm.Encode()))
+	default:
+		if err := r.ParseForm(); err != nil {
+			return r, fmt.Errorf("could not parse form: %w", err)
+		}
+		r.PostForm.Set("model", replacement)
+		replaceRequestBody(r, []byte(r.PostForm.Encode()))
 	}
 
 	return invalidateRequestContext(r), nil

--- a/internal/shared/http.go
+++ b/internal/shared/http.go
@@ -9,11 +9,14 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 type contextkey struct {
@@ -125,6 +128,143 @@ func FetchContext(r *http.Request, cfg config.Config) (ReqContextData, error) {
 	return ReqContextData{}, ErrNoModelInContext
 }
 
+// ExtractModel returns the model name encoded in a request without caching
+// request data in its context.
+func ExtractModel(r *http.Request) (string, error) {
+	data, err := extractContext(r)
+	return data.Model, err
+}
+
+// ReplaceRequestModel replaces model with replacement wherever the request
+// encodes its model ID. It returns a request whose cached model context has
+// been invalidated so downstream handlers resolve the replacement normally.
+func ReplaceRequestModel(r *http.Request, model, replacement string) (*http.Request, error) {
+	if strings.HasPrefix(r.URL.Path, "/upstream/") {
+		upstreamPath := strings.TrimPrefix(r.PathValue("upstreamPath"), "/")
+		if upstreamPath != model && !strings.HasPrefix(upstreamPath, model+"/") {
+			return r, nil
+		}
+
+		remainingPath := strings.TrimPrefix(upstreamPath, model)
+		rewrittenPath := replacement + remainingPath
+		if replacement == "" {
+			rewrittenPath = ""
+		}
+		r.SetPathValue("upstreamPath", rewrittenPath)
+		r.URL.Path = "/upstream/" + rewrittenPath
+		r.URL.RawPath = ""
+		return invalidateRequestContext(r), nil
+	}
+
+	current, err := ExtractModel(r)
+	if err != nil {
+		return r, err
+	}
+	if current != model {
+		return r, nil
+	}
+
+	if r.Method == http.MethodGet {
+		query := r.URL.Query()
+		query.Set("model", replacement)
+		r.URL.RawQuery = query.Encode()
+		return invalidateRequestContext(r), nil
+	}
+
+	contentType := r.Header.Get("Content-Type")
+	switch {
+	case strings.Contains(contentType, "application/json"):
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			return r, fmt.Errorf("could not read request body")
+		}
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		body, err = sjson.SetBytes(body, "model", replacement)
+		if err != nil {
+			return r, fmt.Errorf("could not rewrite model in JSON body: %w", err)
+		}
+		replaceRequestBody(r, body)
+	case strings.Contains(contentType, "multipart/form-data"):
+		if err := r.ParseMultipartForm(32 << 20); err != nil {
+			return r, fmt.Errorf("could not parse multipart form: %w", err)
+		}
+		body, rewrittenContentType, err := replaceMultipartModel(r.MultipartForm, replacement)
+		if err != nil {
+			return r, err
+		}
+		r.MultipartForm = nil
+		r.Form = nil
+		r.PostForm = nil
+		r.Header.Set("Content-Type", rewrittenContentType)
+		replaceRequestBody(r, body)
+	case strings.Contains(contentType, "application/x-www-form-urlencoded"):
+		if err := r.ParseForm(); err != nil {
+			return r, fmt.Errorf("could not parse form: %w", err)
+		}
+		r.PostForm.Set("model", replacement)
+		replaceRequestBody(r, []byte(r.PostForm.Encode()))
+	}
+
+	return invalidateRequestContext(r), nil
+}
+
+func invalidateRequestContext(r *http.Request) *http.Request {
+	if _, ok := ReadContext(r.Context()); !ok {
+		return r
+	}
+	return r.WithContext(context.WithValue(r.Context(), ReqContextKey, struct{}{}))
+}
+
+func replaceRequestBody(r *http.Request, body []byte) {
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.Header.Del("Transfer-Encoding")
+	r.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	r.ContentLength = int64(len(body))
+}
+
+func replaceMultipartModel(form *multipart.Form, replacement string) ([]byte, string, error) {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+
+	for key, values := range form.Value {
+		for _, value := range values {
+			if key == "model" {
+				value = replacement
+			}
+			field, err := mw.CreateFormField(key)
+			if err != nil {
+				return nil, "", fmt.Errorf("error recreating form field %s: %w", key, err)
+			}
+			if _, err := field.Write([]byte(value)); err != nil {
+				return nil, "", fmt.Errorf("error writing form field %s: %w", key, err)
+			}
+		}
+	}
+
+	for key, headers := range form.File {
+		for _, fh := range headers {
+			part, err := mw.CreateFormFile(key, fh.Filename)
+			if err != nil {
+				return nil, "", fmt.Errorf("error recreating form file %s: %w", key, err)
+			}
+			file, err := fh.Open()
+			if err != nil {
+				return nil, "", fmt.Errorf("error opening uploaded file %s: %w", key, err)
+			}
+			if _, err := io.Copy(part, file); err != nil {
+				file.Close()
+				return nil, "", fmt.Errorf("error copying file data %s: %w", key, err)
+			}
+			file.Close()
+		}
+	}
+
+	if err := mw.Close(); err != nil {
+		return nil, "", fmt.Errorf("error finalizing multipart form: %w", err)
+	}
+	return buf.Bytes(), mw.FormDataContentType(), nil
+}
+
 // extractUpstreamContext resolves the model from an /upstream/<model>/... path.
 func extractUpstreamContext(r *http.Request, cfg config.Config) (ReqContextData, bool) {
 	searchName, realName, _, found := FindModelInPath(cfg, strings.TrimPrefix(r.URL.Path, "/upstream"))
@@ -167,7 +307,7 @@ func FindModelInPath(cfg config.Config, path string) (searchName, realName, rema
 			name = name + "/" + part
 		}
 
-		if modelID, ok := cfg.RealModelName(name); ok {
+		if modelID, ok := cfg.ResolveBaseModel(name); ok {
 			searchName = name
 			realName = modelID
 			remainingPath = "/" + strings.Join(parts[i+1:], "/")

--- a/internal/shared/http_test.go
+++ b/internal/shared/http_test.go
@@ -9,11 +9,139 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/mostlygeek/llama-swap/internal/config"
 )
+
+func TestReplaceRequestModel(t *testing.T) {
+	withContext := func(r *http.Request) *http.Request {
+		return r.WithContext(SetContext(r.Context(), ReqContextData{
+			Model:    "public",
+			ModelID:  "public",
+			Metadata: make(map[string]string),
+		}))
+	}
+	assertContextInvalidated := func(t *testing.T, r *http.Request) {
+		t.Helper()
+		if _, ok := ReadContext(r.Context()); ok {
+			t.Fatal("request model context was not invalidated")
+		}
+	}
+	assertBodyLength := func(t *testing.T, r *http.Request, body []byte) {
+		t.Helper()
+		if r.ContentLength != int64(len(body)) {
+			t.Fatalf("ContentLength = %d, want %d", r.ContentLength, len(body))
+		}
+		if got, want := r.Header.Get("Content-Length"), strconv.Itoa(len(body)); got != want {
+			t.Fatalf("Content-Length = %q, want %q", got, want)
+		}
+	}
+
+	t.Run("query", func(t *testing.T) {
+		r := withContext(httptest.NewRequest(http.MethodGet, "/props?model=public", nil))
+		updated, err := ReplaceRequestModel(r, "public", "target")
+		if err != nil {
+			t.Fatalf("ReplaceRequestModel: %v", err)
+		}
+		if got := updated.URL.Query().Get("model"); got != "target" {
+			t.Fatalf("model = %q, want target", got)
+		}
+		assertContextInvalidated(t, updated)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		r := withContext(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(`{"model":"public","prompt":"hello"}`)))
+		r.Header.Set("Content-Type", "application/json")
+		updated, err := ReplaceRequestModel(r, "public", "target")
+		if err != nil {
+			t.Fatalf("ReplaceRequestModel: %v", err)
+		}
+		body, err := io.ReadAll(updated.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if !strings.Contains(string(body), `"model":"target"`) {
+			t.Fatalf("body = %s, want target model", body)
+		}
+		assertBodyLength(t, updated, body)
+		assertContextInvalidated(t, updated)
+	})
+
+	t.Run("urlencoded", func(t *testing.T) {
+		r := withContext(httptest.NewRequest(http.MethodPost, "/", strings.NewReader(url.Values{"model": {"public"}}.Encode())))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		updated, err := ReplaceRequestModel(r, "public", "target")
+		if err != nil {
+			t.Fatalf("ReplaceRequestModel: %v", err)
+		}
+		body, err := io.ReadAll(updated.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		values, err := url.ParseQuery(string(body))
+		if err != nil {
+			t.Fatalf("parse body: %v", err)
+		}
+		if got := values.Get("model"); got != "target" {
+			t.Fatalf("model = %q, want target", got)
+		}
+		assertBodyLength(t, updated, body)
+		assertContextInvalidated(t, updated)
+	})
+
+	t.Run("multipart", func(t *testing.T) {
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		if err := writer.WriteField("model", "public"); err != nil {
+			t.Fatalf("write model: %v", err)
+		}
+		if err := writer.WriteField("prompt", "hello"); err != nil {
+			t.Fatalf("write prompt: %v", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("close multipart: %v", err)
+		}
+		r := withContext(httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body.Bytes())))
+		r.Header.Set("Content-Type", writer.FormDataContentType())
+
+		updated, err := ReplaceRequestModel(r, "public", "target")
+		if err != nil {
+			t.Fatalf("ReplaceRequestModel: %v", err)
+		}
+		rewritten, err := io.ReadAll(updated.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		assertBodyLength(t, updated, rewritten)
+		updated.Body = io.NopCloser(bytes.NewReader(rewritten))
+		if err := updated.ParseMultipartForm(32 << 20); err != nil {
+			t.Fatalf("parse multipart: %v", err)
+		}
+		if got := updated.FormValue("model"); got != "target" {
+			t.Fatalf("model = %q, want target", got)
+		}
+		assertContextInvalidated(t, updated)
+	})
+
+	t.Run("upstream path", func(t *testing.T) {
+		r := withContext(httptest.NewRequest(http.MethodPost, "/upstream/author/public/v1/chat/completions", nil))
+		r.SetPathValue("upstreamPath", "author/public/v1/chat/completions")
+		updated, err := ReplaceRequestModel(r, "author/public", "target")
+		if err != nil {
+			t.Fatalf("ReplaceRequestModel: %v", err)
+		}
+		if got, want := updated.PathValue("upstreamPath"), "target/v1/chat/completions"; got != want {
+			t.Fatalf("upstreamPath = %q, want %q", got, want)
+		}
+		if got, want := updated.URL.Path, "/upstream/target/v1/chat/completions"; got != want {
+			t.Fatalf("URL.Path = %q, want %q", got, want)
+		}
+		assertContextInvalidated(t, updated)
+	})
+}
 
 func TestExtractContext_GET(t *testing.T) {
 	tests := []struct {
@@ -466,6 +594,9 @@ func TestFetchContext_UpstreamPath(t *testing.T) {
 			"author/model": {},
 			"real":         {Aliases: []string{"nick"}},
 		},
+		Peers: config.PeerDictionaryConfig{
+			"remote": {Models: []string{"peer-model"}},
+		},
 	}
 
 	cases := []struct {
@@ -477,6 +608,7 @@ func TestFetchContext_UpstreamPath(t *testing.T) {
 	}{
 		{"known model", "/upstream/m1/v1/chat/completions", "m1", "m1", false},
 		{"model with slash", "/upstream/author/model/v1/chat", "author/model", "author/model", false},
+		{"peer model", "/upstream/peer-model/v1/chat", "peer-model", "peer-model", false},
 		{"unknown model", "/upstream/nope/v1/chat/completions", "", "", true},
 		{"bare model path", "/upstream/m1/", "m1", "m1", false},
 	}

--- a/internal/shared/http_test.go
+++ b/internal/shared/http_test.go
@@ -92,6 +92,38 @@ func TestReplaceRequestModel(t *testing.T) {
 		assertContextInvalidated(t, updated)
 	})
 
+	for _, tc := range []struct {
+		name        string
+		contentType string
+	}{
+		{name: "missing content type"},
+		{name: "other content type", contentType: "text/plain"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := withContext(httptest.NewRequest(http.MethodPost, "/?model=public", nil))
+			if tc.contentType != "" {
+				r.Header.Set("Content-Type", tc.contentType)
+			}
+			updated, err := ReplaceRequestModel(r, "public", "target")
+			if err != nil {
+				t.Fatalf("ReplaceRequestModel: %v", err)
+			}
+			body, err := io.ReadAll(updated.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			values, err := url.ParseQuery(string(body))
+			if err != nil {
+				t.Fatalf("parse body: %v", err)
+			}
+			if got := values.Get("model"); got != "target" {
+				t.Fatalf("model = %q, want target", got)
+			}
+			assertBodyLength(t, updated, body)
+			assertContextInvalidated(t, updated)
+		})
+	}
+
 	t.Run("multipart", func(t *testing.T) {
 		var body bytes.Buffer
 		writer := multipart.NewWriter(&body)

--- a/llama-swap.go
+++ b/llama-swap.go
@@ -108,10 +108,6 @@ func main() {
 	// so a LogToStdout change requires a restart to take effect.
 	muxLog, proxyLog, upstreamLog := server.NewLoggers(cfg.LogToStdout)
 
-	if len(cfg.Profiles) > 0 {
-		proxyLog.Warn("Profile functionality has been removed in favor of Groups. See the README for more information.")
-	}
-
 	applyLogSettings := func(cfg config.Config) {
 		level := logmon.LevelInfo
 		switch strings.ToLower(strings.TrimSpace(cfg.LogLevel)) {
@@ -209,10 +205,6 @@ func main() {
 		if err != nil {
 			proxyLog.Warnf("failed to reload config: %v", err)
 			return
-		}
-
-		if len(newCfg.Profiles) > 0 {
-			proxyLog.Warn("Profile functionality has been removed in favor of Groups. See the README for more information.")
 		}
 
 		if perfMon != nil {

--- a/ui-svelte/src/App.svelte
+++ b/ui-svelte/src/App.svelte
@@ -9,7 +9,14 @@
   import * as Sidebar from "$lib/components/ui/sidebar/index.js";
   import * as Tooltip from "$lib/components/ui/tooltip/index.js";
   import { Separator } from "$lib/components/ui/separator/index.js";
-  import { enableAPIEvents, checkPerformanceEnabled } from "./stores/api";
+  import * as Select from "$lib/components/ui/select/index.js";
+  import {
+    activeProfile,
+    checkPerformanceEnabled,
+    enableAPIEvents,
+    profiles,
+    setActiveProfile,
+  } from "./stores/api";
   import { initScreenWidth, initSystemThemeListener, isDarkMode, themeName, appTitle, connectionState } from "./stores/theme";
   import { currentRoute } from "./stores/route";
   import { selectedPlaygroundTab, playgroundTabs } from "./stores/playground";
@@ -59,6 +66,20 @@
     }
     return routeTitles[$currentRoute] ?? "Activity";
   });
+
+  const noProfileValue = "__none__";
+  let switchingProfile = $state(false);
+
+  async function handleProfileChange(value: string): Promise<void> {
+    switchingProfile = true;
+    try {
+      await setActiveProfile(value === noProfileValue ? null : value);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      switchingProfile = false;
+    }
+  }
 
   function handleRouteLoaded(event: { detail: { route: string | RegExp; location?: string } }) {
     const route = event.detail.route;
@@ -116,6 +137,30 @@
         <Sidebar.Trigger class="-ml-1" />
         <Separator orientation="vertical" class="mr-2 !h-4" />
         <h2 class="truncate pb-0 text-sm font-semibold">{sectionTitle}</h2>
+        {#if $profiles.length > 0}
+          <div class="ml-auto flex items-center gap-2">
+            <span class="text-muted-foreground hidden text-xs sm:inline">Profile</span>
+            <Select.Root
+              type="single"
+              value={$activeProfile ?? noProfileValue}
+              onValueChange={(value) => value && void handleProfileChange(value)}
+            >
+              <Select.Trigger
+                class="w-40"
+                aria-label="Active profile"
+                disabled={switchingProfile}
+              >
+                {$activeProfile ?? "None"}
+              </Select.Trigger>
+              <Select.Content>
+                <Select.Item value={noProfileValue}>None</Select.Item>
+                {#each $profiles as profile (profile.id)}
+                  <Select.Item value={profile.id}>{profile.id}</Select.Item>
+                {/each}
+              </Select.Content>
+            </Select.Root>
+          </div>
+        {/if}
       </header>
 
       <main class="min-h-0 flex-1 overflow-auto p-4">

--- a/ui-svelte/src/components/playground/ModelSelector.svelte
+++ b/ui-svelte/src/components/playground/ModelSelector.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { models } from "../../stores/api";
+  import { models, profileModels } from "../../stores/api";
   import { groupModels } from "../../lib/modelUtils";
   import * as Select from "$lib/components/ui/select/index.js";
 
@@ -15,7 +15,7 @@
 
   let grouped = $derived(groupModels($models, capabilities, matchAny));
   let hasMatching = $derived(grouped.localMatching.length > 0);
-  let hasModels = $derived(hasMatching || grouped.local.length > 0 || Object.keys(grouped.peersByProvider).length > 0);
+  let hasModels = $derived($profileModels.length > 0 || hasMatching || grouped.local.length > 0 || Object.keys(grouped.peersByProvider).length > 0);
 </script>
 
 {#if hasModels}
@@ -28,6 +28,15 @@
     <Select.Trigger class="min-w-0 flex-1 basis-48">{value || placeholder}</Select.Trigger>
     <Select.Content class="max-h-[60vh]">
       <Select.Item value="">{placeholder}</Select.Item>
+      {#if $profileModels.length > 0}
+        <Select.Group>
+          <Select.Label>Profile</Select.Label>
+          {#each $profileModels as model (model.id)}
+            <Select.Item value={model.id}>{model.id}</Select.Item>
+          {/each}
+        </Select.Group>
+        <Select.Separator />
+      {/if}
       {#if hasMatching}
         <Select.Group>
           <Select.Label>Matching Capabilities</Select.Label>

--- a/ui-svelte/src/lib/types.ts
+++ b/ui-svelte/src/lib/types.ts
@@ -23,6 +23,17 @@ export interface Model {
   capabilities?: ModelCapabilities;
 }
 
+export interface Profile {
+  id: string;
+  description: string;
+  pins: Record<string, string>;
+}
+
+export interface ProfileState {
+  active: string | null;
+  profiles: Profile[];
+}
+
 export interface TokenMetrics {
   cache_tokens: number;
   draft_tokens: number;
@@ -138,7 +149,7 @@ export interface PerformanceResponse {
 }
 
 export interface APIEventEnvelope {
-  type: "modelStatus" | "logData" | "activity" | "inflight" | "uiConfig" | "perfsys" | "perfgpu";
+  type: "modelStatus" | "logData" | "activity" | "inflight" | "uiConfig" | "profileChanged" | "perfsys" | "perfgpu";
   data: string;
 }
 

--- a/ui-svelte/src/stores/api.test.ts
+++ b/ui-svelte/src/stores/api.test.ts
@@ -1,12 +1,20 @@
 import { get } from "svelte/store";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  activeProfile,
   activityRevision,
+  fetchProfiles,
   handleAPIEventMessage,
   inFlightRequests,
   inflightRequestEntries,
+  profiles,
+  setActiveProfile,
   uiConfig,
 } from "./api";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("api store event handling", () => {
   it("parses inflight request entries", () => {
@@ -106,5 +114,41 @@ describe("api store event handling", () => {
     );
 
     expect(get(activityRevision)).toBe(1);
+  });
+
+  it("applies profile change events", () => {
+    activeProfile.set(null);
+    handleAPIEventMessage(JSON.stringify({
+      type: "profileChanged",
+      data: JSON.stringify({ active: "coding" }),
+    }));
+    expect(get(activeProfile)).toBe("coding");
+  });
+
+  it("loads and switches profiles", async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          active: null,
+          profiles: [{ id: "coding", description: "Coding", pins: { llm: "real" } }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ active: "coding" }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchProfiles();
+    expect(get(profiles)).toHaveLength(1);
+    expect(get(activeProfile)).toBeNull();
+
+    await setActiveProfile("coding");
+    expect(get(activeProfile)).toBe("coding");
+    expect(mockFetch).toHaveBeenLastCalledWith("/api/profiles/active", expect.objectContaining({
+      method: "PUT",
+      body: JSON.stringify({ name: "coding" }),
+    }));
   });
 });

--- a/ui-svelte/src/stores/api.test.ts
+++ b/ui-svelte/src/stores/api.test.ts
@@ -5,8 +5,11 @@ import {
   activityRevision,
   fetchProfiles,
   handleAPIEventMessage,
+  hasListedModels,
   inFlightRequests,
   inflightRequestEntries,
+  models,
+  profileModels,
   profiles,
   setActiveProfile,
   uiConfig,
@@ -14,6 +17,9 @@ import {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  models.set([]);
+  profiles.set([]);
+  activeProfile.set(null);
 });
 
 describe("api store event handling", () => {
@@ -150,5 +156,58 @@ describe("api store event handling", () => {
       method: "PUT",
       body: JSON.stringify({ name: "coding" }),
     }));
+  });
+
+  it("exposes active profile pins as Playground models", () => {
+    models.set([
+      {
+        id: "real",
+        state: "ready",
+        name: "Real",
+        description: "",
+        unlisted: true,
+        peerID: "",
+        aliases: ["variant"],
+        capabilities: { vision: true },
+      },
+      {
+        id: "peer-model",
+        state: "stopped",
+        name: "",
+        description: "",
+        unlisted: true,
+        peerID: "remote",
+      },
+    ]);
+    profiles.set([{
+      id: "coding",
+      description: "",
+      pins: {
+        public: "variant",
+        "remote-pin": "peer-model",
+        disabled: "",
+        real: "peer-model",
+        variant: "peer-model",
+      },
+    }]);
+    activeProfile.set("coding");
+
+    expect(get(profileModels).map((model) => model.id)).toEqual(["public", "remote-pin"]);
+    expect(get(profileModels)[0]).toMatchObject({
+      id: "public",
+      state: "ready",
+      unlisted: false,
+      capabilities: { vision: true },
+    });
+    expect(get(profileModels)[1]).toMatchObject({
+      id: "remote-pin",
+      peerID: "remote",
+      unlisted: false,
+    });
+    expect(get(hasListedModels)).toBe(true);
+
+    activeProfile.set(null);
+    expect(get(profileModels)).toEqual([]);
+    expect(get(hasListedModels)).toBe(false);
   });
 });

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -11,6 +11,8 @@ import type {
   InflightRequestEntry,
   PerformanceResponse,
   UIConfig,
+  Profile,
+  ProfileState,
 } from "../lib/types";
 import { connectionState } from "./theme";
 
@@ -18,6 +20,8 @@ const LOG_LENGTH_LIMIT = 1024 * 100; /* 100KB of log data */
 
 // Stores
 export const models = writable<Model[]>([]);
+export const profiles = writable<Profile[]>([]);
+export const activeProfile = writable<string | null>(null);
 
 // True when at least one listed (non-unlisted) model is configured.
 export const hasListedModels = derived(models, ($models) => $models.some((m) => !m.unlisted));
@@ -38,6 +42,7 @@ export const versionInfo = writable<VersionInfo>({
 });
 
 let apiEventSource: EventSource | null = null;
+let profileRevision = 0;
 
 function appendLog(newData: string, store: typeof proxyLogs | typeof upstreamLogs): void {
   store.update((prev) => {
@@ -54,6 +59,9 @@ export function enableAPIEvents(enabled: boolean): void {
     inFlightRequests.set(0);
     inflightRequestEntries.set([]);
     uiConfig.set(defaultUIConfig());
+    profiles.set([]);
+    activeProfile.set(null);
+    profileRevision++;
     return;
   }
 
@@ -75,8 +83,12 @@ export function enableAPIEvents(enabled: boolean): void {
       inflightRequestEntries.set([]);
       uiConfig.set(defaultUIConfig());
       models.set([]);
+      profiles.set([]);
+      activeProfile.set(null);
+      profileRevision++;
       retryCount = 0;
       connectionState.set("connected");
+      void fetchProfiles().catch((error) => console.error(error));
     };
 
     apiEventSource.onmessage = (e: MessageEvent) => {
@@ -169,7 +181,40 @@ export function handleAPIEventMessage(data: string): void {
       uiConfig.set(JSON.parse(message.data) as UIConfig);
       break;
     }
+
+    case "profileChanged": {
+      const state = JSON.parse(message.data) as Pick<ProfileState, "active">;
+      profileRevision++;
+      activeProfile.set(state.active);
+      break;
+    }
   }
+}
+
+export async function fetchProfiles(): Promise<ProfileState> {
+  const revision = profileRevision;
+  const response = await fetch("/api/profiles");
+  if (!response.ok) {
+    throw new Error(`Failed to list profiles: ${response.status}`);
+  }
+  const state = await response.json() as ProfileState;
+  profiles.set(state.profiles);
+  if (profileRevision === revision) activeProfile.set(state.active);
+  return state;
+}
+
+export async function setActiveProfile(name: string | null): Promise<void> {
+  const revision = profileRevision;
+  const response = await fetch("/api/profiles/active", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to switch profile: ${response.status}`);
+  }
+  const state = await response.json() as Pick<ProfileState, "active">;
+  if (profileRevision === revision) activeProfile.set(state.active);
 }
 
 // Fetch version info when connected

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -23,8 +23,48 @@ export const models = writable<Model[]>([]);
 export const profiles = writable<Profile[]>([]);
 export const activeProfile = writable<string | null>(null);
 
-// True when at least one listed (non-unlisted) model is configured.
-export const hasListedModels = derived(models, ($models) => $models.some((m) => !m.unlisted));
+// Active profile pins exposed as virtual models for Playground selectors.
+// Concrete model management continues to use `models`.
+export const profileModels = derived(
+  [models, profiles, activeProfile],
+  ([$models, $profiles, $activeProfile]): Model[] => {
+    const profile = $profiles.find((candidate) => candidate.id === $activeProfile);
+    if (!profile) return [];
+
+    const modelIDs = new Set<string>();
+    for (const model of $models) {
+      modelIDs.add(model.id);
+      for (const alias of model.aliases ?? []) modelIDs.add(alias);
+    }
+
+    const result: Model[] = [];
+    for (const [pin, target] of Object.entries(profile.pins)) {
+      if (!target || modelIDs.has(pin)) continue;
+
+      const targetModel = $models.find(
+        (model) => model.id === target || model.aliases?.includes(target),
+      );
+      result.push(targetModel
+        ? { ...targetModel, id: pin, unlisted: false, aliases: undefined }
+        : {
+            id: pin,
+            state: "stopped",
+            name: "",
+            description: "",
+            unlisted: false,
+            peerID: "",
+          });
+    }
+    return result.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
+  },
+);
+
+// True when at least one concrete model or active profile pin is selectable.
+export const hasListedModels = derived(
+  [models, profileModels],
+  ([$models, $profileModels]) =>
+    $profileModels.length > 0 || $models.some((model) => !model.unlisted),
+);
 export const proxyLogs = writable<string>("");
 export const upstreamLogs = writable<string>("");
 export const activityRevision = writable<number>(0);


### PR DESCRIPTION
internal/server: add runtime model profiles

Add configurable model ID profiles that can be switched without restarting.

- rewrite request and upstream model IDs through active profile pins
- expose profile selection through API, SSE, and UI
- validate and document profile configuration

Updates #933
Supercedes: #774 

Screenshot of profile selector when they are defined: 

<img width="1158" height="697" alt="image" src="https://github.com/user-attachments/assets/ea1ac7ce-f589-4935-a0d9-8e89a6f8cb2b" />

Configuration example: 

```yaml
# profiles: named model ID replacements switched at runtime through the UI or API
# - optional, default: empty dictionary
# - one profile or none is active; startup and configuration reload select none
# - pins are applied before aliases, filters, and routing
# - targets may be a local model, peer model, alias, or setParamsByID alias
# - an empty string or YAML null (~) disables the pin with a 404; it is not
#   added to model listings, while existing local, alias, or peer IDs remain
profiles:
  "coding":
    description: "Coding-focused model routing"
    pins:
      "llm-code": "gpt-oss-120b"
      "llm-plan": "qwen-unlisted"
      "image-gen": ~
```