### PR TITLE
Add intel_gpu_top support as monitoring backend

### DIFF
--- a/internal/perf/gpu_parse.go
+++ b/internal/perf/gpu_parse.go
@@ -48,6 +48,115 @@ func ParseNvidiaSmiLine(line string) *GpuStat {
 	}
 }
 
+// ParseIntelGpuTop parses one JSON sample object from intel_gpu_top -J output.
+func ParseIntelGpuTop(data string) *GpuStat {
+	var stats intelGpuTopStat
+	if err := json.Unmarshal([]byte(data), &stats); err != nil {
+		return nil
+	}
+
+	var gpuUtil float64
+	for _, eng := range stats.Engines {
+		if float64(eng.Busy) > gpuUtil {
+			gpuUtil = float64(eng.Busy)
+		}
+	}
+	// Fallback to 100% - RC6% if engine utilization is reported as 0
+	if gpuUtil == 0 && float64(stats.RC6.Value) > 0 && float64(stats.RC6.Value) <= 100.0 {
+		gpuUtil = 100.0 - float64(stats.RC6.Value)
+	}
+
+	var powerDraw float64
+	if float64(stats.Power.GPU) > 0 {
+		powerDraw = float64(stats.Power.GPU)
+	} else if float64(stats.Power.Package) > 0 {
+		powerDraw = float64(stats.Power.Package)
+	}
+
+	var memUsedBytes float64
+	for _, client := range stats.Clients {
+		for _, memType := range []string{"local", "system", "gtt"} {
+			if memMap, ok := client.Memory[memType]; ok {
+				if val, ok2 := memMap["resident"]; ok2 {
+					memUsedBytes += float64(val)
+					break
+				}
+			}
+		}
+	}
+	memUsedMB := int(memUsedBytes / 1024 / 1024)
+
+	return &GpuStat{
+		Timestamp:  time.Now(),
+		ID:         0, // ponytail: intel_gpu_top monitors a single device
+		Name:       "Intel GPU",
+		GpuUtilPct: gpuUtil,
+		MemUsedMB:  memUsedMB,
+		PowerDrawW: powerDraw,
+	}
+}
+
+type intelGpuTopStat struct {
+	Period struct {
+		Duration flexFloat64 `json:"duration"`
+		Unit     string      `json:"unit"`
+	} `json:"period"`
+	Frequency struct {
+		Requested flexFloat64 `json:"requested"`
+		Actual    flexFloat64 `json:"actual"`
+		Unit      string      `json:"unit"`
+	} `json:"frequency"`
+	Power struct {
+		GPU     flexFloat64 `json:"GPU"`
+		Package flexFloat64 `json:"Package"`
+		Unit    string      `json:"unit"`
+	} `json:"power"`
+	RC6 struct {
+		Value flexFloat64 `json:"value"`
+		Unit  string      `json:"unit"`
+	} `json:"rc6"`
+	Engines map[string]intelGpuEngine `json:"engines"`
+	Clients map[string]intelGpuClient `json:"clients"`
+}
+
+type intelGpuEngine struct {
+	Busy flexFloat64 `json:"busy"`
+	Sema flexFloat64 `json:"sema"`
+	Wait flexFloat64 `json:"wait"`
+	Unit string      `json:"unit"`
+}
+
+type intelGpuClient struct {
+	Name          string                               `json:"name"`
+	Pid           string                               `json:"pid"`
+	EngineClasses map[string]intelGpuClientEngineClass `json:"engine-classes"`
+	Memory        map[string]map[string]flexFloat64    `json:"memory"`
+}
+
+type intelGpuClientEngineClass struct {
+	Busy flexFloat64 `json:"busy"`
+	Unit string      `json:"unit"`
+}
+
+// flexFloat64 handles numbers serialized as JSON numbers or strings (e.g. "0.000000")
+type flexFloat64 float64
+
+func (f *flexFloat64) UnmarshalJSON(b []byte) error {
+	s := strings.TrimSpace(string(b))
+	s = strings.Trim(s, `"`)
+	if s == "" || s == "null" || s == "N/A" || s == "-" {
+		*f = 0
+		return nil
+	}
+	val, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		*f = 0
+		return nil
+	}
+	*f = flexFloat64(val)
+	return nil
+}
+
 // mactopOutput maps the subset of mactop's headless JSON output that is
 // relevant to GpuStat. Note that mactop's memory object is whole-system memory,
 // not GPU-attributed; the darwin monitor overlays ioreg's GPU-attributed

--- a/internal/perf/gpu_parse.go
+++ b/internal/perf/gpu_parse.go
@@ -79,7 +79,6 @@ func ParseIntelGpuTop(data string) *GpuStat {
 			if memMap, ok := client.Memory[memType]; ok {
 				if val, ok2 := memMap["resident"]; ok2 {
 					memUsedBytes += float64(val)
-					break
 				}
 			}
 		}

--- a/internal/perf/monitor_test.go
+++ b/internal/perf/monitor_test.go
@@ -265,6 +265,46 @@ func TestParseNvidiaSmiLine_ZeroMemoryTotal(t *testing.T) {
 	assert.Equal(t, 0.0, stat.MemUtilPct)
 }
 
+func TestParseIntelGpuTop_ValidObject(t *testing.T) {
+	// "resident" as a string exercises flexFloat64's string path.
+	data := `{
+		"power": {"GPU": 5.5, "Package": 8.0, "unit": "W"},
+		"rc6": {"value": 40.0, "unit": "%"},
+		"engines": {
+			"Render/3D/0": {"busy": 75.0, "unit": "%"},
+			"Video/0": {"busy": 10.0, "unit": "%"}
+		},
+		"clients": {
+			"1": {"name": "llama-server", "pid": "1234",
+				"memory": {"local": {"resident": "1073741824"}}}
+		}
+	}`
+
+	stat := ParseIntelGpuTop(data)
+	require.NotNil(t, stat)
+	assert.Equal(t, 75.0, stat.GpuUtilPct) // max engine busy, not RC6 fallback
+	assert.Equal(t, 5.5, stat.PowerDrawW)  // GPU preferred over Package
+	assert.Equal(t, 1024, stat.MemUsedMB)  // 1 GiB resident summed across clients
+}
+
+func TestParseIntelGpuTop_RC6Fallback(t *testing.T) {
+	// Engines report 0 busy -> util derived from 100 - rc6, power falls back to Package.
+	data := `{
+		"power": {"GPU": 0.0, "Package": 8.0, "unit": "W"},
+		"rc6": {"value": 40.0, "unit": "%"},
+		"engines": {"Render/3D/0": {"busy": 0.0, "unit": "%"}}
+	}`
+
+	stat := ParseIntelGpuTop(data)
+	require.NotNil(t, stat)
+	assert.Equal(t, 60.0, stat.GpuUtilPct)
+	assert.Equal(t, 8.0, stat.PowerDrawW)
+}
+
+func TestParseIntelGpuTop_Invalid(t *testing.T) {
+	assert.Nil(t, ParseIntelGpuTop("not json"))
+}
+
 const ioregSample = `+-o AGXAcceleratorG13X  <class AGXAcceleratorG13X, id 0x1000009a1, registered, matched, active, busy 0 (39191 ms), retain 108>
     {
       "model" = "Apple M1 Pro"

--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -345,8 +345,8 @@ func tryIntelGpuTop(ctx context.Context, every time.Duration, logger *logmon.Mon
 		return nil, ErrNoGpuTool
 	}
 	ms := int(every.Milliseconds())
-	if ms < 100 {
-		ms = 1000
+	if ms < 5000 {
+		ms = 5000
 	}
 	cmd := exec.CommandContext(ctx, "intel_gpu_top", "-J", "-s", fmt.Sprintf("%d", ms))
 	stdout, err := cmd.StdoutPipe()

--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -45,6 +45,13 @@ func getGpuStats(ctx context.Context, every time.Duration, logger *logmon.Monito
 		logger.Debugf("rocm-smi: %s", err.Error())
 	}
 
+	if ch, err := tryIntelGpuTop(ctx, every, logger); err == nil {
+		logger.Info("using intel_gpu_top for GPU monitoring")
+		return ch, nil
+	} else {
+		logger.Debugf("intel_gpu_top: %s", err.Error())
+	}
+
 	if ch, err := trySysfs(ctx, every, logger); err == nil {
 		logger.Info("using sysfs for GPU monitoring")
 		return ch, nil
@@ -331,6 +338,85 @@ func parseRocmSmiLine(header string, line string) *GpuStat {
 	result.Name = name
 
 	return result
+}
+
+func tryIntelGpuTop(ctx context.Context, every time.Duration, logger *logmon.Monitor) (chan []GpuStat, error) {
+	if _, err := exec.LookPath("intel_gpu_top"); err != nil {
+		return nil, ErrNoGpuTool
+	}
+	ms := int(every.Milliseconds())
+	if ms < 100 {
+		ms = 1000
+	}
+	cmd := exec.CommandContext(ctx, "intel_gpu_top", "-J", "-s", fmt.Sprintf("%d", ms))
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("intel_gpu_top stdout pipe failed: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("intel_gpu_top start failed: %w", err)
+	}
+	ch := make(chan []GpuStat, 1)
+	go func() {
+		defer close(ch)
+		scanner := bufio.NewScanner(stdout)
+		// intel_gpu_top's JSON objects can be large; allow generous line lengths.
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+		// intel_gpu_top -J pretty-prints objects across many lines inside an outer 
+		// "[" that never closes, with objects that may or may not be comma-separated.
+		// stdlib json rejects both variants, so accumulate each top-level object by
+		// brace depth.
+		var jsonBuf strings.Builder
+		depth := 0
+		inString := false
+		escaped := false
+
+		for scanner.Scan() {
+			line := scanner.Text()
+			for _, r := range line {
+				if escaped {
+					escaped = false
+					continue
+				}
+				if r == '\\' && inString {
+					escaped = true
+					continue
+				}
+				if r == '"' {
+					inString = !inString
+					continue
+				}
+				if !inString {
+					if r == '{' {
+						depth++
+					} else if r == '}' {
+						depth--
+					}
+				}
+			}
+			if depth > 0 || jsonBuf.Len() > 0 {
+				jsonBuf.WriteString(line)
+				jsonBuf.WriteByte('\n')
+			}
+			if depth == 0 && jsonBuf.Len() > 0 {
+				str := strings.TrimSpace(jsonBuf.String())
+				str = strings.TrimSuffix(str, ",")
+				if strings.HasPrefix(str, "{") && strings.HasSuffix(str, "}") {
+					stat := ParseIntelGpuTop(str)
+					if stat != nil {
+						select {
+						case ch <- []GpuStat{*stat}:
+						default:
+						}
+					}
+				}
+				jsonBuf.Reset()
+			}
+		}
+		cmd.Wait()
+	}()
+	return ch, nil
 }
 
 func trySysfs(ctx context.Context, every time.Duration, logger *logmon.Monitor) (chan []GpuStat, error) {

--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -344,6 +344,20 @@ func tryIntelGpuTop(ctx context.Context, every time.Duration, logger *logmon.Mon
 	if _, err := exec.LookPath("intel_gpu_top"); err != nil {
 		return nil, ErrNoGpuTool
 	}
+
+    // Probe: list devices to verify GPU is present and accessible.
+	probeCtx, probeCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer probeCancel()
+	probeCmd := exec.CommandContext(probeCtx, "intel_gpu_top", "-L")
+	if out, err := probeCmd.Output(); err != nil {
+		if probeCtx.Err() == context.DeadlineExceeded {
+			logger.Debug("intel_gpu_top -L timed out")
+		} else {
+			logger.Debugf("intel_gpu_top -L: %s", out)
+		}
+		return nil, ErrNoGpuTool
+	}
+
 	ms := int(every.Milliseconds())
 	if ms < 5000 {
 		ms = 5000

--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -345,7 +345,7 @@ func tryIntelGpuTop(ctx context.Context, every time.Duration, logger *logmon.Mon
 		return nil, ErrNoGpuTool
 	}
 
-    // Probe: list devices to verify GPU is present and accessible.
+	// Probe: list devices to verify GPU is present and accessible.
 	probeCtx, probeCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer probeCancel()
 	probeCmd := exec.CommandContext(probeCtx, "intel_gpu_top", "-L")

--- a/internal/perf/monitor_unix.go
+++ b/internal/perf/monitor_unix.go
@@ -363,7 +363,7 @@ func tryIntelGpuTop(ctx context.Context, every time.Duration, logger *logmon.Mon
 		// intel_gpu_top's JSON objects can be large; allow generous line lengths.
 		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
-		// intel_gpu_top -J pretty-prints objects across many lines inside an outer 
+		// intel_gpu_top -J pretty-prints objects across many lines inside an outer
 		// "[" that never closes, with objects that may or may not be comma-separated.
 		// stdlib json rejects both variants, so accumulate each top-level object by
 		// brace depth.


### PR DESCRIPTION
Relates to https://github.com/mostlygeek/llama-swap/discussions/771

Adds support for `intel_gpu_top` as a monitoring backend. Note that the below test was run on an Intel Core Ultra 7 255H iGPU, hence the missing VRAM and GPU temps, which are not applicable to this setup.

<img width="1655" height="874" alt="image" src="https://github.com/user-attachments/assets/48d04baa-faf8-4ea8-83b5-5a35713da444" />

I have not tested on an Intel dGPU.

Made with AI assistance