### PR TITLE
internal/server,shared: fix multipart temp file leak on audio uploads

### DIFF
--- a/internal/server/filters.go
+++ b/internal/server/filters.go
@@ -108,6 +108,9 @@ func CreateFormFilterMiddleware(cfg config.Config) chain.Middleware {
 			}
 
 			r.Body = io.NopCloser(bytes.NewReader(body))
+			if r.MultipartForm != nil {
+				_ = r.MultipartForm.RemoveAll()
+			}
 			r.MultipartForm = nil
 			r.Header.Del("Transfer-Encoding")
 			r.Header.Set("Content-Type", contentType)

--- a/internal/shared/http.go
+++ b/internal/shared/http.go
@@ -192,6 +192,9 @@ func ReplaceRequestModel(r *http.Request, model, replacement string) (*http.Requ
 		if err != nil {
 			return r, err
 		}
+		if r.MultipartForm != nil {
+			_ = r.MultipartForm.RemoveAll()
+		}
 		r.MultipartForm = nil
 		r.Form = nil
 		r.PostForm = nil


### PR DESCRIPTION
## Summary

Multipart uploads larger than the 32 MB `ParseMultipartForm` threshold spill file parts to `$TMPDIR/multipart-*`. Both rewrite paths (`replaceMultipartModel` / `rewriteMultipartModel`) fully buffer every part into memory, then set `r.MultipartForm = nil` without calling `RemoveAll()` — leaking the spill files and simultaneously disabling `net/http`'s automatic end-of-request cleanup, which only runs off a non-nil `MultipartForm` field.

On default Linux setups the spills land in tmpfs `/tmp`, so the leak consumes RAM. Observed in production: a subtitle-generation backlog of movie-length `/v1/audio/transcriptions` uploads accumulated ~47 GB of orphaned `multipart-*` files, pinning 47 GB of memory on a 128 GB inference host.

Present since the endpoint was introduced in #41 (the spill was noted in a comment there but never reaped); #790 added the `MultipartForm = nil` assignment that defeats the stdlib safety net.

## Change

Remove the spill files once the in-memory rewrite has succeeded, immediately before clearing the field, at both sites (`internal/shared/http.go`, `internal/server/filters.go`). Nil-guarded for safety although `MultipartForm` is provably non-nil at both call points today.

## Verification

- Controlled: 65 MB WAV POSTed to `/v1/audio/transcriptions` → HTTP 200, no `multipart-*` remains in `TMPDIR` after the request. Pre-patch: one orphan per request.
- Production: running since 2026-07-19 serving several hundred movie-length uploads at concurrency 2 (whisper.cpp upstream); `TMPDIR` stays clean.
- No behavioral change for JSON endpoints — only form-data endpoints allocate multipart forms.
