### PR TITLE
internal/server,shared: reduce request model body functions to one

### DIFF
--- a/internal/server/filters.go
+++ b/internal/server/filters.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"net/http"
 	"strconv"
 	"strings"
@@ -96,73 +95,19 @@ func CreateFormFilterMiddleware(cfg config.Config) chain.Middleware {
 				return
 			}
 
-			if err := r.ParseMultipartForm(32 << 20); err != nil {
-				shared.SendResponse(w, r, http.StatusBadRequest, fmt.Sprintf("error parsing multipart form: %s", err.Error()))
-				return
-			}
-
-			body, contentType, err := rewriteMultipartModel(r.MultipartForm, useModelName)
+			updated, err := shared.ReplaceRequestModel(r, data.Model, useModelName)
 			if err != nil {
-				shared.SendResponse(w, r, http.StatusInternalServerError, err.Error())
+				shared.SendResponse(w, r, http.StatusBadRequest, err.Error())
 				return
 			}
 
-			r.Body = io.NopCloser(bytes.NewReader(body))
-			r.MultipartForm = nil
-			r.Header.Del("Transfer-Encoding")
-			r.Header.Set("Content-Type", contentType)
-			r.Header.Set("Content-Length", strconv.Itoa(len(body)))
-			r.ContentLength = int64(len(body))
-
-			next.ServeHTTP(w, r)
+			// UseModelName changes only the model name sent upstream. Keep the
+			// original request context so routing and metrics still identify
+			// the configured model.
+			updated = updated.WithContext(r.Context())
+			next.ServeHTTP(w, updated)
 		})
 	}
-}
-
-// rewriteMultipartModel reconstructs a multipart form, replacing the "model"
-// field value with useModelName. It returns the encoded body and the matching
-// Content-Type header (which carries the generated boundary).
-func rewriteMultipartModel(form *multipart.Form, useModelName string) ([]byte, string, error) {
-	var buf bytes.Buffer
-	mw := multipart.NewWriter(&buf)
-
-	for key, values := range form.Value {
-		for _, value := range values {
-			if key == "model" {
-				value = useModelName
-			}
-			field, err := mw.CreateFormField(key)
-			if err != nil {
-				return nil, "", fmt.Errorf("error recreating form field %s: %w", key, err)
-			}
-			if _, err := field.Write([]byte(value)); err != nil {
-				return nil, "", fmt.Errorf("error writing form field %s: %w", key, err)
-			}
-		}
-	}
-
-	for key, headers := range form.File {
-		for _, fh := range headers {
-			part, err := mw.CreateFormFile(key, fh.Filename)
-			if err != nil {
-				return nil, "", fmt.Errorf("error recreating form file %s: %w", key, err)
-			}
-			file, err := fh.Open()
-			if err != nil {
-				return nil, "", fmt.Errorf("error opening uploaded file %s: %w", key, err)
-			}
-			if _, err := io.Copy(part, file); err != nil {
-				file.Close()
-				return nil, "", fmt.Errorf("error copying file data %s: %w", key, err)
-			}
-			file.Close()
-		}
-	}
-
-	if err := mw.Close(); err != nil {
-		return nil, "", fmt.Errorf("error finalizing multipart form: %w", err)
-	}
-	return buf.Bytes(), mw.FormDataContentType(), nil
 }
 
 // resolveFilters returns the filter settings for a requested model. UseModelName

--- a/internal/server/filters_test.go
+++ b/internal/server/filters_test.go
@@ -6,10 +6,10 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/shared"
 	"github.com/tidwall/gjson"
 )
 
@@ -56,54 +56,6 @@ func TestServer_ApplyFilters(t *testing.T) {
 	})
 }
 
-func TestServer_RewriteMultipartModel(t *testing.T) {
-	var buf bytes.Buffer
-	mw := multipart.NewWriter(&buf)
-	mw.WriteField("model", "old-name")
-	mw.WriteField("language", "en")
-	fw, _ := mw.CreateFormFile("file", "audio.wav")
-	fw.Write([]byte("RIFFdata"))
-	mw.Close()
-
-	r := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", &buf)
-	r.Header.Set("Content-Type", mw.FormDataContentType())
-	if err := r.ParseMultipartForm(32 << 20); err != nil {
-		t.Fatalf("ParseMultipartForm: %v", err)
-	}
-
-	body, contentType, err := rewriteMultipartModel(r.MultipartForm, "new-name")
-	if err != nil {
-		t.Fatalf("rewriteMultipartModel: %v", err)
-	}
-
-	parsed, err := multipart.NewReader(bytes.NewReader(body), boundaryOf(t, contentType)).ReadForm(32 << 20)
-	if err != nil {
-		t.Fatalf("re-parse: %v", err)
-	}
-	if got := parsed.Value["model"][0]; got != "new-name" {
-		t.Errorf("model = %q, want new-name", got)
-	}
-	if got := parsed.Value["language"][0]; got != "en" {
-		t.Errorf("language = %q, want en", got)
-	}
-	fh := parsed.File["file"][0]
-	f, _ := fh.Open()
-	data, _ := io.ReadAll(f)
-	f.Close()
-	if string(data) != "RIFFdata" {
-		t.Errorf("file data = %q, want RIFFdata", data)
-	}
-}
-
-func boundaryOf(t *testing.T, contentType string) string {
-	t.Helper()
-	_, params, ok := strings.Cut(contentType, "boundary=")
-	if !ok {
-		t.Fatalf("no boundary in %q", contentType)
-	}
-	return params
-}
-
 func TestServer_FormFilterMiddleware(t *testing.T) {
 	cfg := config.Config{Models: map[string]config.ModelConfig{
 		"whisper": {UseModelName: "whisper-large-v3"},
@@ -119,14 +71,42 @@ func TestServer_FormFilterMiddleware(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", &buf)
 	r.Header.Set("Content-Type", mw.FormDataContentType())
 
-	var gotModel string
+	var gotModel, gotFilename, gotFileBody string
+	var gotContext shared.ReqContextData
 	final := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = r.ParseMultipartForm(32 << 20)
+		if err := r.ParseMultipartForm(shared.MaxMultiPartSize); err != nil {
+			t.Errorf("ParseMultipartForm: %v", err)
+			return
+		}
 		gotModel = r.MultipartForm.Value["model"][0]
+		fileHeader := r.MultipartForm.File["file"][0]
+		gotFilename = fileHeader.Filename
+		file, err := fileHeader.Open()
+		if err != nil {
+			t.Errorf("open file: %v", err)
+			return
+		}
+		data, err := io.ReadAll(file)
+		file.Close()
+		if err != nil {
+			t.Errorf("read file: %v", err)
+			return
+		}
+		gotFileBody = string(data)
+		gotContext, _ = shared.ReadContext(r.Context())
 	})
 	CreateFormFilterMiddleware(cfg)(final).ServeHTTP(httptest.NewRecorder(), r)
 
 	if gotModel != "whisper-large-v3" {
 		t.Errorf("model rewritten to %q, want whisper-large-v3", gotModel)
+	}
+	if gotFilename != "a.wav" {
+		t.Errorf("filename = %q, want a.wav", gotFilename)
+	}
+	if gotFileBody != "xx" {
+		t.Errorf("file body = %q, want xx", gotFileBody)
+	}
+	if gotContext.Model != "whisper" || gotContext.ModelID != "whisper" {
+		t.Errorf("request context = %+v, want original whisper model", gotContext)
 	}
 }

--- a/internal/shared/http.go
+++ b/internal/shared/http.go
@@ -34,6 +34,8 @@ type ReqContextData struct {
 	Metadata map[string]string
 }
 
+const MaxMultiPartSize = 32 << 20
+
 var (
 	ReqContextKey        = &contextkey{"context"}
 	ErrNoModelInContext  = fmt.Errorf("no model in request context")
@@ -185,10 +187,12 @@ func ReplaceRequestModel(r *http.Request, model, replacement string) (*http.Requ
 		}
 		replaceRequestBody(r, body)
 	case strings.Contains(contentType, "multipart/form-data"):
-		if err := r.ParseMultipartForm(32 << 20); err != nil {
+		if err := r.ParseMultipartForm(MaxMultiPartSize); err != nil {
 			return r, fmt.Errorf("could not parse multipart form: %w", err)
 		}
-		body, rewrittenContentType, err := replaceMultipartModel(r.MultipartForm, replacement)
+		form := r.MultipartForm
+		defer form.RemoveAll()
+		body, rewrittenContentType, err := replaceMultipartModel(form, replacement)
 		if err != nil {
 			return r, err
 		}
@@ -396,7 +400,7 @@ func extractContext(r *http.Request) (ReqContextData, error) {
 	// after parsing.
 	r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 	if strings.Contains(contentType, "multipart/form-data") {
-		if err := r.ParseMultipartForm(32 << 20); err != nil {
+		if err := r.ParseMultipartForm(MaxMultiPartSize); err != nil {
 			return ReqContextData{}, fmt.Errorf("error parsing multipart form: %w", err)
 		}
 	} else {

--- a/internal/shared/http_test.go
+++ b/internal/shared/http_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -133,6 +134,13 @@ func TestReplaceRequestModel(t *testing.T) {
 		if err := writer.WriteField("prompt", "hello"); err != nil {
 			t.Fatalf("write prompt: %v", err)
 		}
+		file, err := writer.CreateFormFile("file", "audio.wav")
+		if err != nil {
+			t.Fatalf("create file: %v", err)
+		}
+		if _, err := file.Write([]byte("RIFFdata")); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
 		if err := writer.Close(); err != nil {
 			t.Fatalf("close multipart: %v", err)
 		}
@@ -149,13 +157,82 @@ func TestReplaceRequestModel(t *testing.T) {
 		}
 		assertBodyLength(t, updated, rewritten)
 		updated.Body = io.NopCloser(bytes.NewReader(rewritten))
-		if err := updated.ParseMultipartForm(32 << 20); err != nil {
+		if err := updated.ParseMultipartForm(MaxMultiPartSize); err != nil {
 			t.Fatalf("parse multipart: %v", err)
 		}
 		if got := updated.FormValue("model"); got != "target" {
 			t.Fatalf("model = %q, want target", got)
 		}
+		if got := updated.FormValue("prompt"); got != "hello" {
+			t.Fatalf("prompt = %q, want hello", got)
+		}
+		fileHeader := updated.MultipartForm.File["file"][0]
+		if got := fileHeader.Filename; got != "audio.wav" {
+			t.Fatalf("filename = %q, want audio.wav", got)
+		}
+		uploaded, err := fileHeader.Open()
+		if err != nil {
+			t.Fatalf("open file: %v", err)
+		}
+		fileBody, err := io.ReadAll(uploaded)
+		uploaded.Close()
+		if err != nil {
+			t.Fatalf("read file: %v", err)
+		}
+		if got := string(fileBody); got != "RIFFdata" {
+			t.Fatalf("file body = %q, want RIFFdata", got)
+		}
 		assertContextInvalidated(t, updated)
+	})
+
+	t.Run("multipart temp files cleaned up", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Setenv("TMPDIR", tempDir)
+		t.Setenv("TMP", tempDir)
+		t.Setenv("TEMP", tempDir)
+
+		var body bytes.Buffer
+		writer := multipart.NewWriter(&body)
+		if err := writer.WriteField("model", "public"); err != nil {
+			t.Fatalf("write model: %v", err)
+		}
+		file, err := writer.CreateFormFile("file", "audio.wav")
+		if err != nil {
+			t.Fatalf("create file: %v", err)
+		}
+		if _, err := file.Write([]byte("file-on-disk")); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+		if err := writer.Close(); err != nil {
+			t.Fatalf("close multipart: %v", err)
+		}
+
+		original := append([]byte(nil), body.Bytes()...)
+		r := withContext(httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(original)))
+		r.Header.Set("Content-Type", writer.FormDataContentType())
+		if err := r.ParseMultipartForm(0); err != nil {
+			t.Fatalf("parse multipart: %v", err)
+		}
+		entries, err := os.ReadDir(tempDir)
+		if err != nil {
+			t.Fatalf("read temp dir: %v", err)
+		}
+		if len(entries) == 0 {
+			t.Fatal("multipart file was not written to disk")
+		}
+		r.Body = io.NopCloser(bytes.NewReader(original))
+
+		if _, err := ReplaceRequestModel(r, "public", "target"); err != nil {
+			t.Fatalf("ReplaceRequestModel: %v", err)
+		}
+
+		entries, err = os.ReadDir(tempDir)
+		if err != nil {
+			t.Fatalf("read temp dir: %v", err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("multipart temp files were not removed: %v", entries)
+		}
 	})
 
 	t.Run("upstream path", func(t *testing.T) {


### PR DESCRIPTION
- use shared.ReplaceRequestModel everywhere
- remove magic number for multipart form parsing
- add form.RemoveAll() to clean up temp files

Updates #933
Fixes #937
Supercedes #939