### PR TITLE
internal/server: implement selectors

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -360,7 +360,7 @@
                         "enum": [
                             "warm",
                             "pin",
-                            "balance"
+                            "spillover"
                         ],
                         "description": "How a target is selected for each request."
                     },
@@ -373,18 +373,11 @@
                         },
                         "description": "Ordered target model IDs or aliases. Selector IDs cannot be targets."
                     },
-                    "balance": {
-                        "type": "object",
-                        "properties": {
-                            "spillover": {
-                                "type": "integer",
-                                "minimum": 1,
-                                "default": 1,
-                                "description": "Requests reserved per active target before starting the next balance target."
-                            }
-                        },
-                        "additionalProperties": false,
-                        "default": {}
+                    "spillover": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "default": 1,
+                        "description": "Requests reserved per active target before spilling over to the next target."
                     },
                     "name": {
                         "type": "string",

--- a/config-schema.json
+++ b/config-schema.json
@@ -320,7 +320,7 @@
                     "pins": {
                         "type": "object",
                         "minProperties": 1,
-                        "description": "Model IDs to rewrite while this profile is active. An empty string or null disables the model ID.",
+                        "description": "Model IDs to rewrite while this profile is active. Targets may be concrete models, aliases, peer models, or selector IDs. An empty string or null disables the model ID.",
                         "propertyNames": {
                             "type": "string",
                             "minLength": 1
@@ -335,6 +335,79 @@
                                 }
                             ]
                         }
+                    }
+                },
+                "additionalProperties": false
+            }
+        },
+        "selectors": {
+            "type": "object",
+            "default": {},
+            "description": "Virtual model IDs that select a concrete target for each request. Selectors run after profiles and are not supported on /upstream paths.",
+            "propertyNames": {
+                "type": "string",
+                "minLength": 1
+            },
+            "additionalProperties": {
+                "type": "object",
+                "required": [
+                    "strategy",
+                    "targets"
+                ],
+                "properties": {
+                    "strategy": {
+                        "type": "string",
+                        "enum": [
+                            "warm",
+                            "pin",
+                            "balance"
+                        ],
+                        "description": "How a target is selected for each request."
+                    },
+                    "targets": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "description": "Ordered target model IDs or aliases. Selector IDs cannot be targets."
+                    },
+                    "balance": {
+                        "type": "object",
+                        "properties": {
+                            "spillover": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "default": 1,
+                                "description": "Requests reserved per active target before starting the next balance target."
+                            }
+                        },
+                        "additionalProperties": false,
+                        "default": {}
+                    },
+                    "name": {
+                        "type": "string",
+                        "default": "",
+                        "maxLength": 128,
+                        "description": "Display name used in the /v1/models response."
+                    },
+                    "description": {
+                        "type": "string",
+                        "default": "",
+                        "maxLength": 1024,
+                        "description": "Description used in the /v1/models response."
+                    },
+                    "unlisted": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Hide this selector from /v1/models while keeping it requestable."
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "default": {},
+                        "description": "Arbitrary selector metadata included in /v1/models."
                     }
                 },
                 "additionalProperties": false

--- a/config-schema.json
+++ b/config-schema.json
@@ -373,11 +373,18 @@
                         },
                         "description": "Ordered target model IDs or aliases. Selector IDs cannot be targets."
                     },
-                    "spillover": {
-                        "type": "integer",
-                        "minimum": 1,
-                        "default": 1,
-                        "description": "Requests reserved per active target before spilling over to the next target."
+                    "settings": {
+                        "type": "object",
+                        "properties": {
+                            "spillover": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "default": 1,
+                                "description": "Requests reserved per active target before spilling over to the next target."
+                            }
+                        },
+                        "additionalProperties": false,
+                        "default": {}
                     },
                     "name": {
                         "type": "string",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -174,7 +174,7 @@ upstream:
 # - optional, default: empty dictionary
 # - one profile or none is active; startup and configuration reload select none
 # - pins are applied before aliases, filters, and routing
-# - targets may be a local model, peer model, alias, or setParamsByID alias
+# - targets may be a local model, peer model, alias, setParamsByID alias, or selector
 # - an empty string or YAML null (~) disables the pin with a 404; it is not
 #   added to model listings, while existing local, alias, or peer IDs remain
 profiles:
@@ -184,6 +184,44 @@ profiles:
       "llm-code": "gpt-oss-120b"
       "llm-plan": "qwen-unlisted"
       "image-gen": ~
+
+# selectors: virtual model IDs resolved to concrete targets per request
+# - optional, default: empty dictionary
+# - profiles run first, so a profile pin may target a selector
+# - selector IDs cannot collide with model IDs, aliases, or peer model names
+# - selector targets cannot be other selectors
+# - selectors are not supported on /upstream/<model> paths
+selectors:
+  # warm chooses the first ready target in order, then an already-starting
+  # target, and cold-starts the first target when none are running
+  "coding-model":
+    strategy: warm
+    targets:
+      - "gpt-oss-120b"
+      - "qwen-unlisted"
+    name: "Coding Model"
+    description: "Best currently loaded coding model"
+    metadata:
+      purpose: coding
+
+  # pin always uses the first target; remaining entries are reference data
+  "llm-plan":
+    strategy: pin
+    targets:
+      - "gpt-oss-120b"
+      - "z-ai/glm-4.7"
+
+  # balance spreads requests across local instances that may run concurrently
+  "llama":
+    strategy: balance
+    targets:
+      - "docker-llama"
+      - "modelA"
+      - "modelB"
+    balance:
+      # start the next instance once active instances reach this reservation count
+      # - optional, default: 1
+      spillover: 4
 
 # models: a dictionary of model configurations
 # - required

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -219,9 +219,10 @@ selectors:
       - "docker-llama"
       - "modelA"
       - "modelB"
-    # requests reserved per active target before spilling over to the next target
-    # - optional, default: 1
-    spillover: 4
+    settings:
+      # requests reserved per active target before spilling over to the next target
+      # - optional, default: 1
+      spillover: 4
 
 # models: a dictionary of model configurations
 # - required

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -211,17 +211,17 @@ selectors:
       - "gpt-oss-120b"
       - "z-ai/glm-4.7"
 
-  # balance spreads requests across local instances that may run concurrently
+  # spillover fills local targets to the reservation count in order,
+  # starting the next target when the active targets reach that count
   "llama":
-    strategy: balance
+    strategy: spillover
     targets:
       - "docker-llama"
       - "modelA"
       - "modelB"
-    balance:
-      # start the next instance once active instances reach this reservation count
-      # - optional, default: 1
-      spillover: 4
+    # requests reserved per active target before spilling over to the next target
+    # - optional, default: 1
+    spillover: 4
 
 # models: a dictionary of model configurations
 # - required

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -298,9 +298,10 @@ selectors:
       - "docker-llama"
       - "modelA"
       - "modelB"
-    # requests reserved per active target before spilling over to the next target
-    # - optional, default: 1
-    spillover: 4
+    settings:
+      # requests reserved per active target before spilling over to the next target
+      # - optional, default: 1
+      spillover: 4
 
 # models: a dictionary of model configurations
 # - required

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -290,17 +290,17 @@ selectors:
       - "gpt-oss-120b"
       - "z-ai/glm-4.7"
 
-  # balance spreads requests across local instances that may run concurrently
+  # spillover fills local targets to the reservation count in order,
+  # starting the next target when the active targets reach that count
   "llama":
-    strategy: balance
+    strategy: spillover
     targets:
       - "docker-llama"
       - "modelA"
       - "modelB"
-    balance:
-      # start the next instance once active instances reach this reservation count
-      # - optional, default: 1
-      spillover: 4
+    # requests reserved per active target before spilling over to the next target
+    # - optional, default: 1
+    spillover: 4
 
 # models: a dictionary of model configurations
 # - required

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -253,7 +253,7 @@ apiKeys:
 # - optional, default: empty dictionary
 # - one profile or none is active; startup and configuration reload select none
 # - pins are applied before aliases, filters, and routing
-# - targets may be a local model, peer model, alias, or setParamsByID alias
+# - targets may be a local model, peer model, alias, setParamsByID alias, or selector
 # - an empty string or YAML null (~) disables the pin with a 404; it is not
 #   added to model listings, while existing local, alias, or peer IDs remain
 profiles:
@@ -263,6 +263,44 @@ profiles:
       "llm-code": "gpt-oss-120b"
       "llm-plan": "qwen-unlisted"
       "image-gen": ~
+
+# selectors: virtual model IDs resolved to concrete targets per request
+# - optional, default: empty dictionary
+# - profiles run first, so a profile pin may target a selector
+# - selector IDs cannot collide with model IDs, aliases, or peer model names
+# - selector targets cannot be other selectors
+# - selectors are not supported on /upstream/<model> paths
+selectors:
+  # warm chooses the first ready target in order, then an already-starting
+  # target, and cold-starts the first target when none are running
+  "coding-model":
+    strategy: warm
+    targets:
+      - "gpt-oss-120b"
+      - "qwen-unlisted"
+    name: "Coding Model"
+    description: "Best currently loaded coding model"
+    metadata:
+      purpose: coding
+
+  # pin always uses the first target; remaining entries are reference data
+  "llm-plan":
+    strategy: pin
+    targets:
+      - "gpt-oss-120b"
+      - "z-ai/glm-4.7"
+
+  # balance spreads requests across local instances that may run concurrently
+  "llama":
+    strategy: balance
+    targets:
+      - "docker-llama"
+      - "modelA"
+      - "modelB"
+    balance:
+      # start the next instance once active instances reach this reservation count
+      # - optional, default: 1
+      spillover: 4
 
 # models: a dictionary of model configurations
 # - required

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,20 +141,21 @@ func (c *ProfileConfig) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type Config struct {
-	HealthCheckTimeout int                      `yaml:"healthCheckTimeout"`
-	LogRequests        bool                     `yaml:"logRequests"`
-	LogLevel           string                   `yaml:"logLevel"`
-	LogTimeFormat      string                   `yaml:"logTimeFormat"`
-	LogToStdout        string                   `yaml:"logToStdout"`
-	MetricsMaxInMemory int                      `yaml:"metricsMaxInMemory"`
-	CaptureBuffer      int                      `yaml:"captureBuffer"`
-	Store              *Store                   `yaml:"store"`
-	UI                 UIConfig                 `yaml:"ui"`
-	Performance        PerformanceConfig        `yaml:"performance"`
-	GlobalTTL          int                      `yaml:"globalTTL"`
-	UnloadTimeout      int                      `yaml:"unloadTimeout"`
-	Models             map[string]ModelConfig   `yaml:"models"` /* key is model ID */
-	Profiles           map[string]ProfileConfig `yaml:"profiles"`
+	HealthCheckTimeout int                       `yaml:"healthCheckTimeout"`
+	LogRequests        bool                      `yaml:"logRequests"`
+	LogLevel           string                    `yaml:"logLevel"`
+	LogTimeFormat      string                    `yaml:"logTimeFormat"`
+	LogToStdout        string                    `yaml:"logToStdout"`
+	MetricsMaxInMemory int                       `yaml:"metricsMaxInMemory"`
+	CaptureBuffer      int                       `yaml:"captureBuffer"`
+	Store              *Store                    `yaml:"store"`
+	UI                 UIConfig                  `yaml:"ui"`
+	Performance        PerformanceConfig         `yaml:"performance"`
+	GlobalTTL          int                       `yaml:"globalTTL"`
+	UnloadTimeout      int                       `yaml:"unloadTimeout"`
+	Models             map[string]ModelConfig    `yaml:"models"` /* key is model ID */
+	Profiles           map[string]ProfileConfig  `yaml:"profiles"`
+	Selectors          map[string]SelectorConfig `yaml:"selectors"`
 
 	// routing is the canonical source for swap/scheduling configuration.
 	// New code must read Routing, never the backwards-compat fields below.

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -462,6 +462,10 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		config.Peers[peerName] = peerConfig
 	}
 
+	if err := validateSelectors(config); err != nil {
+		return Config{}, err
+	}
+
 	if err := validateProfiles(config); err != nil {
 		return Config{}, err
 	}
@@ -485,6 +489,9 @@ func validateProfiles(config Config) error {
 				continue
 			}
 			if _, found := config.ResolveBaseModel(target); !found {
+				if _, found := config.Selectors[target]; found {
+					continue
+				}
 				return fmt.Errorf("profiles.%s.pins.%s references unknown model %q", profileName, pin, target)
 			}
 		}

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -18,6 +18,7 @@ var identityMapPaths = map[string]bool{
 	"models":                         true,
 	"groups":                         true,
 	"profiles":                       true,
+	"selectors":                      true,
 	"peers":                          true,
 	"matrix":                         true,
 	"routing.router.settings.groups": true,

--- a/internal/config/selectors.go
+++ b/internal/config/selectors.go
@@ -1,0 +1,166 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	SelectorStrategyWarm    = "warm"
+	SelectorStrategyPin     = "pin"
+	SelectorStrategyBalance = "balance"
+)
+
+// SelectorBalanceConfig contains settings used by the balance strategy.
+type SelectorBalanceConfig struct {
+	Spillover int `yaml:"spillover" json:"spillover"`
+}
+
+// SelectorConfig describes a virtual model ID that resolves to a concrete
+// local model, alias, or peer model for each request.
+type SelectorConfig struct {
+	Strategy    string                `yaml:"strategy" json:"strategy"`
+	Targets     []string              `yaml:"targets" json:"targets"`
+	Balance     SelectorBalanceConfig `yaml:"balance" json:"balance"`
+	Name        string                `yaml:"name" json:"name"`
+	Description string                `yaml:"description" json:"description"`
+	Unlisted    bool                  `yaml:"unlisted" json:"unlisted"`
+	Metadata    map[string]any        `yaml:"metadata" json:"metadata"`
+}
+
+// UnmarshalYAML applies selector defaults while retaining the distinction
+// between an omitted spillover value and an explicitly invalid zero.
+func (c *SelectorConfig) UnmarshalYAML(value *yaml.Node) error {
+	type rawSelectorConfig SelectorConfig
+	defaults := rawSelectorConfig{
+		Targets:  []string{},
+		Balance:  SelectorBalanceConfig{Spillover: 1},
+		Metadata: map[string]any{},
+	}
+	if err := value.Decode(&defaults); err != nil {
+		return err
+	}
+	*c = SelectorConfig(defaults)
+	return nil
+}
+
+func validateSelectors(config Config) error {
+	for selectorID, selector := range config.Selectors {
+		if strings.TrimSpace(selectorID) == "" {
+			return fmt.Errorf("selectors: selector names cannot be empty")
+		}
+		if _, found := config.Models[selectorID]; found {
+			return fmt.Errorf("selectors.%s: name conflicts with model ID %q", selectorID, selectorID)
+		}
+		if _, found := config.aliases[selectorID]; found {
+			return fmt.Errorf("selectors.%s: name conflicts with model alias %q", selectorID, selectorID)
+		}
+		for peerID, peer := range config.Peers {
+			for _, modelID := range peer.Models {
+				if modelID == selectorID {
+					return fmt.Errorf("selectors.%s: name conflicts with peer model %q from peer %q", selectorID, modelID, peerID)
+				}
+			}
+		}
+
+		switch selector.Strategy {
+		case SelectorStrategyPin, SelectorStrategyWarm, SelectorStrategyBalance:
+		case "":
+			return fmt.Errorf("selectors.%s.strategy is required", selectorID)
+		default:
+			return fmt.Errorf("selectors.%s.strategy: unknown strategy %q (valid: warm, pin, balance)", selectorID, selector.Strategy)
+		}
+		if len(selector.Targets) == 0 {
+			return fmt.Errorf("selectors.%s.targets must contain at least one entry", selectorID)
+		}
+
+		resolvedTargets := make([]string, 0, len(selector.Targets))
+		for i, target := range selector.Targets {
+			if _, found := config.Selectors[target]; found {
+				return fmt.Errorf("selectors.%s.targets[%d] references selector %q; selector chaining is not supported", selectorID, i, target)
+			}
+			if _, found := config.ResolveBaseModel(target); !found {
+				return fmt.Errorf("selectors.%s.targets[%d] references unknown model %q", selectorID, i, target)
+			}
+
+			if selector.Strategy == SelectorStrategyWarm || selector.Strategy == SelectorStrategyBalance {
+				realName, local := config.RealModelName(target)
+				if !local {
+					return fmt.Errorf("selectors.%s.targets[%d] must resolve to a local model for strategy %q", selectorID, i, selector.Strategy)
+				}
+				resolvedTargets = append(resolvedTargets, realName)
+			}
+		}
+
+		if selector.Strategy != SelectorStrategyBalance {
+			continue
+		}
+		if selector.Balance.Spillover < 1 {
+			return fmt.Errorf("selectors.%s.balance.spillover must be >= 1", selectorID)
+		}
+
+		seen := make(map[string]struct{}, len(resolvedTargets))
+		for _, target := range resolvedTargets {
+			if _, duplicate := seen[target]; duplicate {
+				return fmt.Errorf("selectors.%s.targets contains duplicate resolved model %q", selectorID, target)
+			}
+			seen[target] = struct{}{}
+		}
+		if err := validateBalanceCoexistence(config, selectorID, resolvedTargets); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateBalanceCoexistence(config Config, selectorID string, targets []string) error {
+	if len(targets) <= 1 {
+		return nil
+	}
+
+	if config.Routing.Router.Use == "matrix" {
+		matrix := config.Routing.Router.Settings.Matrix
+		if matrix != nil {
+			for _, set := range matrix.ExpandedSets {
+				members := make(map[string]struct{}, len(set.Models))
+				for _, modelID := range set.Models {
+					members[modelID] = struct{}{}
+				}
+				allFound := true
+				for _, target := range targets {
+					if _, found := members[target]; !found {
+						allFound = false
+						break
+					}
+				}
+				if allFound {
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("selectors.%s.targets must all appear together in one expanded matrix set", selectorID)
+	}
+
+	groupOf := make(map[string]string, len(config.Models))
+	for groupID, group := range config.Routing.Router.Settings.Groups {
+		for _, member := range group.Members {
+			groupOf[member] = groupID
+		}
+	}
+
+	groupID := groupOf[targets[0]]
+	if groupID == "" {
+		return fmt.Errorf("selectors.%s target %q is not in a routing group", selectorID, targets[0])
+	}
+	if config.Routing.Router.Settings.Groups[groupID].Swap {
+		return fmt.Errorf("selectors.%s balance targets must share a group with swap: false", selectorID)
+	}
+	for _, target := range targets[1:] {
+		if groupOf[target] != groupID {
+			return fmt.Errorf("selectors.%s balance targets must share one routing group", selectorID)
+		}
+	}
+	return nil
+}

--- a/internal/config/selectors.go
+++ b/internal/config/selectors.go
@@ -8,26 +8,21 @@ import (
 )
 
 const (
-	SelectorStrategyWarm    = "warm"
-	SelectorStrategyPin     = "pin"
-	SelectorStrategyBalance = "balance"
+	SelectorStrategyWarm      = "warm"
+	SelectorStrategyPin       = "pin"
+	SelectorStrategySpillover = "spillover"
 )
-
-// SelectorBalanceConfig contains settings used by the balance strategy.
-type SelectorBalanceConfig struct {
-	Spillover int `yaml:"spillover" json:"spillover"`
-}
 
 // SelectorConfig describes a virtual model ID that resolves to a concrete
 // local model, alias, or peer model for each request.
 type SelectorConfig struct {
-	Strategy    string                `yaml:"strategy" json:"strategy"`
-	Targets     []string              `yaml:"targets" json:"targets"`
-	Balance     SelectorBalanceConfig `yaml:"balance" json:"balance"`
-	Name        string                `yaml:"name" json:"name"`
-	Description string                `yaml:"description" json:"description"`
-	Unlisted    bool                  `yaml:"unlisted" json:"unlisted"`
-	Metadata    map[string]any        `yaml:"metadata" json:"metadata"`
+	Strategy    string         `yaml:"strategy" json:"strategy"`
+	Targets     []string       `yaml:"targets" json:"targets"`
+	Spillover   int            `yaml:"spillover" json:"spillover"`
+	Name        string         `yaml:"name" json:"name"`
+	Description string         `yaml:"description" json:"description"`
+	Unlisted    bool           `yaml:"unlisted" json:"unlisted"`
+	Metadata    map[string]any `yaml:"metadata" json:"metadata"`
 }
 
 // UnmarshalYAML applies selector defaults while retaining the distinction
@@ -35,9 +30,9 @@ type SelectorConfig struct {
 func (c *SelectorConfig) UnmarshalYAML(value *yaml.Node) error {
 	type rawSelectorConfig SelectorConfig
 	defaults := rawSelectorConfig{
-		Targets:  []string{},
-		Balance:  SelectorBalanceConfig{Spillover: 1},
-		Metadata: map[string]any{},
+		Targets:   []string{},
+		Spillover: 1,
+		Metadata:  map[string]any{},
 	}
 	if err := value.Decode(&defaults); err != nil {
 		return err
@@ -66,11 +61,11 @@ func validateSelectors(config Config) error {
 		}
 
 		switch selector.Strategy {
-		case SelectorStrategyPin, SelectorStrategyWarm, SelectorStrategyBalance:
+		case SelectorStrategyPin, SelectorStrategyWarm, SelectorStrategySpillover:
 		case "":
 			return fmt.Errorf("selectors.%s.strategy is required", selectorID)
 		default:
-			return fmt.Errorf("selectors.%s.strategy: unknown strategy %q (valid: warm, pin, balance)", selectorID, selector.Strategy)
+			return fmt.Errorf("selectors.%s.strategy: unknown strategy %q (valid: warm, pin, spillover)", selectorID, selector.Strategy)
 		}
 		if len(selector.Targets) == 0 {
 			return fmt.Errorf("selectors.%s.targets must contain at least one entry", selectorID)
@@ -85,7 +80,7 @@ func validateSelectors(config Config) error {
 				return fmt.Errorf("selectors.%s.targets[%d] references unknown model %q", selectorID, i, target)
 			}
 
-			if selector.Strategy == SelectorStrategyWarm || selector.Strategy == SelectorStrategyBalance {
+			if selector.Strategy == SelectorStrategyWarm || selector.Strategy == SelectorStrategySpillover {
 				realName, local := config.RealModelName(target)
 				if !local {
 					return fmt.Errorf("selectors.%s.targets[%d] must resolve to a local model for strategy %q", selectorID, i, selector.Strategy)
@@ -94,11 +89,11 @@ func validateSelectors(config Config) error {
 			}
 		}
 
-		if selector.Strategy != SelectorStrategyBalance {
+		if selector.Strategy != SelectorStrategySpillover {
 			continue
 		}
-		if selector.Balance.Spillover < 1 {
-			return fmt.Errorf("selectors.%s.balance.spillover must be >= 1", selectorID)
+		if selector.Spillover < 1 {
+			return fmt.Errorf("selectors.%s.spillover must be >= 1", selectorID)
 		}
 
 		seen := make(map[string]struct{}, len(resolvedTargets))
@@ -108,14 +103,14 @@ func validateSelectors(config Config) error {
 			}
 			seen[target] = struct{}{}
 		}
-		if err := validateBalanceCoexistence(config, selectorID, resolvedTargets); err != nil {
+		if err := validateSpilloverCoexistence(config, selectorID, resolvedTargets); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func validateBalanceCoexistence(config Config, selectorID string, targets []string) error {
+func validateSpilloverCoexistence(config Config, selectorID string, targets []string) error {
 	if len(targets) <= 1 {
 		return nil
 	}
@@ -155,11 +150,11 @@ func validateBalanceCoexistence(config Config, selectorID string, targets []stri
 		return fmt.Errorf("selectors.%s target %q is not in a routing group", selectorID, targets[0])
 	}
 	if config.Routing.Router.Settings.Groups[groupID].Swap {
-		return fmt.Errorf("selectors.%s balance targets must share a group with swap: false", selectorID)
+		return fmt.Errorf("selectors.%s spillover targets must share a group with swap: false", selectorID)
 	}
 	for _, target := range targets[1:] {
 		if groupOf[target] != groupID {
-			return fmt.Errorf("selectors.%s balance targets must share one routing group", selectorID)
+			return fmt.Errorf("selectors.%s spillover targets must share one routing group", selectorID)
 		}
 	}
 	return nil

--- a/internal/config/selectors.go
+++ b/internal/config/selectors.go
@@ -13,16 +13,21 @@ const (
 	SelectorStrategySpillover = "spillover"
 )
 
+// SelectorSettings contains strategy-specific selector settings.
+type SelectorSettings struct {
+	Spillover int `yaml:"spillover" json:"spillover"`
+}
+
 // SelectorConfig describes a virtual model ID that resolves to a concrete
 // local model, alias, or peer model for each request.
 type SelectorConfig struct {
-	Strategy    string         `yaml:"strategy" json:"strategy"`
-	Targets     []string       `yaml:"targets" json:"targets"`
-	Spillover   int            `yaml:"spillover" json:"spillover"`
-	Name        string         `yaml:"name" json:"name"`
-	Description string         `yaml:"description" json:"description"`
-	Unlisted    bool           `yaml:"unlisted" json:"unlisted"`
-	Metadata    map[string]any `yaml:"metadata" json:"metadata"`
+	Strategy    string           `yaml:"strategy" json:"strategy"`
+	Targets     []string         `yaml:"targets" json:"targets"`
+	Settings    SelectorSettings `yaml:"settings" json:"settings"`
+	Name        string           `yaml:"name" json:"name"`
+	Description string           `yaml:"description" json:"description"`
+	Unlisted    bool             `yaml:"unlisted" json:"unlisted"`
+	Metadata    map[string]any   `yaml:"metadata" json:"metadata"`
 }
 
 // UnmarshalYAML applies selector defaults while retaining the distinction
@@ -30,9 +35,9 @@ type SelectorConfig struct {
 func (c *SelectorConfig) UnmarshalYAML(value *yaml.Node) error {
 	type rawSelectorConfig SelectorConfig
 	defaults := rawSelectorConfig{
-		Targets:   []string{},
-		Spillover: 1,
-		Metadata:  map[string]any{},
+		Targets:  []string{},
+		Settings: SelectorSettings{Spillover: 1},
+		Metadata: map[string]any{},
 	}
 	if err := value.Decode(&defaults); err != nil {
 		return err
@@ -92,8 +97,8 @@ func validateSelectors(config Config) error {
 		if selector.Strategy != SelectorStrategySpillover {
 			continue
 		}
-		if selector.Spillover < 1 {
-			return fmt.Errorf("selectors.%s.spillover must be >= 1", selectorID)
+		if selector.Settings.Spillover < 1 {
+			return fmt.Errorf("selectors.%s.settings.spillover must be >= 1", selectorID)
 		}
 
 		seen := make(map[string]struct{}, len(resolvedTargets))

--- a/internal/config/selectors_test.go
+++ b/internal/config/selectors_test.go
@@ -1,0 +1,343 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Selectors_LoadDefaultsAndFields(t *testing.T) {
+	cfg, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  a:
+    cmd: echo ${PORT}
+  b:
+    cmd: echo ${PORT}
+groups:
+  balanced:
+    swap: false
+    members: [a, b]
+selectors:
+  coding:
+    strategy: warm
+    targets: [a, b]
+    name: Coding Model
+    description: Best available coding model
+    unlisted: true
+    metadata:
+      family: coding
+  workers:
+    strategy: balance
+    targets: [a, b]
+`))
+	require.NoError(t, err)
+
+	coding := cfg.Selectors["coding"]
+	assert.Equal(t, SelectorStrategyWarm, coding.Strategy)
+	assert.Equal(t, []string{"a", "b"}, coding.Targets)
+	assert.Equal(t, 1, coding.Balance.Spillover)
+	assert.Equal(t, "Coding Model", coding.Name)
+	assert.Equal(t, "Best available coding model", coding.Description)
+	assert.True(t, coding.Unlisted)
+	assert.Equal(t, "coding", coding.Metadata["family"])
+
+	workers := cfg.Selectors["workers"]
+	assert.Equal(t, 1, workers.Balance.Spillover)
+}
+
+func TestConfig_Selectors_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  string
+		wantErr string
+	}{
+		{
+			name: "empty selector id",
+			config: `
+selectors:
+  " ":
+    strategy: pin
+    targets: [a]
+`,
+			wantErr: "selector names cannot be empty",
+		},
+		{
+			name: "missing strategy",
+			config: `
+selectors:
+  public:
+    targets: [a]
+`,
+			wantErr: "strategy is required",
+		},
+		{
+			name: "unknown strategy",
+			config: `
+selectors:
+  public:
+    strategy: random
+    targets: [a]
+`,
+			wantErr: "unknown strategy",
+		},
+		{
+			name: "missing targets",
+			config: `
+selectors:
+  public:
+    strategy: pin
+`,
+			wantErr: "targets must contain at least one entry",
+		},
+		{
+			name: "unknown target",
+			config: `
+selectors:
+  public:
+    strategy: pin
+    targets: [missing]
+`,
+			wantErr: `references unknown model "missing"`,
+		},
+		{
+			name: "selector chaining",
+			config: `
+selectors:
+  first:
+    strategy: pin
+    targets: [a]
+  second:
+    strategy: pin
+    targets: [first]
+`,
+			wantErr: "selector chaining is not supported",
+		},
+		{
+			name: "model id collision",
+			config: `
+selectors:
+  a:
+    strategy: pin
+    targets: [a]
+`,
+			wantErr: "name conflicts with model ID",
+		},
+		{
+			name: "explicit alias collision",
+			config: `
+selectors:
+  alias-a:
+    strategy: pin
+    targets: [a]
+`,
+			wantErr: "name conflicts with model alias",
+		},
+		{
+			name: "generated alias collision",
+			config: `
+selectors:
+  variant:
+    strategy: pin
+    targets: [a]
+`,
+			wantErr: "name conflicts with model alias",
+		},
+		{
+			name: "peer collision",
+			config: `
+selectors:
+  remote-model:
+    strategy: pin
+    targets: [a]
+`,
+			wantErr: "name conflicts with peer model",
+		},
+		{
+			name: "warm peer target",
+			config: `
+selectors:
+  public:
+    strategy: warm
+    targets: [remote-model]
+`,
+			wantErr: `must resolve to a local model for strategy "warm"`,
+		},
+		{
+			name: "balance peer target",
+			config: `
+selectors:
+  public:
+    strategy: balance
+    targets: [remote-model]
+`,
+			wantErr: `must resolve to a local model for strategy "balance"`,
+		},
+		{
+			name: "invalid spillover",
+			config: `
+selectors:
+  public:
+    strategy: balance
+    targets: [a]
+    balance:
+      spillover: 0
+`,
+			wantErr: "spillover must be >= 1",
+		},
+		{
+			name: "duplicate resolved balance target",
+			config: `
+selectors:
+  public:
+    strategy: balance
+    targets: [a, alias-a]
+`,
+			wantErr: `duplicate resolved model "a"`,
+		},
+		{
+			name: "balance swapping group",
+			config: `
+selectors:
+  public:
+    strategy: balance
+    targets: [a, b]
+`,
+			wantErr: "must share a group with swap: false",
+		},
+	}
+
+	const base = `
+models:
+  a:
+    cmd: echo ${PORT}
+    aliases: [alias-a]
+    filters:
+      setParamsByID:
+        variant:
+          temperature: 0
+  b:
+    cmd: echo ${PORT}
+peers:
+  remote:
+    proxy: http://example.com
+    models: [remote-model]
+`
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := LoadConfigFromReader(strings.NewReader(base + tc.config))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestConfig_Selectors_BalanceCoexistence(t *testing.T) {
+	t.Run("group", func(t *testing.T) {
+		cfg, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  a:
+    cmd: echo ${PORT}
+  b:
+    cmd: echo ${PORT}
+groups:
+  pool:
+    swap: false
+    members: [a, b]
+selectors:
+  public:
+    strategy: balance
+    targets: [a, b]
+    balance:
+      spillover: 4
+`))
+		require.NoError(t, err)
+		assert.Equal(t, 4, cfg.Selectors["public"].Balance.Spillover)
+	})
+
+	t.Run("matrix common set", func(t *testing.T) {
+		_, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  a:
+    cmd: echo ${PORT}
+  b:
+    cmd: echo ${PORT}
+matrix:
+  vars:
+    A: a
+    B: b
+  sets:
+    pool: "A & B"
+selectors:
+  public:
+    strategy: balance
+    targets: [a, b]
+`))
+		require.NoError(t, err)
+	})
+
+	t.Run("matrix separate sets", func(t *testing.T) {
+		_, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  a:
+    cmd: echo ${PORT}
+  b:
+    cmd: echo ${PORT}
+matrix:
+  vars:
+    A: a
+    B: b
+  sets:
+    pool: "A | B"
+selectors:
+  public:
+    strategy: balance
+    targets: [a, b]
+`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must all appear together in one expanded matrix set")
+	})
+}
+
+func TestConfig_Selectors_ProfileTargetsSelector(t *testing.T) {
+	cfg, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  a:
+    cmd: echo ${PORT}
+selectors:
+  public:
+    strategy: pin
+    targets: [a]
+profiles:
+  coding:
+    pins:
+      llm-code: public
+`))
+	require.NoError(t, err)
+	assert.Equal(t, "public", cfg.Profiles["coding"].Pins["llm-code"])
+}
+
+func TestConfig_Selectors_MergeDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, "a.yaml", `
+models:
+  a:
+    cmd: echo ${PORT}
+selectors:
+  public:
+    strategy: pin
+    targets: [a]
+`)
+	writeYAML(t, dir, "b.yaml", `
+selectors:
+  public:
+    strategy: pin
+    targets: [a]
+`)
+
+	_, err := LoadConfigSources("", dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate selectors "public"`)
+}

--- a/internal/config/selectors_test.go
+++ b/internal/config/selectors_test.go
@@ -37,14 +37,14 @@ selectors:
 	coding := cfg.Selectors["coding"]
 	assert.Equal(t, SelectorStrategyWarm, coding.Strategy)
 	assert.Equal(t, []string{"a", "b"}, coding.Targets)
-	assert.Equal(t, 1, coding.Spillover)
+	assert.Equal(t, 1, coding.Settings.Spillover)
 	assert.Equal(t, "Coding Model", coding.Name)
 	assert.Equal(t, "Best available coding model", coding.Description)
 	assert.True(t, coding.Unlisted)
 	assert.Equal(t, "coding", coding.Metadata["family"])
 
 	workers := cfg.Selectors["workers"]
-	assert.Equal(t, 1, workers.Spillover)
+	assert.Equal(t, 1, workers.Settings.Spillover)
 }
 
 func TestConfig_Selectors_Validation(t *testing.T) {
@@ -181,9 +181,10 @@ selectors:
   public:
     strategy: spillover
     targets: [a]
-    spillover: 0
+    settings:
+      spillover: 0
 `,
-			wantErr: "spillover must be >= 1",
+			wantErr: "settings.spillover must be >= 1",
 		},
 		{
 			name: "duplicate resolved spillover target",
@@ -249,10 +250,11 @@ selectors:
   public:
     strategy: spillover
     targets: [a, b]
-    spillover: 4
+    settings:
+      spillover: 4
 `))
 		require.NoError(t, err)
-		assert.Equal(t, 4, cfg.Selectors["public"].Spillover)
+		assert.Equal(t, 4, cfg.Selectors["public"].Settings.Spillover)
 	})
 
 	t.Run("matrix common set", func(t *testing.T) {

--- a/internal/config/selectors_test.go
+++ b/internal/config/selectors_test.go
@@ -29,7 +29,7 @@ selectors:
     metadata:
       family: coding
   workers:
-    strategy: balance
+    strategy: spillover
     targets: [a, b]
 `))
 	require.NoError(t, err)
@@ -37,14 +37,14 @@ selectors:
 	coding := cfg.Selectors["coding"]
 	assert.Equal(t, SelectorStrategyWarm, coding.Strategy)
 	assert.Equal(t, []string{"a", "b"}, coding.Targets)
-	assert.Equal(t, 1, coding.Balance.Spillover)
+	assert.Equal(t, 1, coding.Spillover)
 	assert.Equal(t, "Coding Model", coding.Name)
 	assert.Equal(t, "Best available coding model", coding.Description)
 	assert.True(t, coding.Unlisted)
 	assert.Equal(t, "coding", coding.Metadata["family"])
 
 	workers := cfg.Selectors["workers"]
-	assert.Equal(t, 1, workers.Balance.Spillover)
+	assert.Equal(t, 1, workers.Spillover)
 }
 
 func TestConfig_Selectors_Validation(t *testing.T) {
@@ -165,43 +165,42 @@ selectors:
 			wantErr: `must resolve to a local model for strategy "warm"`,
 		},
 		{
-			name: "balance peer target",
+			name: "spillover peer target",
 			config: `
 selectors:
   public:
-    strategy: balance
+    strategy: spillover
     targets: [remote-model]
 `,
-			wantErr: `must resolve to a local model for strategy "balance"`,
+			wantErr: `must resolve to a local model for strategy "spillover"`,
 		},
 		{
 			name: "invalid spillover",
 			config: `
 selectors:
   public:
-    strategy: balance
+    strategy: spillover
     targets: [a]
-    balance:
-      spillover: 0
+    spillover: 0
 `,
 			wantErr: "spillover must be >= 1",
 		},
 		{
-			name: "duplicate resolved balance target",
+			name: "duplicate resolved spillover target",
 			config: `
 selectors:
   public:
-    strategy: balance
+    strategy: spillover
     targets: [a, alias-a]
 `,
 			wantErr: `duplicate resolved model "a"`,
 		},
 		{
-			name: "balance swapping group",
+			name: "spillover swapping group",
 			config: `
 selectors:
   public:
-    strategy: balance
+    strategy: spillover
     targets: [a, b]
 `,
 			wantErr: "must share a group with swap: false",
@@ -234,7 +233,7 @@ peers:
 	}
 }
 
-func TestConfig_Selectors_BalanceCoexistence(t *testing.T) {
+func TestConfig_Selectors_SpilloverCoexistence(t *testing.T) {
 	t.Run("group", func(t *testing.T) {
 		cfg, err := LoadConfigFromReader(strings.NewReader(`
 models:
@@ -248,13 +247,12 @@ groups:
     members: [a, b]
 selectors:
   public:
-    strategy: balance
+    strategy: spillover
     targets: [a, b]
-    balance:
-      spillover: 4
+    spillover: 4
 `))
 		require.NoError(t, err)
-		assert.Equal(t, 4, cfg.Selectors["public"].Balance.Spillover)
+		assert.Equal(t, 4, cfg.Selectors["public"].Spillover)
 	})
 
 	t.Run("matrix common set", func(t *testing.T) {
@@ -272,7 +270,7 @@ matrix:
     pool: "A & B"
 selectors:
   public:
-    strategy: balance
+    strategy: spillover
     targets: [a, b]
 `))
 		require.NoError(t, err)
@@ -293,7 +291,7 @@ matrix:
     pool: "A | B"
 selectors:
   public:
-    strategy: balance
+    strategy: spillover
     targets: [a, b]
 `))
 		require.Error(t, err)

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -146,7 +146,13 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 		return "unloaded"
 	}
 
-	newRecord := func(id, name, description string, metadata map[string]any, caps config.ModelCapConfig, status string) modelRecord {
+	newRecord := func(
+		id, name, description string,
+		metadata map[string]any,
+		caps config.ModelCapConfig,
+		status string,
+		internalMetadata map[string]any,
+	) modelRecord {
 		rec := modelRecord{
 			ID:          id,
 			Object:      "model",
@@ -160,8 +166,15 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 		if !caps.Empty() {
 			metadata = filterCappedMetadata(metadata)
 		}
-		if len(metadata) > 0 {
-			rec.Meta = map[string]any{"llamaswap": metadata}
+		llamaSwapMetadata := make(map[string]any, len(metadata)+len(internalMetadata))
+		for key, value := range metadata {
+			llamaSwapMetadata[key] = value
+		}
+		for key, value := range internalMetadata {
+			llamaSwapMetadata[key] = value
+		}
+		if len(llamaSwapMetadata) > 0 {
+			rec.Meta = map[string]any{"llamaswap": llamaSwapMetadata}
 		}
 		return rec
 	}
@@ -176,12 +189,24 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		status := modelStatus(id)
-		data = append(data, newRecord(id, mc.Name, mc.Description, mc.Metadata, mc.Capabilities, status))
+		internalMetadata := map[string]any{"type": "model"}
+		if len(mc.Aliases) > 0 {
+			internalMetadata["aliases"] = mc.Aliases
+		}
+		data = append(data, newRecord(id, mc.Name, mc.Description, mc.Metadata, mc.Capabilities, status, internalMetadata))
 
 		if s.cfg.IncludeAliasesInList {
 			for _, alias := range mc.Aliases {
 				if alias := strings.TrimSpace(alias); alias != "" {
-					data = append(data, newRecord(alias, mc.Name, mc.Description, mc.Metadata, mc.Capabilities, status))
+					data = append(data, newRecord(
+						alias,
+						mc.Name,
+						mc.Description,
+						mc.Metadata,
+						mc.Capabilities,
+						status,
+						map[string]any{"type": "alias", "modelID": id},
+					))
 				}
 			}
 		}
@@ -190,7 +215,15 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 	for peerID, peer := range s.cfg.Peers {
 		for _, modelID := range peer.Models {
 			modelIDs[modelID] = struct{}{}
-			data = append(data, newRecord(modelID, peerID+": "+modelID, "", map[string]any{"peerID": peerID}, config.ModelCapConfig{}, "unloaded"))
+			data = append(data, newRecord(
+				modelID,
+				peerID+": "+modelID,
+				"",
+				nil,
+				config.ModelCapConfig{},
+				"unloaded",
+				map[string]any{"type": "peer", "peerID": peerID},
+			))
 		}
 	}
 
@@ -212,7 +245,15 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 		}
-		data = append(data, newRecord(selectorID, selector.Name, selector.Description, selector.Metadata, config.ModelCapConfig{}, status))
+		data = append(data, newRecord(
+			selectorID,
+			selector.Name,
+			selector.Description,
+			selector.Metadata,
+			config.ModelCapConfig{},
+			status,
+			map[string]any{"type": "selector"},
+		))
 	}
 
 	if profile, ok := s.cfg.Profiles[s.ActiveProfile()]; ok {
@@ -223,7 +264,15 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 			if _, shadowsModel := modelIDs[pin]; shadowsModel {
 				continue
 			}
-			data = append(data, newRecord(pin, "", "", nil, config.ModelCapConfig{}, "unloaded"))
+			data = append(data, newRecord(
+				pin,
+				"",
+				"",
+				nil,
+				config.ModelCapConfig{},
+				"unloaded",
+				map[string]any{"type": "profile"},
+			))
 		}
 	}
 

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -135,7 +135,7 @@ func filterCappedMetadata(md map[string]any) map[string]any {
 // (with optional aliases) plus peer models.
 func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 	created := time.Now().Unix()
-	data := make([]modelRecord, 0, len(s.cfg.Models))
+	data := make([]modelRecord, 0, len(s.cfg.Models)+len(s.cfg.Selectors))
 	running := s.local.RunningModels()
 	modelIDs := make(map[string]struct{})
 
@@ -192,6 +192,26 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 			modelIDs[modelID] = struct{}{}
 			data = append(data, newRecord(modelID, peerID+": "+modelID, "", map[string]any{"peerID": peerID}, config.ModelCapConfig{}, "unloaded"))
 		}
+	}
+
+	for selectorID, selector := range s.cfg.Selectors {
+		modelIDs[selectorID] = struct{}{}
+		if selector.Unlisted {
+			continue
+		}
+		status := "unloaded"
+		for _, target := range selector.Targets {
+			modelID, local := s.cfg.RealModelName(target)
+			if !local {
+				continue
+			}
+			state := running[modelID]
+			if state == process.StateReady || state == process.StateStarting {
+				status = "loaded"
+				break
+			}
+		}
+		data = append(data, newRecord(selectorID, selector.Name, selector.Description, selector.Metadata, config.ModelCapConfig{}, status))
 	}
 
 	if profile, ok := s.cfg.Profiles[s.ActiveProfile()]; ok {

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -202,12 +202,13 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 		status := "unloaded"
 		for _, target := range selector.Targets {
 			modelID, local := s.cfg.RealModelName(target)
-			if !local {
-				continue
+			if local {
+				state := running[modelID]
+				if state == process.StateReady || state == process.StateStarting {
+					status = "loaded"
+				}
 			}
-			state := running[modelID]
-			if state == process.StateReady || state == process.StateStarting {
-				status = "loaded"
+			if selector.Strategy == config.SelectorStrategyPin || status == "loaded" {
 				break
 			}
 		}

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -130,6 +130,12 @@ func (mp *metricsMonitor) record(modelID string, r *http.Request, recorder *resp
 			tm.Metadata[k] = v
 		}
 	}
+	if selectorID := selectorFromContext(r.Context()); selectorID != "" {
+		if tm.Metadata == nil {
+			tm.Metadata = make(map[string]string)
+		}
+		tm.Metadata["selector"] = selectorID
+	}
 
 	queueAndEmit := func() {
 		stored, ok := mp.queueMetrics(tm)

--- a/internal/server/profiles_test.go
+++ b/internal/server/profiles_test.go
@@ -239,18 +239,22 @@ func TestServer_Profile_ModelListings(t *testing.T) {
 		Data []modelRecord `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
-	names := make(map[string]string)
+	records := make(map[string]modelRecord)
 	for _, record := range response.Data {
-		names[record.ID] = record.Name
+		records[record.ID] = record
 	}
-	assert.Contains(t, names, "public")
-	assert.Empty(t, names["public"])
-	assert.Equal(t, "Real Model", names["real"])
-	assert.Equal(t, "remote: remote-model", names["remote-model"])
-	assert.Contains(t, names, "expose")
-	assert.Empty(t, names["expose"])
-	assert.NotContains(t, names, "disabled")
-	assert.NotContains(t, names, "hidden")
+	assert.Contains(t, records, "public")
+	assert.Empty(t, records["public"].Name)
+	assert.Equal(t, "Real Model", records["real"].Name)
+	assert.Equal(t, "remote: remote-model", records["remote-model"].Name)
+	assert.Contains(t, records, "expose")
+	assert.Empty(t, records["expose"].Name)
+	assert.NotContains(t, records, "disabled")
+	assert.NotContains(t, records, "hidden")
+	require.Contains(t, records["public"].Meta, "llamaswap")
+	metadata, ok := records["public"].Meta["llamaswap"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "profile", metadata["type"])
 
 	status := s.modelStatus()
 	byID := make(map[string]apiModel)

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -1,0 +1,230 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/mostlygeek/llama-swap/internal/chain"
+	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/process"
+	"github.com/mostlygeek/llama-swap/internal/shared"
+)
+
+type selectorContextKey struct{}
+
+func withSelectorContext(r *http.Request, selectorID string) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), selectorContextKey{}, selectorID))
+}
+
+func selectorFromContext(ctx context.Context) string {
+	selectorID, _ := ctx.Value(selectorContextKey{}).(string)
+	return selectorID
+}
+
+type balanceTarget struct {
+	target  string
+	modelID string
+}
+
+type selectorBalanceState struct {
+	mu        sync.Mutex
+	spillover int
+	targets   []balanceTarget
+	inflight  map[string]int
+	rr        uint64
+}
+
+type selectorBalanceTracker struct {
+	states map[string]*selectorBalanceState
+}
+
+func newSelectorBalanceTracker(cfg config.Config) *selectorBalanceTracker {
+	tracker := &selectorBalanceTracker{states: make(map[string]*selectorBalanceState)}
+	for selectorID, selector := range cfg.Selectors {
+		if selector.Strategy != config.SelectorStrategyBalance {
+			continue
+		}
+		state := &selectorBalanceState{
+			spillover: selector.Balance.Spillover,
+			targets:   make([]balanceTarget, 0, len(selector.Targets)),
+			inflight:  make(map[string]int, len(selector.Targets)),
+		}
+		for _, target := range selector.Targets {
+			modelID, _ := cfg.RealModelName(target)
+			state.targets = append(state.targets, balanceTarget{target: target, modelID: modelID})
+		}
+		tracker.states[selectorID] = state
+	}
+	return tracker
+}
+
+func (t *selectorBalanceTracker) release(selectorID, modelID string) {
+	if t == nil {
+		return
+	}
+	state := t.states[selectorID]
+	if state == nil {
+		return
+	}
+	state.mu.Lock()
+	if state.inflight[modelID] > 0 {
+		state.inflight[modelID]--
+	}
+	state.mu.Unlock()
+}
+
+// CreateSelectorMiddleware resolves selector model IDs after profile rewrites
+// and before the normal request context, filters, routing, and metrics pipeline.
+func CreateSelectorMiddleware(s *Server) chain.Middleware {
+	balances := newSelectorBalanceTracker(s.cfg)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if len(s.cfg.Selectors) == 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			model, err := shared.ExtractModel(r)
+			if err != nil || model == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			selector, found := s.cfg.Selectors[model]
+			if !found {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			var target string
+			switch selector.Strategy {
+			case config.SelectorStrategyPin:
+				target, err = strategyPin(selector)
+			case config.SelectorStrategyWarm:
+				target, err = strategyWarm(s.cfg, selector, s.local.RunningModels())
+			case config.SelectorStrategyBalance:
+				target, err = strategyBalance(model, balances, s.local.RunningModels())
+			default:
+				err = fmt.Errorf("unknown selector strategy %q", selector.Strategy)
+			}
+			if err != nil {
+				shared.SendResponse(w, r, http.StatusServiceUnavailable, err.Error())
+				return
+			}
+
+			updated, err := shared.ReplaceRequestModel(r, model, target)
+			if err != nil {
+				if selector.Strategy == config.SelectorStrategyBalance {
+					if modelID, found := s.cfg.RealModelName(target); found {
+						balances.release(model, modelID)
+					}
+				}
+				shared.SendResponse(w, r, http.StatusBadRequest, err.Error())
+				return
+			}
+
+			if selector.Strategy == config.SelectorStrategyBalance {
+				modelID, _ := s.cfg.RealModelName(target)
+				defer balances.release(model, modelID)
+			}
+			next.ServeHTTP(w, withSelectorContext(updated, model))
+		})
+	}
+}
+
+func strategyPin(selector config.SelectorConfig) (string, error) {
+	if len(selector.Targets) == 0 {
+		return "", fmt.Errorf("selector has no targets")
+	}
+	return selector.Targets[0], nil
+}
+
+func strategyWarm(cfg config.Config, selector config.SelectorConfig, running map[string]process.ProcessState) (string, error) {
+	if len(selector.Targets) == 0 {
+		return "", fmt.Errorf("selector has no targets")
+	}
+
+	for _, target := range selector.Targets {
+		modelID, _ := cfg.RealModelName(target)
+		if running[modelID] == process.StateReady {
+			return target, nil
+		}
+	}
+	for _, target := range selector.Targets {
+		modelID, _ := cfg.RealModelName(target)
+		if running[modelID] == process.StateStarting {
+			return target, nil
+		}
+	}
+	return selector.Targets[0], nil
+}
+
+func strategyBalance(selectorID string, tracker *selectorBalanceTracker, running map[string]process.ProcessState) (string, error) {
+	if tracker == nil || tracker.states[selectorID] == nil {
+		return "", fmt.Errorf("balance selector %q is not configured", selectorID)
+	}
+	state := tracker.states[selectorID]
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	active := make([]balanceTarget, 0, len(state.targets))
+	cold := make([]balanceTarget, 0, len(state.targets))
+	for _, target := range state.targets {
+		processState, runningNow := running[target.modelID]
+		switch {
+		case processState == process.StateStopping || processState == process.StateShutdown:
+			continue
+		case processState == process.StateReady || processState == process.StateStarting:
+			active = append(active, target)
+		case state.inflight[target.modelID] > 0:
+			active = append(active, target)
+		case !runningNow || processState == process.StateStopped:
+			cold = append(cold, target)
+		}
+	}
+
+	if len(active) == 0 {
+		if len(cold) == 0 {
+			return "", fmt.Errorf("selector %q has no available balance targets", selectorID)
+		}
+		return state.reserve(cold[0]), nil
+	}
+
+	minimum := state.minimum(active)
+	if minimum < state.spillover {
+		return state.reserveLeastBusy(active), nil
+	}
+	if len(cold) > 0 {
+		return state.reserve(cold[0]), nil
+	}
+	return state.reserveLeastBusy(active), nil
+}
+
+func (s *selectorBalanceState) reserve(target balanceTarget) string {
+	s.inflight[target.modelID]++
+	return target.target
+}
+
+func (s *selectorBalanceState) reserveLeastBusy(targets []balanceTarget) string {
+	minimum := s.minimum(targets)
+	tied := make([]balanceTarget, 0, len(targets))
+	for _, target := range targets {
+		if s.inflight[target.modelID] == minimum {
+			tied = append(tied, target)
+		}
+	}
+	target := tied[s.rr%uint64(len(tied))]
+	s.rr++
+	return s.reserve(target)
+}
+
+func (s *selectorBalanceState) minimum(targets []balanceTarget) int {
+	minimum := -1
+	for _, target := range targets {
+		if count := s.inflight[target.modelID]; minimum < 0 || count < minimum {
+			minimum = count
+		}
+	}
+	return minimum
+}

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -23,44 +23,44 @@ func selectorFromContext(ctx context.Context) string {
 	return selectorID
 }
 
-type balanceTarget struct {
+type spilloverTarget struct {
 	target  string
 	modelID string
 }
 
-type selectorBalanceState struct {
+type selectorSpilloverState struct {
 	mu        sync.Mutex
 	spillover int
-	targets   []balanceTarget
+	targets   []spilloverTarget
 	inflight  map[string]int
 	rr        uint64
 }
 
-type selectorBalanceTracker struct {
-	states map[string]*selectorBalanceState
+type selectorSpilloverTracker struct {
+	states map[string]*selectorSpilloverState
 }
 
-func newSelectorBalanceTracker(cfg config.Config) *selectorBalanceTracker {
-	tracker := &selectorBalanceTracker{states: make(map[string]*selectorBalanceState)}
+func newSelectorSpilloverTracker(cfg config.Config) *selectorSpilloverTracker {
+	tracker := &selectorSpilloverTracker{states: make(map[string]*selectorSpilloverState)}
 	for selectorID, selector := range cfg.Selectors {
-		if selector.Strategy != config.SelectorStrategyBalance {
+		if selector.Strategy != config.SelectorStrategySpillover {
 			continue
 		}
-		state := &selectorBalanceState{
-			spillover: selector.Balance.Spillover,
-			targets:   make([]balanceTarget, 0, len(selector.Targets)),
+		state := &selectorSpilloverState{
+			spillover: selector.Spillover,
+			targets:   make([]spilloverTarget, 0, len(selector.Targets)),
 			inflight:  make(map[string]int, len(selector.Targets)),
 		}
 		for _, target := range selector.Targets {
 			modelID, _ := cfg.RealModelName(target)
-			state.targets = append(state.targets, balanceTarget{target: target, modelID: modelID})
+			state.targets = append(state.targets, spilloverTarget{target: target, modelID: modelID})
 		}
 		tracker.states[selectorID] = state
 	}
 	return tracker
 }
 
-func (t *selectorBalanceTracker) release(selectorID, modelID string) {
+func (t *selectorSpilloverTracker) release(selectorID, modelID string) {
 	if t == nil {
 		return
 	}
@@ -78,7 +78,7 @@ func (t *selectorBalanceTracker) release(selectorID, modelID string) {
 // CreateSelectorMiddleware resolves selector model IDs after profile rewrites
 // and before the normal request context, filters, routing, and metrics pipeline.
 func CreateSelectorMiddleware(s *Server) chain.Middleware {
-	balances := newSelectorBalanceTracker(s.cfg)
+	spillovers := newSelectorSpilloverTracker(s.cfg)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if len(s.cfg.Selectors) == 0 {
@@ -103,8 +103,8 @@ func CreateSelectorMiddleware(s *Server) chain.Middleware {
 				target, err = strategyPin(selector)
 			case config.SelectorStrategyWarm:
 				target, err = strategyWarm(s.cfg, selector, s.local.RunningModels())
-			case config.SelectorStrategyBalance:
-				target, err = strategyBalance(model, balances, s.local.RunningModels())
+			case config.SelectorStrategySpillover:
+				target, err = strategySpillover(model, spillovers, s.local.RunningModels())
 			default:
 				err = fmt.Errorf("unknown selector strategy %q", selector.Strategy)
 			}
@@ -115,9 +115,9 @@ func CreateSelectorMiddleware(s *Server) chain.Middleware {
 
 			updated, err := shared.ReplaceRequestModel(r, model, target)
 			if err != nil {
-				if selector.Strategy == config.SelectorStrategyBalance {
+				if selector.Strategy == config.SelectorStrategySpillover {
 					if modelID, found := s.cfg.RealModelName(target); found {
-						balances.release(model, modelID)
+						spillovers.release(model, modelID)
 					}
 				}
 				shared.SendResponse(w, r, http.StatusBadRequest, err.Error())
@@ -126,9 +126,9 @@ func CreateSelectorMiddleware(s *Server) chain.Middleware {
 
 			s.proxylog.Debugf("selector: id=%s target=%s", model, target)
 
-			if selector.Strategy == config.SelectorStrategyBalance {
+			if selector.Strategy == config.SelectorStrategySpillover {
 				modelID, _ := s.cfg.RealModelName(target)
-				defer balances.release(model, modelID)
+				defer spillovers.release(model, modelID)
 			}
 			next.ServeHTTP(w, withSelectorContext(updated, model))
 		})
@@ -162,16 +162,16 @@ func strategyWarm(cfg config.Config, selector config.SelectorConfig, running map
 	return selector.Targets[0], nil
 }
 
-func strategyBalance(selectorID string, tracker *selectorBalanceTracker, running map[string]process.ProcessState) (string, error) {
+func strategySpillover(selectorID string, tracker *selectorSpilloverTracker, running map[string]process.ProcessState) (string, error) {
 	if tracker == nil || tracker.states[selectorID] == nil {
-		return "", fmt.Errorf("balance selector %q is not configured", selectorID)
+		return "", fmt.Errorf("spillover selector %q is not configured", selectorID)
 	}
 	state := tracker.states[selectorID]
 	state.mu.Lock()
 	defer state.mu.Unlock()
 
-	active := make([]balanceTarget, 0, len(state.targets))
-	cold := make([]balanceTarget, 0, len(state.targets))
+	active := make([]spilloverTarget, 0, len(state.targets))
+	cold := make([]spilloverTarget, 0, len(state.targets))
 	for _, target := range state.targets {
 		processState, runningNow := running[target.modelID]
 		switch {
@@ -188,7 +188,7 @@ func strategyBalance(selectorID string, tracker *selectorBalanceTracker, running
 
 	if len(active) == 0 {
 		if len(cold) == 0 {
-			return "", fmt.Errorf("selector %q has no available balance targets", selectorID)
+			return "", fmt.Errorf("selector %q has no available spillover targets", selectorID)
 		}
 		return state.reserve(cold[0]), nil
 	}
@@ -203,14 +203,14 @@ func strategyBalance(selectorID string, tracker *selectorBalanceTracker, running
 	return state.reserveLeastBusy(active), nil
 }
 
-func (s *selectorBalanceState) reserve(target balanceTarget) string {
+func (s *selectorSpilloverState) reserve(target spilloverTarget) string {
 	s.inflight[target.modelID]++
 	return target.target
 }
 
-func (s *selectorBalanceState) reserveLeastBusy(targets []balanceTarget) string {
+func (s *selectorSpilloverState) reserveLeastBusy(targets []spilloverTarget) string {
 	minimum := s.minimum(targets)
-	tied := make([]balanceTarget, 0, len(targets))
+	tied := make([]spilloverTarget, 0, len(targets))
 	for _, target := range targets {
 		if s.inflight[target.modelID] == minimum {
 			tied = append(tied, target)
@@ -221,7 +221,7 @@ func (s *selectorBalanceState) reserveLeastBusy(targets []balanceTarget) string 
 	return s.reserve(target)
 }
 
-func (s *selectorBalanceState) minimum(targets []balanceTarget) int {
+func (s *selectorSpilloverState) minimum(targets []spilloverTarget) int {
 	minimum := -1
 	for _, target := range targets {
 		if count := s.inflight[target.modelID]; minimum < 0 || count < minimum {

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -47,7 +47,7 @@ func newSelectorSpilloverTracker(cfg config.Config) *selectorSpilloverTracker {
 			continue
 		}
 		state := &selectorSpilloverState{
-			spillover: selector.Spillover,
+			spillover: selector.Settings.Spillover,
 			targets:   make([]spilloverTarget, 0, len(selector.Targets)),
 			inflight:  make(map[string]int, len(selector.Targets)),
 		}

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -124,6 +124,8 @@ func CreateSelectorMiddleware(s *Server) chain.Middleware {
 				return
 			}
 
+			s.proxylog.Debugf("selector: id=%s target=%s", model, target)
+
 			if selector.Strategy == config.SelectorStrategyBalance {
 				modelID, _ := s.cfg.RealModelName(target)
 				defer balances.release(model, modelID)

--- a/internal/server/selector_test.go
+++ b/internal/server/selector_test.go
@@ -316,6 +316,7 @@ func TestServer_Selector_ModelListings(t *testing.T) {
 	metadata, ok := public.Meta["llamaswap"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "testing", metadata["purpose"])
+	assert.Equal(t, "selector", metadata["type"])
 	assert.NotContains(t, byID, "hidden-selector")
 }
 

--- a/internal/server/selector_test.go
+++ b/internal/server/selector_test.go
@@ -53,7 +53,8 @@ selectors:
   balanced:
     strategy: spillover
     targets: [a, b, c]
-    spillover: 1
+    settings:
+      spillover: 1
   hidden-selector:
     strategy: pin
     targets: [a]
@@ -128,9 +129,9 @@ func TestServer_SelectorStrategySpillover(t *testing.T) {
 		},
 		Selectors: map[string]config.SelectorConfig{
 			"pool": {
-				Strategy:  config.SelectorStrategySpillover,
-				Targets:   []string{"a", "b", "c"},
-				Spillover: 2,
+				Strategy: config.SelectorStrategySpillover,
+				Targets:  []string{"a", "b", "c"},
+				Settings: config.SelectorSettings{Spillover: 2},
 			},
 		},
 	}

--- a/internal/server/selector_test.go
+++ b/internal/server/selector_test.go
@@ -51,10 +51,9 @@ selectors:
     strategy: warm
     targets: [a, b, c]
   balanced:
-    strategy: balance
+    strategy: spillover
     targets: [a, b, c]
-    balance:
-      spillover: 1
+    spillover: 1
   hidden-selector:
     strategy: pin
     targets: [a]
@@ -120,7 +119,7 @@ func TestServer_SelectorStrategyWarm(t *testing.T) {
 	assert.Equal(t, "a", target)
 }
 
-func TestServer_SelectorStrategyBalance(t *testing.T) {
+func TestServer_SelectorStrategySpillover(t *testing.T) {
 	cfg := config.Config{
 		Models: map[string]config.ModelConfig{
 			"a": {},
@@ -129,26 +128,26 @@ func TestServer_SelectorStrategyBalance(t *testing.T) {
 		},
 		Selectors: map[string]config.SelectorConfig{
 			"pool": {
-				Strategy: config.SelectorStrategyBalance,
-				Targets:  []string{"a", "b", "c"},
-				Balance:  config.SelectorBalanceConfig{Spillover: 2},
+				Strategy:  config.SelectorStrategySpillover,
+				Targets:   []string{"a", "b", "c"},
+				Spillover: 2,
 			},
 		},
 	}
-	tracker := newSelectorBalanceTracker(cfg)
+	tracker := newSelectorSpilloverTracker(cfg)
 
-	first, err := strategyBalance("pool", tracker, nil)
+	first, err := strategySpillover("pool", tracker, nil)
 	require.NoError(t, err)
-	second, err := strategyBalance("pool", tracker, nil)
+	second, err := strategySpillover("pool", tracker, nil)
 	require.NoError(t, err)
-	third, err := strategyBalance("pool", tracker, nil)
+	third, err := strategySpillover("pool", tracker, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "a", first)
 	assert.Equal(t, "a", second)
 	assert.Equal(t, "b", third)
 
 	tracker.release("pool", "a")
-	target, err := strategyBalance("pool", tracker, map[string]process.ProcessState{
+	target, err := strategySpillover("pool", tracker, map[string]process.ProcessState{
 		"a": process.StateReady,
 		"b": process.StateReady,
 		"c": process.StateReady,
@@ -156,14 +155,14 @@ func TestServer_SelectorStrategyBalance(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "c", target)
 
-	stoppedTracker := newSelectorBalanceTracker(cfg)
-	_, err = strategyBalance("pool", stoppedTracker, map[string]process.ProcessState{
+	stoppedTracker := newSelectorSpilloverTracker(cfg)
+	_, err = strategySpillover("pool", stoppedTracker, map[string]process.ProcessState{
 		"a": process.StateStopping,
 		"b": process.StateStopping,
 		"c": process.StateShutdown,
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no available balance targets")
+	assert.Contains(t, err.Error(), "no available spillover targets")
 }
 
 func TestServer_SelectorMiddleware_RewritesBeforeFiltersAndRecordsActivity(t *testing.T) {
@@ -217,7 +216,7 @@ func TestServer_SelectorMiddleware_ProfileRunsFirst(t *testing.T) {
 	assert.Equal(t, "public", entries[0].Metadata["selector"])
 }
 
-func TestServer_SelectorMiddleware_BalanceReservations(t *testing.T) {
+func TestServer_SelectorMiddleware_SpilloverReservations(t *testing.T) {
 	cfg := selectorTestConfig(t)
 	local := newStubRouter([]string{"a", "b", "c"}, "")
 	local.running = map[string]process.ProcessState{
@@ -254,7 +253,7 @@ func TestServer_SelectorMiddleware_BalanceReservations(t *testing.T) {
 	<-done
 }
 
-func TestServer_SelectorMiddleware_AllBalanceTargetsStopping(t *testing.T) {
+func TestServer_SelectorMiddleware_AllSpilloverTargetsStopping(t *testing.T) {
 	cfg := selectorTestConfig(t)
 	local := newStubRouter([]string{"a", "b", "c"}, "")
 	local.running = map[string]process.ProcessState{
@@ -267,7 +266,7 @@ func TestServer_SelectorMiddleware_AllBalanceTargetsStopping(t *testing.T) {
 	w := httptest.NewRecorder()
 	s.ServeHTTP(w, chatRequest("balanced"))
 	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
-	assert.Contains(t, w.Body.String(), "no available balance targets")
+	assert.Contains(t, w.Body.String(), "no available spillover targets")
 }
 
 func TestServer_SelectorMiddleware_UpstreamUnsupported(t *testing.T) {

--- a/internal/server/selector_test.go
+++ b/internal/server/selector_test.go
@@ -318,3 +318,30 @@ func TestServer_Selector_ModelListings(t *testing.T) {
 	assert.Equal(t, "testing", metadata["purpose"])
 	assert.NotContains(t, byID, "hidden-selector")
 }
+
+func TestServer_Selector_ModelListingPinUsesFirstTarget(t *testing.T) {
+	cfg := selectorTestConfig(t)
+	selector := cfg.Selectors["public"]
+	selector.Targets = []string{"a", "b"}
+	cfg.Selectors["public"] = selector
+
+	local := newStubRouter([]string{"a", "b", "c"}, "")
+	local.running = map[string]process.ProcessState{"b": process.StateReady}
+	s := selectorTestServer(t, cfg, local)
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var response struct {
+		Data []modelRecord `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	for _, record := range response.Data {
+		if record.ID == "public" {
+			assert.Equal(t, "unloaded", record.Status["value"])
+			return
+		}
+	}
+	t.Fatal("public selector missing from model listing")
+}

--- a/internal/server/selector_test.go
+++ b/internal/server/selector_test.go
@@ -1,0 +1,320 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/process"
+	"github.com/mostlygeek/llama-swap/internal/shared"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func selectorTestConfig(t *testing.T) config.Config {
+	t.Helper()
+	cfg, err := config.LoadConfigFromReader(strings.NewReader(`
+models:
+  a:
+    cmd: echo ${PORT}
+    aliases: [alias-a]
+    filters:
+      setParamsByID:
+        variant:
+          thinking: true
+  b:
+    cmd: echo ${PORT}
+  c:
+    cmd: echo ${PORT}
+groups:
+  balanced:
+    swap: false
+    members: [a, b, c]
+peers:
+  remote:
+    proxy: http://example.com
+    models: [remote-model]
+selectors:
+  public:
+    strategy: pin
+    targets: [variant, remote-model]
+    name: Public Model
+    description: Public selector
+    metadata:
+      purpose: testing
+  warm:
+    strategy: warm
+    targets: [a, b, c]
+  balanced:
+    strategy: balance
+    targets: [a, b, c]
+    balance:
+      spillover: 1
+  hidden-selector:
+    strategy: pin
+    targets: [a]
+    unlisted: true
+profiles:
+  coding:
+    pins:
+      llm-code: public
+`))
+	require.NoError(t, err)
+	return cfg
+}
+
+func selectorTestServer(t *testing.T, cfg config.Config, local *stubRouter) *Server {
+	t.Helper()
+	s := newTestServer(local, newStubRouter(nil, ""))
+	s.cfg = cfg
+	s.routes()
+	t.Cleanup(func() { s.store.Close() })
+	return s
+}
+
+func TestServer_SelectorStrategyPin(t *testing.T) {
+	target, err := strategyPin(config.SelectorConfig{Targets: []string{"first", "second"}})
+	require.NoError(t, err)
+	assert.Equal(t, "first", target)
+}
+
+func TestServer_SelectorStrategyWarm(t *testing.T) {
+	cfg := config.Config{
+		Models: map[string]config.ModelConfig{
+			"a": {},
+			"b": {},
+			"c": {},
+		},
+	}
+	selector := config.SelectorConfig{Targets: []string{"a", "b", "c"}}
+
+	target, err := strategyWarm(cfg, selector, map[string]process.ProcessState{
+		"a": process.StateStarting,
+		"c": process.StateReady,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "c", target)
+
+	target, err = strategyWarm(cfg, selector, map[string]process.ProcessState{
+		"a": process.StateStarting,
+		"b": process.StateReady,
+		"c": process.StateReady,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "b", target)
+
+	target, err = strategyWarm(cfg, selector, map[string]process.ProcessState{
+		"a": process.StateStarting,
+		"b": process.StateStarting,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "a", target)
+
+	target, err = strategyWarm(cfg, selector, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "a", target)
+}
+
+func TestServer_SelectorStrategyBalance(t *testing.T) {
+	cfg := config.Config{
+		Models: map[string]config.ModelConfig{
+			"a": {},
+			"b": {},
+			"c": {},
+		},
+		Selectors: map[string]config.SelectorConfig{
+			"pool": {
+				Strategy: config.SelectorStrategyBalance,
+				Targets:  []string{"a", "b", "c"},
+				Balance:  config.SelectorBalanceConfig{Spillover: 2},
+			},
+		},
+	}
+	tracker := newSelectorBalanceTracker(cfg)
+
+	first, err := strategyBalance("pool", tracker, nil)
+	require.NoError(t, err)
+	second, err := strategyBalance("pool", tracker, nil)
+	require.NoError(t, err)
+	third, err := strategyBalance("pool", tracker, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "a", first)
+	assert.Equal(t, "a", second)
+	assert.Equal(t, "b", third)
+
+	tracker.release("pool", "a")
+	target, err := strategyBalance("pool", tracker, map[string]process.ProcessState{
+		"a": process.StateReady,
+		"b": process.StateReady,
+		"c": process.StateReady,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "c", target)
+
+	stoppedTracker := newSelectorBalanceTracker(cfg)
+	_, err = strategyBalance("pool", stoppedTracker, map[string]process.ProcessState{
+		"a": process.StateStopping,
+		"b": process.StateStopping,
+		"c": process.StateShutdown,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no available balance targets")
+}
+
+func TestServer_SelectorMiddleware_RewritesBeforeFiltersAndRecordsActivity(t *testing.T) {
+	cfg := selectorTestConfig(t)
+	local := newStubRouter([]string{"a", "b", "c"}, "")
+	var received shared.ReqContextData
+	var body []byte
+	local.serveHTTP = func(w http.ResponseWriter, r *http.Request) {
+		received, _ = shared.ReadContext(r.Context())
+		body, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"usage":{"prompt_tokens":2,"completion_tokens":3}}`))
+	}
+	s := selectorTestServer(t, cfg, local)
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, chatRequest("public"))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	assert.Equal(t, "variant", received.Model)
+	assert.Equal(t, "a", received.ModelID)
+	assert.Equal(t, "variant", gjson.GetBytes(body, "model").String())
+	assert.True(t, gjson.GetBytes(body, "thinking").Bool())
+
+	entries := metricsEntries(t, s.metrics)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "a", entries[0].Model)
+	assert.Equal(t, "public", entries[0].Metadata["selector"])
+}
+
+func TestServer_SelectorMiddleware_ProfileRunsFirst(t *testing.T) {
+	cfg := selectorTestConfig(t)
+	local := newStubRouter([]string{"a", "b", "c"}, "")
+	var received shared.ReqContextData
+	local.serveHTTP = func(w http.ResponseWriter, r *http.Request) {
+		received, _ = shared.ReadContext(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"usage":{}}`))
+	}
+	s := selectorTestServer(t, cfg, local)
+	_, err := s.setActiveProfile("coding")
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, chatRequest("llm-code"))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, "a", received.ModelID)
+
+	entries := metricsEntries(t, s.metrics)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "public", entries[0].Metadata["selector"])
+}
+
+func TestServer_SelectorMiddleware_BalanceReservations(t *testing.T) {
+	cfg := selectorTestConfig(t)
+	local := newStubRouter([]string{"a", "b", "c"}, "")
+	local.running = map[string]process.ProcessState{
+		"a": process.StateReady,
+		"b": process.StateReady,
+		"c": process.StateReady,
+	}
+	selected := make(chan string, 2)
+	release := make(chan struct{})
+	local.serveHTTP = func(w http.ResponseWriter, r *http.Request) {
+		data, _ := shared.ReadContext(r.Context())
+		selected <- data.ModelID
+		<-release
+		w.WriteHeader(http.StatusOK)
+	}
+	s := selectorTestServer(t, cfg, local)
+
+	done := make(chan struct{}, 2)
+	go func() {
+		s.ServeHTTP(httptest.NewRecorder(), chatRequest("balanced"))
+		done <- struct{}{}
+	}()
+	first := <-selected
+
+	go func() {
+		s.ServeHTTP(httptest.NewRecorder(), chatRequest("balanced"))
+		done <- struct{}{}
+	}()
+	second := <-selected
+
+	assert.NotEqual(t, first, second)
+	close(release)
+	<-done
+	<-done
+}
+
+func TestServer_SelectorMiddleware_AllBalanceTargetsStopping(t *testing.T) {
+	cfg := selectorTestConfig(t)
+	local := newStubRouter([]string{"a", "b", "c"}, "")
+	local.running = map[string]process.ProcessState{
+		"a": process.StateStopping,
+		"b": process.StateStopping,
+		"c": process.StateShutdown,
+	}
+	s := selectorTestServer(t, cfg, local)
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, chatRequest("balanced"))
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Body.String(), "no available balance targets")
+}
+
+func TestServer_SelectorMiddleware_UpstreamUnsupported(t *testing.T) {
+	cfg := selectorTestConfig(t)
+	local := newStubRouter([]string{"a", "b", "c"}, "")
+	called := false
+	local.serveHTTP = func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	}
+	s := selectorTestServer(t, cfg, local)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/upstream/public/v1/chat/completions", strings.NewReader(`{"model":"public"}`))
+	req.Header.Set("Content-Type", "application/json")
+	s.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.False(t, called)
+}
+
+func TestServer_Selector_ModelListings(t *testing.T) {
+	cfg := selectorTestConfig(t)
+	local := newStubRouter([]string{"a", "b", "c"}, "")
+	local.running = map[string]process.ProcessState{"a": process.StateStarting}
+	s := selectorTestServer(t, cfg, local)
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var response struct {
+		Data []modelRecord `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	byID := make(map[string]modelRecord)
+	for _, record := range response.Data {
+		byID[record.ID] = record
+	}
+
+	public, found := byID["public"]
+	require.True(t, found)
+	assert.Equal(t, "Public Model", public.Name)
+	assert.Equal(t, "Public selector", public.Description)
+	assert.Equal(t, "loaded", public.Status["value"])
+	require.Contains(t, public.Meta, "llamaswap")
+	metadata, ok := public.Meta["llamaswap"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "testing", metadata["purpose"])
+	assert.NotContains(t, byID, "hidden-selector")
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -239,6 +239,7 @@ func (s *Server) routes() {
 	modelChain := chain.New(
 		authMW,
 		CreateProfileMiddleware(s),
+		CreateSelectorMiddleware(s),
 		CreateRequestContextMiddleware(s.cfg),
 		CreateInflightMiddleware(s.inflight),
 		CreateFilterMiddleware(s.cfg),

--- a/ui-svelte/src/components/playground/ConcurrencyInterface.svelte
+++ b/ui-svelte/src/components/playground/ConcurrencyInterface.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { models } from "../../stores/api";
+  import { playgroundModels, selectorModels } from "../../stores/api";
   import { persistentStore } from "../../stores/persistent";
   import { streamChatCompletion } from "../../lib/chatApi";
   import { Button } from "$lib/components/ui/button/index.js";
@@ -44,8 +44,12 @@
 
   let timelineMaxMs = $derived(Math.max(100, ...Object.values(runs).map((r) => r.elapsedMs)));
 
-  let availableModels = $derived($models.filter((m) => !m.unlisted));
-  let hasModels = $derived(availableModels.length > 0);
+  let availableModels = $derived($playgroundModels.filter((model) => model.playgroundType !== "selector"));
+  let modeSections = $derived([
+    { label: "Selectors", ids: $selectorModels.map((model) => model.id) },
+    { label: "Models", ids: availableModels.map((model) => model.id) },
+  ].filter((section) => section.ids.length > 0));
+  let hasModels = $derived(modeSections.length > 0);
   let canRun = $derived(!isRunning && $testListStore.length > 0 && $promptStore.trim() !== "");
 
   function newId(): string {
@@ -396,18 +400,27 @@
         {#if !hasModels}
           <div class="p-3 text-sm text-muted-foreground text-center">No models configured.</div>
         {:else}
-          <div class="divide-y divide-gray-100 dark:divide-white/5">
-            {#each availableModels as m (m.id)}
-              <button
-                type="button"
-                class="hover:bg-accent hover:text-foreground flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-sm font-normal transition-colors disabled:pointer-events-none disabled:opacity-50"
-                onclick={() => addModel(m.id)}
-                disabled={isRunning}
-                title="Add {m.id}"
-              >
-                <span class="text-primary" aria-hidden="true">+</span>
-                <span class="truncate flex-1">{m.id}</span>
-              </button>
+          <div class="divide-y divide-border">
+            {#each modeSections as section (section.label)}
+              <div>
+                <div class="bg-muted/50 px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                  {section.label}
+                </div>
+                <div class="divide-y divide-gray-100 dark:divide-white/5">
+                  {#each section.ids as id (id)}
+                    <button
+                      type="button"
+                      class="hover:bg-accent hover:text-foreground flex w-full items-center gap-1.5 px-2 py-1.5 text-left text-sm font-normal transition-colors disabled:pointer-events-none disabled:opacity-50"
+                      onclick={() => addModel(id)}
+                      disabled={isRunning}
+                      title="Add {id}"
+                    >
+                      <span class="text-primary" aria-hidden="true">+</span>
+                      <span class="truncate flex-1">{id}</span>
+                    </button>
+                  {/each}
+                </div>
+              </div>
             {/each}
           </div>
         {/if}

--- a/ui-svelte/src/components/playground/ModelSelector.svelte
+++ b/ui-svelte/src/components/playground/ModelSelector.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { models, profileModels } from "../../stores/api";
+  import { playgroundModels, profileModels, selectorModels } from "../../stores/api";
   import { groupModels } from "../../lib/modelUtils";
   import * as Select from "$lib/components/ui/select/index.js";
 
@@ -13,9 +13,19 @@
 
   let { value = $bindable(), placeholder = "Select a model...", disabled = false, capabilities, matchAny = false }: Props = $props();
 
-  let grouped = $derived(groupModels($models, capabilities, matchAny));
+  let grouped = $derived(groupModels(
+    $playgroundModels.filter((model) => model.playgroundType === "model" || model.playgroundType === "peer"),
+    capabilities,
+    matchAny,
+  ));
   let hasMatching = $derived(grouped.localMatching.length > 0);
-  let hasModels = $derived($profileModels.length > 0 || hasMatching || grouped.local.length > 0 || Object.keys(grouped.peersByProvider).length > 0);
+  let hasModels = $derived(
+    $profileModels.length > 0
+      || $selectorModels.length > 0
+      || hasMatching
+      || grouped.local.length > 0
+      || Object.keys(grouped.peersByProvider).length > 0
+  );
 </script>
 
 {#if hasModels}
@@ -47,6 +57,15 @@
                 <Select.Item value={alias}>↳ {alias}</Select.Item>
               {/each}
             {/if}
+          {/each}
+        </Select.Group>
+        <Select.Separator />
+      {/if}
+      {#if $selectorModels.length > 0}
+        <Select.Group>
+          <Select.Label>Selectors</Select.Label>
+          {#each $selectorModels as model (model.id)}
+            <Select.Item value={model.id}>{model.id}</Select.Item>
           {/each}
         </Select.Group>
         <Select.Separator />

--- a/ui-svelte/src/lib/types.ts
+++ b/ui-svelte/src/lib/types.ts
@@ -1,6 +1,7 @@
 export type ConnectionState = "connected" | "connecting" | "disconnected";
 
 export type ModelStatus = "ready" | "starting" | "stopping" | "stopped" | "shutdown" | "unknown";
+export type PlaygroundModelType = "model" | "peer" | "selector" | "profile";
 
 export interface ModelCapabilities {
   vision?: boolean;
@@ -19,6 +20,7 @@ export interface Model {
   description: string;
   unlisted: boolean;
   peerID: string;
+  playgroundType?: PlaygroundModelType;
   aliases?: string[];
   capabilities?: ModelCapabilities;
 }

--- a/ui-svelte/src/routes/Playground.svelte
+++ b/ui-svelte/src/routes/Playground.svelte
@@ -8,6 +8,7 @@
   import ConcurrencyInterface from "../components/playground/ConcurrencyInterface.svelte";
   import * as Card from "$lib/components/ui/card/index.js";
   import { Tabs, TabsList, TabsTrigger } from "$lib/components/ui/tabs/index.js";
+  import { fetchPlaygroundModels, models } from "../stores/api";
   import { selectedPlaygroundTab, playgroundTabs, type PlaygroundTab } from "../stores/playground";
 
   const tabComponents: Record<PlaygroundTab, Component> = {
@@ -18,6 +19,11 @@
     rerank: RerankInterface,
     concurrency: ConcurrencyInterface,
   };
+
+  $effect(() => {
+    void $models;
+    void fetchPlaygroundModels();
+  });
 </script>
 
 <Card.Root class="flex h-full flex-col gap-0 overflow-hidden p-4">

--- a/ui-svelte/src/routes/Playground.svelte
+++ b/ui-svelte/src/routes/Playground.svelte
@@ -11,6 +11,8 @@
   import { fetchPlaygroundModels, models } from "../stores/api";
   import { selectedPlaygroundTab, playgroundTabs, type PlaygroundTab } from "../stores/playground";
 
+  const MODEL_REFRESH_DEBOUNCE_MS = 200;
+
   const tabComponents: Record<PlaygroundTab, Component> = {
     chat: ChatInterface,
     images: ImageInterface,
@@ -20,9 +22,19 @@
     concurrency: ConcurrencyInterface,
   };
 
+  let initializedModels = false;
   $effect(() => {
     void $models;
-    void fetchPlaygroundModels();
+    if (!initializedModels) {
+      initializedModels = true;
+      void fetchPlaygroundModels();
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      void fetchPlaygroundModels();
+    }, MODEL_REFRESH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timeout);
   });
 </script>
 

--- a/ui-svelte/src/stores/api.test.ts
+++ b/ui-svelte/src/stores/api.test.ts
@@ -3,14 +3,17 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   activeProfile,
   activityRevision,
+  fetchPlaygroundModels,
   fetchProfiles,
   handleAPIEventMessage,
   hasListedModels,
   inFlightRequests,
   inflightRequestEntries,
   models,
+  playgroundModels,
   profileModels,
   profiles,
+  selectorModels,
   setActiveProfile,
   uiConfig,
 } from "./api";
@@ -18,6 +21,7 @@ import {
 afterEach(() => {
   vi.unstubAllGlobals();
   models.set([]);
+  playgroundModels.set([]);
   profiles.set([]);
   activeProfile.set(null);
 });
@@ -158,55 +162,57 @@ describe("api store event handling", () => {
     }));
   });
 
-  it("exposes active profile pins as Playground models", () => {
-    models.set([
-      {
-        id: "real",
-        state: "ready",
-        name: "Real",
-        description: "",
-        unlisted: true,
-        peerID: "",
-        aliases: ["variant"],
-        capabilities: { vision: true },
-      },
-      {
-        id: "peer-model",
-        state: "stopped",
-        name: "",
-        description: "",
-        unlisted: true,
-        peerID: "remote",
-      },
-    ]);
-    profiles.set([{
-      id: "coding",
-      description: "",
-      pins: {
-        public: "variant",
-        "remote-pin": "peer-model",
-        disabled: "",
-        real: "peer-model",
-        variant: "peer-model",
-      },
-    }]);
-    activeProfile.set("coding");
+  it("loads Playground models and virtual model types from v1/models", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [
+          {
+            id: "real",
+            name: "Real",
+            capabilities: { vision: true },
+            meta: { llamaswap: { type: "model", aliases: ["variant", "alternate"] } },
+          },
+          {
+            id: "variant",
+            meta: { llamaswap: { type: "alias", modelID: "real" } },
+          },
+          {
+            id: "remote-model",
+            meta: { llamaswap: { type: "peer", peerID: "remote" } },
+          },
+          {
+            id: "pool",
+            meta: { llamaswap: { type: "selector" } },
+          },
+          {
+            id: "public",
+            meta: { llamaswap: { type: "profile" } },
+          },
+        ],
+      }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
 
-    expect(get(profileModels).map((model) => model.id)).toEqual(["public", "remote-pin"]);
-    expect(get(profileModels)[0]).toMatchObject({
-      id: "public",
-      state: "ready",
-      unlisted: false,
+    await fetchPlaygroundModels();
+
+    expect(mockFetch).toHaveBeenCalledWith("/v1/models");
+    expect(get(playgroundModels).map((model) => model.id)).not.toContain("variant");
+    expect(get(playgroundModels).find((model) => model.id === "real")).toMatchObject({
+      aliases: ["variant", "alternate"],
       capabilities: { vision: true },
+      playgroundType: "model",
     });
-    expect(get(profileModels)[1]).toMatchObject({
-      id: "remote-pin",
+    expect(get(playgroundModels).find((model) => model.id === "remote-model")).toMatchObject({
       peerID: "remote",
-      unlisted: false,
+      playgroundType: "peer",
     });
+    expect(get(selectorModels).map((model) => model.id)).toEqual(["pool"]);
+    expect(get(profileModels).map((model) => model.id)).toEqual(["public"]);
     expect(get(hasListedModels)).toBe(true);
 
-    activeProfile.set(null);
+    playgroundModels.set([]);
+    expect(get(selectorModels)).toEqual([]);
     expect(get(profileModels)).toEqual([]);
     expect(get(hasListedModels)).toBe(false);
   });

--- a/ui-svelte/src/stores/api.test.ts
+++ b/ui-svelte/src/stores/api.test.ts
@@ -216,4 +216,36 @@ describe("api store event handling", () => {
     expect(get(profileModels)).toEqual([]);
     expect(get(hasListedModels)).toBe(false);
   });
+
+  it("coalesces overlapping Playground model refreshes", async () => {
+    type ModelResponse = {
+      ok: boolean;
+      json: () => Promise<{ data: [] }>;
+    };
+    let resolveFirst!: (response: ModelResponse) => void;
+    const firstResponse = new Promise<ModelResponse>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const mockFetch = vi.fn()
+      .mockReturnValueOnce(firstResponse)
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [] }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const first = fetchPlaygroundModels();
+    const overlapping = fetchPlaygroundModels();
+
+    expect(overlapping).toBe(first);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    resolveFirst({
+      ok: true,
+      json: async () => ({ data: [] }),
+    });
+    await first;
+
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+  });
 });

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -55,6 +55,8 @@ export const versionInfo = writable<VersionInfo>({
 let apiEventSource: EventSource | null = null;
 let profileRevision = 0;
 let playgroundModelsRequest = 0;
+let playgroundModelsFetch: Promise<Model[]> | null = null;
+let playgroundModelsRefreshQueued = false;
 
 function appendLog(newData: string, store: typeof proxyLogs | typeof upstreamLogs): void {
   store.update((prev) => {
@@ -72,6 +74,7 @@ export function enableAPIEvents(enabled: boolean): void {
     inflightRequestEntries.set([]);
     uiConfig.set(defaultUIConfig());
     playgroundModelsRequest++;
+    playgroundModelsRefreshQueued = false;
     playgroundModels.set([]);
     profiles.set([]);
     activeProfile.set(null);
@@ -97,6 +100,8 @@ export function enableAPIEvents(enabled: boolean): void {
       inflightRequestEntries.set([]);
       uiConfig.set(defaultUIConfig());
       models.set([]);
+      playgroundModelsRequest++;
+      playgroundModelsRefreshQueued = false;
       playgroundModels.set([]);
       profiles.set([]);
       activeProfile.set(null);
@@ -263,8 +268,7 @@ interface ModelListRecord {
   };
 }
 
-export async function fetchPlaygroundModels(): Promise<Model[]> {
-  const request = ++playgroundModelsRequest;
+async function loadPlaygroundModels(request: number): Promise<Model[]> {
   try {
     const response = await fetch("/v1/models");
     if (!response.ok) {
@@ -313,6 +317,25 @@ export async function fetchPlaygroundModels(): Promise<Model[]> {
     console.error("Failed to fetch Playground models:", error);
     return [];
   }
+}
+
+export function fetchPlaygroundModels(): Promise<Model[]> {
+  if (playgroundModelsFetch) {
+    playgroundModelsRefreshQueued = true;
+    return playgroundModelsFetch;
+  }
+
+  const request = ++playgroundModelsRequest;
+  const currentFetch = loadPlaygroundModels(request).finally(() => {
+    if (playgroundModelsFetch !== currentFetch) return;
+    playgroundModelsFetch = null;
+    if (playgroundModelsRefreshQueued) {
+      playgroundModelsRefreshQueued = false;
+      void fetchPlaygroundModels();
+    }
+  });
+  playgroundModelsFetch = currentFetch;
+  return currentFetch;
 }
 
 export async function getActivity(params: {

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -13,6 +13,7 @@ import type {
   UIConfig,
   Profile,
   ProfileState,
+  PlaygroundModelType,
 } from "../lib/types";
 import { connectionState } from "./theme";
 
@@ -20,51 +21,21 @@ const LOG_LENGTH_LIMIT = 1024 * 100; /* 100KB of log data */
 
 // Stores
 export const models = writable<Model[]>([]);
+export const playgroundModels = writable<Model[]>([]);
 export const profiles = writable<Profile[]>([]);
 export const activeProfile = writable<string | null>(null);
 
-// Active profile pins exposed as virtual models for Playground selectors.
-// Concrete model management continues to use `models`.
+// Model records used by Playground come from the OpenAI-compatible listing.
 export const profileModels = derived(
-  [models, profiles, activeProfile],
-  ([$models, $profiles, $activeProfile]): Model[] => {
-    const profile = $profiles.find((candidate) => candidate.id === $activeProfile);
-    if (!profile) return [];
-
-    const modelIDs = new Set<string>();
-    for (const model of $models) {
-      modelIDs.add(model.id);
-      for (const alias of model.aliases ?? []) modelIDs.add(alias);
-    }
-
-    const result: Model[] = [];
-    for (const [pin, target] of Object.entries(profile.pins)) {
-      if (!target || modelIDs.has(pin)) continue;
-
-      const targetModel = $models.find(
-        (model) => model.id === target || model.aliases?.includes(target),
-      );
-      result.push(targetModel
-        ? { ...targetModel, id: pin, unlisted: false, aliases: undefined }
-        : {
-            id: pin,
-            state: "stopped",
-            name: "",
-            description: "",
-            unlisted: false,
-            peerID: "",
-          });
-    }
-    return result.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }));
-  },
+  playgroundModels,
+  ($playgroundModels) => $playgroundModels.filter((model) => model.playgroundType === "profile"),
+);
+export const selectorModels = derived(
+  playgroundModels,
+  ($playgroundModels) => $playgroundModels.filter((model) => model.playgroundType === "selector"),
 );
 
-// True when at least one concrete model or active profile pin is selectable.
-export const hasListedModels = derived(
-  [models, profileModels],
-  ([$models, $profileModels]) =>
-    $profileModels.length > 0 || $models.some((model) => !model.unlisted),
-);
+export const hasListedModels = derived(playgroundModels, ($playgroundModels) => $playgroundModels.length > 0);
 export const proxyLogs = writable<string>("");
 export const upstreamLogs = writable<string>("");
 export const activityRevision = writable<number>(0);
@@ -83,6 +54,7 @@ export const versionInfo = writable<VersionInfo>({
 
 let apiEventSource: EventSource | null = null;
 let profileRevision = 0;
+let playgroundModelsRequest = 0;
 
 function appendLog(newData: string, store: typeof proxyLogs | typeof upstreamLogs): void {
   store.update((prev) => {
@@ -99,6 +71,8 @@ export function enableAPIEvents(enabled: boolean): void {
     inFlightRequests.set(0);
     inflightRequestEntries.set([]);
     uiConfig.set(defaultUIConfig());
+    playgroundModelsRequest++;
+    playgroundModels.set([]);
     profiles.set([]);
     activeProfile.set(null);
     profileRevision++;
@@ -123,6 +97,7 @@ export function enableAPIEvents(enabled: boolean): void {
       inflightRequestEntries.set([]);
       uiConfig.set(defaultUIConfig());
       models.set([]);
+      playgroundModels.set([]);
       profiles.set([]);
       activeProfile.set(null);
       profileRevision++;
@@ -273,16 +248,69 @@ connectionState.subscribe(async (status) => {
   }
 });
 
-export async function listModels(): Promise<Model[]> {
+interface ModelListRecord {
+  id: string;
+  name?: string;
+  description?: string;
+  capabilities?: Model["capabilities"];
+  meta?: {
+    llamaswap?: {
+      type?: PlaygroundModelType | "alias";
+      aliases?: string[];
+      modelID?: string;
+      peerID?: string;
+    };
+  };
+}
+
+export async function fetchPlaygroundModels(): Promise<Model[]> {
+  const request = ++playgroundModelsRequest;
   try {
-    const response = await fetch("/api/models/");
+    const response = await fetch("/v1/models");
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-    const data = await response.json();
-    return data || [];
+    const responseData = await response.json() as { data?: ModelListRecord[] };
+    const records = responseData.data ?? [];
+    const aliasesByModel = new Map<string, Set<string>>();
+    for (const record of records) {
+      const metadata = record.meta?.llamaswap;
+      if (metadata?.aliases) {
+        aliasesByModel.set(record.id, new Set(metadata.aliases));
+      }
+      if (metadata?.type === "alias" && metadata.modelID) {
+        const aliases = aliasesByModel.get(metadata.modelID) ?? new Set<string>();
+        aliases.add(record.id);
+        aliasesByModel.set(metadata.modelID, aliases);
+      }
+    }
+    const newModels = records
+      .filter((record) => record.meta?.llamaswap?.type !== "alias")
+      .map((record): Model => {
+        const metadata = record.meta?.llamaswap;
+        const metadataType = metadata?.type;
+        const playgroundType: PlaygroundModelType = metadataType && metadataType !== "alias"
+          ? metadataType
+          : "model";
+        return {
+          id: record.id,
+          state: "unknown",
+          name: record.name ?? "",
+          description: record.description ?? "",
+          unlisted: false,
+          peerID: metadata?.peerID ?? "",
+          playgroundType,
+          aliases: [...(aliasesByModel.get(record.id) ?? [])],
+          capabilities: record.capabilities,
+        };
+      });
+    newModels.sort((a, b) => {
+      return (a.name + a.id).localeCompare(b.name + b.id, undefined, { numeric: true });
+    });
+    if (request === playgroundModelsRequest) playgroundModels.set(newModels);
+    return newModels;
   } catch (error) {
-    console.error("Failed to fetch models:", error);
+    console.error("Failed to fetch Playground models:", error);
     return [];
   }
 }


### PR DESCRIPTION
Implement selectors with pin, warm and balance strategies.

Example configuration: 

```yaml
# selectors: virtual model IDs resolved to concrete targets per request
# - optional, default: empty dictionary
# - profiles run first, so a profile pin may target a selector
# - selector IDs cannot collide with model IDs, aliases, or peer model names
# - selector targets cannot be other selectors
# - selectors are not supported on /upstream/<model> paths
selectors:
  # warm chooses the first ready target in order, then an already-starting
  # target, and cold-starts the first target when none are running
  "coding-model":
    strategy: warm
    targets:
      - "gpt-oss-120b"
      - "qwen-unlisted"
    name: "Coding Model"
    description: "Best currently loaded coding model"
    metadata:
      purpose: coding

  # pin always uses the first target; remaining entries are reference data
  "llm-plan":
    strategy: pin
    targets:
      - "gpt-oss-120b"
      - "z-ai/glm-4.7"

  # balance spreads requests across local instances that may run concurrently
  "llama":
    strategy: balance
    targets:
      - "docker-llama"
      - "modelA"
      - "modelB"
    balance:
      # start the next instance once active instances reach this reservation count
      # - optional, default: 1
      spillover: 4
```

Fixes: #719, #933 
Closes: #902