### PR TITLE
ui-svelte: remove audio file size limit

### DIFF
--- a/ui-svelte/src/components/playground/AudioInterface.svelte
+++ b/ui-svelte/src/components/playground/AudioInterface.svelte
@@ -23,7 +23,6 @@
   let copied = $state(false);
 
   const ACCEPTED_FORMATS = ['.mp3', '.wav', '.ogg'];
-  const MAX_FILE_SIZE = 25 * 1024 * 1024; // 25MB
 
   let canTranscribe = $derived(selectedFile !== null && $selectedModelStore !== "" && !isTranscribing);
 
@@ -32,10 +31,6 @@
 
     if (!ACCEPTED_FORMATS.includes(ext)) {
       return { valid: false, error: 'Invalid file type. Accepted: MP3, WAV, OGG' };
-    }
-
-    if (file.size > MAX_FILE_SIZE) {
-      return { valid: false, error: 'File too large. Maximum: 25MB' };
     }
 
     return { valid: true };
@@ -179,7 +174,7 @@
           <div>
             <p class="mb-2">Drag and drop an audio file here</p>
             <p class="text-sm">or use the Browse button below</p>
-            <p class="text-xs mt-4">Accepted formats: MP3, WAV, OGG (max 25MB)</p>
+            <p class="text-xs mt-4">Accepted formats: MP3, WAV, OGG</p>
           </div>
         </div>
       {/if}


### PR DESCRIPTION
Remove the 25MB max file size check from the audio transcription playground. The limit was arbitrary and blocked valid uploads.

- drop `MAX_FILE_SIZE` constant and size validation
- drop "(max 25MB)" hint from the drop zone

fixes #947

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXiJ5JypcN5jRS6iz7WTCo)_