### PR TITLE
Fix process start race during concurrent stop operations

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -28,7 +28,28 @@ type Process interface {
 
 	// WaitReady blocks until the process is ready to serve requests
 	// or the context is cancelled. It returns nil when the process is ready
+	//
+	// WaitReady only subscribes, it never starts anything, and it cannot tell
+	// "stopped, but a start is coming" apart from "stopped, and nothing is
+	// coming" — a subscription that arrives after a start has already failed or
+	// been aborted waits for a process nobody is going to start. Pass a context
+	// with a deadline if that matters. Callers that want the process serving
+	// should use EnsureReady, which has neither problem.
 	WaitReady(context.Context) error
+
+	// EnsureReady brings the process to a ready state and blocks until it is
+	// serving, the start fails, or ctx is cancelled. The timeout parameter
+	// controls how long to wait for the process to become ready.
+	//
+	// Unlike Run, the decision of whether a start is needed is made inside the
+	// process's own state machine, so callers never inspect State() first and
+	// cannot race a concurrent transition:
+	//
+	//	ready    -> returns nil immediately
+	//	stopped  -> starts the process and waits for it to become ready
+	//	stopping -> waits for the stop to finish, then starts
+	//	shutdown -> returns an error
+	EnsureReady(ctx context.Context, timeout time.Duration) error
 
 	// Stop blocks until the process has terminated. It returns nil when
 	// the process terminated as expected (exit 0)

--- a/internal/process/process_command.go
+++ b/internal/process/process_command.go
@@ -37,9 +37,15 @@ const cmdWaitDelay = 10 * time.Second
 // bounds the rare case where a process is still alive when its context is cut.
 const parentCancelGraceTimeout = time.Second
 
-type runReq struct {
+// startReq asks the run loop to bring the process up. Run and EnsureReady share
+// this one request type — and therefore one code path — so there is only ever a
+// single way to start a process. block selects the caller's semantics: Run parks
+// its response until the process terminates, EnsureReady is answered as soon as
+// the process is ready or the start fails.
+type startReq struct {
 	timeout time.Duration
 	respond chan error
+	block   bool
 }
 
 type stopReq struct {
@@ -72,7 +78,7 @@ type ProcessCommand struct {
 	// pipe-close backstop from dominating their runtime.
 	waitDelay time.Duration
 
-	runCh       chan runReq
+	startCh     chan startReq
 	stopCh      chan stopReq
 	waitReadyCh chan waitReadyReq
 
@@ -103,7 +109,7 @@ func New(
 		processLogger: processLogger,
 		proxyLogger:   proxyLogger,
 
-		runCh:       make(chan runReq),
+		startCh:     make(chan startReq),
 		stopCh:      make(chan stopReq),
 		waitReadyCh: make(chan waitReadyReq),
 		waitDelay:   cmdWaitDelay,
@@ -154,8 +160,9 @@ func (p *ProcessCommand) run() {
 	)
 
 	// notifyWaiters wakes every blocked WaitReady caller with the given result.
-	// Used on transitions out of StateStarting (ready, failed, aborted, or
-	// shutdown) — anything that resolves the "is it ready yet?" question.
+	// It must be called on every transition into a state that resolves the
+	// "is it ready yet?" question — ready, failed, aborted, shutdown, stopped,
+	// or exited. Missing one strands the subscriber forever (issue #946).
 	notifyWaiters := func(err error) {
 		for _, w := range readyWaiters {
 			select {
@@ -209,6 +216,12 @@ func (p *ProcessCommand) run() {
 			cmdCancel = nil
 			p.handler.Store(nil)
 			setState(StateStopped)
+			p.proxyLogger.Warnf("<%s> upstream process exited unexpectedly", p.id)
+			// Safety net: readyWaiters is normally empty here because
+			// WaitReady is answered immediately while StateReady. Notifying
+			// anyway keeps the invariant that no transition into a settled
+			// state can leave a subscriber parked forever.
+			notifyWaiters(fmt.Errorf("[%s] upstream exited unexpectedly", p.id))
 			respondRun(fmt.Errorf("[%s] upstream exited unexpectedly", p.id))
 
 		// WaitReady: if we're already in a terminal-for-this-question state,
@@ -224,12 +237,31 @@ func (p *ProcessCommand) run() {
 				readyWaiters = append(readyWaiters, req)
 			}
 
-		// Run: start the upstream process. Only valid from StateStopped.
+		// Start the upstream process (Run or EnsureReady — see startReq).
 		// doStart can take a long time (health-check polling), so it runs in
 		// a separate goroutine and we wait on resultCh. While waiting we also
 		// listen for an incoming Stop — that's how callers cancel an in-flight
 		// start.
-		case req := <-p.runCh:
+		case req := <-p.startCh:
+			// EnsureReady answers straight from the current state when the
+			// "is it ready?" question is already settled. There is deliberately
+			// no StateStopping case: a stop keeps this loop parked inside
+			// killProcess and out of the select, so a request can only ever be
+			// received once the stop has finished and state is Stopped again.
+			// Waiting on the channel IS the synchronisation — the caller never
+			// has to guess the state from outside.
+			if !req.block {
+				switch state {
+				case StateReady:
+					req.respond <- nil
+					continue
+				case StateShutdown:
+					req.respond <- fmt.Errorf("[%s] shutdown", p.id)
+					continue
+				}
+			}
+			// Only valid from StateStopped. For Run this is also the "second
+			// Run while already running" rejection.
 			if state != StateStopped {
 				req.respond <- fmt.Errorf("[%s] could not be started in %s state", p.id, state)
 				continue
@@ -259,10 +291,15 @@ func (p *ProcessCommand) run() {
 					p.handler.Store(&fn)
 					setState(StateReady)
 					notifyWaiters(nil)
-					// Park the Run response — Run blocks until the process
-					// terminates, so we only fire this when Stop, parentCtx,
-					// or the upstream exit takes the process down.
-					runResp = req.respond
+					if req.block {
+						// Park the Run response — Run blocks until the process
+						// terminates, so we only fire this when Stop, parentCtx,
+						// or the upstream exit takes the process down.
+						runResp = req.respond
+					} else {
+						// EnsureReady's question is answered: it's ready.
+						req.respond <- nil
+					}
 
 					// Start TTL goroutine if configured — self-terminates
 					// when state leaves StateReady.
@@ -337,6 +374,7 @@ func (p *ProcessCommand) run() {
 
 		// Stop: tear down a running process.
 		case stop := <-p.stopCh:
+			toreDown := cmd != nil
 			if cmd != nil {
 				setState(StateStopping)
 				p.killProcess(cmd, cmdCancel, cmdDone, stop.timeout)
@@ -348,6 +386,15 @@ func (p *ProcessCommand) run() {
 			// Stop is a no-op (and not an error) when already Stopped — this
 			// is what makes it idempotent for callers that don't track state.
 			setState(StateStopped)
+			if toreDown {
+				// A process we just killed is not going to become ready, so
+				// release anyone parked on that question rather than leaving
+				// them stranded (issue #946). Guarded on having actually torn
+				// something down: an idempotent no-op Stop must not cancel a
+				// subscriber waiting on a start that hasn't happened yet, which
+				// is the legitimate `go Run(); WaitReady()` ordering.
+				notifyWaiters(fmt.Errorf("[%s] stopped", p.id))
+			}
 			respondRun(nil)
 			stop.respond <- nil
 		}
@@ -615,18 +662,49 @@ func (p *ProcessCommand) ID() string {
 }
 
 func (p *ProcessCommand) Run(timeout time.Duration) error {
-	req := runReq{
+	req := startReq{
 		timeout: timeout,
 		respond: make(chan error, 1),
+		block:   true,
 	}
 	select {
-	case p.runCh <- req:
+	case p.startCh <- req:
 	case <-p.parentCtx.Done():
 		return fmt.Errorf("[%s] shutdown", p.id)
 	}
 	select {
 	case err := <-req.respond:
 		return err
+	case <-p.parentCtx.Done():
+		return fmt.Errorf("[%s] shutdown", p.id)
+	}
+}
+
+// EnsureReady brings the process to a ready state and blocks until it is
+// serving. See the Process interface for the full state-by-state contract.
+//
+// The send on startCh is the synchronisation point: it can only be received
+// when the run loop is back at its select, so a stop that is still in progress
+// naturally holds the request until the process is really stopped. Callers must
+// not inspect State() first — that read races the run loop and is what caused
+// issue #946.
+func (p *ProcessCommand) EnsureReady(ctx context.Context, timeout time.Duration) error {
+	req := startReq{
+		timeout: timeout,
+		respond: make(chan error, 1),
+	}
+	select {
+	case p.startCh <- req:
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-p.parentCtx.Done():
+		return fmt.Errorf("[%s] shutdown", p.id)
+	}
+	select {
+	case err := <-req.respond:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
 	case <-p.parentCtx.Done():
 		return fmt.Errorf("[%s] shutdown", p.id)
 	}

--- a/internal/process/process_command_test.go
+++ b/internal/process/process_command_test.go
@@ -51,6 +51,109 @@ func runAsync(t *testing.T, p *ProcessCommand) <-chan error {
 	return ch
 }
 
+// waitForState polls until the process reaches want, failing the test if it
+// does not get there in time.
+func waitForState(t *testing.T, p *ProcessCommand, want ProcessState) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := p.State(); got == want {
+			return
+		}
+		time.Sleep(testPollInterval)
+	}
+	t.Fatalf("state is %s, want %s", p.State(), want)
+}
+
+// TestProcessCommand_EnsureReadyDuringStop is the regression test for issue
+// #946: a caller that wants the process serving while it is being stopped must
+// wait for the stop to finish and then get a freshly started process, instead
+// of hanging forever.
+//
+// -ignore-sig-term makes the upstream survive the graceful signal, so the
+// process sits in StateStopping for the whole unload timeout rather than
+// milliseconds. That is the deterministic form of the reporter's `kill -STOP`
+// reproduction: EnsureReady is provably called mid-stop.
+func TestProcessCommand_EnsureReadyDuringStop(t *testing.T) {
+	skipIfNoSimpleResponder(t)
+
+	cmd, port := simpleResponderCmd(t, "-silent", "-ignore-sig-term")
+	p := newProcessCommand(t, config.ModelConfig{
+		Cmd:                cmd,
+		Proxy:              fmt.Sprintf("http://127.0.0.1:%d", port),
+		CheckEndpoint:      "/health",
+		HealthCheckTimeout: 10,
+	})
+	t.Cleanup(func() { p.Stop(testStopTimeout) }) //nolint: errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := p.EnsureReady(ctx, testStartTimeout); err != nil {
+		t.Fatalf("EnsureReady: %v", err)
+	}
+
+	stopDone := make(chan struct{})
+	go func() {
+		defer close(stopDone)
+		p.Stop(testStopTimeout) //nolint: errcheck
+	}()
+
+	waitForState(t, p, StateStopping)
+
+	if err := p.EnsureReady(ctx, testStartTimeout); err != nil {
+		t.Fatalf("EnsureReady during stop: %v", err)
+	}
+	if got := p.State(); got != StateReady {
+		t.Errorf("State() = %s, want %s", got, StateReady)
+	}
+
+	select {
+	case <-stopDone:
+	case <-time.After(testReturnTimeout):
+		t.Error("Stop did not return")
+	}
+}
+
+// TestProcessCommand_EnsureReadyIsIdempotent covers the settled states:
+// EnsureReady on a ready process is a no-op, and it reports an error once the
+// process has been shut down.
+func TestProcessCommand_EnsureReadyIsIdempotent(t *testing.T) {
+	skipIfNoSimpleResponder(t)
+
+	parentCtx, cancelParent := context.WithCancel(context.Background())
+	logger := logmon.NewWriter(io.Discard)
+	cmd, port := simpleResponderCmd(t, "-silent")
+	p, err := New(parentCtx, t.Name(), config.ModelConfig{
+		Cmd:                cmd,
+		Proxy:              fmt.Sprintf("http://127.0.0.1:%d", port),
+		CheckEndpoint:      "/health",
+		HealthCheckTimeout: 10,
+	}, logger, logger)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { p.Stop(testStopTimeout) }) //nolint: errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	for i := 0; i < 3; i++ {
+		if err := p.EnsureReady(ctx, testStartTimeout); err != nil {
+			t.Fatalf("EnsureReady call %d: %v", i+1, err)
+		}
+		if got := p.State(); got != StateReady {
+			t.Fatalf("State() = %s after call %d, want %s", got, i+1, StateReady)
+		}
+	}
+
+	cancelParent()
+	waitForState(t, p, StateShutdown)
+	if err := p.EnsureReady(ctx, testStartTimeout); err == nil {
+		t.Error("EnsureReady after shutdown: expected error, got nil")
+	}
+}
+
 func TestProcessCommand_StartStop(t *testing.T) {
 	skipIfNoSimpleResponder(t)
 

--- a/internal/router/base.go
+++ b/internal/router/base.go
@@ -255,16 +255,19 @@ func (b *baseRouter) doSwap(modelID string, toStop []string) {
 	}
 	wg.Wait()
 
+	// EnsureReady rather than a State() check followed by Run: the router must
+	// not assume anything about the process. Deciding out here means acting on
+	// a snapshot that the process's own run loop can invalidate at any moment —
+	// a TTL unload landing in that window used to leave the swap waiting on a
+	// process nobody was ever going to start (issue #946). EnsureReady makes
+	// the same decision inside the process, where the state is owned.
 	target := b.processes[modelID]
-	if target.State() == process.StateStopped {
-		go func() {
-			if err := target.Run(timeout); err != nil {
-				b.logger.Warnf("%s: running %s exited: %v", b.name, modelID, err)
-			}
-		}()
+	err := target.EnsureReady(b.shutdownCtx, timeout)
+	if err != nil && b.shutdownCtx.Err() == nil {
+		// Quiet during shutdown: every in-flight swap fails at once there, and
+		// that is expected rather than worth a warning per model.
+		b.logger.Warnf("%s: starting %s failed: %v", b.name, modelID, err)
 	}
-
-	err := target.WaitReady(b.shutdownCtx)
 
 	select {
 	case b.swapDoneCh <- scheduler.SwapDone{ModelID: modelID, Err: err}:

--- a/internal/router/base_test.go
+++ b/internal/router/base_test.go
@@ -345,6 +345,70 @@ func TestBaseRouter_OnDemandStart(t *testing.T) {
 	}
 }
 
+// TestBaseRouter_RequestDuringStop is the router-level regression test for
+// issue #946. A process being stopped outside the router's knowledge (a TTL
+// unload, a crash, an operator kill) must not wedge the swap machinery: the
+// request has to wait for the stop to finish and then start the model.
+//
+// Before the fix doSwap read State(), saw StateStopping, skipped the start, and
+// then subscribed to a process nobody would ever start — stranding the swap, so
+// every later request for the model joined the same zombie swap and hung.
+func TestBaseRouter_RequestDuringStop(t *testing.T) {
+	a := newFakeProcess("a")
+	a.markReady()
+	a.autoReady = true
+	// Pin Stop so the process sits in StateStopping while the request arrives.
+	a.stopBlock = make(chan struct{})
+
+	b := newTestBase(t, map[string]process.Process{"a": a}, &stubPlanner{})
+
+	// Stop the process directly, the way the process's own TTL goroutine does —
+	// the router is never told about it.
+	stopDone := make(chan struct{})
+	go func() {
+		defer close(stopDone)
+		_ = a.Stop(time.Second)
+	}()
+	waitSignal(t, a.stopStarted, "a.stopStarted")
+
+	if got := a.State(); got != process.StateStopping {
+		t.Fatalf("State()=%s want %s before request", got, process.StateStopping)
+	}
+
+	w := httptest.NewRecorder()
+	served := make(chan struct{})
+	go func() {
+		defer close(served)
+		b.ServeHTTP(w, newRequest("a"))
+	}()
+
+	// The router must ask the process to start even though it is mid-stop, and
+	// leave the process to decide when. The stop is still pinned here, so this
+	// signal can only arrive from a start requested during StateStopping —
+	// which is precisely what the old State()-then-Run code refused to do.
+	waitSignal(t, a.ensureAsked, "a.ensureAsked")
+
+	// Let the unload complete. The request must now start the model itself.
+	close(a.stopBlock)
+	<-stopDone
+
+	select {
+	case <-served:
+	case <-t.Context().Done():
+		t.Fatalf("request during stop never completed: %v", context.Cause(t.Context()))
+	}
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	if got := a.runCalls.Load(); got != 1 {
+		t.Errorf("runCalls=%d want 1 (model must be restarted after the unload)", got)
+	}
+	if got := a.serveCalls.Load(); got != 1 {
+		t.Errorf("serveCalls=%d want 1", got)
+	}
+}
+
 func TestBaseRouter_ContextCancel(t *testing.T) {
 	a := newFakeProcess("a")
 	// autoReady=false so swap parks forever until we mark ready.

--- a/internal/router/design.md
+++ b/internal/router/design.md
@@ -123,6 +123,24 @@ finishes it posts a `SwapDone` onto `swapDoneCh`, which the run loop delivers as
 quick events (`OnRequest` to start, `OnSwapDone` to finish) and everything in
 between is handled normally.
 
+### `doSwap` never decides from a process state snapshot
+
+To start the target, `doSwap` calls a single `process.EnsureReady`. It
+deliberately does **not** read `State()` and branch on the result. Processes
+change state on their own — a TTL unload, a crash, an operator kill — so any
+state the router reads is already stale by the time it acts on it. `EnsureReady`
+takes that decision inside the process's own single-writer run loop, where the
+state is owned: ready is a no-op, stopped starts, and a stop still in flight
+holds the request until it finishes and then starts.
+
+This is the rule that matters when extending the router: **advisory reads of
+process state are fine** (which model to evict, what `/running` reports — being
+slightly stale is harmless there), but **a read that gates a mutation is a bug**.
+Move that decision into the process instead. Getting this wrong is what caused
+issue #946: a request arriving during a TTL unload saw `StateStopping`, skipped
+the start, and then waited forever on a process nobody was going to start —
+which wedged that model's swap slot and hung every later request for it.
+
 ### In-flight tracking and `trackedServe`
 
 When the scheduler grants a request, the handler it hands back is wrapped by
@@ -279,7 +297,7 @@ Method by method, as implemented in `base.go`:
   state, and whether this router handles the model at all. The scheduler uses it
   for the "unknown model" check and the "already ready" fast path. Safe to call
   any time because the process map is fixed at construction and `State()` is a
-  snapshot.
+  snapshot. Advisory only — never branch a start or stop on it (see above).
 
 - **`RunningModels()`** — the state of every process that isn't stopped or shut
   down. The scheduler unions its keys with its own in-flight swap targets to

--- a/internal/router/helpers_test.go
+++ b/internal/router/helpers_test.go
@@ -38,8 +38,19 @@ type fakeProcess struct {
 	state       process.ProcessState
 	readyCh     chan struct{}
 	stopCh      chan struct{}
-	runStarted  chan struct{} // closed on the first Run call
+	runStarted  chan struct{} // closed on the first Run/EnsureReady call that starts
 	stopStarted chan struct{} // closed on the first Stop call
+	// ensureAsked is closed when EnsureReady is first called, before it
+	// serializes against an in-flight Stop. Tests use it to observe that the
+	// router asked for a start rather than deciding for itself not to.
+	ensureAsked chan struct{}
+
+	// opMu serializes Stop against EnsureReady the way ProcessCommand's run
+	// loop does: a stop keeps that loop parked inside killProcess, so a start
+	// request cannot even be received until the stop has finished. Without
+	// this the fake would let a start decision be made against a stale state,
+	// which is exactly the bug being guarded against (issue #946).
+	opMu sync.Mutex
 
 	autoReady bool
 
@@ -80,6 +91,7 @@ func newFakeProcess(id string) *fakeProcess {
 		stopCh:       make(chan struct{}),
 		runStarted:   make(chan struct{}),
 		stopStarted:  make(chan struct{}),
+		ensureAsked:  make(chan struct{}),
 		serveStarted: make(chan struct{}),
 	}
 }
@@ -87,12 +99,27 @@ func newFakeProcess(id string) *fakeProcess {
 func (f *fakeProcess) setState(s process.ProcessState) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.setStateLocked(s)
+}
+
+func (f *fakeProcess) setStateLocked(s process.ProcessState) {
 	f.state = s
-	if s == process.StateReady {
+	switch s {
+	case process.StateReady:
 		select {
 		case <-f.readyCh:
 		default:
 			close(f.readyCh)
+		}
+	case process.StateStopped:
+		// A stopped process is no longer ready. Re-arm readyCh so a later
+		// WaitReady/EnsureReady blocks until it is started again, mirroring
+		// ProcessCommand — a latched-open readyCh would let a caller believe
+		// a stopped process is serving.
+		select {
+		case <-f.readyCh:
+			f.readyCh = make(chan struct{})
+		default:
 		}
 	}
 }
@@ -130,6 +157,9 @@ func (f *fakeProcess) Run(_ time.Duration) error {
 }
 
 func (f *fakeProcess) Stop(timeout time.Duration) error {
+	f.opMu.Lock()
+	defer f.opMu.Unlock()
+
 	f.stopCalls.Add(1)
 	if f.onStop != nil {
 		f.onStop(f.id)
@@ -144,10 +174,14 @@ func (f *fakeProcess) Stop(timeout time.Duration) error {
 	default:
 		close(f.stopStarted)
 	}
+	if f.state != process.StateStopped {
+		f.setStateLocked(process.StateStopping)
+	}
 	f.mu.Unlock()
 
 	// Test hook: hold Stop here so the test can prove multiple Stops are
-	// in flight at the same time before any of them complete.
+	// in flight at the same time before any of them complete. While held the
+	// process reports StateStopping, as a real one does.
 	if f.stopBlock != nil {
 		<-f.stopBlock
 	}
@@ -157,7 +191,7 @@ func (f *fakeProcess) Stop(timeout time.Duration) error {
 	if f.state == process.StateStopped {
 		return nil
 	}
-	f.state = process.StateStopped
+	f.setStateLocked(process.StateStopped)
 	select {
 	case <-f.stopCh:
 	default:
@@ -173,6 +207,53 @@ func (f *fakeProcess) lastStopTimeout() time.Duration {
 		return 0
 	}
 	return f.stopTimeouts[len(f.stopTimeouts)-1]
+}
+
+// EnsureReady mirrors ProcessCommand.EnsureReady: it takes the start decision
+// under opMu (the fake's stand-in for the run loop) so a stop still in flight
+// holds the caller until the process is really stopped, then starts.
+func (f *fakeProcess) EnsureReady(ctx context.Context, _ time.Duration) error {
+	f.mu.Lock()
+	select {
+	case <-f.ensureAsked:
+	default:
+		close(f.ensureAsked)
+	}
+	f.mu.Unlock()
+
+	f.opMu.Lock()
+	f.mu.Lock()
+	switch f.state {
+	case process.StateReady:
+		f.mu.Unlock()
+		f.opMu.Unlock()
+		return nil
+	case process.StateShutdown:
+		f.mu.Unlock()
+		f.opMu.Unlock()
+		return fmt.Errorf("fakeProcess %s: shutdown", f.id)
+	}
+	// Counted as a run: EnsureReady is how the router starts a process now.
+	f.runCalls.Add(1)
+	f.setStateLocked(process.StateStarting)
+	select {
+	case <-f.runStarted:
+	default:
+		close(f.runStarted)
+	}
+	rc := f.readyCh
+	f.mu.Unlock()
+	f.opMu.Unlock()
+
+	if f.autoReady {
+		f.setState(process.StateReady)
+	}
+	select {
+	case <-rc:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (f *fakeProcess) WaitReady(ctx context.Context) error {


### PR DESCRIPTION
## Summary

Fixes issue #946 where a request arriving during a process stop would hang forever. The router was reading process state and making start/stop decisions based on that snapshot, which could become stale by the time the decision was acted upon. This change moves the start decision into the process's own state machine where it can be made atomically.

## Key Changes

- **Renamed `runReq` to `startReq`** with a new `block` field to distinguish between `Run()` (blocking until process terminates) and the new `EnsureReady()` (non-blocking, answers when ready or failed)

- **Added `EnsureReady()` method** to the `Process` interface and `ProcessCommand` that brings a process to ready state without blocking on termination. The decision of whether to start is made inside the process's run loop, eliminating race conditions

- **Updated process state machine** to:
  - Call `notifyWaiters()` on all terminal state transitions (not just `StateStarting` exits) to prevent subscribers from hanging
  - Handle `EnsureReady` requests that arrive during `StateStopping` by waiting for the stop to complete before starting
  - Notify waiters when a process exits unexpectedly or is stopped

- **Updated router's `doSwap()`** to call `EnsureReady()` instead of reading `State()` and conditionally calling `Run()`. This ensures the start decision is made atomically within the process's run loop

- **Added comprehensive tests**:
  - `TestProcessCommand_EnsureReadyDuringStop`: Regression test verifying requests during stop wait for completion then start
  - `TestProcessCommand_EnsureReadyIsIdempotent`: Verifies idempotent behavior on ready/shutdown states
  - `TestBaseRouter_RequestDuringStop`: Router-level test ensuring requests during TTL unload don't hang
  - Updated `fakeProcess` to mirror `ProcessCommand` behavior with proper synchronization

- **Updated design documentation** to clarify that advisory state reads are fine, but mutations must never be gated on state snapshots

## Implementation Details

The core fix is that `EnsureReady()` sends a request to the process's run loop, which then decides whether to start based on the current state. This is safe because:
- The run loop is single-threaded and owns the state
- A stop in flight keeps the loop parked in `killProcess()`, so start requests cannot be received until the stop completes
- The send on `startCh` is the synchronization point that naturally serializes against in-flight stops

This follows the principle: **advisory reads of process state are fine, but reads that gate mutations must happen inside the process's own state machine**.

https://claude.ai/code/session_019hYxUXB2Cx8xLY4wEELoYC