### PR TITLE
internal/server,ui-svelte: add peer model namespaces

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -174,7 +174,7 @@ upstream:
 # - optional, default: empty dictionary
 # - one profile or none is active; startup and configuration reload select none
 # - pins are applied before aliases, filters, and routing
-# - targets may be a local model, peer model, alias, setParamsByID alias, or selector
+# - targets may be a local model, fully qualified peer model, alias, setParamsByID alias, or selector
 # - an empty string or YAML null (~) disables the pin with a 404; it is not
 #   added to model listings, while existing local, alias, or peer IDs remain
 profiles:
@@ -188,7 +188,7 @@ profiles:
 # selectors: virtual model IDs resolved to concrete targets per request
 # - optional, default: empty dictionary
 # - profiles run first, so a profile pin may target a selector
-# - selector IDs cannot collide with model IDs, aliases, or peer model names
+# - selector IDs cannot collide with model IDs, aliases, or fully qualified peer model names
 # - selector targets cannot be other selectors
 # - selectors are not supported on /upstream/<model> paths
 selectors:
@@ -211,7 +211,7 @@ selectors:
       - "gpt-oss-120b"
       - "z-ai/glm-4.7"
 
-  # spillover fills local targets to the reservation count in order,
+  # spillover fills local or remote targets to the reservation count in order,
   # starting the next target when the active targets reach that count
   "llama":
     strategy: spillover
@@ -660,6 +660,10 @@ routing:
 # - optional, default empty dictionary
 # - peers can be another llama-swap
 # - peers can be any server that provides the /v1/ generative api endpoints supported by llama-swap
+# - peer models are always addressable as <peer ID>/<model ID>
+# - an unqualified model ID is accepted only when exactly one peer provides it
+# - local model IDs and aliases take precedence over unqualified peer model IDs
+# - fully qualified peer names are reserved and are the peer IDs shown by /v1/models
 peers:
   # keys is the peer'd ID
   llama-swap-peer:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -253,7 +253,7 @@ apiKeys:
 # - optional, default: empty dictionary
 # - one profile or none is active; startup and configuration reload select none
 # - pins are applied before aliases, filters, and routing
-# - targets may be a local model, peer model, alias, setParamsByID alias, or selector
+# - targets may be a local model, fully qualified peer model, alias, setParamsByID alias, or selector
 # - an empty string or YAML null (~) disables the pin with a 404; it is not
 #   added to model listings, while existing local, alias, or peer IDs remain
 profiles:
@@ -267,7 +267,7 @@ profiles:
 # selectors: virtual model IDs resolved to concrete targets per request
 # - optional, default: empty dictionary
 # - profiles run first, so a profile pin may target a selector
-# - selector IDs cannot collide with model IDs, aliases, or peer model names
+# - selector IDs cannot collide with model IDs, aliases, or fully qualified peer model names
 # - selector targets cannot be other selectors
 # - selectors are not supported on /upstream/<model> paths
 selectors:
@@ -290,7 +290,7 @@ selectors:
       - "gpt-oss-120b"
       - "z-ai/glm-4.7"
 
-  # spillover fills local targets to the reservation count in order,
+  # spillover fills local or remote targets to the reservation count in order,
   # starting the next target when the active targets reach that count
   "llama":
     strategy: spillover
@@ -615,6 +615,10 @@ hooks:
 # - optional, default empty dictionary
 # - peers can be another llama-swap
 # - peers can be any server that provides the /v1/ generative api endpoints supported by llama-swap
+# - peer models are always addressable as <peer ID>/<model ID>
+# - an unqualified model ID is accepted only when exactly one peer provides it
+# - local model IDs and aliases take precedence over unqualified peer model IDs
+# - fully qualified peer names are reserved and are the peer IDs shown by /v1/models
 peers:
   # keys is the peer'd ID
   llama-swap-peer:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -248,12 +248,8 @@ func (c *Config) ResolveBaseModel(search string) (string, bool) {
 	if realName, found := c.RealModelName(search); found {
 		return realName, true
 	}
-	for _, peer := range c.Peers {
-		for _, modelID := range peer.Models {
-			if modelID == search {
-				return search, true
-			}
-		}
+	if _, _, found := c.ResolvePeerModel(search); found {
+		return search, true
 	}
 	return "", false
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -462,6 +462,10 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		config.Peers[peerName] = peerConfig
 	}
 
+	if err := ValidatePeerNamespace(config); err != nil {
+		return Config{}, err
+	}
+
 	if err := validateSelectors(config); err != nil {
 		return Config{}, err
 	}

--- a/internal/config/peer.go
+++ b/internal/config/peer.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net/url"
+	"sort"
 )
 
 type PeerDictionaryConfig map[string]PeerConfig
@@ -15,6 +16,123 @@ type PeerConfig struct {
 
 	// Timeout settings for proxy connections
 	Timeouts TimeoutsConfig `yaml:"timeouts"`
+}
+
+// PeerModelFQN returns the fully qualified routing name for a peer model.
+// Peer and model IDs may both contain slashes, so callers must treat the
+// result as an exact configured name rather than parsing it by segments.
+func PeerModelFQN(peerID, modelID string) string {
+	return peerID + "/" + modelID
+}
+
+// ResolvePeerModel resolves an exact fully qualified peer model name or an
+// unqualified model name provided by exactly one peer. Fully qualified names
+// take precedence over unqualified names that happen to contain the same text.
+func (c *Config) ResolvePeerModel(search string) (peerID, modelID string, found bool) {
+	for id, peer := range c.Peers {
+		seen := make(map[string]struct{})
+		for _, model := range peer.Models {
+			if _, duplicate := seen[model]; duplicate {
+				continue
+			}
+			seen[model] = struct{}{}
+			if PeerModelFQN(id, model) != search {
+				continue
+			}
+			if found && (peerID != id || modelID != model) {
+				return "", "", false
+			}
+			peerID, modelID, found = id, model, true
+		}
+	}
+	if found {
+		return peerID, modelID, true
+	}
+
+	for id, peer := range c.Peers {
+		seen := make(map[string]struct{})
+		for _, model := range peer.Models {
+			if _, duplicate := seen[model]; duplicate {
+				continue
+			}
+			seen[model] = struct{}{}
+			if model != search {
+				continue
+			}
+			if found && (peerID != id || modelID != model) {
+				return "", "", false
+			}
+			peerID, modelID, found = id, model, true
+		}
+	}
+	return peerID, modelID, found
+}
+
+// ValidatePeerNamespace ensures every configured peer model has an
+// unambiguous, reserved fully qualified name.
+func ValidatePeerNamespace(c Config) error {
+	type peerTarget struct {
+		peerID  string
+		modelID string
+	}
+
+	fqnTargets := make(map[string]peerTarget)
+	peerIDs := make([]string, 0, len(c.Peers))
+	for peerID := range c.Peers {
+		peerIDs = append(peerIDs, peerID)
+	}
+	sort.Strings(peerIDs)
+
+	for _, peerID := range peerIDs {
+		seen := make(map[string]struct{})
+		for _, modelID := range c.Peers[peerID].Models {
+			if _, duplicate := seen[modelID]; duplicate {
+				continue
+			}
+			seen[modelID] = struct{}{}
+
+			fqn := PeerModelFQN(peerID, modelID)
+			if existing, ok := fqnTargets[fqn]; ok {
+				return fmt.Errorf(
+					"peer model name %q is ambiguous between peers.%s model %q and peers.%s model %q",
+					fqn, existing.peerID, existing.modelID, peerID, modelID,
+				)
+			}
+			fqnTargets[fqn] = peerTarget{peerID: peerID, modelID: modelID}
+		}
+	}
+
+	reserved := make([]string, 0, len(fqnTargets))
+	for fqn := range fqnTargets {
+		reserved = append(reserved, fqn)
+	}
+	sort.Strings(reserved)
+
+	for _, fqn := range reserved {
+		if _, ok := c.Models[fqn]; ok {
+			return fmt.Errorf("model ID %q conflicts with fully qualified peer model name", fqn)
+		}
+		for modelID, model := range c.Models {
+			for _, alias := range model.Aliases {
+				if alias == fqn {
+					return fmt.Errorf("model %s alias %q conflicts with fully qualified peer model name", modelID, fqn)
+				}
+			}
+		}
+		if _, ok := c.aliases[fqn]; ok {
+			return fmt.Errorf("model alias %q conflicts with fully qualified peer model name", fqn)
+		}
+		if _, ok := c.Selectors[fqn]; ok {
+			return fmt.Errorf("selector ID %q conflicts with fully qualified peer model name", fqn)
+		}
+		for profileID, profile := range c.Profiles {
+			if _, ok := profile.Pins[fqn]; ok {
+				return fmt.Errorf("profile %s pin %q conflicts with fully qualified peer model name", profileID, fqn)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (c *PeerConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/internal/config/peer_test.go
+++ b/internal/config/peer_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -205,5 +206,142 @@ filters:
 	}
 	if config.Filters.SetParams["max_tokens"] != 1000 {
 		t.Errorf("expected max_tokens 1000, got %v", config.Filters.SetParams["max_tokens"])
+	}
+}
+
+func TestConfig_ResolvePeerModel(t *testing.T) {
+	cfg := Config{
+		Models: map[string]ModelConfig{"shared": {}},
+		Peers: PeerDictionaryConfig{
+			"p1": {Models: []string{"shared", "org/model"}},
+			"p2": {Models: []string{"shared", "unique"}},
+		},
+	}
+
+	tests := []struct {
+		search      string
+		wantPeerID  string
+		wantModelID string
+		wantFound   bool
+	}{
+		{search: "p1/shared", wantPeerID: "p1", wantModelID: "shared", wantFound: true},
+		{search: "p2/shared", wantPeerID: "p2", wantModelID: "shared", wantFound: true},
+		{search: "p1/org/model", wantPeerID: "p1", wantModelID: "org/model", wantFound: true},
+		{search: "unique", wantPeerID: "p2", wantModelID: "unique", wantFound: true},
+		{search: "shared", wantFound: false},
+		{search: "missing", wantFound: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.search, func(t *testing.T) {
+			peerID, modelID, found := cfg.ResolvePeerModel(tt.search)
+			if peerID != tt.wantPeerID || modelID != tt.wantModelID || found != tt.wantFound {
+				t.Fatalf(
+					"ResolvePeerModel(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tt.search, peerID, modelID, found,
+					tt.wantPeerID, tt.wantModelID, tt.wantFound,
+				)
+			}
+		})
+	}
+
+	if got, found := cfg.ResolveBaseModel("shared"); !found || got != "shared" {
+		t.Fatalf("ResolveBaseModel(shared) = (%q, %v), want local model", got, found)
+	}
+	if got, found := cfg.ResolveBaseModel("p1/shared"); !found || got != "p1/shared" {
+		t.Fatalf("ResolveBaseModel(p1/shared) = (%q, %v), want peer FQN", got, found)
+	}
+}
+
+func TestConfig_ResolvePeerModel_FQNPrecedesBareName(t *testing.T) {
+	cfg := Config{Peers: PeerDictionaryConfig{
+		"p1": {Models: []string{"model"}},
+		"p2": {Models: []string{"p1/model"}},
+	}}
+
+	peerID, modelID, found := cfg.ResolvePeerModel("p1/model")
+	if !found || peerID != "p1" || modelID != "model" {
+		t.Fatalf("ResolvePeerModel(p1/model) = (%q, %q, %v), want p1/model FQN", peerID, modelID, found)
+	}
+
+	peerID, modelID, found = cfg.ResolvePeerModel("p2/p1/model")
+	if !found || peerID != "p2" || modelID != "p1/model" {
+		t.Fatalf("ResolvePeerModel(p2/p1/model) = (%q, %q, %v), want p2 raw slash model", peerID, modelID, found)
+	}
+}
+
+func TestConfig_ValidatePeerNamespace(t *testing.T) {
+	t.Run("ambiguous constructed name", func(t *testing.T) {
+		cfg := Config{Peers: PeerDictionaryConfig{
+			"a":   {Models: []string{"b/c"}},
+			"a/b": {Models: []string{"c"}},
+		}}
+		if err := ValidatePeerNamespace(cfg); err == nil {
+			t.Fatal("expected ambiguous peer FQN error")
+		}
+	})
+
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{
+			name: "local model",
+			mutate: func(cfg *Config) {
+				cfg.Models["peer/model"] = ModelConfig{}
+			},
+		},
+		{
+			name: "local alias",
+			mutate: func(cfg *Config) {
+				cfg.Models["local"] = ModelConfig{Aliases: []string{"peer/model"}}
+			},
+		},
+		{
+			name: "selector",
+			mutate: func(cfg *Config) {
+				cfg.Selectors["peer/model"] = SelectorConfig{}
+			},
+		},
+		{
+			name: "profile pin",
+			mutate: func(cfg *Config) {
+				cfg.Profiles["profile"] = ProfileConfig{Pins: map[string]string{"peer/model": "local"}}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				Models:    map[string]ModelConfig{},
+				Peers:     PeerDictionaryConfig{"peer": {Models: []string{"model"}}},
+				Selectors: map[string]SelectorConfig{},
+				Profiles:  map[string]ProfileConfig{},
+			}
+			tt.mutate(&cfg)
+			if err := ValidatePeerNamespace(cfg); err == nil {
+				t.Fatal("expected reserved peer FQN conflict")
+			}
+		})
+	}
+}
+
+func TestConfig_LoadPeerNamespaceConflict(t *testing.T) {
+	_, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  local:
+    cmd: echo ${PORT}
+    filters:
+      setParamsByID:
+        peer/model:
+          temperature: 0.5
+peers:
+  peer:
+    proxy: http://example.com
+    models: [model]
+`))
+	if err == nil || !strings.Contains(err.Error(), "conflicts with fully qualified peer model name") {
+		t.Fatalf("LoadConfigFromReader error = %v, want peer FQN conflict", err)
 	}
 }

--- a/internal/config/profile_test.go
+++ b/internal/config/profile_test.go
@@ -30,6 +30,7 @@ profiles:
       alias: local-fast
       variant: local-thinking
       peer: peer-model
+      peer-qualified: remote/peer-model
       disabled-empty: ""
       disabled-null: ~
       local: peer-model
@@ -51,6 +52,7 @@ profiles:
 		{"alias", "local-fast", "local", false},
 		{"variant", "local-thinking", "local", false},
 		{"peer", "peer-model", "peer-model", false},
+		{"peer-qualified", "remote/peer-model", "remote/peer-model", false},
 		{"local", "peer-model", "peer-model", false},
 		{"disabled-empty", "", "", true},
 		{"disabled-null", "", "", true},

--- a/internal/config/selectors.go
+++ b/internal/config/selectors.go
@@ -57,13 +57,6 @@ func validateSelectors(config Config) error {
 		if _, found := config.aliases[selectorID]; found {
 			return fmt.Errorf("selectors.%s: name conflicts with model alias %q", selectorID, selectorID)
 		}
-		for peerID, peer := range config.Peers {
-			for _, modelID := range peer.Models {
-				if modelID == selectorID {
-					return fmt.Errorf("selectors.%s: name conflicts with peer model %q from peer %q", selectorID, modelID, peerID)
-				}
-			}
-		}
 
 		switch selector.Strategy {
 		case SelectorStrategyPin, SelectorStrategyWarm, SelectorStrategySpillover:
@@ -77,6 +70,7 @@ func validateSelectors(config Config) error {
 		}
 
 		resolvedTargets := make([]string, 0, len(selector.Targets))
+		localTargets := make([]string, 0, len(selector.Targets))
 		for i, target := range selector.Targets {
 			if _, found := config.Selectors[target]; found {
 				return fmt.Errorf("selectors.%s.targets[%d] references selector %q; selector chaining is not supported", selectorID, i, target)
@@ -85,10 +79,18 @@ func validateSelectors(config Config) error {
 				return fmt.Errorf("selectors.%s.targets[%d] references unknown model %q", selectorID, i, target)
 			}
 
-			if selector.Strategy == SelectorStrategyWarm || selector.Strategy == SelectorStrategySpillover {
-				realName, local := config.RealModelName(target)
+			realName, local := config.RealModelName(target)
+			if selector.Strategy == SelectorStrategyWarm {
 				if !local {
 					return fmt.Errorf("selectors.%s.targets[%d] must resolve to a local model for strategy %q", selectorID, i, selector.Strategy)
+				}
+			}
+			if selector.Strategy == SelectorStrategySpillover {
+				if local {
+					localTargets = append(localTargets, realName)
+				} else {
+					peerID, modelID, _ := config.ResolvePeerModel(target)
+					realName = PeerModelFQN(peerID, modelID)
 				}
 				resolvedTargets = append(resolvedTargets, realName)
 			}
@@ -108,7 +110,7 @@ func validateSelectors(config Config) error {
 			}
 			seen[target] = struct{}{}
 		}
-		if err := validateSpilloverCoexistence(config, selectorID, resolvedTargets); err != nil {
+		if err := validateSpilloverCoexistence(config, selectorID, localTargets); err != nil {
 			return err
 		}
 	}

--- a/internal/config/selectors_test.go
+++ b/internal/config/selectors_test.go
@@ -145,16 +145,6 @@ selectors:
 			wantErr: "name conflicts with model alias",
 		},
 		{
-			name: "peer collision",
-			config: `
-selectors:
-  remote-model:
-    strategy: pin
-    targets: [a]
-`,
-			wantErr: "name conflicts with peer model",
-		},
-		{
 			name: "warm peer target",
 			config: `
 selectors:
@@ -163,16 +153,6 @@ selectors:
     targets: [remote-model]
 `,
 			wantErr: `must resolve to a local model for strategy "warm"`,
-		},
-		{
-			name: "spillover peer target",
-			config: `
-selectors:
-  public:
-    strategy: spillover
-    targets: [remote-model]
-`,
-			wantErr: `must resolve to a local model for strategy "spillover"`,
 		},
 		{
 			name: "invalid spillover",
@@ -195,6 +175,16 @@ selectors:
     targets: [a, alias-a]
 `,
 			wantErr: `duplicate resolved model "a"`,
+		},
+		{
+			name: "duplicate resolved peer spillover target",
+			config: `
+selectors:
+  public:
+    strategy: spillover
+    targets: [remote-model, remote/remote-model]
+`,
+			wantErr: `duplicate resolved model "remote/remote-model"`,
 		},
 		{
 			name: "spillover swapping group",
@@ -232,6 +222,21 @@ peers:
 			assert.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
+}
+
+func TestConfig_Selectors_PeerModelFQN(t *testing.T) {
+	cfg, err := LoadConfigFromReader(strings.NewReader(`
+peers:
+  remote:
+    proxy: http://example.com
+    models: [remote-model]
+selectors:
+  remote-model:
+    strategy: spillover
+    targets: [remote/remote-model]
+`))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"remote/remote-model"}, cfg.Selectors["remote-model"].Targets)
 }
 
 func TestConfig_Selectors_SpilloverCoexistence(t *testing.T) {
@@ -298,6 +303,37 @@ selectors:
 `))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "must all appear together in one expanded matrix set")
+	})
+
+	t.Run("remote targets", func(t *testing.T) {
+		_, err := LoadConfigFromReader(strings.NewReader(`
+peers:
+  remote:
+    proxy: http://example.com
+    models: [a, b]
+selectors:
+  public:
+    strategy: spillover
+    targets: [remote/a, remote/b]
+`))
+		require.NoError(t, err)
+	})
+
+	t.Run("mixed local and remote targets", func(t *testing.T) {
+		_, err := LoadConfigFromReader(strings.NewReader(`
+models:
+  local:
+    cmd: echo ${PORT}
+peers:
+  remote:
+    proxy: http://example.com
+    models: [remote-model]
+selectors:
+  public:
+    strategy: spillover
+    targets: [local, remote/remote-model]
+`))
+		require.NoError(t, err)
 	})
 }
 

--- a/internal/router/peer.go
+++ b/internal/router/peer.go
@@ -24,10 +24,15 @@ type peerMember struct {
 	apiKey       string
 }
 
+type peerRoute struct {
+	member  *peerMember
+	modelID string
+}
+
 type Peer struct {
 	cfg    config.Config
 	logger *logmon.Monitor
-	peers  map[string]*peerMember
+	peers  map[string]*peerRoute
 
 	shutdownCtx  context.Context
 	shutdownFn   context.CancelFunc
@@ -36,8 +41,13 @@ type Peer struct {
 }
 
 func NewPeer(cfg config.Config, logger *logmon.Monitor) (*Peer, error) {
+	if err := config.ValidatePeerNamespace(cfg); err != nil {
+		return nil, err
+	}
+
 	peers := cfg.Peers
-	modelMap := make(map[string]*peerMember)
+	modelMap := make(map[string]*peerRoute)
+	bareRoutes := make(map[string][]*peerRoute)
 
 	peerIDs := make([]string, 0, len(peers))
 	for peerID := range peers {
@@ -93,13 +103,27 @@ func NewPeer(cfg config.Config, logger *logmon.Monitor) (*Peer, error) {
 			apiKey:       peer.ApiKey,
 		}
 
+		seen := make(map[string]struct{})
 		for _, modelID := range peer.Models {
-			if _, found := modelMap[modelID]; found {
-				logger.Warnf("peer %s: model %s already mapped to another peer, skipping", peerID, modelID)
+			if _, duplicate := seen[modelID]; duplicate {
 				continue
 			}
-			modelMap[modelID] = pp
+			seen[modelID] = struct{}{}
+
+			route := &peerRoute{member: pp, modelID: modelID}
+			modelMap[config.PeerModelFQN(peerID, modelID)] = route
+			bareRoutes[modelID] = append(bareRoutes[modelID], route)
 		}
+	}
+
+	for modelID, routes := range bareRoutes {
+		if len(routes) != 1 {
+			continue
+		}
+		if _, reserved := modelMap[modelID]; reserved {
+			continue
+		}
+		modelMap[modelID] = routes[0]
 	}
 
 	shutdownCtx, shutdownFn := context.WithCancel(context.Background())
@@ -159,14 +183,23 @@ func (r *Peer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	pp, found := r.peers[data.ModelID]
+	route, found := r.peers[data.ModelID]
 	if !found {
 		r.logger.Warnf("peer model not found: %s", data.ModelID)
 		shared.SendError(w, req, ErrNoPeerModelFound)
 		return
 	}
+	pp := route.member
 
-	r.logger.Debugf("peer: routing model %s to peer %s", data.ModelID, pp.peerID)
+	r.logger.Debugf("peer: routing model %s to peer %s as %s", data.ModelID, pp.peerID, route.modelID)
+
+	if data.Model != route.modelID {
+		req, err = shared.ReplaceRequestModel(req, data.Model, route.modelID)
+		if err != nil {
+			shared.SendResponse(w, req, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
 
 	if pp.apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+pp.apiKey)

--- a/internal/router/peer_test.go
+++ b/internal/router/peer_test.go
@@ -49,14 +49,20 @@ func TestNewPeer_SinglePeer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(pr.peers) != 2 {
-		t.Fatalf("expected 2 entries, got %d", len(pr.peers))
+	if len(pr.peers) != 4 {
+		t.Fatalf("expected 4 entries, got %d", len(pr.peers))
 	}
 	if _, ok := pr.peers["model-a"]; !ok {
 		t.Error("expected model-a to be mapped")
 	}
 	if _, ok := pr.peers["model-b"]; !ok {
 		t.Error("expected model-b to be mapped")
+	}
+	if _, ok := pr.peers["peer1/model-a"]; !ok {
+		t.Error("expected peer1/model-a to be mapped")
+	}
+	if _, ok := pr.peers["peer1/model-b"]; !ok {
+		t.Error("expected peer1/model-b to be mapped")
 	}
 	if _, ok := pr.peers["model-c"]; ok {
 		t.Error("expected model-c to not be mapped")
@@ -83,10 +89,15 @@ func TestNewPeer_MultiplePeers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(pr.peers) != 4 {
-		t.Fatalf("expected 4 entries, got %d", len(pr.peers))
+	if len(pr.peers) != 8 {
+		t.Fatalf("expected 8 entries, got %d", len(pr.peers))
 	}
 	for _, m := range []string{"model-a", "model-b", "model-c", "model-d"} {
+		if _, ok := pr.peers[m]; !ok {
+			t.Errorf("expected %s to be mapped", m)
+		}
+	}
+	for _, m := range []string{"peer1/model-a", "peer1/model-b", "peer2/model-c", "peer2/model-d"} {
 		if _, ok := pr.peers[m]; !ok {
 			t.Errorf("expected %s to be mapped", m)
 		}
@@ -113,11 +124,84 @@ func TestNewPeer_DuplicateModel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(pr.peers) != 1 {
-		t.Fatalf("expected 1 entry for duplicate model, got %d", len(pr.peers))
+	if len(pr.peers) != 2 {
+		t.Fatalf("expected 2 qualified entries for duplicate model, got %d", len(pr.peers))
 	}
-	if _, ok := pr.peers["duplicate-model"]; !ok {
-		t.Error("expected duplicate-model to be mapped")
+	if _, ok := pr.peers["duplicate-model"]; ok {
+		t.Error("duplicate bare model should not be mapped")
+	}
+	if _, ok := pr.peers["alpha-peer/duplicate-model"]; !ok {
+		t.Error("expected alpha-peer/duplicate-model to be mapped")
+	}
+	if _, ok := pr.peers["beta-peer/duplicate-model"]; !ok {
+		t.Error("expected beta-peer/duplicate-model to be mapped")
+	}
+}
+
+func TestNewPeer_FQNPrecedesCollidingBareModel(t *testing.T) {
+	proxyURL, _ := url.Parse("http://peer.example.com")
+	pr, err := NewPeer(config.Config{Peers: config.PeerDictionaryConfig{
+		"p1": {
+			ProxyURL: proxyURL,
+			Models:   []string{"model"},
+		},
+		"p2": {
+			ProxyURL: proxyURL,
+			Models:   []string{"p1/model"},
+		},
+	}}, testLogger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := pr.peers["p1/model"]; got == nil || got.member.peerID != "p1" || got.modelID != "model" {
+		t.Fatalf("p1/model route = %#v, want p1 model", got)
+	}
+	if got := pr.peers["p2/p1/model"]; got == nil || got.member.peerID != "p2" || got.modelID != "p1/model" {
+		t.Fatalf("p2/p1/model route = %#v, want p2 p1/model", got)
+	}
+}
+
+func TestPeer_ServeHTTP_QualifiedModelRewritten(t *testing.T) {
+	var upstreamModel string
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := shared.ExtractModel(r)
+		if err != nil {
+			t.Errorf("ExtractModel: %v", err)
+		} else {
+			upstreamModel = data
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer testServer.Close()
+
+	proxyURL, _ := url.Parse(testServer.URL)
+	pr, err := NewPeer(config.Config{Peers: config.PeerDictionaryConfig{
+		"strix": {
+			Proxy:    testServer.URL,
+			ProxyURL: proxyURL,
+			Models:   []string{"Q3.6-27B-MTP"},
+		},
+	}}, testLogger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/chat/completions",
+		strings.NewReader(`{"model":"strix/Q3.6-27B-MTP","prompt":"hello"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	pr.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if upstreamModel != "Q3.6-27B-MTP" {
+		t.Fatalf("upstream model = %q, want Q3.6-27B-MTP", upstreamModel)
 	}
 }
 
@@ -589,7 +673,7 @@ func TestNewPeer_CustomTimeouts(t *testing.T) {
 		t.Fatal("expected model1 to be mapped")
 	}
 
-	transport, ok := member.reverseProxy.Transport.(*http.Transport)
+	transport, ok := member.member.reverseProxy.Transport.(*http.Transport)
 	if !ok {
 		t.Fatal("expected Transport to be *http.Transport")
 	}

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -214,9 +214,14 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 
 	for peerID, peer := range s.cfg.Peers {
 		for _, modelID := range peer.Models {
-			modelIDs[modelID] = struct{}{}
+			fqn := config.PeerModelFQN(peerID, modelID)
+			modelIDs[fqn] = struct{}{}
+			if resolvedPeer, resolvedModel, found := s.cfg.ResolvePeerModel(modelID); found &&
+				resolvedPeer == peerID && resolvedModel == modelID {
+				modelIDs[modelID] = struct{}{}
+			}
 			data = append(data, newRecord(
-				modelID,
+				fqn,
 				peerID+": "+modelID,
 				"",
 				nil,

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -49,11 +49,54 @@ func TestServer_HandleListModels(t *testing.T) {
 	for _, m := range resp.Data {
 		ids[m.ID] = true
 	}
-	if !ids["visible"] || !ids["remote-model"] {
+	if !ids["visible"] || !ids["peer1/remote-model"] {
 		t.Errorf("missing expected models: %v", ids)
 	}
 	if ids["hidden"] {
 		t.Error("unlisted model should not appear")
+	}
+}
+
+func TestServer_HandleListModels_PeerNamespaces(t *testing.T) {
+	s := newTestServer(newStubRouter(nil, ""), newStubRouter(nil, ""))
+	s.cfg = config.Config{
+		Models: map[string]config.ModelConfig{"shared": {}},
+		Peers: config.PeerDictionaryConfig{
+			"cuda":  {Models: []string{"shared"}},
+			"strix": {Models: []string{"shared"}},
+		},
+	}
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v1/models", nil))
+
+	var resp struct {
+		Data []modelRecord `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	ids := make(map[string]bool)
+	for _, model := range resp.Data {
+		ids[model.ID] = true
+	}
+	for _, id := range []string{"shared", "cuda/shared", "strix/shared"} {
+		if !ids[id] {
+			t.Errorf("missing model %q from %v", id, ids)
+		}
+	}
+	if len(ids) != 3 {
+		t.Errorf("model IDs = %v, want exactly local and two qualified peers", ids)
+	}
+
+	statusIDs := make(map[string]bool)
+	for _, model := range s.modelStatus() {
+		statusIDs[model.Id] = true
+	}
+	for _, id := range []string{"shared", "cuda/shared", "strix/shared"} {
+		if !statusIDs[id] {
+			t.Errorf("missing status model %q from %v", id, statusIDs)
+		}
 	}
 }
 
@@ -121,8 +164,8 @@ func TestServer_HandleListModels_Status(t *testing.T) {
 	if statuses["unloaded-model"] != "unloaded" {
 		t.Errorf("unloaded-model status = %q, want unloaded", statuses["unloaded-model"])
 	}
-	if statuses["remote-model"] != "unloaded" {
-		t.Errorf("remote-model status = %q, want unloaded", statuses["remote-model"])
+	if statuses["peer1/remote-model"] != "unloaded" {
+		t.Errorf("peer1/remote-model status = %q, want unloaded", statuses["peer1/remote-model"])
 	}
 }
 

--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/event"
 	"github.com/mostlygeek/llama-swap/internal/perf"
 	"github.com/mostlygeek/llama-swap/internal/shared"
@@ -124,7 +125,7 @@ func (s *Server) modelStatus() []apiModel {
 
 	for peerID, peer := range s.cfg.Peers {
 		for _, modelID := range peer.Models {
-			models = append(models, apiModel{Id: modelID, PeerID: peerID})
+			models = append(models, apiModel{Id: config.PeerModelFQN(peerID, modelID), PeerID: peerID})
 		}
 	}
 

--- a/internal/server/filters.go
+++ b/internal/server/filters.go
@@ -117,12 +117,8 @@ func resolveFilters(cfg config.Config, requested string) (useModelName string, f
 		mc := cfg.Models[realName]
 		return mc.UseModelName, mc.Filters.Filters, true
 	}
-	for _, peer := range cfg.Peers {
-		for _, m := range peer.Models {
-			if m == requested {
-				return "", peer.Filters, true
-			}
-		}
+	if peerID, _, found := cfg.ResolvePeerModel(requested); found {
+		return "", cfg.Peers[peerID].Filters, true
 	}
 	return "", config.Filters{}, false
 }

--- a/internal/server/filters_test.go
+++ b/internal/server/filters_test.go
@@ -56,6 +56,27 @@ func TestServer_ApplyFilters(t *testing.T) {
 	})
 }
 
+func TestServer_ResolveFilters_QualifiedPeer(t *testing.T) {
+	want := config.Filters{StripParams: "temperature"}
+	cfg := config.Config{Peers: config.PeerDictionaryConfig{
+		"remote": {
+			Models:  []string{"org/model"},
+			Filters: want,
+		},
+	}}
+
+	useModelName, got, ok := resolveFilters(cfg, "remote/org/model")
+	if !ok {
+		t.Fatal("qualified peer filters were not resolved")
+	}
+	if useModelName != "" {
+		t.Fatalf("useModelName = %q, want empty for peer", useModelName)
+	}
+	if got.StripParams != want.StripParams {
+		t.Fatalf("StripParams = %q, want %q", got.StripParams, want.StripParams)
+	}
+}
+
 func TestServer_FormFilterMiddleware(t *testing.T) {
 	cfg := config.Config{Models: map[string]config.ModelConfig{
 		"whisper": {UseModelName: "whisper-large-v3"},

--- a/internal/server/profiles_test.go
+++ b/internal/server/profiles_test.go
@@ -246,7 +246,7 @@ func TestServer_Profile_ModelListings(t *testing.T) {
 	assert.Contains(t, records, "public")
 	assert.Empty(t, records["public"].Name)
 	assert.Equal(t, "Real Model", records["real"].Name)
-	assert.Equal(t, "remote: remote-model", records["remote-model"].Name)
+	assert.Equal(t, "remote: remote-model", records["remote/remote-model"].Name)
 	assert.Contains(t, records, "expose")
 	assert.Empty(t, records["expose"].Name)
 	assert.NotContains(t, records, "disabled")
@@ -263,7 +263,7 @@ func TestServer_Profile_ModelListings(t *testing.T) {
 	}
 	assert.Contains(t, byID, "real")
 	assert.Contains(t, byID, "hidden")
-	assert.Equal(t, "remote", byID["remote-model"].PeerID)
+	assert.Equal(t, "remote", byID["remote/remote-model"].PeerID)
 	assert.NotContains(t, byID, "public")
 	assert.NotContains(t, byID, "expose")
 	assert.NotContains(t, byID, "disabled")

--- a/internal/server/selector.go
+++ b/internal/server/selector.go
@@ -26,6 +26,7 @@ func selectorFromContext(ctx context.Context) string {
 type spilloverTarget struct {
 	target  string
 	modelID string
+	local   bool
 }
 
 type selectorSpilloverState struct {
@@ -52,15 +53,23 @@ func newSelectorSpilloverTracker(cfg config.Config) *selectorSpilloverTracker {
 			inflight:  make(map[string]int, len(selector.Targets)),
 		}
 		for _, target := range selector.Targets {
-			modelID, _ := cfg.RealModelName(target)
-			state.targets = append(state.targets, spilloverTarget{target: target, modelID: modelID})
+			modelID, local := cfg.RealModelName(target)
+			if !local {
+				peerID, peerModelID, _ := cfg.ResolvePeerModel(target)
+				modelID = config.PeerModelFQN(peerID, peerModelID)
+			}
+			state.targets = append(state.targets, spilloverTarget{
+				target:  target,
+				modelID: modelID,
+				local:   local,
+			})
 		}
 		tracker.states[selectorID] = state
 	}
 	return tracker
 }
 
-func (t *selectorSpilloverTracker) release(selectorID, modelID string) {
+func (t *selectorSpilloverTracker) release(selectorID, target string) {
 	if t == nil {
 		return
 	}
@@ -69,8 +78,11 @@ func (t *selectorSpilloverTracker) release(selectorID, modelID string) {
 		return
 	}
 	state.mu.Lock()
-	if state.inflight[modelID] > 0 {
-		state.inflight[modelID]--
+	for _, candidate := range state.targets {
+		if candidate.target == target && state.inflight[candidate.modelID] > 0 {
+			state.inflight[candidate.modelID]--
+			break
+		}
 	}
 	state.mu.Unlock()
 }
@@ -116,9 +128,7 @@ func CreateSelectorMiddleware(s *Server) chain.Middleware {
 			updated, err := shared.ReplaceRequestModel(r, model, target)
 			if err != nil {
 				if selector.Strategy == config.SelectorStrategySpillover {
-					if modelID, found := s.cfg.RealModelName(target); found {
-						spillovers.release(model, modelID)
-					}
+					spillovers.release(model, target)
 				}
 				shared.SendResponse(w, r, http.StatusBadRequest, err.Error())
 				return
@@ -127,8 +137,7 @@ func CreateSelectorMiddleware(s *Server) chain.Middleware {
 			s.proxylog.Debugf("selector: id=%s target=%s", model, target)
 
 			if selector.Strategy == config.SelectorStrategySpillover {
-				modelID, _ := s.cfg.RealModelName(target)
-				defer spillovers.release(model, modelID)
+				defer spillovers.release(model, target)
 			}
 			next.ServeHTTP(w, withSelectorContext(updated, model))
 		})
@@ -173,6 +182,15 @@ func strategySpillover(selectorID string, tracker *selectorSpilloverTracker, run
 	active := make([]spilloverTarget, 0, len(state.targets))
 	cold := make([]spilloverTarget, 0, len(state.targets))
 	for _, target := range state.targets {
+		if !target.local {
+			if state.inflight[target.modelID] > 0 {
+				active = append(active, target)
+			} else {
+				cold = append(cold, target)
+			}
+			continue
+		}
+
 		processState, runningNow := running[target.modelID]
 		switch {
 		case processState == process.StateStopping || processState == process.StateShutdown:

--- a/internal/server/selector_test.go
+++ b/internal/server/selector_test.go
@@ -42,7 +42,7 @@ peers:
 selectors:
   public:
     strategy: pin
-    targets: [variant, remote-model]
+    targets: [variant, remote/remote-model]
     name: Public Model
     description: Public selector
     metadata:
@@ -164,6 +164,36 @@ func TestServer_SelectorStrategySpillover(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no available spillover targets")
+}
+
+func TestServer_SelectorStrategySpillover_RemoteModels(t *testing.T) {
+	cfg := config.Config{
+		Peers: config.PeerDictionaryConfig{
+			"remote": {Models: []string{"a", "b"}},
+		},
+		Selectors: map[string]config.SelectorConfig{
+			"pool": {
+				Strategy: config.SelectorStrategySpillover,
+				Targets:  []string{"remote/a", "remote/b"},
+				Settings: config.SelectorSettings{Spillover: 1},
+			},
+		},
+	}
+	tracker := newSelectorSpilloverTracker(cfg)
+
+	first, err := strategySpillover("pool", tracker, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "remote/a", first)
+
+	second, err := strategySpillover("pool", tracker, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "remote/b", second)
+
+	tracker.release("pool", first)
+	tracker.release("pool", second)
+	target, err := strategySpillover("pool", tracker, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "remote/a", target)
 }
 
 func TestServer_SelectorMiddleware_RewritesBeforeFiltersAndRecordsActivity(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -200,6 +200,23 @@ func TestServer_RouteToPeerModel(t *testing.T) {
 	}
 }
 
+func TestServer_RouteToLocalModel_PrefersLocalCollision(t *testing.T) {
+	s := newTestServer(
+		newStubRouter([]string{"shared"}, "local response"),
+		newStubRouter([]string{"shared"}, "peer response"),
+	)
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, chatRequest("shared"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	if w.Body.String() != "local response" {
+		t.Errorf("body=%q want local response", w.Body.String())
+	}
+}
+
 func TestServer_UnknownModelReturns404(t *testing.T) {
 	s := newTestServer(
 		newStubRouter([]string{"local-model"}, ""),

--- a/internal/shared/http_test.go
+++ b/internal/shared/http_test.go
@@ -745,6 +745,43 @@ func TestFetchContext_UpstreamPath(t *testing.T) {
 	}
 }
 
+func TestFindModelInPath_PeerNamespaces(t *testing.T) {
+	cfg := config.Config{
+		Models: map[string]config.ModelConfig{"local": {}},
+		Peers: config.PeerDictionaryConfig{
+			"p1": {Models: []string{"shared", "org/model"}},
+			"p2": {Models: []string{"shared", "unique"}},
+		},
+	}
+
+	tests := []struct {
+		path      string
+		wantName  string
+		wantModel string
+		wantRest  string
+		wantFound bool
+	}{
+		{"/p1/shared/v1/chat", "p1/shared", "p1/shared", "/v1/chat", true},
+		{"/p2/shared/v1/chat", "p2/shared", "p2/shared", "/v1/chat", true},
+		{"/p1/org/model/v1/chat", "p1/org/model", "p1/org/model", "/v1/chat", true},
+		{"/unique/v1/chat", "unique", "unique", "/v1/chat", true},
+		{"/shared/v1/chat", "", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			name, modelID, rest, found := FindModelInPath(cfg, tt.path)
+			if name != tt.wantName || modelID != tt.wantModel || rest != tt.wantRest || found != tt.wantFound {
+				t.Fatalf(
+					"FindModelInPath(%q) = (%q, %q, %q, %v), want (%q, %q, %q, %v)",
+					tt.path, name, modelID, rest, found,
+					tt.wantName, tt.wantModel, tt.wantRest, tt.wantFound,
+				)
+			}
+		})
+	}
+}
+
 func TestFetchContext_UpstreamPath_DoesNotReadBody(t *testing.T) {
 	cfg := config.Config{Models: map[string]config.ModelConfig{"m1": {}}}
 	body := `{"model":"should-not-matter"}`

--- a/ui-svelte/src/components/AppSidebar.svelte
+++ b/ui-svelte/src/components/AppSidebar.svelte
@@ -36,8 +36,11 @@
     return path === "/" ? current === "/" : current.startsWith(path);
   }
 
-  let visibleModels = $derived(
-    $showUnlistedModels ? $models : $models.filter((m) => !m.unlisted),
+  let visibleLocalModels = $derived(
+    $models.filter((model) => !model.peerID && ($showUnlistedModels || !model.unlisted)),
+  );
+  let visiblePeerModels = $derived(
+    $models.filter((model) => model.peerID && ($showUnlistedModels || !model.unlisted)),
   );
 
   type DotColor = "grey" | "yellow" | "green";
@@ -53,6 +56,21 @@
     green: "bg-success",
   };
 </script>
+
+{#snippet modelMenuItem(model: Model)}
+  <Sidebar.MenuSubItem>
+    <Sidebar.MenuSubButton
+      isActive={$currentRoute === `/models/${encodeURIComponent(model.id)}`}
+    >
+      {#snippet child({ props })}
+        <a href="/models/{encodeURIComponent(model.id)}" use:link {...props}>
+          <span class={`size-2 shrink-0 rounded-full ${dotClass[statusDotColor(model)]}`}></span>
+          <span class="flex-1 truncate">{model.id}</span>
+        </a>
+      {/snippet}
+    </Sidebar.MenuSubButton>
+  </Sidebar.MenuSubItem>
+{/snippet}
 
 <Sidebar.Root collapsible="icon">
   <Sidebar.Header>
@@ -136,20 +154,17 @@
               </Sidebar.MenuButton>
               <Collapsible.Content>
                 <Sidebar.MenuSub>
-                  {#each visibleModels as model (model.id)}
-                    <Sidebar.MenuSubItem>
-                      <Sidebar.MenuSubButton
-                        isActive={$currentRoute === `/models/${encodeURIComponent(model.id)}`}
-                      >
-                        {#snippet child({ props })}
-                          <a href="/models/{encodeURIComponent(model.id)}" use:link {...props}>
-                            <span class={`size-2 shrink-0 rounded-full ${dotClass[statusDotColor(model)]}`}></span>
-                            <span class="flex-1 truncate">{model.id}</span>
-                          </a>
-                        {/snippet}
-                      </Sidebar.MenuSubButton>
-                    </Sidebar.MenuSubItem>
+                  {#each visibleLocalModels as model (model.id)}
+                    {@render modelMenuItem(model)}
                   {/each}
+                  {#if visiblePeerModels.length > 0}
+                    <li class="text-sidebar-foreground/70 px-2 pt-2 pb-1 text-xs font-medium">
+                      Peers
+                    </li>
+                    {#each visiblePeerModels as model (model.id)}
+                      {@render modelMenuItem(model)}
+                    {/each}
+                  {/if}
                 </Sidebar.MenuSub>
               </Collapsible.Content>
             </Collapsible.Root>

--- a/ui-svelte/src/components/playground/ConcurrencyInterface.svelte
+++ b/ui-svelte/src/components/playground/ConcurrencyInterface.svelte
@@ -44,10 +44,18 @@
 
   let timelineMaxMs = $derived(Math.max(100, ...Object.values(runs).map((r) => r.elapsedMs)));
 
-  let availableModels = $derived($playgroundModels.filter((model) => model.playgroundType !== "selector"));
+  let availableModels = $derived(
+    $playgroundModels.filter(
+      (model) => model.playgroundType !== "selector" && model.playgroundType !== "peer"
+    )
+  );
+  let peerModels = $derived(
+    $playgroundModels.filter((model) => model.playgroundType === "peer")
+  );
   let modeSections = $derived([
     { label: "Selectors", ids: $selectorModels.map((model) => model.id) },
     { label: "Models", ids: availableModels.map((model) => model.id) },
+    { label: "Peers", ids: peerModels.map((model) => model.id) },
   ].filter((section) => section.ids.length > 0));
   let hasModels = $derived(modeSections.length > 0);
   let canRun = $derived(!isRunning && $testListStore.length > 0 && $promptStore.trim() !== "");

--- a/ui-svelte/src/components/playground/ModelSelector.svelte
+++ b/ui-svelte/src/components/playground/ModelSelector.svelte
@@ -24,7 +24,7 @@
       || $selectorModels.length > 0
       || hasMatching
       || grouped.local.length > 0
-      || Object.keys(grouped.peersByProvider).length > 0
+      || grouped.peers.length > 0
   );
 </script>
 
@@ -84,14 +84,14 @@
         </Select.Group>
         <Select.Separator />
       {/if}
-      {#each Object.entries(grouped.peersByProvider).sort(([a], [b]) => a.localeCompare(b)) as [peerId, peerModels] (peerId)}
+      {#if grouped.peers.length > 0}
         <Select.Group>
-          <Select.Label>Peer: {peerId}</Select.Label>
-          {#each peerModels as model (model.id)}
+          <Select.Label>Peers</Select.Label>
+          {#each grouped.peers as model (model.id)}
             <Select.Item value={model.id}>{model.id}</Select.Item>
           {/each}
         </Select.Group>
-      {/each}
+      {/if}
     </Select.Content>
   </Select.Root>
 {/if}

--- a/ui-svelte/src/lib/modelUtils.test.ts
+++ b/ui-svelte/src/lib/modelUtils.test.ts
@@ -63,7 +63,7 @@ describe("groupModels", () => {
     makeModel({ id: "chat-model", capabilities: { vision: true } }),
     makeModel({ id: "audio-model", capabilities: { audio_transcriptions: true } }),
     makeModel({ id: "no-caps-model" }),
-    makeModel({ id: "peer-model", peerID: "peer1" }),
+    makeModel({ id: "peer1/peer-model", peerID: "peer1" }),
     makeModel({ id: "unlisted-model", unlisted: true, capabilities: { vision: true } }),
   ];
 
@@ -73,10 +73,10 @@ describe("groupModels", () => {
     expect([...result.localMatching, ...result.local].every((m) => !m.unlisted)).toBe(true);
   });
 
-  it("separates peer models into peersByProvider", () => {
+  it("separates peer models into peers", () => {
     const result = groupModels(models);
-    expect(result.peersByProvider["peer1"]).toHaveLength(1);
-    expect(result.peersByProvider["peer1"][0].id).toBe("peer-model");
+    expect(result.peers).toHaveLength(1);
+    expect(result.peers[0].id).toBe("peer1/peer-model");
   });
 
   it("without capabilities, all local models go to local (non-matching)", () => {

--- a/ui-svelte/src/lib/modelUtils.ts
+++ b/ui-svelte/src/lib/modelUtils.ts
@@ -3,7 +3,7 @@ import type { Model } from "./types";
 export interface GroupedModels {
   local: Model[];
   localMatching: Model[];
-  peersByProvider: Record<string, Model[]>;
+  peers: Model[];
 }
 
 export function matchesCapabilities(model: Model, required: string[], matchAny = false): boolean {
@@ -19,7 +19,7 @@ export function matchesCapabilities(model: Model, required: string[], matchAny =
 export function groupModels(models: Model[], capabilities?: string[], matchAny = false): GroupedModels {
   const available = models.filter((m) => !m.unlisted);
   const local = available.filter((m) => !m.peerID);
-  const peerModels = available.filter((m) => m.peerID);
+  const peers = available.filter((m) => m.peerID);
 
   let localMatching: Model[] = [];
   let localRest: Model[] = [];
@@ -36,15 +36,5 @@ export function groupModels(models: Model[], capabilities?: string[], matchAny =
     localRest = local;
   }
 
-  const peersByProvider = peerModels.reduce(
-    (acc, model) => {
-      const peerId = model.peerID || "unknown";
-      if (!acc[peerId]) acc[peerId] = [];
-      acc[peerId].push(model);
-      return acc;
-    },
-    {} as Record<string, Model[]>
-  );
-
-  return { local: localRest, localMatching, peersByProvider };
+  return { local: localRest, localMatching, peers };
 }

--- a/ui-svelte/src/routes/ModelDetail.svelte
+++ b/ui-svelte/src/routes/ModelDetail.svelte
@@ -31,17 +31,19 @@
           <span class="text-muted-foreground text-sm">({model.id})</span>
           <span class="text-muted-foreground text-xs uppercase tracking-wide">{model.state}</span>
           <div class="ml-auto flex items-center gap-2">
-            <a
-              href={`/upstream/${encodeURIComponent(modelId)}/`}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="text-muted-foreground hover:text-foreground"
-              title="Open model server"
-              aria-label="Open model server"
-            >
-              <ExternalLink class="size-4" />
-            </a>
-            <ModelLoadButton {model} size="sm" />
+            {#if !model.peerID}
+              <a
+                href={`/upstream/${encodeURIComponent(modelId)}/`}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-muted-foreground hover:text-foreground"
+                title="Open model server"
+                aria-label="Open model server"
+              >
+                <ExternalLink class="size-4" />
+              </a>
+              <ModelLoadButton {model} size="sm" />
+            {/if}
           </div>
         </div>
         {#if model.description}

--- a/ui-svelte/src/routes/ModelsDash.svelte
+++ b/ui-svelte/src/routes/ModelsDash.svelte
@@ -107,17 +107,19 @@
               {#if model.unlisted}
                 <Tag class="px-1.5 text-[0.625rem] uppercase">unlisted</Tag>
               {/if}
-              <a
-                href="/upstream/{encodeURIComponent(model.id)}/"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-muted-foreground hover:text-foreground"
-                title="Open model server"
-                aria-label="Open model server"
+              {#if !model.peerID}
+                <a
+                  href="/upstream/{encodeURIComponent(model.id)}/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-muted-foreground hover:text-foreground"
+                  title="Open model server"
+                  aria-label="Open model server"
               >
                 <ExternalLink class="size-4" />
               </a>
-              <ModelLoadButton {model} />
+                <ModelLoadButton {model} />
+              {/if}
             </div>
           {/each}
         </div>

--- a/ui-svelte/src/stores/api.test.ts
+++ b/ui-svelte/src/stores/api.test.ts
@@ -178,7 +178,7 @@ describe("api store event handling", () => {
             meta: { llamaswap: { type: "alias", modelID: "real" } },
           },
           {
-            id: "remote-model",
+            id: "remote/remote-model",
             meta: { llamaswap: { type: "peer", peerID: "remote" } },
           },
           {
@@ -203,7 +203,7 @@ describe("api store event handling", () => {
       capabilities: { vision: true },
       playgroundType: "model",
     });
-    expect(get(playgroundModels).find((model) => model.id === "remote-model")).toMatchObject({
+    expect(get(playgroundModels).find((model) => model.id === "remote/remote-model")).toMatchObject({
       peerID: "remote",
       playgroundType: "peer",
     });


### PR DESCRIPTION
Address peer models by fully qualified names across routing, selectors, model listings, and the UI.

- support fully qualified peer/model routing names
- support peer models in selector spillover targets
- show peer models in Playground model pickers

fixes #944