### PR TITLE
internal/config: refactor macro expansion

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -32,13 +32,14 @@
                 "pattern": "^[a-zA-Z0-9_-]+$",
                 "not": {
                     "enum": [
+                        "PID",
                         "PORT",
                         "MODEL_ID"
                     ]
                 }
             },
             "default": {},
-            "description": "A dictionary of string substitutions. Macros are reusable snippets used in model cmd, cmdStop, proxy, checkEndpoint, filters.stripParams. Macro names must be <64 chars, match ^[a-zA-Z0-9_-]+$, and not be PORT or MODEL_ID. Values can be string, number, or boolean. Macros can reference other macros defined before them."
+            "description": "A dictionary of string substitutions. Global macros can be used in any configuration value; model macros are scoped to their model. Macro names must be <64 chars, match ^[a-zA-Z0-9_-]+$, and not be PID, PORT, or MODEL_ID. Values can be string, number, or boolean. Macros can reference other macros defined before them."
         },
         "timeouts": {
             "type": "object",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -119,16 +119,19 @@ unloadTimeout: 10
 # macros: a dictionary of string substitutions
 # - optional, default: empty dictionary
 # - macros are reusable snippets
-# - used in a model's cmd, cmdStop, proxy, checkEndpoint, filters.stripParams
+# - global macros can be used in any configuration value
+# - model macros can be used in any value within that model
 # - useful for reducing common configuration settings
 # - macro names are strings and must be less than 64 characters
 # - macro names must match the regex ^[a-zA-Z0-9_-]+$
-# - macro names must not be a reserved name: PORT or MODEL_ID
+# - macro names must not be a reserved name: PID, PORT, or MODEL_ID
 # - macro values can be numbers, bools, or strings
 # - macros can contain other macros, but they must be defined before they are used
 # - environment variables can be referenced with ${env.VAR_NAME} syntax
 #   - env macros are substituted first, before regular macros
 #   - if the env var is not set, config loading will fail with an error
+# - ${PORT} is assigned while loading each model that uses it in cmd
+# - ${PID} is substituted when a model's cmdStop runs
 macros:
   # Example of a multi-line macro
   "latest-llama": >

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -210,16 +210,19 @@ unloadTimeout: 10
 # macros: a dictionary of string substitutions
 # - optional, default: empty dictionary
 # - macros are reusable snippets
-# - used in a model's cmd, cmdStop, proxy, checkEndpoint, filters.stripParams
+# - global macros can be used in any configuration value
+# - model macros can be used in any value within that model
 # - useful for reducing common configuration settings
 # - macro names are strings and must be less than 64 characters
 # - macro names must match the regex ^[a-zA-Z0-9_-]+$
-# - macro names must not be a reserved name: PORT or MODEL_ID
+# - macro names must not be a reserved name: PID, PORT, or MODEL_ID
 # - macro values can be numbers, bools, or strings
 # - macros can contain other macros, but they must be defined before they are used
 # - environment variables can be referenced with ${env.VAR_NAME} syntax
 #   - env macros are substituted first, before regular macros
 #   - if the env var is not set, config loading will fail with an error
+# - ${PORT} is assigned while loading each model that uses it in cmd
+# - ${PID} is substituted when a model's cmdStop runs
 macros:
   # Example of a multi-line macro
   "latest-llama": >

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,15 +63,6 @@ func (ml MacroList) Get(name string) (any, bool) {
 	return nil, false
 }
 
-// ToMap converts MacroList to a map (for backward compatibility if needed)
-func (ml MacroList) ToMap() map[string]any {
-	result := make(map[string]any, len(ml))
-	for _, entry := range ml {
-		result[entry.Name] = entry.Value
-	}
-	return result
-}
-
 type GroupConfig struct {
 	Swap       bool     `yaml:"swap"`
 	Exclusive  bool     `yaml:"exclusive"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -298,6 +298,14 @@ macros:
 			expectedError: "macro name 'MODEL_ID' is reserved",
 		},
 		{
+			name: "global macro named PID",
+			config: `
+macros:
+  PID: 1234
+`,
+			expectedError: "macro name 'PID' is reserved",
+		},
+		{
 			name: "model macro named PORT",
 			config: `
 models:

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -25,7 +25,17 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		return Config{}, err
 	}
 
-	// Unmarshal into full Config with defaults
+	raw, macroConfig, err := resolveConfigMacros(yamlStr)
+	if err != nil {
+		return Config{}, err
+	}
+
+	var node yaml.Node
+	if err = node.Encode(raw); err != nil {
+		return Config{}, err
+	}
+
+	// Decode the resolved values into the full Config with defaults.
 	config := Config{
 		HealthCheckTimeout: 120,
 		StartPort:          5800,
@@ -41,8 +51,13 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 			"X-Litellm-Session-Id",
 		}}},
 	}
-	if err = yaml.Unmarshal([]byte(yamlStr), &config); err != nil {
+	if err = node.Decode(&config); err != nil {
 		return Config{}, err
+	}
+	config.Macros = macroConfig.Macros
+	for modelID, modelConfig := range config.Models {
+		modelConfig.Macros = macroConfig.Models[modelID].Macros
+		config.Models[modelID] = modelConfig
 	}
 
 	if config.HealthCheckTimeout < 15 {
@@ -103,28 +118,16 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		}
 	}
 
-	// Validate global macros
-	for _, macro := range config.Macros {
-		if err = validateMacro(macro.Name, macro.Value); err != nil {
-			return Config{}, err
-		}
-	}
-
-	// Get and sort all model IDs for consistent port assignment
+	// Sort model IDs for deterministic validation and normalization.
 	modelIds := make([]string, 0, len(config.Models))
 	for modelId := range config.Models {
 		modelIds = append(modelIds, modelId)
 	}
 	sort.Strings(modelIds)
 
-	nextPort := config.StartPort
 	for _, modelId := range modelIds {
 		modelConfig := config.Models[modelId]
 		modelConfig.HealthCheckTimeout = config.HealthCheckTimeout
-
-		// Strip comments from command fields
-		modelConfig.Cmd = StripComments(modelConfig.Cmd)
-		modelConfig.CmdStop = StripComments(modelConfig.CmdStop)
 
 		// set model TTL to globalTTL it is the default value
 		if modelConfig.UnloadAfter == MODEL_CONFIG_DEFAULT_TTL {
@@ -143,148 +146,8 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 			modelConfig.UnloadTimeout = config.UnloadTimeout
 		}
 
-		// Validate model macros
-		for _, macro := range modelConfig.Macros {
-			if err = validateMacro(macro.Name, macro.Value); err != nil {
-				return Config{}, fmt.Errorf("model %s: %s", modelId, err.Error())
-			}
-		}
-
-		// Build merged macro list: MODEL_ID + global macros + model macros (model overrides global)
-		mergedMacros := make(MacroList, 0, len(config.Macros)+len(modelConfig.Macros)+1)
-		mergedMacros = append(mergedMacros, MacroEntry{Name: "MODEL_ID", Value: modelId})
-		mergedMacros = append(mergedMacros, config.Macros...)
-
-		// Add model macros (override globals with same name)
-		for _, entry := range modelConfig.Macros {
-			found := false
-			for i, existing := range mergedMacros {
-				if existing.Name == entry.Name {
-					mergedMacros[i] = entry
-					found = true
-					break
-				}
-			}
-			if !found {
-				mergedMacros = append(mergedMacros, entry)
-			}
-		}
-
-		// Substitute remaining macros in model fields (LIFO order)
-		for i := len(mergedMacros) - 1; i >= 0; i-- {
-			entry := mergedMacros[i]
-			macroSlug := fmt.Sprintf("${%s}", entry.Name)
-			macroStr := fmt.Sprintf("%v", entry.Value)
-
-			modelConfig.Cmd = strings.ReplaceAll(modelConfig.Cmd, macroSlug, macroStr)
-			modelConfig.CmdStop = strings.ReplaceAll(modelConfig.CmdStop, macroSlug, macroStr)
-			modelConfig.Proxy = strings.ReplaceAll(modelConfig.Proxy, macroSlug, macroStr)
-			modelConfig.CheckEndpoint = strings.ReplaceAll(modelConfig.CheckEndpoint, macroSlug, macroStr)
-			modelConfig.Filters.StripParams = strings.ReplaceAll(modelConfig.Filters.StripParams, macroSlug, macroStr)
-			modelConfig.Name = strings.ReplaceAll(modelConfig.Name, macroSlug, macroStr)
-			modelConfig.Description = strings.ReplaceAll(modelConfig.Description, macroSlug, macroStr)
-
-			// Substitute macros in SetParamsByID keys and values
-			if len(modelConfig.Filters.SetParamsByID) > 0 {
-				newSetParamsByID := make(map[string]map[string]any, len(modelConfig.Filters.SetParamsByID))
-				for key, paramMap := range modelConfig.Filters.SetParamsByID {
-					newKey := strings.ReplaceAll(key, macroSlug, macroStr)
-					newValAny, err := substituteMacroInValue(any(paramMap), entry.Name, entry.Value)
-					if err != nil {
-						return Config{}, fmt.Errorf("model %s filters.setParamsByID: %s", modelId, err.Error())
-					}
-					newParamMap, ok := newValAny.(map[string]any)
-					if !ok {
-						return Config{}, fmt.Errorf("model %s filters.setParamsByID: unexpected type after macro substitution", modelId)
-					}
-					newSetParamsByID[newKey] = newParamMap
-				}
-				modelConfig.Filters.SetParamsByID = newSetParamsByID
-			}
-
-			// Substitute in metadata (type-preserving)
-			if len(modelConfig.Metadata) > 0 {
-				result, err := substituteMacroInValue(modelConfig.Metadata, entry.Name, entry.Value)
-				if err != nil {
-					return Config{}, fmt.Errorf("model %s metadata: %s", modelId, err.Error())
-				}
-				modelConfig.Metadata = result.(map[string]any)
-			}
-		}
-
-		// Resolve macros in capabilities (they couldn't be decoded properly
-		// during YAML unmarshal because e.g. "${default_ctx}" is not an int).
-		if err := modelConfig.Capabilities.ResolveMacros(mergedMacros); err != nil {
+		if err := modelConfig.Capabilities.Validate(); err != nil {
 			return Config{}, fmt.Errorf("model %s: %w", modelId, err)
-		}
-
-		// Handle PORT macro - only allocate if cmd uses it
-		cmdHasPort := strings.Contains(modelConfig.Cmd, "${PORT}")
-		proxyHasPort := strings.Contains(modelConfig.Proxy, "${PORT}")
-		if cmdHasPort || proxyHasPort {
-			if !cmdHasPort && proxyHasPort {
-				return Config{}, fmt.Errorf("model %s: proxy uses ${PORT} but cmd does not - ${PORT} is only available when used in cmd", modelId)
-			}
-
-			macroSlug := "${PORT}"
-			macroStr := fmt.Sprintf("%v", nextPort)
-
-			modelConfig.Cmd = strings.ReplaceAll(modelConfig.Cmd, macroSlug, macroStr)
-			modelConfig.CmdStop = strings.ReplaceAll(modelConfig.CmdStop, macroSlug, macroStr)
-			modelConfig.Proxy = strings.ReplaceAll(modelConfig.Proxy, macroSlug, macroStr)
-			modelConfig.Name = strings.ReplaceAll(modelConfig.Name, macroSlug, macroStr)
-			modelConfig.Description = strings.ReplaceAll(modelConfig.Description, macroSlug, macroStr)
-
-			if len(modelConfig.Metadata) > 0 {
-				result, err := substituteMacroInValue(modelConfig.Metadata, "PORT", nextPort)
-				if err != nil {
-					return Config{}, fmt.Errorf("model %s metadata: %s", modelId, err.Error())
-				}
-				modelConfig.Metadata = result.(map[string]any)
-			}
-
-			nextPort++
-		}
-
-		// Validate no unknown macros remain
-		fieldMap := map[string]string{
-			"cmd":                 modelConfig.Cmd,
-			"cmdStop":             modelConfig.CmdStop,
-			"proxy":               modelConfig.Proxy,
-			"checkEndpoint":       modelConfig.CheckEndpoint,
-			"filters.stripParams": modelConfig.Filters.StripParams,
-			"name":                modelConfig.Name,
-			"description":         modelConfig.Description,
-		}
-
-		for fieldName, fieldValue := range fieldMap {
-			matches := macroPatternRegex.FindAllStringSubmatch(fieldValue, -1)
-			for _, match := range matches {
-				macroName := match[1]
-				if macroName == "PID" && fieldName == "cmdStop" {
-					continue // replaced at runtime
-				}
-				if macroName == "PORT" || macroName == "MODEL_ID" {
-					return Config{}, fmt.Errorf("macro '${%s}' should have been substituted in %s.%s", macroName, modelId, fieldName)
-				}
-				return Config{}, fmt.Errorf("unknown macro '${%s}' found in %s.%s", macroName, modelId, fieldName)
-			}
-		}
-
-		if len(modelConfig.Metadata) > 0 {
-			if err := validateNestedForUnknownMacros(modelConfig.Metadata, fmt.Sprintf("model %s metadata", modelId)); err != nil {
-				return Config{}, err
-			}
-		}
-
-		// Validate SetParamsByID keys and values
-		for key, paramMap := range modelConfig.Filters.SetParamsByID {
-			if matches := macroPatternRegex.FindAllStringSubmatch(key, -1); len(matches) > 0 {
-				return Config{}, fmt.Errorf("unknown macro '${%s}' found in model %s filters.setParamsByID key", matches[0][1], modelId)
-			}
-			if err := validateNestedForUnknownMacros(any(paramMap), fmt.Sprintf("model %s filters.setParamsByID[%s]", modelId, key)); err != nil {
-				return Config{}, err
-			}
 		}
 
 		// Auto-register setParamsByID keys as aliases (skip the model's own ID)
@@ -424,42 +287,6 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 			return Config{}, fmt.Errorf("apiKeys[%d]: api key cannot contain spaces", i)
 		}
 		config.RequiredAPIKeys[i] = apikey
-	}
-
-	// Process peers with global macro substitution
-	for peerName, peerConfig := range config.Peers {
-		// Substitute global macros (LIFO order)
-		for i := len(config.Macros) - 1; i >= 0; i-- {
-			entry := config.Macros[i]
-			macroSlug := fmt.Sprintf("${%s}", entry.Name)
-			macroStr := fmt.Sprintf("%v", entry.Value)
-
-			peerConfig.ApiKey = strings.ReplaceAll(peerConfig.ApiKey, macroSlug, macroStr)
-			peerConfig.Filters.StripParams = strings.ReplaceAll(peerConfig.Filters.StripParams, macroSlug, macroStr)
-
-			// Substitute in setParams (type-preserving)
-			if len(peerConfig.Filters.SetParams) > 0 {
-				result, err := substituteMacroInValue(peerConfig.Filters.SetParams, entry.Name, entry.Value)
-				if err != nil {
-					return Config{}, fmt.Errorf("peers.%s.filters.setParams: %w", peerName, err)
-				}
-				peerConfig.Filters.SetParams = result.(map[string]any)
-			}
-		}
-
-		// Validate no unknown macros remain
-		if matches := macroPatternRegex.FindAllStringSubmatch(peerConfig.ApiKey, -1); len(matches) > 0 {
-			return Config{}, fmt.Errorf("peers.%s.apiKey: unknown macro '${%s}'", peerName, matches[0][1])
-		}
-		if matches := macroPatternRegex.FindAllStringSubmatch(peerConfig.Filters.StripParams, -1); len(matches) > 0 {
-			return Config{}, fmt.Errorf("peers.%s.filters.stripParams: unknown macro '${%s}'", peerName, matches[0][1])
-		}
-		if len(peerConfig.Filters.SetParams) > 0 {
-			if err := validateNestedForUnknownMacros(peerConfig.Filters.SetParams, fmt.Sprintf("peers.%s.filters.setParams", peerName)); err != nil {
-				return Config{}, err
-			}
-		}
-		config.Peers[peerName] = peerConfig
 	}
 
 	if err := ValidatePeerNamespace(config); err != nil {

--- a/internal/config/macro_test.go
+++ b/internal/config/macro_test.go
@@ -1,0 +1,161 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_MacroNameValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		expectedErr string
+	}{
+		{
+			name: "invalid characters",
+			content: `
+macros:
+  bad.name: value
+`,
+			expectedErr: "contains invalid characters",
+		},
+		{
+			name: "name exceeds maximum length",
+			content: fmt.Sprintf(`
+macros:
+  %s: value
+`, strings.Repeat("a", 64)),
+			expectedErr: "exceeds maximum length",
+		},
+		{
+			name: "model macro named PID",
+			content: `
+models:
+  model1:
+    macros:
+      PID: 1234
+`,
+			expectedErr: "model model1: macro name 'PID' is reserved",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadConfigFromReader(strings.NewReader(tt.content))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
+}
+
+func TestConfig_ModelMacroDoesNotLeakToOtherModels(t *testing.T) {
+	content := `
+models:
+  owner:
+    macros:
+      LOCAL: owner-value
+    cmd: echo ${LOCAL}
+    proxy: http://localhost:8080
+  other:
+    cmd: echo ${LOCAL}
+    proxy: http://localhost:8081
+`
+
+	_, err := LoadConfigFromReader(strings.NewReader(content))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown macro '${LOCAL}' found in other.cmd")
+}
+
+func TestConfig_ModelMacrosExpandMaterializedYAMLAnchors(t *testing.T) {
+	content := `
+defs:
+  model: &model
+    cmd: echo ${LOCAL}
+    proxy: http://localhost:8080
+    env: ["MODEL_VALUE=${LOCAL}"]
+    metadata:
+      value: "${LOCAL}"
+
+models:
+  first:
+    <<: *model
+    macros:
+      LOCAL: first-value
+  second:
+    <<: *model
+    macros:
+      LOCAL: second-value
+`
+
+	config, err := LoadConfigFromReader(strings.NewReader(content))
+	require.NoError(t, err)
+
+	for modelID, expected := range map[string]string{
+		"first":  "first-value",
+		"second": "second-value",
+	} {
+		model := config.Models[modelID]
+		assert.Equal(t, "echo "+expected, model.Cmd)
+		assert.Equal(t, []string{"MODEL_VALUE=" + expected}, model.Env)
+		assert.Equal(t, expected, model.Metadata["value"])
+	}
+}
+
+func TestConfig_MacroResolvedStartPort(t *testing.T) {
+	content := `
+macros:
+  FIRST_PORT: 6200
+startPort: "${FIRST_PORT}"
+models:
+  model1:
+    cmd: server --port ${PORT}
+`
+
+	config, err := LoadConfigFromReader(strings.NewReader(content))
+	require.NoError(t, err)
+	assert.Equal(t, 6200, config.StartPort)
+	assert.Equal(t, "server --port 6200", config.Models["model1"].Cmd)
+	assert.Equal(t, "http://localhost:6200", config.Models["model1"].Proxy)
+}
+
+func TestConfig_RuntimeMacrosIntroducedByRegularMacros(t *testing.T) {
+	t.Run("PID remains deferred after regular expansion", func(t *testing.T) {
+		content := `
+macros:
+  STOP_COMMAND: kill ${PID}
+models:
+  model1:
+    cmd: server
+    cmdStop: "${STOP_COMMAND}"
+    proxy: http://localhost:8080
+`
+
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		require.NoError(t, err)
+		assert.Equal(t, "kill ${PID}", config.Models["model1"].CmdStop)
+	})
+
+	t.Run("PORT expands in setParamsByID keys", func(t *testing.T) {
+		content := `
+startPort: 6300
+models:
+  model1:
+    cmd: server --port ${PORT}
+    filters:
+      setParamsByID:
+        "model1:${PORT}":
+          temperature: 0.5
+`
+
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		require.NoError(t, err)
+
+		model := config.Models["model1"]
+		assert.Contains(t, model.Filters.SetParamsByID, "model1:6300")
+		assert.Contains(t, model.Aliases, "model1:6300")
+	})
+}

--- a/internal/config/macros.go
+++ b/internal/config/macros.go
@@ -3,7 +3,9 @@ package config
 import (
 	"fmt"
 	"os"
+	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -14,6 +16,15 @@ var (
 	macroPatternRegex = regexp.MustCompile(`\$\{([a-zA-Z0-9_-]+)\}`)
 	envMacroRegex     = regexp.MustCompile(`\$\{env\.([a-zA-Z_][a-zA-Z0-9_]*)\}`)
 )
+
+type modelMacroConfig struct {
+	Macros MacroList `yaml:"macros"`
+}
+
+type configMacroConfig struct {
+	Macros MacroList                   `yaml:"macros"`
+	Models map[string]modelMacroConfig `yaml:"models"`
+}
 
 // validateMacro validates macro name and value constraints
 func validateMacro(name string, value any) error {
@@ -39,41 +50,355 @@ func validateMacro(name string, value any) error {
 	}
 
 	switch name {
-	case "PORT", "MODEL_ID":
+	case "PID", "PORT", "MODEL_ID":
 		return fmt.Errorf("macro name '%s' is reserved", name)
 	}
 
 	return nil
 }
 
-// validateNestedForUnknownMacros recursively checks for any remaining macro references in nested structures
-func validateNestedForUnknownMacros(value any, context string) error {
+// resolveConfigMacros expands all non-environment macros before the typed
+// configuration is decoded. Decoding into untyped values first materializes
+// YAML aliases and preserves scalar macro values.
+func resolveConfigMacros(yamlStr string) (map[string]any, configMacroConfig, error) {
+	// Environment macros have already been expanded by LoadConfigFromReader.
+	// From here the flow is:
+	//
+	//  1. Read and validate the ordered macro declarations.
+	//  2. Decode a second, untyped view of the YAML so direct replacements can
+	//     retain their scalar types and YAML aliases are fully materialized.
+	//  3. Expand global values, then each model with its effective global and
+	//     model-local scope.
+	//  4. Allocate the runtime-derived PORT value in stable model-ID order.
+	//  5. Reject anything unresolved before the caller decodes the result into
+	//     Config.
+	//
+	// The declarations and untyped values intentionally remain separate:
+	// MacroList preserves declaration order, while map[string]any is the value
+	// tree that can be transformed without first satisfying Config's concrete
+	// field types.
+	var declarations configMacroConfig
+	if err := yaml.Unmarshal([]byte(yamlStr), &declarations); err != nil {
+		return nil, configMacroConfig{}, err
+	}
+
+	// Validate declarations before touching the value tree. This produces
+	// declaration-focused errors and prevents reserved runtime macros from
+	// entering the ordinary replacement list.
+	for _, macro := range declarations.Macros {
+		if err := validateMacro(macro.Name, macro.Value); err != nil {
+			return nil, configMacroConfig{}, err
+		}
+	}
+	for modelID, model := range declarations.Models {
+		for _, macro := range model.Macros {
+			if err := validateMacro(macro.Name, macro.Value); err != nil {
+				return nil, configMacroConfig{}, fmt.Errorf("model %s: %s", modelID, err)
+			}
+		}
+	}
+
+	var raw map[string]any
+	if err := yaml.Unmarshal([]byte(yamlStr), &raw); err != nil {
+		return nil, configMacroConfig{}, err
+	}
+	if raw == nil {
+		raw = make(map[string]any)
+	}
+
+	// Macro declarations are definitions, not substitution targets. They are
+	// restored on the typed Config after expansion so their original order and
+	// values remain observable.
+	delete(raw, "macros")
+
+	// Prepare models before expansion. Macro blocks are detached for the same
+	// reason as the global block. Command comments must be removed before a
+	// placeholder in a comment can expand into executable text, and the proxy
+	// default must exist now so its PORT placeholder participates in the same
+	// generic model pass as explicitly configured values.
+	models, _ := raw["models"].(map[string]any)
+	for modelID, value := range models {
+		model, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		delete(model, "macros")
+		stripRawCommandComments(model)
+		if proxy, found := model["proxy"]; !found || proxy == nil {
+			model["proxy"] = MODEL_CONFIG_DEFAULT_PROXY
+		}
+		models[modelID] = model
+	}
+
+	// Global macros apply to every top-level configuration value except models,
+	// which also need their model-local macro scope.
+	for key, value := range raw {
+		if key == "models" {
+			continue
+		}
+		raw[key] = substituteMacroList(value, declarations.Macros)
+	}
+
+	// startPort may itself contain a global macro, so read it only after the
+	// global pass. Sorting models preserves the existing deterministic port
+	// allocation contract.
+	startPort, err := rawStartPort(raw)
+	if err != nil {
+		return nil, configMacroConfig{}, err
+	}
+
+	modelIDs := make([]string, 0, len(models))
+	for modelID := range models {
+		modelIDs = append(modelIDs, modelID)
+	}
+	sort.Strings(modelIDs)
+
+	nextPort := startPort
+	for _, modelID := range modelIDs {
+		model, ok := models[modelID].(map[string]any)
+		if !ok {
+			continue
+		}
+
+		// mergeModelMacros adds MODEL_ID, overlays model definitions on globals,
+		// and preserves declaration order. The recursive substitution then
+		// covers every model value; setParamsByID keys are handled separately
+		// because ordinary mapping keys are intentionally not macro targets.
+		macros := mergeModelMacros(modelID, declarations.Macros, declarations.Models[modelID].Macros)
+		resolved := substituteMacroList(model, macros)
+		model = resolved.(map[string]any)
+		if err := substituteSetParamsByIDKeys(model, macros); err != nil {
+			return nil, configMacroConfig{}, fmt.Errorf("model %s filters.setParamsByID: %w", modelID, err)
+		}
+
+		cmd, _ := model["cmd"].(string)
+		proxy, _ := model["proxy"].(string)
+		cmdHasPort := strings.Contains(cmd, "${PORT}")
+		proxyHasPort := strings.Contains(proxy, "${PORT}")
+		if cmdHasPort || proxyHasPort {
+			// PORT is available only to models whose command requests an
+			// automatically allocated port. Once allocated, apply it throughout
+			// that model just like a typed macro value.
+			if !cmdHasPort && proxyHasPort {
+				return nil, configMacroConfig{}, fmt.Errorf("model %s: proxy uses ${PORT} but cmd does not - ${PORT} is only available when used in cmd", modelID)
+			}
+
+			portMacro := MacroList{{Name: "PORT", Value: nextPort}}
+			resolved = substituteMacroList(model, portMacro)
+			model = resolved.(map[string]any)
+			if err := substituteSetParamsByIDKeys(model, portMacro); err != nil {
+				return nil, configMacroConfig{}, fmt.Errorf("model %s filters.setParamsByID: %w", modelID, err)
+			}
+			nextPort++
+		}
+
+		if err := validateSetParamsByIDKeys(model, modelID); err != nil {
+			return nil, configMacroConfig{}, err
+		}
+		models[modelID] = model
+	}
+	raw["models"] = models
+
+	// This is the final boundary before concrete YAML decoding. PID is allowed
+	// to survive only in cmdStop for process-time substitution; every other
+	// recognized placeholder must have been resolved by this point.
+	if err := validateConfigMacroUses(raw); err != nil {
+		return nil, configMacroConfig{}, err
+	}
+	return raw, declarations, nil
+}
+
+func stripRawCommandComments(model map[string]any) {
+	for _, field := range []string{"cmd", "cmdStop"} {
+		if value, ok := model[field].(string); ok {
+			model[field] = StripComments(value)
+		}
+	}
+}
+
+func rawStartPort(raw map[string]any) (int, error) {
+	var node yaml.Node
+	if err := node.Encode(raw); err != nil {
+		return 0, err
+	}
+	value := struct {
+		StartPort int `yaml:"startPort"`
+	}{StartPort: 5800}
+	if err := node.Decode(&value); err != nil {
+		return 0, err
+	}
+	if value.StartPort < 1 {
+		return 0, fmt.Errorf("startPort must be greater than 1")
+	}
+	return value.StartPort, nil
+}
+
+func mergeModelMacros(modelID string, global, model MacroList) MacroList {
+	merged := make(MacroList, 0, len(global)+len(model)+1)
+	merged = append(merged, MacroEntry{Name: "MODEL_ID", Value: modelID})
+	merged = append(merged, global...)
+
+	for _, entry := range model {
+		found := false
+		for i, existing := range merged {
+			if existing.Name == entry.Name {
+				merged[i] = entry
+				found = true
+				break
+			}
+		}
+		if !found {
+			merged = append(merged, entry)
+		}
+	}
+	return merged
+}
+
+func substituteMacroList(resolved any, macros MacroList) any {
+	for i := len(macros) - 1; i >= 0; i-- {
+		resolved = substituteMacroInValue(resolved, macros[i].Name, macros[i].Value)
+	}
+	return resolved
+}
+
+func substituteSetParamsByIDKeys(model map[string]any, macros MacroList) error {
+	filters, ok := model["filters"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	params, ok := filters["setParamsByID"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	resolved := make(map[string]any, len(params))
+	for key, value := range params {
+		newKey := key
+		for i := len(macros) - 1; i >= 0; i-- {
+			entry := macros[i]
+			newKey = strings.ReplaceAll(newKey, fmt.Sprintf("${%s}", entry.Name), fmt.Sprintf("%v", entry.Value))
+		}
+		if _, exists := resolved[newKey]; exists {
+			return fmt.Errorf("keys %q and %q resolve to the same value", key, newKey)
+		}
+		resolved[newKey] = value
+	}
+	filters["setParamsByID"] = resolved
+	return nil
+}
+
+func validateSetParamsByIDKeys(model map[string]any, modelID string) error {
+	filters, ok := model["filters"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	params, ok := filters["setParamsByID"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	for key := range params {
+		if matches := macroPatternRegex.FindAllStringSubmatch(key, -1); len(matches) > 0 {
+			return fmt.Errorf("unknown macro '${%s}' found in model %s filters.setParamsByID key", matches[0][1], modelID)
+		}
+	}
+	return nil
+}
+
+func validateConfigMacroUses(raw map[string]any) error {
+	knownFields := make(map[string]struct{})
+	configType := reflect.TypeOf(Config{})
+	for i := 0; i < configType.NumField(); i++ {
+		field := configType.Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
+		name := strings.Split(field.Tag.Get("yaml"), ",")[0]
+		if name != "" && name != "-" {
+			knownFields[name] = struct{}{}
+		}
+	}
+
+	for key, value := range raw {
+		if _, known := knownFields[key]; !known {
+			continue
+		}
+		if key != "models" {
+			if err := validateMacroUses(value, key, "", "", false); err != nil {
+				return err
+			}
+			continue
+		}
+
+		models, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		for modelID, modelValue := range models {
+			model, ok := modelValue.(map[string]any)
+			if !ok {
+				continue
+			}
+			for field, fieldValue := range model {
+				if err := validateMacroUses(fieldValue, "models."+modelID+"."+field, modelID, field, field == "cmdStop"); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateMacroUses(value any, path, modelID, fieldPath string, allowPID bool) error {
 	switch v := value.(type) {
 	case string:
 		matches := macroPatternRegex.FindAllStringSubmatch(v, -1)
 		for _, match := range matches {
 			macroName := match[1]
-			return fmt.Errorf("%s: unknown macro '${%s}'", context, macroName)
+			if macroName == "PID" && allowPID {
+				continue
+			}
+			if modelID != "" {
+				switch fieldPath {
+				case "cmd", "cmdStop", "proxy", "checkEndpoint", "filters.stripParams", "name", "description":
+					if macroName == "PORT" || macroName == "MODEL_ID" {
+						return fmt.Errorf("macro '${%s}' should have been substituted in %s.%s", macroName, modelID, fieldPath)
+					}
+					return fmt.Errorf("unknown macro '${%s}' found in %s.%s", macroName, modelID, fieldPath)
+				}
+
+				context := "model " + modelID + " " + fieldPath
+				if strings.HasPrefix(fieldPath, "capabilities.") {
+					context = "model " + modelID + " capabilities"
+				} else if strings.HasPrefix(fieldPath, "metadata.") {
+					context = "model " + modelID + " metadata"
+				}
+				return fmt.Errorf("%s: unknown macro '${%s}'", context, macroName)
+			}
+			return fmt.Errorf("%s: unknown macro '${%s}'", path, macroName)
 		}
-		// Check for unsubstituted env macros
 		envMatches := envMacroRegex.FindAllStringSubmatch(v, -1)
 		for _, match := range envMatches {
 			varName := match[1]
-			return fmt.Errorf("%s: environment variable '%s' not set", context, varName)
+			return fmt.Errorf("%s: environment variable '%s' not set", path, varName)
 		}
 		return nil
 
 	case map[string]any:
-		for _, val := range v {
-			if err := validateNestedForUnknownMacros(val, context); err != nil {
+		for key, val := range v {
+			childPath := path + "." + key
+			childFieldPath := fieldPath
+			if modelID != "" {
+				childFieldPath = fieldPath + "." + key
+			}
+			if err := validateMacroUses(val, childPath, modelID, childFieldPath, allowPID); err != nil {
 				return err
 			}
 		}
 		return nil
 
 	case []any:
-		for _, val := range v {
-			if err := validateNestedForUnknownMacros(val, context); err != nil {
+		for i, val := range v {
+			if err := validateMacroUses(val, fmt.Sprintf("%s[%d]", path, i), modelID, fieldPath, allowPID); err != nil {
 				return err
 			}
 		}
@@ -86,8 +411,7 @@ func validateNestedForUnknownMacros(value any, context string) error {
 }
 
 // substituteMacroInValue recursively substitutes a single macro in a value structure
-// This is called once per macro, allowing LIFO substitution order
-func substituteMacroInValue(value any, macroName string, macroValue any) (any, error) {
+func substituteMacroInValue(value any, macroName string, macroValue any) any {
 	macroSlug := fmt.Sprintf("${%s}", macroName)
 	macroStr := fmt.Sprintf("%v", macroValue)
 
@@ -95,41 +419,33 @@ func substituteMacroInValue(value any, macroName string, macroValue any) (any, e
 	case string:
 		// Check if this is a direct macro substitution
 		if v == macroSlug {
-			return macroValue, nil
+			return macroValue
 		}
 		// Handle string interpolation
 		if strings.Contains(v, macroSlug) {
-			return strings.ReplaceAll(v, macroSlug, macroStr), nil
+			return strings.ReplaceAll(v, macroSlug, macroStr)
 		}
-		return v, nil
+		return v
 
 	case map[string]any:
 		// Recursively process map values
 		newMap := make(map[string]any)
 		for key, val := range v {
-			newVal, err := substituteMacroInValue(val, macroName, macroValue)
-			if err != nil {
-				return nil, err
-			}
-			newMap[key] = newVal
+			newMap[key] = substituteMacroInValue(val, macroName, macroValue)
 		}
-		return newMap, nil
+		return newMap
 
 	case []any:
 		// Recursively process slice elements
 		newSlice := make([]any, len(v))
 		for i, val := range v {
-			newVal, err := substituteMacroInValue(val, macroName, macroValue)
-			if err != nil {
-				return nil, err
-			}
-			newSlice[i] = newVal
+			newSlice[i] = substituteMacroInValue(val, macroName, macroValue)
 		}
-		return newSlice, nil
+		return newSlice
 
 	default:
 		// Return scalar types as-is
-		return value, nil
+		return value
 	}
 }
 

--- a/internal/config/macros_refactor_test.go
+++ b/internal/config/macros_refactor_test.go
@@ -1,0 +1,167 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_MacrosAcrossConfiguration(t *testing.T) {
+	content := `
+macros:
+  GLOBAL_TTL: 120
+  MODEL_TTL: 45
+  SESSION_HEADER: X-Macro-Session
+  LOADING: true
+  MODEL_NAME: model1
+
+globalTTL: "${GLOBAL_TTL}"
+sendLoadingState: "${LOADING}"
+ui:
+  activity:
+    session_id: ["${SESSION_HEADER}"]
+hooks:
+  on_startup:
+    preload: ["${MODEL_NAME}"]
+
+models:
+  model1:
+    macros:
+      MODEL_TTL: 30
+      CONNECT_TIMEOUT: 12
+    cmd: server --port ${PORT}
+    ttl: "${MODEL_TTL}"
+    timeouts:
+      connect: "${CONNECT_TIMEOUT}"
+    env:
+      - "MODEL=${MODEL_ID}"
+`
+
+	config, err := LoadConfigFromReader(strings.NewReader(content))
+	require.NoError(t, err)
+
+	assert.Equal(t, 120, config.GlobalTTL)
+	assert.True(t, config.SendLoadingState)
+	assert.Equal(t, []string{"X-Macro-Session"}, config.UI.Activity.SessionID)
+	assert.Equal(t, []string{"model1"}, config.Hooks.OnStartup.Preload)
+
+	model := config.Models["model1"]
+	assert.Equal(t, 30, model.UnloadAfter)
+	assert.Equal(t, 12, model.Timeouts.Connect)
+	assert.Equal(t, []string{"MODEL=model1"}, model.Env)
+}
+
+func TestConfig_MacroMapKeyScope(t *testing.T) {
+	t.Run("ordinary keys remain literal", func(t *testing.T) {
+		content := `
+macros:
+  KEY: expanded
+models:
+  model1:
+    cmd: server
+    proxy: http://localhost:8080
+    metadata:
+      "${KEY}": value
+`
+
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		require.NoError(t, err)
+		assert.Equal(t, "value", config.Models["model1"].Metadata["${KEY}"])
+		assert.NotContains(t, config.Models["model1"].Metadata, "expanded")
+	})
+
+	t.Run("setParamsByID key collisions fail", func(t *testing.T) {
+		content := `
+macros:
+  FIRST: shared
+  SECOND: shared
+models:
+  model1:
+    cmd: server
+    proxy: http://localhost:8080
+    filters:
+      setParamsByID:
+        "${FIRST}":
+          temperature: 0.1
+        "${SECOND}":
+          temperature: 0.2
+`
+
+		_, err := LoadConfigFromReader(strings.NewReader(content))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resolve to the same value")
+	})
+}
+
+func TestConfig_MacroForwardReferenceRejected(t *testing.T) {
+	content := `
+macros:
+  FIRST: "value-${SECOND}"
+  SECOND: later
+models:
+  model1:
+    cmd: echo ${FIRST}
+    proxy: http://localhost:8080
+`
+
+	_, err := LoadConfigFromReader(strings.NewReader(content))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown macro '${SECOND}'")
+}
+
+func TestConfig_RuntimeMacros(t *testing.T) {
+	t.Run("PORT applies throughout its model", func(t *testing.T) {
+		content := `
+startPort: 6100
+models:
+  model1:
+    cmd: server --port ${PORT}
+    proxy: http://localhost:${PORT}
+    checkEndpoint: /health/${PORT}
+    aliases: ["port-${PORT}"]
+    metadata:
+      port: "${PORT}"
+`
+
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		require.NoError(t, err)
+
+		model := config.Models["model1"]
+		assert.Equal(t, "server --port 6100", model.Cmd)
+		assert.Equal(t, "http://localhost:6100", model.Proxy)
+		assert.Equal(t, "/health/6100", model.CheckEndpoint)
+		assert.Equal(t, []string{"port-6100"}, model.Aliases)
+		assert.Equal(t, 6100, model.Metadata["port"])
+	})
+
+	t.Run("PID remains deferred in cmdStop", func(t *testing.T) {
+		content := `
+models:
+  model1:
+    cmd: server
+    cmdStop: kill ${PID}
+    proxy: http://localhost:8080
+`
+
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		require.NoError(t, err)
+		assert.Equal(t, "kill ${PID}", config.Models["model1"].CmdStop)
+	})
+
+	t.Run("PID is rejected outside cmdStop", func(t *testing.T) {
+		content := `
+models:
+  model1:
+    cmd: server
+    proxy: http://localhost:8080
+    metadata:
+      pid: "${PID}"
+`
+
+		_, err := LoadConfigFromReader(strings.NewReader(content))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown macro '${PID}'")
+	})
+}

--- a/internal/config/model_config.go
+++ b/internal/config/model_config.go
@@ -4,12 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
-
-	"gopkg.in/yaml.v3"
 )
 
 const (
-	MODEL_CONFIG_DEFAULT_TTL = -1
+	MODEL_CONFIG_DEFAULT_TTL   = -1
+	MODEL_CONFIG_DEFAULT_PROXY = "http://localhost:${PORT}"
 )
 
 var validModalities = map[string]struct{}{
@@ -21,59 +20,12 @@ var validModalities = map[string]struct{}{
 // ModelCapConfig defines what modalities and features a model supports.
 // Used in /v1/models to inform clients. An empty block (all zero values) is
 // treated as not configured.
-//
-// The custom UnmarshalYAML stores an untyped representation so YAML anchors
-// can be resolved before macro substitution. After ResolveMacros is called
-// the typed fields (In, Out, Tools, Reranker, Context) are populated.
 type ModelCapConfig struct {
 	In       []string `yaml:"in"`
 	Out      []string `yaml:"out"`
 	Tools    bool     `yaml:"tools"`
 	Reranker bool     `yaml:"reranker"`
 	Context  int      `yaml:"context"`
-
-	raw map[string]any
-}
-
-// UnmarshalYAML decodes capabilities into an untyped map. This materializes
-// YAML aliases and merge keys while allowing macro placeholders in fields
-// that will ultimately be decoded as ints or bools.
-func (c *ModelCapConfig) UnmarshalYAML(value *yaml.Node) error {
-	return value.Decode(&c.raw)
-}
-
-// ResolveMacros substitutes all macros in the untyped representation (LIFO
-// order matching LoadConfigFromReader), then decodes the resolved values into
-// the typed fields.
-func (c *ModelCapConfig) ResolveMacros(macros MacroList) error {
-	if c.raw == nil {
-		return c.Validate()
-	}
-
-	var resolved any = c.raw
-	for i := len(macros) - 1; i >= 0; i-- {
-		entry := macros[i]
-		var err error
-		resolved, err = substituteMacroInValue(resolved, entry.Name, entry.Value)
-		if err != nil {
-			return fmt.Errorf("capabilities: failed macro substitution: %w", err)
-		}
-	}
-	if err := validateNestedForUnknownMacros(resolved, "capabilities"); err != nil {
-		return err
-	}
-
-	var node yaml.Node
-	if err := node.Encode(resolved); err != nil {
-		return fmt.Errorf("capabilities: failed to encode after macro substitution: %w", err)
-	}
-	*c = ModelCapConfig{}
-	type rawCap ModelCapConfig
-	if err := node.Decode((*rawCap)(c)); err != nil {
-		return fmt.Errorf("capabilities: failed to decode after macro substitution: %w", err)
-	}
-
-	return c.Validate()
 }
 
 // Empty returns true when all fields are at their zero values.
@@ -159,7 +111,7 @@ func (m *ModelConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	defaults := rawModelConfig{
 		Cmd:              "",
 		CmdStop:          "",
-		Proxy:            "http://localhost:${PORT}",
+		Proxy:            MODEL_CONFIG_DEFAULT_PROXY,
 		Aliases:          []string{},
 		Env:              []string{},
 		CheckEndpoint:    "/health",


### PR DESCRIPTION
Resolve configuration macros against an untyped YAML representation before decoding the typed Config. This materializes YAML anchors and preserves scalar types without maintaining field-specific replacement paths.

- apply environment, global, and model macros in their defined scopes
- centralize MODEL_ID, PORT, PID, key, and unknown-macro handling
- remove the capability-specific raw decoder and replacement loops
- document macro ordering, scope, and runtime behavior
- add coverage for anchors, scope isolation, validation, and runtime macros

fixes #919