### PR TITLE
internal/config: relax matrix model reference constraints

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -591,23 +591,23 @@ routing:
       # A model that appears in no set can only run on its own.
       #
       matrix:
-        # vars: short aliases for model IDs (alphanumeric, 1-8 chars)
-        # - required: sets and evict_costs reference these names, not model IDs
+        # vars: optional aliases for model IDs
+        # - names may contain alphanumeric, "-", or "." characters (1-32 chars)
         # - map each short name to a real model ID (not a model alias)
         # - keeps the set expressions short and readable
+        # - sets and evict_costs may mix vars with real model IDs
+        # - a var takes precedence when its name is also a real model ID
         vars:
           g: gemma-model
           q: qwen-model
           m: mistral-model
           v: voxtral-model
           e: reranker-model
-          L: llama-70B
-          sd: stable-diffusion
 
         # evict_costs: relative cost of losing a running model (default: 1)
         evict_costs:
           v: 50 # vllm backend, slow cold start
-          L: 30 # 70B weights, slow to load
+          llama-70B: 30 # 70B weights, slow to load
 
         # sets: named combinations of models that may run together.
         # Each value is an expression built from these operators:
@@ -617,28 +617,28 @@ routing:
         #   +ref  inline the expression of another set
         #
         # Each expression expands into one or more concrete sets:
-        #   "L"                  → [L]
+        #   "model-a"            → [model-a]
         #   "a & b"              → [a, b]
         #   "a | b"              → [a], [b]
         #   "(a | b) & c"        → [a, c], [b, c]
         #   "(a | b) & (c | d)"  → [a,c], [a,d], [b,c], [b,d]
         #   "+llms & v"          → inline the llms set, then AND with v
         sets:
-          # An LLM plus TTS. Switching between g/q/m keeps v loaded.
-          # expands to: [g,v], [q,v], [m,v]
-          standard: "(g | q | m) & v"
+          # An LLM plus TTS. Vars and real model IDs may be mixed.
+          # expands to: [g,v], [qwen-model,v], [m,v]
+          standard: "(g | qwen-model | m) & v"
 
           # An LLM plus TTS plus reranker.
           # expands to: [g,v,e], [q,v,e]
           with_rerank: "(g | q) & v & e"
 
           # An LLM plus image generation, no TTS.
-          # expands to: [g,sd], [q,sd]
-          creative: "(g | q) & sd"
+          # expands to: [g,stable-diffusion], [q,stable-diffusion]
+          creative: "(g | q) & stable-diffusion"
 
           # The 70B model uses every GPU, so it can only run alone.
-          # expands to: [L]
-          full: "L"
+          # Vars are not required when using real model IDs.
+          full: "llama-70B"
 
   # scheduler: how queued requests are ordered.
   # The default and only valid scheduler is "fifo"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -545,24 +545,22 @@ models:
 # A model not appearing in any set can only run alone.
 #
 matrix:
-  # vars: short names for models (alphanumeric, 1-8 chars)
-  # - required for sets and evict_costs settings
+  # vars: optional short names for models (alphanumeric, "-", or ".", 1-32 chars)
   # - each entry is a short name to a real model ID. Do not use an alias
   # - used to keep set DSL logic short and easier to read
-  # - sets and evict_costs only use identifiers defined in vars
+  # - sets and evict_costs may mix vars with real model IDs
+  # - a var takes precedence when its name is also a real model ID
   vars:
     g: gemma-model
     q: qwen-model
     m: mistral-model
     v: voxtral-model
     e: reranker-model
-    L: llama-70B
-    sd: stable-diffusion
 
   # evict_costs: relative cost of losing a running model (default: 1)
   evict_costs:
     v: 50 # vllm backend, slow cold start
-    L: 30 # 70B weights, slow to load
+    llama-70B: 30 # 70B weights, slow to load
 
   # sets: named sets of concurrent model combinations
   # Values are DSL strings with operators:
@@ -572,28 +570,28 @@ matrix:
   #   +ref  inline another set's expression
   #
   # Expansion examples:
-  #   "L"                  → [L]
+  #   "model-a"            → [model-a]
   #   "a & b"              → [a, b]
   #   "a | b"              → [a], [b]
   #   "(a | b) & c"        → [a, c], [b, c]
   #   "(a | b) & (c | d)"  → [a,c], [a,d], [b,c], [b,d]
   #   "+llms & v"          → expands llms inline, then applies & v
   sets:
-    # LLM + TTS: switching between g/q/m won't evict v
-    # expands to: [g,v], [q,v], [m,v]
-    standard: "(g | q | m) & v"
+    # LLM + TTS: vars and real model IDs may be mixed
+    # expands to: [g,v], [qwen-model,v], [m,v]
+    standard: "(g | qwen-model | m) & v"
 
     # LLM + TTS + reranker
     # expands to: [g,v,e], [q,v,e]
     with_rerank: "(g | q) & v & e"
 
     # LLM + image generation, no TTS
-    # expands to: [g,sd], [q,sd]
-    creative: "(g | q) & sd"
+    # expands to: [g,stable-diffusion], [q,stable-diffusion]
+    creative: "(g | q) & stable-diffusion"
 
     # 70B model uses all GPUs, can only run alone
-    # expands to: [L]
-    full: "L"
+    # vars are not required when using real model IDs
+    full: "llama-70B"
 
 # hooks: a dictionary of event triggers and actions
 # - optional, default: empty dictionary

--- a/internal/config/matrix.go
+++ b/internal/config/matrix.go
@@ -3,12 +3,11 @@ package config
 import (
 	"fmt"
 	"regexp"
-	"sort"
 
 	"gopkg.in/yaml.v3"
 )
 
-var varKeyPattern = regexp.MustCompile(`^[a-zA-Z0-9]{1,8}$`)
+var varKeyPattern = regexp.MustCompile(`^[a-zA-Z0-9.-]{1,32}$`)
 
 // MatrixConfig represents the swap matrix configuration block.
 type MatrixConfig struct {
@@ -69,15 +68,11 @@ func ValidateMatrix(matrix MatrixConfig, models map[string]ModelConfig) ([]Expan
 		return nil, fmt.Errorf("matrix must define at least one set")
 	}
 
-	if len(matrix.Var) == 0 {
-		return nil, fmt.Errorf("matrix must define at least one var")
-	}
-
 	// Validate var entries
 	if matrix.Var != nil {
 		for id, modelName := range matrix.Var {
 			if !varKeyPattern.MatchString(id) {
-				return nil, fmt.Errorf("var key %q must be alphanumeric and 1-8 characters", id)
+				return nil, fmt.Errorf("var key %q must contain only alphanumeric, '-' or '.' characters and be 1-32 characters long", id)
 			}
 			if _, exists := models[modelName]; !exists {
 				return nil, fmt.Errorf("var key %q references unknown model %q", id, modelName)
@@ -91,8 +86,8 @@ func ValidateMatrix(matrix MatrixConfig, models map[string]ModelConfig) ([]Expan
 			if cost <= 0 {
 				return nil, fmt.Errorf("evict_cost for %q must be a positive integer, got %d", key, cost)
 			}
-			if _, ok := matrix.Var[key]; !ok {
-				return nil, fmt.Errorf("evict_costs: unknown var ID %q", key)
+			if _, ok := resolveMatrixModel(key, matrix.Var, models); !ok {
+				return nil, fmt.Errorf("evict_costs: unknown var or model %q", key)
 			}
 		}
 	}
@@ -143,21 +138,20 @@ func ValidateMatrix(matrix MatrixConfig, models map[string]ModelConfig) ([]Expan
 
 		resolvedRefs[name] = combos
 
-		// Resolve var IDs to real model names
+		// Resolve var IDs and direct model names to real model names.
 		for _, combo := range combos {
-			resolved := make([]string, len(combo))
-			for i, ident := range combo {
-				realName, ok := matrix.Var[ident]
+			resolved := make([]string, 0, len(combo))
+			for _, ident := range combo {
+				realName, ok := resolveMatrixModel(ident, matrix.Var, models)
 				if !ok {
-					return nil, fmt.Errorf("set %q: unknown var ID %q", name, ident)
+					return nil, fmt.Errorf("set %q: unknown var or model %q", name, ident)
 				}
-				resolved[i] = realName
+				resolved = append(resolved, realName)
 			}
-			sort.Strings(resolved)
 			allExpanded = append(allExpanded, ExpandedSet{
 				SetName: name,
 				DSL:     dsl,
-				Models:  resolved,
+				Models:  dedupAndSort(resolved),
 			})
 		}
 
@@ -168,6 +162,16 @@ func ValidateMatrix(matrix MatrixConfig, models map[string]ModelConfig) ([]Expan
 	}
 
 	return allExpanded, nil
+}
+
+func resolveMatrixModel(ident string, vars map[string]string, models map[string]ModelConfig) (string, bool) {
+	if modelName, ok := vars[ident]; ok {
+		return modelName, true
+	}
+	if _, ok := models[ident]; ok {
+		return ident, true
+	}
+	return "", false
 }
 
 // topologicalSort returns set names in dependency order.

--- a/internal/config/matrix_test.go
+++ b/internal/config/matrix_test.go
@@ -89,33 +89,89 @@ func TestValidateMatrix_WithRef(t *testing.T) {
 	assert.Equal(t, []string{"gemma", "reranker", "voxtral"}, megaEntries[0].Models)
 }
 
-func TestValidateMatrix_MapIDRequired(t *testing.T) {
-	// DSL cannot use real model names directly — must use var IDs
-	models := makeModels("gemma", "voxtral")
+func TestValidateMatrix_DirectAndMixedModelNames(t *testing.T) {
+	models := makeModels("gemma", "qwen", "voxtral")
 
-	matrix := MatrixConfig{
-		Var: map[string]string{"g": "gemma"},
-		Sets: OrderedSets{
-			{Name: "combo", DSL: "g & voxtral"},
-		},
-	}
+	t.Run("direct model names without vars", func(t *testing.T) {
+		matrix := MatrixConfig{
+			Sets: OrderedSets{{Name: "combo", DSL: "gemma & voxtral"}},
+		}
 
-	_, err := ValidateMatrix(matrix, models)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown var ID")
+		expanded, err := ValidateMatrix(matrix, models)
+		require.NoError(t, err)
+		require.Len(t, expanded, 1)
+		assert.Equal(t, []string{"gemma", "voxtral"}, expanded[0].Models)
+	})
+
+	t.Run("mixed vars and model names", func(t *testing.T) {
+		matrix := MatrixConfig{
+			Var: map[string]string{"g": "gemma"},
+			Sets: OrderedSets{
+				{Name: "base", DSL: "g | qwen"},
+				{Name: "combo", DSL: "+base & voxtral"},
+			},
+		}
+
+		expanded, err := ValidateMatrix(matrix, models)
+		require.NoError(t, err)
+		comboEntries := filterBySetName(expanded, "combo")
+		require.Len(t, comboEntries, 2)
+		assert.Equal(t, []string{"gemma", "voxtral"}, comboEntries[0].Models)
+		assert.Equal(t, []string{"qwen", "voxtral"}, comboEntries[1].Models)
+	})
+
+	t.Run("deduplicates after resolution", func(t *testing.T) {
+		matrix := MatrixConfig{
+			Var:  map[string]string{"g": "gemma"},
+			Sets: OrderedSets{{Name: "combo", DSL: "g & gemma"}},
+		}
+
+		expanded, err := ValidateMatrix(matrix, models)
+		require.NoError(t, err)
+		require.Len(t, expanded, 1)
+		assert.Equal(t, []string{"gemma"}, expanded[0].Models)
+	})
+
+	t.Run("vars take precedence over model names", func(t *testing.T) {
+		matrix := MatrixConfig{
+			Var:  map[string]string{"qwen": "gemma"},
+			Sets: OrderedSets{{Name: "combo", DSL: "qwen"}},
+		}
+
+		expanded, err := ValidateMatrix(matrix, models)
+		require.NoError(t, err)
+		require.Len(t, expanded, 1)
+		assert.Equal(t, []string{"gemma"}, expanded[0].Models)
+	})
 }
 
-func TestValidateMatrix_InvalidAliasKey(t *testing.T) {
+func TestValidateMatrix_VarKeyValidation(t *testing.T) {
 	models := makeModels("gemma")
+
+	valid := []string{
+		"abcdefghijklmnopqrstuvwxyzABCDEF",
+		"model-var",
+		"model.var",
+	}
+	for _, key := range valid {
+		t.Run("valid "+key, func(t *testing.T) {
+			matrix := MatrixConfig{
+				Var:  map[string]string{key: "gemma"},
+				Sets: OrderedSets{{Name: "s", DSL: key}},
+			}
+			_, err := ValidateMatrix(matrix, models)
+			require.NoError(t, err)
+		})
+	}
 
 	tests := []struct {
 		name   string
 		alias  string
 		errMsg string
 	}{
-		{"too long", "abcdefghi", "alphanumeric and 1-8 characters"},
-		{"has underscore", "a_b", "alphanumeric and 1-8 characters"},
-		{"has hyphen", "a-b", "alphanumeric and 1-8 characters"},
+		{"too long", "abcdefghijklmnopqrstuvwxyzABCDEFG", "1-32 characters"},
+		{"has underscore", "a_b", "only alphanumeric, '-' or '.'"},
+		{"empty", "", "1-32 characters"},
 	}
 
 	for _, tt := range tests {
@@ -169,7 +225,7 @@ func TestValidateMatrix_EvictCostInvalid(t *testing.T) {
 		assert.Contains(t, err.Error(), "positive integer")
 	})
 
-	t.Run("unknown var ID in evict_costs", func(t *testing.T) {
+	t.Run("unknown var or model in evict_costs", func(t *testing.T) {
 		matrix := MatrixConfig{
 			Var:        map[string]string{"g": "gemma"},
 			EvictCosts: map[string]int{"unknown": 5},
@@ -177,7 +233,16 @@ func TestValidateMatrix_EvictCostInvalid(t *testing.T) {
 		}
 		_, err := ValidateMatrix(matrix, models)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "unknown var ID")
+		assert.Contains(t, err.Error(), "unknown var or model")
+	})
+
+	t.Run("direct model name in evict_costs", func(t *testing.T) {
+		matrix := MatrixConfig{
+			EvictCosts: map[string]int{"gemma": 5},
+			Sets:       OrderedSets{{Name: "s", DSL: "gemma"}},
+		}
+		_, err := ValidateMatrix(matrix, models)
+		require.NoError(t, err)
 	})
 }
 
@@ -230,7 +295,7 @@ func TestValidateMatrix_UnknownMapIDInDSL(t *testing.T) {
 
 	_, err := ValidateMatrix(matrix, models)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown var ID")
+	assert.Contains(t, err.Error(), "unknown var or model")
 }
 
 func TestValidateMatrix_ResolvedEvictCosts(t *testing.T) {
@@ -240,14 +305,16 @@ func TestValidateMatrix_ResolvedEvictCosts(t *testing.T) {
 			"L": "llama70B",
 		},
 		EvictCosts: map[string]int{
-			"L": 30,
-			"g": 5,
+			"L":       30,
+			"g":       5,
+			"mistral": 10,
 		},
 	}
 
 	costs := mc.ResolvedEvictCosts()
 	assert.Equal(t, 30, costs["llama70B"])
 	assert.Equal(t, 5, costs["gemma"])
+	assert.Equal(t, 10, costs["mistral"])
 }
 
 func TestValidateMatrix_ConfigXOR(t *testing.T) {


### PR DESCRIPTION
- increase matrix.var id size to 32 characters and allow - and .
- model IDs can be used in matrix sets and evict_costs

fixes: #699
closes: #715