### PR TITLE
ui-svelte: show profiles on model page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@ Only use these technologies:
 
 - Run `gofmt -w <file>` before committing to fix any formatting
 - Use this format for commit messages:
+- When referencing issues use "fix: #123", "update: #123"
+- Use "fix" when the branch resolves an issue
+- Use "update" when the branch only contributes to the issue
 
 ```
 internal/server: short clear description of change
@@ -39,7 +42,8 @@ Add new feature that implements functionality X and Y.
 - key change 2
 - key change 3
 
-fixes #123
+fix: #123
+update: #456
 ```
 
 ## Code Reviews

--- a/ui-svelte/src/routes/ModelsDash.svelte
+++ b/ui-svelte/src/routes/ModelsDash.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { link } from "svelte-spa-router";
-  import { models, unloadAllModels } from "../stores/api";
+  import { activeProfile, models, profiles, unloadAllModels } from "../stores/api";
   import { statusDotColor } from "../stores/modelLoad";
   import { showUnlistedModels as showUnlisted } from "../stores/modelDisplay";
+  import type { Model } from "../lib/types";
   import ModelLoadButton from "../components/ModelLoadButton.svelte";
   import Tag from "../components/Tag.svelte";
   import * as Card from "$lib/components/ui/card/index.js";
@@ -15,6 +16,16 @@
 
   let visibleModels = $derived(
     $showUnlisted ? $models : $models.filter((m) => !m.unlisted)
+  );
+  let localModels = $derived(visibleModels.filter((model) => !model.peerID));
+  let peerModels = $derived(visibleModels.filter((model) => model.peerID));
+  let selectedProfile = $derived(
+    $profiles.find((profile) => profile.id === $activeProfile)
+  );
+  let profileMappings = $derived(
+    Object.entries(selectedProfile?.pins ?? {}).sort(([a], [b]) =>
+      a.localeCompare(b, undefined, { numeric: true })
+    )
   );
 
   let readyCount = $derived($models.filter((m) => m.state === "ready").length);
@@ -31,6 +42,70 @@
     }
   }
 </script>
+
+{#snippet modelRow(model: Model)}
+  <div class="hover:bg-muted/50 flex items-center gap-3 px-4 py-2.5">
+    {#if !model.peerID}
+      <span class={`size-2.5 shrink-0 rounded-full ${statusDotColor(model)}`}></span>
+    {/if}
+    <a
+      href="/models/{encodeURIComponent(model.id)}"
+      use:link
+      class="min-w-0 flex-1"
+    >
+      <div class="truncate text-sm font-medium">{model.name || model.id}</div>
+      <div class="text-muted-foreground truncate text-xs">
+        {model.id}
+        {#if model.aliases && model.aliases.length > 0}
+          · {model.aliases.join(", ")}
+        {/if}
+      </div>
+    </a>
+    <span class="text-muted-foreground text-xs uppercase tracking-wide">
+      {model.state}
+    </span>
+    {#if model.unlisted}
+      <Tag class="px-1.5 text-[0.625rem] uppercase">unlisted</Tag>
+    {/if}
+    {#if !model.peerID}
+      <a
+        href="/upstream/{encodeURIComponent(model.id)}/"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-muted-foreground hover:text-foreground"
+        title="Open model server"
+        aria-label="Open model server"
+      >
+        <ExternalLink class="size-4" />
+      </a>
+      <ModelLoadButton {model} />
+    {/if}
+  </div>
+{/snippet}
+
+{#snippet modelSection(title: string, sectionModels: Model[])}
+  <Card.Root class="shrink-0 gap-0 overflow-hidden py-0">
+    <Card.Header class="shrink-0 border-b px-4 py-2.5">
+      <div class="flex items-center gap-2">
+        <Card.Title class="text-sm">{title}</Card.Title>
+        <span class="text-muted-foreground text-xs">{sectionModels.length}</span>
+      </div>
+    </Card.Header>
+    <Card.Content class="p-0">
+      {#if sectionModels.length === 0}
+        <div class="text-muted-foreground px-4 py-6 text-center text-sm">
+          No {title.toLowerCase()} available
+        </div>
+      {:else}
+        <div class="divide-y">
+          {#each sectionModels as model (model.id)}
+            {@render modelRow(model)}
+          {/each}
+        </div>
+      {/if}
+    </Card.Content>
+  </Card.Root>
+{/snippet}
 
 <div class="flex h-full flex-col gap-4 overflow-y-auto p-2">
   <Card.Root class="shrink-0 gap-0 overflow-hidden py-0">
@@ -77,53 +152,49 @@
     </Card.Content>
   </Card.Root>
 
-  <Card.Root class="min-h-0 flex-1 gap-0 overflow-hidden py-0">
-    <Card.Content class="overflow-y-auto p-0">
-      {#if visibleModels.length === 0}
-        <div class="text-muted-foreground px-4 py-8 text-center text-sm">
-          No models available
-        </div>
-      {:else}
-        <div class="divide-y">
-          {#each visibleModels as model (model.id)}
-            <div class="hover:bg-muted/50 flex items-center gap-3 px-4 py-2.5">
-              <span class={`size-2.5 shrink-0 rounded-full ${statusDotColor(model)}`}></span>
-              <a
-                href="/models/{encodeURIComponent(model.id)}"
-                use:link
-                class="min-w-0 flex-1"
-              >
-                <div class="truncate text-sm font-medium">{model.name || model.id}</div>
-                <div class="text-muted-foreground truncate text-xs">
-                  {model.id}
-                  {#if model.aliases && model.aliases.length > 0}
-                    · {model.aliases.join(", ")}
+  <div class="flex min-h-0 shrink-0 flex-col gap-4">
+    {#if $profiles.length > 0}
+      <Card.Root class="shrink-0 gap-0 overflow-hidden py-0">
+        <Card.Header class="shrink-0 border-b px-4 py-2.5">
+          <div class="flex items-center gap-2">
+            <Card.Title class="text-sm">Profile models</Card.Title>
+            {#if selectedProfile}
+              <Tag>{$activeProfile}</Tag>
+              <Tag class="bg-success/15 text-success">Active</Tag>
+            {/if}
+            <span class="text-muted-foreground ml-auto text-xs">
+              {profileMappings.length} {profileMappings.length === 1 ? "mapping" : "mappings"}
+            </span>
+          </div>
+          {#if selectedProfile?.description}
+            <p class="text-muted-foreground text-xs">{selectedProfile.description}</p>
+          {/if}
+        </Card.Header>
+        <Card.Content class="p-0">
+          {#if !selectedProfile}
+            <div class="text-muted-foreground px-4 py-6 text-center text-sm">
+              No active profile
+            </div>
+          {:else}
+            <div class="divide-y">
+              {#each profileMappings as [modelID, target] (modelID)}
+                <div class="hover:bg-muted/50 flex items-center gap-2 px-4 py-2.5">
+                  <span class="max-w-[45%] truncate text-sm font-medium">{modelID}</span>
+                  <span class="text-muted-foreground text-xs" aria-hidden="true">→</span>
+                  {#if target}
+                    <span class="min-w-0 truncate text-sm">{target}</span>
+                  {:else}
+                    <Tag class="px-1.5 text-[0.625rem] uppercase">disabled</Tag>
                   {/if}
                 </div>
-              </a>
-              <span class="text-muted-foreground text-xs uppercase tracking-wide">
-                {model.state}
-              </span>
-              {#if model.unlisted}
-                <Tag class="px-1.5 text-[0.625rem] uppercase">unlisted</Tag>
-              {/if}
-              {#if !model.peerID}
-                <a
-                  href="/upstream/{encodeURIComponent(model.id)}/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="text-muted-foreground hover:text-foreground"
-                  title="Open model server"
-                  aria-label="Open model server"
-              >
-                <ExternalLink class="size-4" />
-              </a>
-                <ModelLoadButton {model} />
-              {/if}
+              {/each}
             </div>
-          {/each}
-        </div>
-      {/if}
-    </Card.Content>
-  </Card.Root>
+          {/if}
+        </Card.Content>
+      </Card.Root>
+    {/if}
+
+    {@render modelSection("Local models", localModels)}
+    {@render modelSection("Peer models", peerModels)}
+  </div>
 </div>


### PR DESCRIPTION
Show active profile mappings separately from configured local and peer models.

- display profile pin targets and disabled mappings
- group local and peer models into dedicated sections
- identify the selected profile with an active status badge

fix: #961