### PR TITLE
docker: install rocm-smi for vulkan backend

### DIFF
--- a/docker/unified/Dockerfile
+++ b/docker/unified/Dockerfile
@@ -139,6 +139,7 @@ ENV PATH="/usr/local/bin:${PATH}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgomp1 libvulkan1 mesa-vulkan-drivers \
+    rocm-smi \
     python3 curl ca-certificates \
     libavcodec60 libavformat60 libavutil58 libswresample4 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add the rocm-smi package to the vulkan container image so performance monitoring for AMD GPUs is available out of the box.