### PR TITLE
ui-svelte: show configured selectors and strategies on Models page

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -250,6 +250,14 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 				break
 			}
 		}
+		internalMetadata := map[string]any{
+			"type":     "selector",
+			"strategy": selector.Strategy,
+			"targets":  selector.Targets,
+		}
+		if selector.Strategy == config.SelectorStrategySpillover {
+			internalMetadata["spillover"] = selector.Settings.Spillover
+		}
 		data = append(data, newRecord(
 			selectorID,
 			selector.Name,
@@ -257,7 +265,7 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 			selector.Metadata,
 			config.ModelCapConfig{},
 			status,
-			map[string]any{"type": "selector"},
+			internalMetadata,
 		))
 	}
 

--- a/internal/server/selector_test.go
+++ b/internal/server/selector_test.go
@@ -347,6 +347,18 @@ func TestServer_Selector_ModelListings(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "testing", metadata["purpose"])
 	assert.Equal(t, "selector", metadata["type"])
+	assert.Equal(t, config.SelectorStrategyPin, metadata["strategy"])
+	assert.Equal(t, []any{"variant", "remote/remote-model"}, metadata["targets"])
+	assert.NotContains(t, metadata, "spillover")
+
+	balanced, found := byID["balanced"]
+	require.True(t, found)
+	balancedMetadata, ok := balanced.Meta["llamaswap"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, config.SelectorStrategySpillover, balancedMetadata["strategy"])
+	assert.Equal(t, []any{"a", "b", "c"}, balancedMetadata["targets"])
+	assert.Equal(t, float64(1), balancedMetadata["spillover"])
+
 	assert.NotContains(t, byID, "hidden-selector")
 }
 

--- a/ui-svelte/src/lib/types.ts
+++ b/ui-svelte/src/lib/types.ts
@@ -23,6 +23,10 @@ export interface Model {
   playgroundType?: PlaygroundModelType;
   aliases?: string[];
   capabilities?: ModelCapabilities;
+  // selector-only fields from the v1/models llamaswap metadata
+  strategy?: string;
+  targets?: string[];
+  spillover?: number;
 }
 
 export interface Profile {

--- a/ui-svelte/src/routes/ModelDetail.svelte
+++ b/ui-svelte/src/routes/ModelDetail.svelte
@@ -13,7 +13,13 @@
 
   let modelId = $derived($params?.id ?? "");
 
-  let model = $derived<Model | undefined>($models.find((m) => m.id === modelId));
+  // Resolve the route param to a model record by ID, falling back to an
+  // alias match so links to alias targets (e.g. selector targets) resolve.
+  let model = $derived<Model | undefined>(
+    $models.find((m) => m.id === modelId) ??
+      $models.find((m) => m.aliases?.includes(modelId)),
+  );
+  let resolvedId = $derived(model?.id ?? modelId);
 </script>
 
 <div class="flex h-full flex-col gap-4 overflow-y-auto p-2">
@@ -33,7 +39,7 @@
           <div class="ml-auto flex items-center gap-2">
             {#if !model.peerID}
               <a
-                href={`/upstream/${encodeURIComponent(modelId)}/`}
+                href={`/upstream/${encodeURIComponent(resolvedId)}/`}
                 target="_blank"
                 rel="noopener noreferrer"
                 class="text-muted-foreground hover:text-foreground"
@@ -64,12 +70,12 @@
 
       <!-- Activity -->
       <TabsContent value="activity">
-        <ModelActivityTab modelId={modelId} />
+        <ModelActivityTab modelId={resolvedId} />
       </TabsContent>
 
       <!-- Logs -->
       <TabsContent value="logs" class="min-h-0 flex-1">
-        <ModelLogsTab modelId={modelId} />
+        <ModelLogsTab modelId={resolvedId} />
       </TabsContent>
 
       <!-- Details -->

--- a/ui-svelte/src/routes/ModelsDash.svelte
+++ b/ui-svelte/src/routes/ModelsDash.svelte
@@ -1,6 +1,15 @@
 <script lang="ts">
+  import { onMount } from "svelte";
+  import type { Snippet } from "svelte";
   import { link } from "svelte-spa-router";
-  import { activeProfile, models, profiles, unloadAllModels } from "../stores/api";
+  import {
+    activeProfile,
+    fetchPlaygroundModels,
+    models,
+    profiles,
+    selectorModels,
+    unloadAllModels,
+  } from "../stores/api";
   import { statusDotColor } from "../stores/modelLoad";
   import { showUnlistedModels as showUnlisted } from "../stores/modelDisplay";
   import type { Model } from "../lib/types";
@@ -10,9 +19,13 @@
   import { Button } from "$lib/components/ui/button/index.js";
   import * as Switch from "$lib/components/ui/switch/index.js";
   import * as Label from "$lib/components/ui/label/index.js";
-  import { PowerOff, Loader2, ExternalLink, SquareStack, Eye } from "@lucide/svelte";
+  import { PowerOff, Loader2, ExternalLink, SquareStack } from "@lucide/svelte";
 
   let unloadingAll = $state(false);
+
+  onMount(() => {
+    void fetchPlaygroundModels();
+  });
 
   let visibleModels = $derived(
     $showUnlisted ? $models : $models.filter((m) => !m.unlisted)
@@ -83,12 +96,17 @@
   </div>
 {/snippet}
 
-{#snippet modelSection(title: string, sectionModels: Model[])}
+{#snippet modelSection(title: string, sectionModels: Model[], headerExtra?: Snippet)}
   <Card.Root class="shrink-0 gap-0 overflow-hidden py-0">
     <Card.Header class="shrink-0 border-b px-4 py-2.5">
       <div class="flex items-center gap-2">
         <Card.Title class="text-sm">{title}</Card.Title>
         <span class="text-muted-foreground text-xs">{sectionModels.length}</span>
+        {#if headerExtra}
+          <div class="ml-auto flex items-center gap-2">
+            {@render headerExtra()}
+          </div>
+        {/if}
       </div>
     </Card.Header>
     <Card.Content class="p-0">
@@ -105,6 +123,20 @@
       {/if}
     </Card.Content>
   </Card.Root>
+{/snippet}
+
+{#snippet unlistedToggle()}
+  <Label.Root for="show-unlisted-toggle" class="text-sm">
+    Show unlisted models
+  </Label.Root>
+  <Switch.Root
+    id="show-unlisted-toggle"
+    checked={$showUnlisted}
+    onCheckedChange={(v) => showUnlisted.set(v)}
+  />
+  <span class="text-muted-foreground text-xs">
+    {$models.filter((m) => m.unlisted).length} unlisted
+  </span>
 {/snippet}
 
 <div class="flex h-full flex-col gap-4 overflow-y-auto p-2">
@@ -136,20 +168,6 @@
         </div>
       </div>
     </Card.Header>
-    <Card.Content class="flex items-center gap-2 px-4 py-2">
-      <Eye class="text-muted-foreground size-4" />
-      <Label.Root for="show-unlisted-toggle" class="text-sm">
-        Show unlisted models
-      </Label.Root>
-      <Switch.Root
-        id="show-unlisted-toggle"
-        checked={$showUnlisted}
-        onCheckedChange={(v) => showUnlisted.set(v)}
-      />
-      <span class="text-muted-foreground text-xs">
-        {$models.filter((m) => m.unlisted).length} unlisted
-      </span>
-    </Card.Content>
   </Card.Root>
 
   <div class="flex min-h-0 shrink-0 flex-col gap-4">
@@ -157,7 +175,7 @@
       <Card.Root class="shrink-0 gap-0 overflow-hidden py-0">
         <Card.Header class="shrink-0 border-b px-4 py-2.5">
           <div class="flex items-center gap-2">
-            <Card.Title class="text-sm">Profile models</Card.Title>
+            <Card.Title class="text-sm">Profiles</Card.Title>
             {#if selectedProfile}
               <Tag>{$activeProfile}</Tag>
               <Tag class="bg-success/15 text-success">Active</Tag>
@@ -194,7 +212,53 @@
       </Card.Root>
     {/if}
 
-    {@render modelSection("Local models", localModels)}
+    {#if $selectorModels.length > 0}
+      <Card.Root class="shrink-0 gap-0 overflow-hidden py-0">
+        <Card.Header class="shrink-0 border-b px-4 py-2.5">
+          <div class="flex items-center gap-2">
+            <Card.Title class="text-sm">Selectors</Card.Title>
+            <span class="text-muted-foreground ml-auto text-xs">
+              {$selectorModels.length} {$selectorModels.length === 1 ? "selector" : "selectors"}
+            </span>
+          </div>
+        </Card.Header>
+        <Card.Content class="p-0">
+          <div class="divide-y">
+            {#each $selectorModels as selector (selector.id)}
+              <div class="hover:bg-muted/50 flex items-center gap-2 px-4 py-2.5">
+                <div class="min-w-0 flex-1">
+                  <div class="truncate text-sm font-medium">
+                    {selector.name ? `${selector.id} - ${selector.name}` : selector.id}
+                  </div>
+                  {#if selector.description}
+                    <div class="text-muted-foreground truncate text-xs">
+                      {selector.description}
+                    </div>
+                  {/if}
+                  <div class="text-muted-foreground flex flex-wrap items-center gap-x-1 text-xs">
+                    <span>targets:</span>
+                    {#each selector.targets ?? [] as target, i (target)}
+                      {#if i > 0}<span>,</span>{/if}
+                      <a
+                        href="/models/{encodeURIComponent(target)}"
+                        use:link
+                        class="hover:text-foreground hover:underline"
+                      >{target}</a>
+                    {/each}
+                  </div>
+                </div>
+                {#if selector.strategy === "spillover" && selector.spillover}
+                  <Tag>spillover {selector.spillover}</Tag>
+                {/if}
+                <Tag class="px-1.5 text-[0.625rem] uppercase">{selector.strategy}</Tag>
+              </div>
+            {/each}
+          </div>
+        </Card.Content>
+      </Card.Root>
+    {/if}
+
+    {@render modelSection("Local models", localModels, unlistedToggle)}
     {@render modelSection("Peer models", peerModels)}
   </div>
 </div>

--- a/ui-svelte/src/stores/api.test.ts
+++ b/ui-svelte/src/stores/api.test.ts
@@ -183,7 +183,14 @@ describe("api store event handling", () => {
           },
           {
             id: "pool",
-            meta: { llamaswap: { type: "selector" } },
+            meta: {
+              llamaswap: {
+                type: "selector",
+                strategy: "spillover",
+                targets: ["real", "remote/remote-model"],
+                spillover: 4,
+              },
+            },
           },
           {
             id: "public",
@@ -208,6 +215,11 @@ describe("api store event handling", () => {
       playgroundType: "peer",
     });
     expect(get(selectorModels).map((model) => model.id)).toEqual(["pool"]);
+    expect(get(selectorModels)[0]).toMatchObject({
+      strategy: "spillover",
+      targets: ["real", "remote/remote-model"],
+      spillover: 4,
+    });
     expect(get(profileModels).map((model) => model.id)).toEqual(["public"]);
     expect(get(hasListedModels)).toBe(true);
 

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -264,6 +264,9 @@ interface ModelListRecord {
       aliases?: string[];
       modelID?: string;
       peerID?: string;
+      strategy?: string;
+      targets?: string[];
+      spillover?: number;
     };
   };
 }
@@ -306,6 +309,9 @@ async function loadPlaygroundModels(request: number): Promise<Model[]> {
           playgroundType,
           aliases: [...(aliasesByModel.get(record.id) ?? [])],
           capabilities: record.capabilities,
+          strategy: metadata?.strategy,
+          targets: metadata?.targets ?? [],
+          spillover: metadata?.spillover,
         };
       });
     newModels.sort((a, b) => {


### PR DESCRIPTION
Surface selector strategy and targets via the existing /v1/models listing (meta.llamaswap) and render them in a Selectors card under the Profiles card.

- add strategy, targets, and spillover to selector records in /v1/models
- map selector metadata onto Model in the playground models loader
- render Selectors card: id - name, description, linked targets
- move the unlisted-models toggle into the Local models header
- rename "Profile models" section to "Profiles"

fix: #974