### PR TITLE
internal/hw: detect inference host hardware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
+	github.com/yusufpapurcu/wmi v1.2.4
 	golang.org/x/sys v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.53.0
@@ -75,7 +76,6 @@ require (
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.52.0 // indirect

--- a/internal/hw/README.md
+++ b/internal/hw/README.md
@@ -1,0 +1,156 @@
+# Hardware detection
+
+The `hw` package creates a versioned `HardwareSnapshot` for the machine that
+runs llama-swap. The snapshot describes hardware visible to the llama-swap
+process. It does not try to describe hardware hidden by a container, virtual
+machine, device filter, or operating-system permission.
+
+The public entry point is:
+
+```go
+snapshot, err := hw.Detect(ctx, version)
+```
+
+llama-swap calls `Detect` once during startup. The result is kept unchanged for
+the life of the process, including configuration reloads.
+
+## Design goals
+
+- Produce the version 1 `HardwareSnapshot` wire format.
+- Use the same object for detection, the API response, and later reporting.
+- Work without elevated privileges.
+- Prefer operating-system APIs and tools that are normally available with a
+  GPU driver.
+- Keep platform-specific code behind Go build tags.
+- Return partial information when a field cannot be detected safely.
+- Never invent a value for an unknown fact.
+
+This package detects static facts such as model names, memory capacity, and
+driver versions. Live utilization, temperature, and memory usage belong in
+`internal/perf`.
+
+## Detection flow
+
+`Detect` builds a snapshot in this order:
+
+1. Set schema, capture, architecture, and operating-system defaults.
+2. Read host, CPU, and system-memory information with `gopsutil`.
+3. Adjust system memory for platform rules. Linux prefers non-device physical
+   pages from `/proc/zoneinfo` over usable `MemTotal`, then applies any cgroup
+   limit.
+4. Run the platform-specific environment and accelerator probes.
+5. Merge accelerator records that describe the same visible device.
+6. Sort accelerators and assign dense, zero-based report indexes.
+7. Validate the completed snapshot before returning it.
+
+The supplied context controls external commands and normal `gopsutil` calls.
+A canceled context stops detection and returns the context error.
+
+System memory and schema validation are required for a usable snapshot. Most
+CPU, operating-system, environment, and accelerator fields are best effort. A
+failed optional probe leaves its fields `null`, uses an allowed unknown value,
+or produces an empty accelerator list.
+
+## Snapshot concepts
+
+### Inference-host scope
+
+`capture.scope` is always `inference_host`. The snapshot must describe the
+machine running llama-swap, not a browser, API client, or monitoring server.
+
+### Missing, unknown, and other
+
+Optional facts use pointers so unavailable values encode as JSON `null`. Do
+not use placeholder strings such as `"unknown"` or sentinel numbers such as
+`-1`.
+
+Some enum-like fields have both `unknown` and `other` values:
+
+- `unknown` means detection could not determine the value.
+- `other` means detection found a value that is not in the schema enum. The
+  matching `raw_*` field must contain the original value.
+
+Vendor and model strings are open-ended. Do not add a vendor or model
+allowlist.
+
+### Units
+
+- Memory capacities are integer bytes.
+- Power limits are finite watts.
+- CPU counts are positive integers when present.
+- Timestamps are UTC.
+
+### Accelerator memory
+
+Accelerator memory uses one of four kinds:
+
+- `dedicated`: memory owned by the accelerator.
+- `unified`: one coherent pool shared by CPU and accelerator, such as Apple
+  unified memory.
+- `shared_system`: system memory that the accelerator may borrow.
+- `unknown`: the memory relationship could not be determined.
+
+Do not add unified or shared-system capacity to total system memory. Those
+values describe the same physical memory from another point of view.
+
+### Accelerator identity and index
+
+Platform probes return an internal `detectedAccelerator`. Its `identity` may be
+a PCI address, UUID, LUID, or another stable value available during one
+detection run. The identity is used only to merge results from multiple probes.
+It is never included in `HardwareSnapshot` JSON.
+
+An accelerator's public `index` is assigned after merging and sorting. It is a
+report-local index, not a PCI index or durable hardware identifier.
+
+When records merge, an existing non-null value wins. A later record fills only
+missing fields. Put the most authoritative probe first when adding a new probe.
+
+## Platform probes
+
+| Platform | Environment and memory | Accelerators |
+| --- | --- | --- |
+| Linux | `gopsutil`, `/proc/zoneinfo`, WSL markers, virtualization metadata, `systemd-detect-virt`, container markers, cgroup memory limits | `nvidia-smi`, `rocm-smi`, AMD KFD topology, and DRM/sysfs |
+| macOS | `gopsutil` and `sysctl` virtualization state | `system_profiler`, including Apple unified memory and Metal |
+| Windows | `gopsutil` and WMI system metadata | `nvidia-smi`, DXGI, and WMI driver metadata or fallback enumeration |
+| Other Go platforms | Common host, CPU, and memory data | No platform accelerator probe |
+
+NVIDIA parsing is shared because `nvidia-smi` has the same static query format
+on supported Linux and Windows systems.
+
+## File layout
+
+- `types.go`: versioned snapshot types and JSON field names.
+- `validate.go`: schema and cross-field checks.
+- `detect.go`: common detection, normalization, merging, and final indexing.
+- `nvidia.go`: shared one-shot NVIDIA detection and parsing.
+- `amd_linux.go`: Linux ROCm and KFD topology detection for AMD GPUs.
+- `detect_linux.go`: Linux environment, memory, and generic DRM/sysfs probes.
+- `detect_darwin.go`: macOS environment and `system_profiler` probes.
+- `detect_windows.go`: Windows environment and WMI enrichment.
+- `dxgi_windows.go`: native Windows DXGI adapter enumeration.
+- `detect_other.go`: safe fallback for other operating systems.
+- `hardware_*_test.go`: common and platform-specific tests.
+
+## Adding or changing detection
+
+When extending this package:
+
+1. Keep wire-format changes in `types.go` and update `SchemaVersion` only when
+   the external schema requires a new version.
+2. Add matching validation before producing a new value.
+3. Use a platform build tag for operating-system APIs and commands.
+4. Pass the detection context to every external command.
+5. Treat command absence, permissions, and unsupported driver fields as normal
+   detection outcomes.
+6. Normalize byte units and names at the probe boundary.
+7. Give each accelerator the best private identity available so duplicate
+   records can merge.
+8. Do not expose private identities or tool-specific fields in the snapshot.
+9. Add parser tests that use captured text or JSON instead of requiring local
+   hardware.
+10. Cross-compile platform-specific tests or the full binary after changing
+    build-tagged code.
+
+Use `HardwareSnapshot.Validate` as the final contract check. A detector should
+not return a snapshot that fails validation.

--- a/internal/hw/amd_linux.go
+++ b/internal/hw/amd_linux.go
@@ -1,0 +1,191 @@
+//go:build linux
+
+package hw
+
+import (
+	"bufio"
+	"context"
+	"encoding/csv"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+func detectAMD(ctx context.Context) []detectedAccelerator {
+	var result []detectedAccelerator
+	if rocm, err := detectROCm(ctx); err == nil {
+		result = append(result, rocm...)
+	}
+	if kfd, err := detectAMDKFD(
+		"/sys/class/kfd/kfd/topology/nodes",
+		"/sys/class/drm",
+		"/dev/dri",
+	); err == nil {
+		result = append(result, kfd...)
+	}
+	return result
+}
+
+func detectROCm(ctx context.Context) ([]detectedAccelerator, error) {
+	if _, err := exec.LookPath("rocm-smi"); err != nil {
+		return nil, err
+	}
+	args := []string{"-i", "--showmeminfo", "vram", "--showproductname", "--showdriverversion", "--showmaxpower", "--showbus", "--csv"}
+	output, err := exec.CommandContext(ctx, "rocm-smi", args...).Output()
+	if err != nil {
+		fallback := []string{"-i", "--showmeminfo", "vram", "--showproductname", "--showbus", "--csv"}
+		output, err = exec.CommandContext(ctx, "rocm-smi", fallback...).Output()
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying rocm-smi: %w", err)
+	}
+	return parseROCmCSV(string(output))
+}
+
+func parseROCmCSV(output string) ([]detectedAccelerator, error) {
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	var header []string
+	var result []detectedAccelerator
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		row, err := csv.NewReader(strings.NewReader(line)).Read()
+		if err != nil {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(row[0]), "device") {
+			header = row
+			continue
+		}
+		if len(header) == 0 || len(row) != len(header) {
+			continue
+		}
+		fields := make(map[string]string, len(row))
+		for i := range row {
+			fields[strings.ToLower(strings.TrimSpace(header[i]))] = strings.TrimSpace(row[i])
+		}
+		model := firstROCmField(fields, "card series", "device name", "card model")
+		architecture := firstROCmField(fields, "gfx version")
+		identity := normalizePCIIdentity(firstROCmField(fields, "pci bus", "pci bus id", "bus"))
+		if identity == "" {
+			identity = firstROCmField(fields, "guid", "unique id")
+		}
+		memoryBytes, _ := strconv.ParseUint(firstROCmField(fields, "vram total memory (b)"), 10, 64)
+		memory := AcceleratorMemory{Kind: "dedicated"}
+		if memoryBytes > 0 {
+			memory.CapacityBytes = uint64Ptr(memoryBytes)
+		}
+		driverVersion := firstROCmField(fields, "driver version")
+		var driver *Driver
+		if version := nonEmptyStringPtr(driverVersion); version != nil {
+			driver = &Driver{Name: stringPtr("amdgpu"), Version: version}
+		}
+		power, _ := parseOptionalFloat(firstROCmField(fields, "max graphics package power (w)", "maximum graphics package power (w)"))
+		accelerator := Accelerator{
+			Kind:         "gpu",
+			Vendor:       stringPtr("AMD"),
+			Model:        nonEmptyStringPtr(model),
+			Architecture: nonEmptyStringPtr(architecture),
+			Memory:       memory,
+			Driver:       driver,
+		}
+		if power > 0 {
+			accelerator.PowerLimitWatts = float64Ptr(power)
+		}
+		result = append(result, detectedAccelerator{identity: identity, value: accelerator})
+	}
+	return result, scanner.Err()
+}
+
+func firstROCmField(fields map[string]string, names ...string) string {
+	for _, name := range names {
+		if value := strings.TrimSpace(fields[name]); value != "" && !strings.EqualFold(value, "n/a") {
+			return value
+		}
+	}
+	return ""
+}
+
+func detectAMDKFD(nodesRoot, drmRoot, deviceRoot string) ([]detectedAccelerator, error) {
+	propertyPaths, err := filepath.Glob(filepath.Join(nodesRoot, "*", "properties"))
+	if err != nil {
+		return nil, err
+	}
+
+	var result []detectedAccelerator
+	for _, propertyPath := range propertyPaths {
+		properties, err := readKFDProperties(propertyPath)
+		if err != nil {
+			continue
+		}
+		architecture := formatGFXTarget(properties["gfx_target_version"])
+		renderMinor := properties["drm_render_minor"]
+		if architecture == "" || renderMinor == 0 {
+			continue
+		}
+
+		renderNode := fmt.Sprintf("renderD%d", renderMinor)
+		if _, err := os.Stat(filepath.Join(deviceRoot, renderNode)); err != nil {
+			continue
+		}
+		devicePath, err := filepath.EvalSymlinks(filepath.Join(drmRoot, renderNode, "device"))
+		if err != nil || pciVendorName(readTrimmed(filepath.Join(devicePath, "vendor"))) != "AMD" {
+			continue
+		}
+		identity := normalizePCIIdentity(filepath.Base(devicePath))
+		if identity == "" {
+			continue
+		}
+
+		result = append(result, detectedAccelerator{
+			identity: identity,
+			value: Accelerator{
+				Kind:         "gpu",
+				Vendor:       stringPtr("AMD"),
+				Architecture: stringPtr(architecture),
+				Memory:       AcceleratorMemory{Kind: "unknown"},
+			},
+		})
+	}
+	return result, nil
+}
+
+func readKFDProperties(path string) (map[string]uint64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	properties := make(map[string]uint64)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) != 2 {
+			continue
+		}
+		value, err := strconv.ParseUint(fields[1], 10, 64)
+		if err == nil {
+			properties[fields[0]] = value
+		}
+	}
+	return properties, scanner.Err()
+}
+
+func formatGFXTarget(version uint64) string {
+	if version < 10000 {
+		return ""
+	}
+	major := version / 10000
+	minor := (version / 100) % 100
+	stepping := version % 100
+	if major == 0 || minor > 9 || stepping > 15 {
+		return ""
+	}
+	return fmt.Sprintf("gfx%d%d%x", major, minor, stepping)
+}

--- a/internal/hw/detect.go
+++ b/internal/hw/detect.go
@@ -58,9 +58,6 @@ func Detect(ctx context.Context, detectorVersion string) (HardwareSnapshot, erro
 	snapshot.Memory.CapacityBytes = capacity
 
 	detected, err := detectPlatform(ctx, &snapshot)
-	if ctx.Err() != nil {
-		return HardwareSnapshot{}, ctx.Err()
-	}
 	if err == nil {
 		snapshot.Accelerators = finalizeAccelerators(detected)
 	}
@@ -181,8 +178,11 @@ func mergeAccelerator(dst *Accelerator, src Accelerator) {
 	if dst.Architecture == nil {
 		dst.Architecture = src.Architecture
 	}
+	if dst.Memory.Kind == "" || dst.Memory.Kind == "unknown" {
+		dst.Memory.Kind = src.Memory.Kind
+	}
 	if dst.Memory.CapacityBytes == nil {
-		dst.Memory = src.Memory
+		dst.Memory.CapacityBytes = src.Memory.CapacityBytes
 	}
 	if dst.Driver == nil {
 		dst.Driver = src.Driver

--- a/internal/hw/detect.go
+++ b/internal/hw/detect.go
@@ -1,0 +1,223 @@
+package hw
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/shirou/gopsutil/v4/cpu"
+	"github.com/shirou/gopsutil/v4/host"
+	"github.com/shirou/gopsutil/v4/mem"
+)
+
+func Detect(ctx context.Context, detectorVersion string) (HardwareSnapshot, error) {
+	detectorVersion = strings.TrimSpace(detectorVersion)
+	if detectorVersion == "" {
+		return HardwareSnapshot{}, fmt.Errorf("detector version is required")
+	}
+
+	snapshot := HardwareSnapshot{
+		SchemaVersion: SchemaVersion,
+		CapturedAt:    time.Now().UTC(),
+		Capture: HardwareCapture{
+			Scope:  CaptureScopeInferenceHost,
+			Method: CaptureMethodDetected,
+			Detector: &DetectorInfo{
+				Name:    "llama-swap",
+				Version: detectorVersion,
+			},
+		},
+		Architecture: normalizeArchitecture(runtime.GOARCH),
+		OperatingSystem: OperatingSystem{
+			Family: normalizeOS(runtime.GOOS),
+		},
+		Environment:  ExecutionEnvironment{Kind: "unknown"},
+		Accelerators: []Accelerator{},
+	}
+	if snapshot.OperatingSystem.Family == "other" {
+		snapshot.OperatingSystem.RawFamily = stringPtr(runtime.GOOS)
+	}
+
+	if info, err := host.InfoWithContext(ctx); err == nil {
+		populateOperatingSystem(&snapshot.OperatingSystem, info)
+		snapshot.Environment = detectEnvironment(ctx, info)
+	}
+	populateCPU(ctx, &snapshot.CPU)
+
+	virtualMemory, err := mem.VirtualMemoryWithContext(ctx)
+	if err != nil {
+		return HardwareSnapshot{}, fmt.Errorf("detecting system memory: %w", err)
+	}
+	capacity := platformMemoryCapacity(virtualMemory.Total)
+	if capacity == 0 {
+		return HardwareSnapshot{}, fmt.Errorf("detecting system memory: reported zero capacity")
+	}
+	snapshot.Memory.CapacityBytes = capacity
+
+	detected, err := detectPlatform(ctx, &snapshot)
+	if ctx.Err() != nil {
+		return HardwareSnapshot{}, ctx.Err()
+	}
+	if err == nil {
+		snapshot.Accelerators = finalizeAccelerators(detected)
+	}
+
+	if err := snapshot.Validate(); err != nil {
+		return HardwareSnapshot{}, fmt.Errorf("validating detected hardware: %w", err)
+	}
+	return snapshot, nil
+}
+
+func normalizeArchitecture(raw string) Architecture {
+	switch raw {
+	case "amd64":
+		return Architecture{Name: "x86_64", RawName: stringPtr(raw)}
+	case "arm64", "ppc64le", "riscv64", "s390x":
+		return Architecture{Name: raw}
+	case "arm":
+		return Architecture{Name: "armv7", RawName: stringPtr(raw)}
+	default:
+		return Architecture{Name: "other", RawName: stringPtr(raw)}
+	}
+}
+
+func normalizeOS(raw string) string {
+	switch raw {
+	case "linux", "windows", "freebsd":
+		return raw
+	case "darwin":
+		return "macos"
+	default:
+		return "other"
+	}
+}
+
+func populateOperatingSystem(out *OperatingSystem, info *host.InfoStat) {
+	if out.Family == "other" {
+		out.RawFamily = nonEmptyStringPtr(runtime.GOOS)
+	}
+	name := strings.TrimSpace(info.Platform)
+	if out.Family == "macos" {
+		name = "macOS"
+	} else if out.Family == "windows" && name == "" {
+		name = "Windows"
+	}
+	out.Name = nonEmptyStringPtr(name)
+	out.Version = nonEmptyStringPtr(info.PlatformVersion)
+	out.Kernel = nonEmptyStringPtr(info.KernelVersion)
+}
+
+func populateCPU(ctx context.Context, out *CPU) {
+	infos, _ := cpu.InfoWithContext(ctx)
+	for _, info := range infos {
+		if out.Vendor == nil {
+			out.Vendor = nonEmptyStringPtr(info.VendorID)
+		}
+		if out.Model == nil {
+			out.Model = nonEmptyStringPtr(info.ModelName)
+		}
+	}
+
+	logical, logicalErr := cpu.CountsWithContext(ctx, true)
+	if logicalErr == nil && logical > 0 {
+		out.LogicalThreadCount = intPtr(logical)
+	}
+	physical, physicalErr := cpu.CountsWithContext(ctx, false)
+	if physicalErr == nil && physical > 0 && (logical <= 0 || physical <= logical) {
+		out.PhysicalCoreCount = intPtr(physical)
+	}
+
+	sockets := map[string]struct{}{}
+	for _, info := range infos {
+		if id := strings.TrimSpace(info.PhysicalID); id != "" {
+			sockets[id] = struct{}{}
+		}
+	}
+	if len(sockets) > 0 {
+		out.SocketCount = intPtr(len(sockets))
+	} else if (runtime.GOOS == "darwin" || runtime.GOOS == "windows") && len(infos) > 0 {
+		out.SocketCount = intPtr(len(infos))
+	}
+}
+
+func finalizeAccelerators(found []detectedAccelerator) []Accelerator {
+	merged := make([]detectedAccelerator, 0, len(found))
+	byIdentity := make(map[string]int)
+	for _, candidate := range found {
+		if candidate.identity != "" {
+			if index, ok := byIdentity[candidate.identity]; ok {
+				mergeAccelerator(&merged[index].value, candidate.value)
+				continue
+			}
+			byIdentity[candidate.identity] = len(merged)
+		}
+		merged = append(merged, candidate)
+	}
+	sort.SliceStable(merged, func(i, j int) bool {
+		left, right := merged[i].identity, merged[j].identity
+		if left != right {
+			return left < right
+		}
+		return stringValue(merged[i].value.Model) < stringValue(merged[j].value.Model)
+	})
+	result := make([]Accelerator, len(merged))
+	for i := range merged {
+		result[i] = merged[i].value
+		result[i].Index = i
+	}
+	return result
+}
+
+func mergeAccelerator(dst *Accelerator, src Accelerator) {
+	if dst.Vendor == nil {
+		dst.Vendor = src.Vendor
+	}
+	if dst.Model == nil {
+		dst.Model = src.Model
+	}
+	if dst.Architecture == nil {
+		dst.Architecture = src.Architecture
+	}
+	if dst.Memory.CapacityBytes == nil {
+		dst.Memory = src.Memory
+	}
+	if dst.Driver == nil {
+		dst.Driver = src.Driver
+	} else if src.Driver != nil {
+		if dst.Driver.Name == nil {
+			dst.Driver.Name = src.Driver.Name
+		}
+		if dst.Driver.Version == nil {
+			dst.Driver.Version = src.Driver.Version
+		}
+	}
+	if dst.PowerLimitWatts == nil {
+		dst.PowerLimitWatts = src.PowerLimitWatts
+	}
+}
+
+func stringPtr(value string) *string { return &value }
+
+func nonEmptyStringPtr(value string) *string {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.EqualFold(value, "n/a") || strings.EqualFold(value, "unknown") {
+		return nil
+	}
+	return &value
+}
+
+func intPtr(value int) *int { return &value }
+
+func uint64Ptr(value uint64) *uint64 { return &value }
+
+func float64Ptr(value float64) *float64 { return &value }
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}

--- a/internal/hw/detect_darwin.go
+++ b/internal/hw/detect_darwin.go
@@ -1,0 +1,165 @@
+//go:build darwin
+
+package hw
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/shirou/gopsutil/v4/host"
+)
+
+var appleArchitecturePattern = regexp.MustCompile(`(?i)\bApple\s+M\d+`)
+
+func detectPlatform(ctx context.Context, snapshot *HardwareSnapshot) ([]detectedAccelerator, error) {
+	output, err := exec.CommandContext(ctx, "system_profiler", "-json", "SPHardwareDataType", "SPDisplaysDataType").Output()
+	if err != nil {
+		return nil, fmt.Errorf("running system_profiler: %w", err)
+	}
+	return parseSystemProfiler(output, snapshot)
+}
+
+func detectEnvironment(ctx context.Context, _ *host.InfoStat) ExecutionEnvironment {
+	output, err := exec.CommandContext(ctx, "sysctl", "-n", "kern.hv_vmm_present").Output()
+	if err != nil {
+		return ExecutionEnvironment{Kind: "unknown"}
+	}
+	switch strings.TrimSpace(string(output)) {
+	case "1":
+		return ExecutionEnvironment{Kind: "virtual_machine"}
+	case "0":
+		return ExecutionEnvironment{Kind: "native"}
+	default:
+		return ExecutionEnvironment{Kind: "unknown"}
+	}
+}
+
+func platformMemoryCapacity(total uint64) uint64 { return total }
+
+func parseSystemProfiler(data []byte, snapshot *HardwareSnapshot) ([]detectedAccelerator, error) {
+	var root map[string][]map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("parsing system_profiler output: %w", err)
+	}
+	if hardware := root["SPHardwareDataType"]; len(hardware) > 0 {
+		chip := firstMapString(hardware[0], "chip_type", "cpu_type")
+		if snapshot.CPU.Model == nil {
+			snapshot.CPU.Model = nonEmptyStringPtr(chip)
+		}
+		if strings.HasPrefix(strings.ToLower(chip), "apple ") {
+			snapshot.CPU.Vendor = stringPtr("Apple")
+		}
+	}
+
+	var result []detectedAccelerator
+	for index, display := range root["SPDisplaysDataType"] {
+		model := firstMapString(display, "sppci_model", "chipset_model", "_name")
+		vendorRaw := firstMapString(display, "spdisplays_vendor", "vendor")
+		vendor := displayVendor(vendorRaw, model)
+		if model == "" && vendor == "" {
+			continue
+		}
+
+		memory := AcceleratorMemory{Kind: "unknown"}
+		if vendor == "Apple" {
+			memory.Kind = "unified"
+			memory.CapacityBytes = uint64Ptr(snapshot.Memory.CapacityBytes)
+		} else {
+			shared := strings.EqualFold(firstMapString(display, "spdisplays_vram_shared"), "spdisplays_yes")
+			if shared {
+				memory.Kind = "shared_system"
+			} else {
+				memory.Kind = "dedicated"
+			}
+			if capacity := parseProfilerMemory(firstMapString(display, "spdisplays_vram", "_spdisplays_vram")); capacity > 0 {
+				memory.CapacityBytes = uint64Ptr(capacity)
+			}
+		}
+
+		architecture := ""
+		if match := appleArchitecturePattern.FindString(model); match != "" {
+			architecture = match
+		}
+		var driver *Driver
+		if firstMapString(display, "spdisplays_metal", "spdisplays_metal_support") != "" {
+			driver = &Driver{Name: stringPtr("Metal")}
+		}
+		result = append(result, detectedAccelerator{
+			identity: fmt.Sprintf("display-%04d", index),
+			value: Accelerator{
+				Kind:         "gpu",
+				Vendor:       nonEmptyStringPtr(vendor),
+				Model:        nonEmptyStringPtr(model),
+				Architecture: nonEmptyStringPtr(architecture),
+				Memory:       memory,
+				Driver:       driver,
+			},
+		})
+	}
+	return result, nil
+}
+
+func firstMapString(values map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := values[key]; ok {
+			switch typed := value.(type) {
+			case string:
+				if strings.TrimSpace(typed) != "" {
+					return strings.TrimSpace(typed)
+				}
+			case json.Number:
+				return typed.String()
+			case float64:
+				return strconv.FormatFloat(typed, 'f', -1, 64)
+			}
+		}
+	}
+	return ""
+}
+
+func displayVendor(raw, model string) string {
+	combined := strings.ToLower(raw + " " + model)
+	switch {
+	case strings.Contains(combined, "apple"):
+		return "Apple"
+	case strings.Contains(combined, "nvidia"):
+		return "NVIDIA"
+	case strings.Contains(combined, "amd"), strings.Contains(combined, "ati"):
+		return "AMD"
+	case strings.Contains(combined, "intel"):
+		return "Intel"
+	default:
+		if before, _, ok := strings.Cut(raw, " ("); ok {
+			return strings.TrimSpace(before)
+		}
+		return strings.TrimSpace(raw)
+	}
+}
+
+func parseProfilerMemory(value string) uint64 {
+	fields := strings.Fields(strings.ReplaceAll(value, ",", ""))
+	if len(fields) == 0 {
+		return 0
+	}
+	amount, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil || amount <= 0 {
+		return 0
+	}
+	multiplier := float64(1024 * 1024)
+	if len(fields) > 1 {
+		switch strings.ToLower(fields[1]) {
+		case "kb":
+			multiplier = 1024
+		case "gb":
+			multiplier = 1024 * 1024 * 1024
+		case "tb":
+			multiplier = 1024 * 1024 * 1024 * 1024
+		}
+	}
+	return uint64(amount * multiplier)
+}

--- a/internal/hw/detect_linux.go
+++ b/internal/hw/detect_linux.go
@@ -1,0 +1,258 @@
+//go:build linux
+
+package hw
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/shirou/gopsutil/v4/host"
+)
+
+var drmCardPattern = regexp.MustCompile(`^card\d+$`)
+
+func detectPlatform(ctx context.Context, snapshot *HardwareSnapshot) ([]detectedAccelerator, error) {
+	var result []detectedAccelerator
+	if nvidia, err := detectNvidia(ctx); err == nil {
+		result = append(result, nvidia...)
+	}
+	result = append(result, detectAMD(ctx)...)
+	if sysfs, err := detectDRMSysfs(); err == nil {
+		result = append(result, sysfs...)
+	}
+	return result, nil
+}
+
+func detectEnvironment(ctx context.Context, info *host.InfoStat) ExecutionEnvironment {
+	kernel := strings.ToLower(info.KernelVersion)
+	if strings.Contains(kernel, "microsoft") || strings.Contains(kernel, "wsl") {
+		return ExecutionEnvironment{Kind: "wsl", Name: stringPtr("WSL")}
+	}
+
+	system := strings.ToLower(strings.TrimSpace(info.VirtualizationSystem))
+	role := strings.ToLower(strings.TrimSpace(info.VirtualizationRole))
+	if role == "guest" {
+		switch system {
+		case "docker", "lxc", "rkt", "podman", "containerd", "systemd-nspawn":
+			return ExecutionEnvironment{Kind: "container", Name: nonEmptyStringPtr(displayEnvironmentName(system))}
+		default:
+			return ExecutionEnvironment{Kind: "virtual_machine", Name: nonEmptyStringPtr(displayEnvironmentName(system))}
+		}
+	}
+	if system != "" && role == "host" {
+		return ExecutionEnvironment{Kind: "native"}
+	}
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return ExecutionEnvironment{Kind: "container", Name: stringPtr("Docker")}
+	}
+	if path, err := exec.LookPath("systemd-detect-virt"); err == nil {
+		command := exec.CommandContext(ctx, path)
+		output, commandErr := command.Output()
+		name := strings.TrimSpace(string(output))
+		if commandErr == nil && name != "" && name != "none" {
+			kind := "virtual_machine"
+			if isContainerEnvironment(name) {
+				kind = "container"
+			}
+			return ExecutionEnvironment{Kind: kind, Name: nonEmptyStringPtr(displayEnvironmentName(name))}
+		}
+		if exitErr := new(exec.ExitError); errors.As(commandErr, &exitErr) && exitErr.ExitCode() == 1 {
+			return ExecutionEnvironment{Kind: "native"}
+		}
+	}
+	return ExecutionEnvironment{Kind: "unknown"}
+}
+
+func isContainerEnvironment(value string) bool {
+	switch strings.ToLower(value) {
+	case "docker", "lxc", "rkt", "podman", "containerd", "systemd-nspawn":
+		return true
+	default:
+		return false
+	}
+}
+
+func displayEnvironmentName(value string) string {
+	switch strings.ToLower(value) {
+	case "docker":
+		return "Docker"
+	case "kvm":
+		return "KVM"
+	case "vmware":
+		return "VMware"
+	case "vbox":
+		return "VirtualBox"
+	case "hyperv":
+		return "Hyper-V"
+	case "lxc":
+		return "LXC"
+	default:
+		return value
+	}
+}
+
+func platformMemoryCapacity(total uint64) uint64 {
+	if physical := zoneinfoMemoryCapacity("/proc/zoneinfo", uint64(os.Getpagesize())); physical > total {
+		total = physical
+	}
+	return limitedMemoryCapacity(total, []string{
+		"/sys/fs/cgroup/memory.max",
+		"/sys/fs/cgroup/memory/memory.limit_in_bytes",
+	})
+}
+
+func zoneinfoMemoryCapacity(path string, pageSize uint64) uint64 {
+	if pageSize == 0 {
+		return 0
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+
+	var presentPages uint64
+	includeZone := false
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 4 && fields[0] == "Node" && fields[2] == "zone" {
+			includeZone = fields[3] != "Device"
+			continue
+		}
+		if !includeZone || len(fields) != 2 || fields[0] != "present" {
+			continue
+		}
+		pages, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil || pages > ^uint64(0)-presentPages {
+			return 0
+		}
+		presentPages += pages
+	}
+	if presentPages == 0 || presentPages > ^uint64(0)/pageSize {
+		return 0
+	}
+	return presentPages * pageSize
+}
+
+func limitedMemoryCapacity(total uint64, paths []string) uint64 {
+	capacity := total
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		value := strings.TrimSpace(string(data))
+		if value == "" || value == "max" {
+			continue
+		}
+		limit, err := strconv.ParseUint(value, 10, 64)
+		if err == nil && limit > 0 && limit < capacity {
+			capacity = limit
+		}
+	}
+	return capacity
+}
+
+func detectDRMSysfs() ([]detectedAccelerator, error) {
+	paths, err := filepath.Glob("/sys/class/drm/card*")
+	if err != nil {
+		return nil, err
+	}
+	var result []detectedAccelerator
+	for _, cardPath := range paths {
+		if !drmCardPattern.MatchString(filepath.Base(cardPath)) {
+			continue
+		}
+		devicePath := filepath.Join(cardPath, "device")
+		resolved, err := filepath.EvalSymlinks(devicePath)
+		if err != nil || !hasAccessibleRenderNode(devicePath) {
+			continue
+		}
+		vendorID := readTrimmed(filepath.Join(devicePath, "vendor"))
+		vendor := pciVendorName(vendorID)
+		if vendor == "" {
+			continue
+		}
+		memoryBytes, _ := strconv.ParseUint(readTrimmed(filepath.Join(devicePath, "mem_info_vram_total")), 10, 64)
+		memory := AcceleratorMemory{Kind: "shared_system"}
+		if memoryBytes > 0 {
+			memory.Kind = "dedicated"
+			memory.CapacityBytes = uint64Ptr(memoryBytes)
+		}
+		driverName := ""
+		if driverPath, err := filepath.EvalSymlinks(filepath.Join(devicePath, "driver")); err == nil {
+			driverName = filepath.Base(driverPath)
+		}
+		driverVersion := ""
+		if driverName != "" {
+			driverVersion = readTrimmed(filepath.Join("/sys/module", driverName, "version"))
+		}
+		var driver *Driver
+		if driverName != "" || driverVersion != "" {
+			driver = &Driver{Name: nonEmptyStringPtr(driverName), Version: nonEmptyStringPtr(driverVersion)}
+		}
+		model := readTrimmed(filepath.Join(devicePath, "product_name"))
+		powerLimit := readPowerLimit(devicePath)
+		result = append(result, detectedAccelerator{
+			identity: normalizePCIIdentity(filepath.Base(resolved)),
+			value: Accelerator{
+				Kind:            "gpu",
+				Vendor:          stringPtr(vendor),
+				Model:           nonEmptyStringPtr(model),
+				Memory:          memory,
+				Driver:          driver,
+				PowerLimitWatts: powerLimit,
+			},
+		})
+	}
+	return result, nil
+}
+
+func hasAccessibleRenderNode(devicePath string) bool {
+	nodes, _ := filepath.Glob(filepath.Join(devicePath, "drm", "renderD*"))
+	for _, node := range nodes {
+		if _, err := os.Stat(filepath.Join("/dev/dri", filepath.Base(node))); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func pciVendorName(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "0x10de":
+		return "NVIDIA"
+	case "0x1002", "0x1022":
+		return "AMD"
+	case "0x8086":
+		return "Intel"
+	case "0x106b":
+		return "Apple"
+	default:
+		return ""
+	}
+}
+
+func readPowerLimit(devicePath string) *float64 {
+	paths, _ := filepath.Glob(filepath.Join(devicePath, "hwmon", "hwmon*", "power1_cap"))
+	for _, path := range paths {
+		microwatts, err := strconv.ParseFloat(readTrimmed(path), 64)
+		if err == nil && microwatts > 0 {
+			return float64Ptr(microwatts / 1_000_000)
+		}
+	}
+	return nil
+}
+
+func readTrimmed(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/internal/hw/detect_other.go
+++ b/internal/hw/detect_other.go
@@ -1,0 +1,19 @@
+//go:build !linux && !darwin && !windows
+
+package hw
+
+import (
+	"context"
+
+	"github.com/shirou/gopsutil/v4/host"
+)
+
+func detectPlatform(context.Context, *HardwareSnapshot) ([]detectedAccelerator, error) {
+	return nil, nil
+}
+
+func detectEnvironment(context.Context, *host.InfoStat) ExecutionEnvironment {
+	return ExecutionEnvironment{Kind: "unknown"}
+}
+
+func platformMemoryCapacity(total uint64) uint64 { return total }

--- a/internal/hw/detect_windows.go
+++ b/internal/hw/detect_windows.go
@@ -4,12 +4,16 @@ package hw
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/shirou/gopsutil/v4/host"
 	"github.com/yusufpapurcu/wmi"
 )
+
+const wmiQueryTimeout = 5 * time.Second
 
 type win32VideoController struct {
 	Name                 string
@@ -39,7 +43,10 @@ func detectPlatform(ctx context.Context, _ *HardwareSnapshot) ([]detectedAcceler
 	}
 
 	var controllers []win32VideoController
-	if err := wmi.Query("SELECT Name, AdapterCompatibility, DriverVersion, PNPDeviceID FROM Win32_VideoController", &controllers); err != nil {
+	if err := queryWMI(ctx, "SELECT Name, AdapterCompatibility, DriverVersion, PNPDeviceID FROM Win32_VideoController", &controllers); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return result, nil
+		}
 		if len(result) > 0 {
 			return result, nil
 		}
@@ -74,9 +81,9 @@ func detectPlatform(ctx context.Context, _ *HardwareSnapshot) ([]detectedAcceler
 	return result, nil
 }
 
-func detectEnvironment(_ context.Context, _ *host.InfoStat) ExecutionEnvironment {
+func detectEnvironment(ctx context.Context, _ *host.InfoStat) ExecutionEnvironment {
 	var systems []win32ComputerSystem
-	if err := wmi.Query("SELECT Manufacturer, Model FROM Win32_ComputerSystem", &systems); err != nil || len(systems) == 0 {
+	if err := queryWMI(ctx, "SELECT Manufacturer, Model FROM Win32_ComputerSystem", &systems); err != nil || len(systems) == 0 {
 		return ExecutionEnvironment{Kind: "unknown"}
 	}
 	combined := strings.ToLower(systems[0].Manufacturer + " " + systems[0].Model)
@@ -92,6 +99,23 @@ func detectEnvironment(_ context.Context, _ *host.InfoStat) ExecutionEnvironment
 		}
 	}
 	return ExecutionEnvironment{Kind: "unknown"}
+}
+
+func queryWMI(ctx context.Context, query string, destination any) error {
+	ctx, cancel := context.WithTimeout(ctx, wmiQueryTimeout)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- wmi.Query(query, destination)
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func platformMemoryCapacity(total uint64) uint64 { return total }

--- a/internal/hw/detect_windows.go
+++ b/internal/hw/detect_windows.go
@@ -1,0 +1,127 @@
+//go:build windows
+
+package hw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/shirou/gopsutil/v4/host"
+	"github.com/yusufpapurcu/wmi"
+)
+
+type win32VideoController struct {
+	Name                 string
+	AdapterCompatibility string
+	DriverVersion        string
+	PNPDeviceID          string
+}
+
+type win32ComputerSystem struct {
+	Manufacturer string
+	Model        string
+}
+
+func detectPlatform(ctx context.Context, _ *HardwareSnapshot) ([]detectedAccelerator, error) {
+	var result []detectedAccelerator
+	if nvidia, err := detectNvidia(ctx); err == nil {
+		result = append(result, nvidia...)
+	}
+	if dxgi, err := detectDXGI(); err == nil {
+		for _, candidate := range dxgi {
+			if index := matchingAccelerator(result, stringValue(candidate.value.Vendor), stringValue(candidate.value.Model)); index >= 0 {
+				mergeAccelerator(&result[index].value, candidate.value)
+				continue
+			}
+			result = append(result, candidate)
+		}
+	}
+
+	var controllers []win32VideoController
+	if err := wmi.Query("SELECT Name, AdapterCompatibility, DriverVersion, PNPDeviceID FROM Win32_VideoController", &controllers); err != nil {
+		if len(result) > 0 {
+			return result, nil
+		}
+		return nil, fmt.Errorf("querying Win32_VideoController: %w", err)
+	}
+	for _, controller := range controllers {
+		if isSoftwareDisplayAdapter(controller.Name) {
+			continue
+		}
+		vendor := windowsVendor(controller.AdapterCompatibility, controller.Name, controller.PNPDeviceID)
+		if index := matchingAccelerator(result, vendor, controller.Name); index >= 0 {
+			if version := nonEmptyStringPtr(controller.DriverVersion); version != nil {
+				result[index].value.Driver = &Driver{Name: nonEmptyStringPtr(vendor), Version: version}
+			}
+			continue
+		}
+		var driver *Driver
+		if version := nonEmptyStringPtr(controller.DriverVersion); version != nil {
+			driver = &Driver{Name: nonEmptyStringPtr(vendor), Version: version}
+		}
+		result = append(result, detectedAccelerator{
+			identity: strings.ToLower(strings.TrimSpace(controller.PNPDeviceID)),
+			value: Accelerator{
+				Kind:   "gpu",
+				Vendor: nonEmptyStringPtr(vendor),
+				Model:  nonEmptyStringPtr(controller.Name),
+				Memory: AcceleratorMemory{Kind: "unknown"},
+				Driver: driver,
+			},
+		})
+	}
+	return result, nil
+}
+
+func detectEnvironment(_ context.Context, _ *host.InfoStat) ExecutionEnvironment {
+	var systems []win32ComputerSystem
+	if err := wmi.Query("SELECT Manufacturer, Model FROM Win32_ComputerSystem", &systems); err != nil || len(systems) == 0 {
+		return ExecutionEnvironment{Kind: "unknown"}
+	}
+	combined := strings.ToLower(systems[0].Manufacturer + " " + systems[0].Model)
+	for needle, name := range map[string]string{
+		"virtual machine": "Hyper-V",
+		"vmware":          "VMware",
+		"virtualbox":      "VirtualBox",
+		"kvm":             "KVM",
+		"qemu":            "QEMU",
+	} {
+		if strings.Contains(combined, needle) {
+			return ExecutionEnvironment{Kind: "virtual_machine", Name: stringPtr(name)}
+		}
+	}
+	return ExecutionEnvironment{Kind: "unknown"}
+}
+
+func platformMemoryCapacity(total uint64) uint64 { return total }
+
+func isSoftwareDisplayAdapter(name string) bool {
+	name = strings.ToLower(name)
+	return strings.Contains(name, "microsoft basic display") ||
+		strings.Contains(name, "remote display") ||
+		strings.Contains(name, "indirect display")
+}
+
+func windowsVendor(compatibility, name, pnpID string) string {
+	combined := strings.ToLower(compatibility + " " + name + " " + pnpID)
+	switch {
+	case strings.Contains(combined, "ven_10de"), strings.Contains(combined, "nvidia"):
+		return "NVIDIA"
+	case strings.Contains(combined, "ven_1002"), strings.Contains(combined, "advanced micro devices"), strings.Contains(combined, " amd"), strings.HasPrefix(combined, "amd"):
+		return "AMD"
+	case strings.Contains(combined, "ven_8086"), strings.Contains(combined, "intel"):
+		return "Intel"
+	default:
+		return strings.TrimSpace(compatibility)
+	}
+}
+
+func matchingAccelerator(found []detectedAccelerator, vendor, model string) int {
+	for i, accelerator := range found {
+		if strings.EqualFold(stringValue(accelerator.value.Vendor), vendor) && strings.EqualFold(stringValue(accelerator.value.Model), model) {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/hw/dxgi_windows.go
+++ b/internal/hw/dxgi_windows.go
@@ -74,7 +74,7 @@ func detectDXGI() ([]detectedAccelerator, error) {
 			break
 		}
 		if hresultFailed(hresult) || adapter == nil {
-			continue
+			break
 		}
 
 		var desc dxgiAdapterDesc

--- a/internal/hw/dxgi_windows.go
+++ b/internal/hw/dxgi_windows.go
@@ -1,0 +1,140 @@
+//go:build windows && amd64
+
+package hw
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	dxgiDLL               = windows.NewLazySystemDLL("dxgi.dll")
+	procCreateDXGIFactory = dxgiDLL.NewProc("CreateDXGIFactory")
+)
+
+var iidIDXGIFactory = windows.GUID{
+	Data1: 0x7b7166ec,
+	Data2: 0x21c7,
+	Data3: 0x44ae,
+	Data4: [8]byte{0xb2, 0x1a, 0xc9, 0xae, 0x32, 0x1a, 0xe3, 0x69},
+}
+
+const dxgiErrorNotFound = 0x887a0002
+
+type dxgiObject struct {
+	vtable *[10]uintptr
+}
+
+type dxgiAdapterDesc struct {
+	Description           [128]uint16
+	VendorID              uint32
+	DeviceID              uint32
+	SubSysID              uint32
+	Revision              uint32
+	DedicatedVideoMemory  uintptr
+	DedicatedSystemMemory uintptr
+	SharedSystemMemory    uintptr
+	AdapterLUIDLowPart    uint32
+	AdapterLUIDHighPart   int32
+}
+
+func init() {
+	if unsafe.Sizeof(dxgiAdapterDesc{}) != 304 {
+		panic("unexpected DXGI_ADAPTER_DESC size")
+	}
+}
+
+func detectDXGI() ([]detectedAccelerator, error) {
+	if err := procCreateDXGIFactory.Find(); err != nil {
+		return nil, err
+	}
+	var factory *dxgiObject
+	hresult, _, _ := procCreateDXGIFactory.Call(
+		uintptr(unsafe.Pointer(&iidIDXGIFactory)),
+		uintptr(unsafe.Pointer(&factory)),
+	)
+	if hresultFailed(hresult) || factory == nil {
+		return nil, fmt.Errorf("CreateDXGIFactory failed: HRESULT 0x%08x", uint32(hresult))
+	}
+	defer releaseDXGI(factory)
+
+	var result []detectedAccelerator
+	for index := uint32(0); ; index++ {
+		var adapter *dxgiObject
+		hresult, _, _ = syscall.SyscallN(
+			factory.vtable[7],
+			uintptr(unsafe.Pointer(factory)),
+			uintptr(index),
+			uintptr(unsafe.Pointer(&adapter)),
+		)
+		if uint32(hresult) == dxgiErrorNotFound {
+			break
+		}
+		if hresultFailed(hresult) || adapter == nil {
+			continue
+		}
+
+		var desc dxgiAdapterDesc
+		descResult, _, _ := syscall.SyscallN(
+			adapter.vtable[8],
+			uintptr(unsafe.Pointer(adapter)),
+			uintptr(unsafe.Pointer(&desc)),
+		)
+		releaseDXGI(adapter)
+		if hresultFailed(descResult) {
+			continue
+		}
+
+		model := windows.UTF16ToString(desc.Description[:])
+		if isSoftwareDisplayAdapter(model) {
+			continue
+		}
+		vendor := windowsPCIVendor(desc.VendorID)
+		memory := AcceleratorMemory{Kind: "unknown"}
+		if desc.DedicatedVideoMemory > 0 {
+			capacity := uint64(desc.DedicatedVideoMemory)
+			memory = AcceleratorMemory{Kind: "dedicated", CapacityBytes: &capacity}
+		} else if desc.SharedSystemMemory > 0 {
+			capacity := uint64(desc.SharedSystemMemory)
+			memory = AcceleratorMemory{Kind: "shared_system", CapacityBytes: &capacity}
+		}
+		result = append(result, detectedAccelerator{
+			identity: fmt.Sprintf("luid:%08x:%08x", uint32(desc.AdapterLUIDHighPart), desc.AdapterLUIDLowPart),
+			value: Accelerator{
+				Kind:   "gpu",
+				Vendor: nonEmptyStringPtr(vendor),
+				Model:  nonEmptyStringPtr(model),
+				Memory: memory,
+			},
+		})
+	}
+	return result, nil
+}
+
+func releaseDXGI(object *dxgiObject) {
+	if object != nil && object.vtable != nil {
+		syscall.SyscallN(object.vtable[2], uintptr(unsafe.Pointer(object)))
+	}
+}
+
+func hresultFailed(result uintptr) bool {
+	return int32(uint32(result)) < 0
+}
+
+func windowsPCIVendor(id uint32) string {
+	switch id {
+	case 0x10de:
+		return "NVIDIA"
+	case 0x1002, 0x1022:
+		return "AMD"
+	case 0x8086:
+		return "Intel"
+	case 0x106b:
+		return "Apple"
+	default:
+		return ""
+	}
+}

--- a/internal/hw/dxgi_windows_other.go
+++ b/internal/hw/dxgi_windows_other.go
@@ -1,0 +1,9 @@
+//go:build windows && !amd64
+
+package hw
+
+import "fmt"
+
+func detectDXGI() ([]detectedAccelerator, error) {
+	return nil, fmt.Errorf("DXGI hardware detection is not implemented on this architecture")
+}

--- a/internal/hw/hardware_darwin_test.go
+++ b/internal/hw/hardware_darwin_test.go
@@ -1,0 +1,35 @@
+//go:build darwin
+
+package hw
+
+import "testing"
+
+func TestHardware_DarwinSystemProfilerAppleSilicon(t *testing.T) {
+	snapshot := validTestSnapshot()
+	snapshot.OperatingSystem.Family = "macos"
+	snapshot.Memory.CapacityBytes = 64 * 1024 * 1024 * 1024
+	data := []byte(`{
+  "SPHardwareDataType": [{"chip_type":"Apple M4 Max"}],
+  "SPDisplaysDataType": [{
+    "_name":"Apple M4 Max",
+    "spdisplays_vendor":"sppci_vendor_Apple",
+    "spdisplays_metal":"spdisplays_supported"
+  }]
+}`)
+	got, err := parseSystemProfiler(data, &snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stringValue(snapshot.CPU.Model) != "Apple M4 Max" || stringValue(snapshot.CPU.Vendor) != "Apple" {
+		t.Fatalf("CPU = %+v", snapshot.CPU)
+	}
+	if len(got) != 1 || got[0].value.Memory.Kind != "unified" || *got[0].value.Memory.CapacityBytes != snapshot.Memory.CapacityBytes {
+		t.Fatalf("accelerators = %+v", got)
+	}
+}
+
+func TestHardware_DarwinProfilerMemory(t *testing.T) {
+	if got := parseProfilerMemory("24 GB"); got != 24*1024*1024*1024 {
+		t.Fatalf("parseProfilerMemory() = %d", got)
+	}
+}

--- a/internal/hw/hardware_linux_test.go
+++ b/internal/hw/hardware_linux_test.go
@@ -1,0 +1,114 @@
+//go:build linux
+
+package hw
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestHardware_LinuxCgroupMemoryLimit(t *testing.T) {
+	dir := t.TempDir()
+	limited := filepath.Join(dir, "memory.max")
+	unlimited := filepath.Join(dir, "unlimited")
+	if err := os.WriteFile(limited, []byte("2147483648\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(unlimited, []byte("max\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := limitedMemoryCapacity(8*1024*1024*1024, []string{unlimited, limited}); got != 2*1024*1024*1024 {
+		t.Fatalf("limitedMemoryCapacity() = %d", got)
+	}
+}
+
+func TestHardware_LinuxZoneinfoMemoryCapacity(t *testing.T) {
+	dir := t.TempDir()
+	zoneinfo := `Node 0, zone DMA
+        spanned  524288
+        present  393216
+        managed  390000
+Node 0, zone Normal
+        spanned  33554432
+        present  33161216
+        managed  32000000
+Node 0, zone Device
+        spanned  524288
+        present  524288
+        managed  0
+`
+	path := filepath.Join(dir, "zoneinfo")
+	if err := os.WriteFile(path, []byte(zoneinfo), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := zoneinfoMemoryCapacity(path, 4096); got != 128*1024*1024*1024 {
+		t.Fatalf("zoneinfoMemoryCapacity() = %d", got)
+	}
+}
+
+func TestHardware_LinuxKFDArchitecture(t *testing.T) {
+	root := t.TempDir()
+	nodesRoot := filepath.Join(root, "kfd", "nodes")
+	drmRoot := filepath.Join(root, "drm")
+	deviceRoot := filepath.Join(root, "dev", "dri")
+	pciDevice := filepath.Join(root, "pci", "0000:65:00.0")
+	for _, path := range []string{
+		filepath.Join(nodesRoot, "1"),
+		filepath.Join(drmRoot, "renderD128"),
+		deviceRoot,
+		pciDevice,
+	} {
+		if err := os.MkdirAll(path, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	properties := "gfx_target_version 110501\ndrm_render_minor 128\nvendor_id 4098\n"
+	if err := os.WriteFile(filepath.Join(nodesRoot, "1", "properties"), []byte(properties), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pciDevice, "vendor"), []byte("0x1002\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deviceRoot, "renderD128"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(pciDevice, filepath.Join(drmRoot, "renderD128", "device")); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := detectAMDKFD(nodesRoot, drmRoot, deviceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].identity != "0000:65:00.0" || stringValue(got[0].value.Architecture) != "gfx1151" {
+		t.Fatalf("detectAMDKFD() = %+v", got)
+	}
+}
+
+func TestHardware_LinuxGFXTargetFormatting(t *testing.T) {
+	tests := map[uint64]string{
+		0:      "",
+		90010:  "gfx90a",
+		110000: "gfx1100",
+		110501: "gfx1151",
+	}
+	for version, want := range tests {
+		if got := formatGFXTarget(version); got != want {
+			t.Errorf("formatGFXTarget(%d) = %q, want %q", version, got, want)
+		}
+	}
+}
+
+func TestHardware_ParseROCmCSV(t *testing.T) {
+	output := "device,Device Name,GUID,VRAM Total Memory (B),Card Series,GFX Version,Driver version,PCI Bus,Max Graphics Package Power (W)\n" +
+		"card0,AMD Radeon,abc,25769803776,Radeon RX 7900 XTX,gfx1100,6.12.12,0000:03:00.0,339\n"
+	got, err := parseROCmCSV(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].identity != "0000:03:00.0" || stringValue(got[0].value.Model) != "Radeon RX 7900 XTX" {
+		t.Fatalf("parseROCmCSV() = %+v", got)
+	}
+}

--- a/internal/hw/hardware_test.go
+++ b/internal/hw/hardware_test.go
@@ -1,0 +1,141 @@
+package hw
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHardware_ArchitectureNormalization(t *testing.T) {
+	tests := []struct {
+		raw     string
+		name    string
+		rawName string
+	}{
+		{raw: "amd64", name: "x86_64", rawName: "amd64"},
+		{raw: "arm64", name: "arm64"},
+		{raw: "arm", name: "armv7", rawName: "arm"},
+		{raw: "mips64", name: "other", rawName: "mips64"},
+	}
+	for _, test := range tests {
+		t.Run(test.raw, func(t *testing.T) {
+			got := normalizeArchitecture(test.raw)
+			if got.Name != test.name || stringValue(got.RawName) != test.rawName {
+				t.Fatalf("normalizeArchitecture(%q) = %+v", test.raw, got)
+			}
+		})
+	}
+}
+
+func TestHardware_ValidateValidSnapshot(t *testing.T) {
+	snapshot := validTestSnapshot()
+	if err := snapshot.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
+func TestHardware_ValidateRejectsInvalidCounts(t *testing.T) {
+	snapshot := validTestSnapshot()
+	physical, logical := 16, 8
+	snapshot.CPU.PhysicalCoreCount = &physical
+	snapshot.CPU.LogicalThreadCount = &logical
+	if err := snapshot.Validate(); err == nil {
+		t.Fatal("Validate() error = nil, want invalid CPU counts")
+	}
+}
+
+func TestHardware_FinalizeAcceleratorsMergesAndRemovesIdentity(t *testing.T) {
+	capacity := uint64(24 * 1024 * 1024 * 1024)
+	found := []detectedAccelerator{
+		{identity: "0000:02:00.0", value: Accelerator{Kind: "gpu", Vendor: stringPtr("NVIDIA"), Memory: AcceleratorMemory{Kind: "dedicated", CapacityBytes: &capacity}}},
+		{identity: "0000:02:00.0", value: Accelerator{Kind: "gpu", Model: stringPtr("RTX 4090"), Memory: AcceleratorMemory{Kind: "unknown"}}},
+	}
+	got := finalizeAccelerators(found)
+	if len(got) != 1 || got[0].Index != 0 || stringValue(got[0].Model) != "RTX 4090" {
+		t.Fatalf("finalizeAccelerators() = %+v", got)
+	}
+	data, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) == "" || strings.Contains(string(data), "0000:02:00.0") || strings.Contains(string(data), "uuid") || strings.Contains(string(data), "bus_id") {
+		t.Fatalf("serialized accelerators leak identity: %s", data)
+	}
+}
+
+func TestHardware_FinalizeAcceleratorsPreservesMixedVendors(t *testing.T) {
+	found := []detectedAccelerator{
+		{identity: "0000:01:00.0", value: Accelerator{Kind: "gpu", Vendor: stringPtr("NVIDIA"), Model: stringPtr("RTX 4090"), Memory: AcceleratorMemory{Kind: "dedicated"}}},
+		{identity: "0000:65:00.0", value: Accelerator{Kind: "gpu", Vendor: stringPtr("AMD"), Architecture: stringPtr("gfx1151"), Memory: AcceleratorMemory{Kind: "unknown"}}},
+		{identity: "0000:65:00.0", value: Accelerator{Kind: "gpu", Vendor: stringPtr("AMD"), Model: stringPtr("Radeon 8060S"), Memory: AcceleratorMemory{Kind: "shared_system"}}},
+	}
+
+	got := finalizeAccelerators(found)
+	if len(got) != 2 {
+		t.Fatalf("finalizeAccelerators() returned %d devices, want 2: %+v", len(got), got)
+	}
+	if stringValue(got[0].Vendor) != "NVIDIA" || stringValue(got[1].Vendor) != "AMD" {
+		t.Fatalf("finalizeAccelerators() vendors = %q, %q", stringValue(got[0].Vendor), stringValue(got[1].Vendor))
+	}
+	if stringValue(got[1].Architecture) != "gfx1151" || stringValue(got[1].Model) != "Radeon 8060S" {
+		t.Fatalf("finalizeAccelerators() AMD device = %+v", got[1])
+	}
+}
+
+func TestHardware_DetectLocalHost(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	snapshot, err := Detect(ctx, "test")
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if err := snapshot.Validate(); err != nil {
+		t.Fatalf("detected snapshot is invalid: %v", err)
+	}
+}
+
+func TestHardware_ParseNvidiaCSV(t *testing.T) {
+	records, err := parseNvidiaCSV("0, NVIDIA GeForce RTX 4090, GPU-abc, 00000000:01:00.0, 24564, 570.124.06, 450.00\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].memoryBytes != 24564*1024*1024 || records[0].powerLimit != 450 {
+		t.Fatalf("parseNvidiaCSV() = %+v", records)
+	}
+}
+
+func TestHardware_NvidiaComputeCapabilityArchitectures(t *testing.T) {
+	records := []nvidiaRecord{
+		{index: 0, name: "Tesla P40"},
+		{index: 1, name: "Tesla P40"},
+		{index: 2, name: "NVIDIA GeForce RTX 3090"},
+		{index: 3, name: "NVIDIA GeForce RTX 3090", architecture: "Ampere"},
+	}
+	applyNvidiaComputeCapabilities(records, "0, 6.1\n1, 6.1\n2, 8.6\n3, 8.6\n")
+
+	want := []string{"Pascal", "Pascal", "Ampere", "Ampere"}
+	for i := range records {
+		if records[i].architecture != want[i] {
+			t.Errorf("records[%d].architecture = %q, want %q", i, records[i].architecture, want[i])
+		}
+	}
+}
+
+func validTestSnapshot() HardwareSnapshot {
+	return HardwareSnapshot{
+		SchemaVersion: SchemaVersion,
+		CapturedAt:    time.Now().UTC(),
+		Capture: HardwareCapture{
+			Scope:    CaptureScopeInferenceHost,
+			Method:   CaptureMethodDetected,
+			Detector: &DetectorInfo{Name: "llama-swap", Version: "test"},
+		},
+		Architecture:    Architecture{Name: "x86_64"},
+		OperatingSystem: OperatingSystem{Family: "linux"},
+		Environment:     ExecutionEnvironment{Kind: "unknown"},
+		Memory:          SystemMemory{CapacityBytes: 1024},
+		Accelerators:    []Accelerator{},
+	}
+}

--- a/internal/hw/hardware_test.go
+++ b/internal/hw/hardware_test.go
@@ -66,10 +66,11 @@ func TestHardware_FinalizeAcceleratorsMergesAndRemovesIdentity(t *testing.T) {
 }
 
 func TestHardware_FinalizeAcceleratorsPreservesMixedVendors(t *testing.T) {
+	capacity := uint64(32 * 1024 * 1024 * 1024)
 	found := []detectedAccelerator{
 		{identity: "0000:01:00.0", value: Accelerator{Kind: "gpu", Vendor: stringPtr("NVIDIA"), Model: stringPtr("RTX 4090"), Memory: AcceleratorMemory{Kind: "dedicated"}}},
-		{identity: "0000:65:00.0", value: Accelerator{Kind: "gpu", Vendor: stringPtr("AMD"), Architecture: stringPtr("gfx1151"), Memory: AcceleratorMemory{Kind: "unknown"}}},
-		{identity: "0000:65:00.0", value: Accelerator{Kind: "gpu", Vendor: stringPtr("AMD"), Model: stringPtr("Radeon 8060S"), Memory: AcceleratorMemory{Kind: "shared_system"}}},
+		{identity: "0000:65:00.0", value: Accelerator{Kind: "gpu", Vendor: stringPtr("AMD"), Architecture: stringPtr("gfx1151"), Memory: AcceleratorMemory{Kind: "unified"}}},
+		{identity: "0000:65:00.0", value: Accelerator{Kind: "gpu", Vendor: stringPtr("AMD"), Model: stringPtr("Radeon 8060S"), Memory: AcceleratorMemory{Kind: "dedicated", CapacityBytes: &capacity}}},
 	}
 
 	got := finalizeAccelerators(found)
@@ -81,6 +82,9 @@ func TestHardware_FinalizeAcceleratorsPreservesMixedVendors(t *testing.T) {
 	}
 	if stringValue(got[1].Architecture) != "gfx1151" || stringValue(got[1].Model) != "Radeon 8060S" {
 		t.Fatalf("finalizeAccelerators() AMD device = %+v", got[1])
+	}
+	if got[1].Memory.Kind != "unified" || got[1].Memory.CapacityBytes == nil || *got[1].Memory.CapacityBytes != capacity {
+		t.Fatalf("finalizeAccelerators() AMD memory = %+v", got[1].Memory)
 	}
 }
 

--- a/internal/hw/hardware_windows_test.go
+++ b/internal/hw/hardware_windows_test.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package hw
+
+import "testing"
+
+func TestHardware_WindowsVendorNormalization(t *testing.T) {
+	if got := windowsVendor("", "AMD Radeon RX 7900 XTX", `PCI\VEN_1002&DEV_744C`); got != "AMD" {
+		t.Fatalf("windowsVendor() = %q", got)
+	}
+	if got := windowsVendor("NVIDIA", "GeForce RTX 4090", `PCI\VEN_10DE&DEV_2684`); got != "NVIDIA" {
+		t.Fatalf("windowsVendor() = %q", got)
+	}
+}
+
+func TestHardware_WindowsFiltersSoftwareAdapters(t *testing.T) {
+	for _, name := range []string{"Microsoft Basic Display Adapter", "Microsoft Remote Display Adapter"} {
+		if !isSoftwareDisplayAdapter(name) {
+			t.Fatalf("isSoftwareDisplayAdapter(%q) = false", name)
+		}
+	}
+}

--- a/internal/hw/nvidia.go
+++ b/internal/hw/nvidia.go
@@ -1,0 +1,213 @@
+package hw
+
+import (
+	"context"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+var errNvidiaSMINotAvailable = errors.New("nvidia-smi not available")
+
+type nvidiaRecord struct {
+	index        int
+	name         string
+	uuid         string
+	busID        string
+	architecture string
+	memoryBytes  uint64
+	driver       string
+	powerLimit   float64
+}
+
+func detectNvidia(ctx context.Context) ([]detectedAccelerator, error) {
+	if _, err := exec.LookPath("nvidia-smi"); err != nil {
+		return nil, errNvidiaSMINotAvailable
+	}
+
+	const fields = "index,name,uuid,pci.bus_id,memory.total,driver_version,power.limit"
+	output, err := exec.CommandContext(ctx, "nvidia-smi", "--query-gpu="+fields, "--format=csv,noheader,nounits").Output()
+	if err != nil {
+		return nil, fmt.Errorf("querying nvidia-smi: %w", err)
+	}
+	records, err := parseNvidiaCSV(string(output))
+	if err != nil {
+		return nil, err
+	}
+
+	architectureOutput, architectureErr := exec.CommandContext(ctx, "nvidia-smi", "--query-gpu=index,architecture", "--format=csv,noheader,nounits").Output()
+	if architectureErr == nil {
+		applyNvidiaArchitectures(records, string(architectureOutput))
+	}
+	if hasMissingNvidiaArchitecture(records) {
+		computeOutput, computeErr := exec.CommandContext(ctx, "nvidia-smi", "--query-gpu=index,compute_cap", "--format=csv,noheader,nounits").Output()
+		if computeErr == nil {
+			applyNvidiaComputeCapabilities(records, string(computeOutput))
+		}
+	}
+
+	result := make([]detectedAccelerator, 0, len(records))
+	for _, record := range records {
+		memory := AcceleratorMemory{Kind: "dedicated"}
+		if record.memoryBytes > 0 {
+			memory.CapacityBytes = uint64Ptr(record.memoryBytes)
+		}
+		var driver *Driver
+		if version := nonEmptyStringPtr(record.driver); version != nil {
+			driver = &Driver{Name: stringPtr("NVIDIA"), Version: version}
+		}
+		identity := normalizePCIIdentity(record.busID)
+		if identity == "" {
+			identity = strings.TrimSpace(record.uuid)
+		}
+		accelerator := Accelerator{
+			Kind:         "gpu",
+			Vendor:       stringPtr("NVIDIA"),
+			Model:        nonEmptyStringPtr(record.name),
+			Architecture: nonEmptyStringPtr(record.architecture),
+			Memory:       memory,
+			Driver:       driver,
+		}
+		if record.powerLimit > 0 {
+			accelerator.PowerLimitWatts = float64Ptr(record.powerLimit)
+		}
+		result = append(result, detectedAccelerator{identity: identity, value: accelerator})
+	}
+	return result, nil
+}
+
+func parseNvidiaCSV(output string) ([]nvidiaRecord, error) {
+	reader := csv.NewReader(strings.NewReader(output))
+	reader.TrimLeadingSpace = true
+	rows, err := reader.ReadAll()
+	if err != nil {
+		return nil, fmt.Errorf("parsing nvidia-smi output: %w", err)
+	}
+	result := make([]nvidiaRecord, 0, len(rows))
+	for _, row := range rows {
+		if len(row) != 7 {
+			return nil, fmt.Errorf("parsing nvidia-smi output: expected 7 columns, got %d", len(row))
+		}
+		index, err := strconv.Atoi(strings.TrimSpace(row[0]))
+		if err != nil {
+			return nil, fmt.Errorf("parsing nvidia-smi index: %w", err)
+		}
+		memoryMiB, _ := parseOptionalFloat(row[4])
+		powerLimit, _ := parseOptionalFloat(row[6])
+		result = append(result, nvidiaRecord{
+			index:       index,
+			name:        strings.TrimSpace(row[1]),
+			uuid:        strings.TrimSpace(row[2]),
+			busID:       strings.TrimSpace(row[3]),
+			memoryBytes: uint64(memoryMiB * 1024 * 1024),
+			driver:      strings.TrimSpace(row[5]),
+			powerLimit:  powerLimit,
+		})
+	}
+	return result, nil
+}
+
+func applyNvidiaArchitectures(records []nvidiaRecord, output string) {
+	applyNvidiaIndexedValues(records, output, func(record *nvidiaRecord, value string) {
+		record.architecture = value
+	})
+}
+
+func applyNvidiaComputeCapabilities(records []nvidiaRecord, output string) {
+	applyNvidiaIndexedValues(records, output, func(record *nvidiaRecord, value string) {
+		if record.architecture == "" {
+			record.architecture = nvidiaArchitectureForComputeCapability(value)
+		}
+	})
+}
+
+func applyNvidiaIndexedValues(records []nvidiaRecord, output string, apply func(*nvidiaRecord, string)) {
+	reader := csv.NewReader(strings.NewReader(output))
+	reader.TrimLeadingSpace = true
+	rows, err := reader.ReadAll()
+	if err != nil {
+		return
+	}
+	byIndex := make(map[int]*nvidiaRecord, len(records))
+	for i := range records {
+		byIndex[records[i].index] = &records[i]
+	}
+	for _, row := range rows {
+		if len(row) != 2 {
+			continue
+		}
+		index, err := strconv.Atoi(strings.TrimSpace(row[0]))
+		record := byIndex[index]
+		value := strings.TrimSpace(row[1])
+		if err == nil && record != nil && nonEmptyStringPtr(value) != nil {
+			apply(record, value)
+		}
+	}
+}
+
+func hasMissingNvidiaArchitecture(records []nvidiaRecord) bool {
+	for i := range records {
+		if records[i].architecture == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func nvidiaArchitectureForComputeCapability(value string) string {
+	switch strings.TrimSpace(value) {
+	case "2.0", "2.1":
+		return "Fermi"
+	case "3.0", "3.2", "3.5", "3.7":
+		return "Kepler"
+	case "5.0", "5.2", "5.3":
+		return "Maxwell"
+	case "6.0", "6.1", "6.2":
+		return "Pascal"
+	case "7.0", "7.2":
+		return "Volta"
+	case "7.5":
+		return "Turing"
+	case "8.0", "8.6", "8.7":
+		return "Ampere"
+	case "8.9":
+		return "Ada Lovelace"
+	case "9.0":
+		return "Hopper"
+	case "10.0", "10.3", "11.0", "12.0", "12.1":
+		return "Blackwell"
+	default:
+		return ""
+	}
+}
+
+func parseOptionalFloat(value string) (float64, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" || strings.EqualFold(value, "n/a") || strings.EqualFold(value, "[not supported]") {
+		return 0, false
+	}
+	parsed, err := strconv.ParseFloat(value, 64)
+	return parsed, err == nil
+}
+
+func normalizePCIIdentity(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" || strings.EqualFold(value, "n/a") {
+		return ""
+	}
+	parts := strings.Split(value, ":")
+	if len(parts) == 2 {
+		value = "0000:" + value
+		parts = strings.Split(value, ":")
+	}
+	if len(parts) == 3 {
+		if domain, err := strconv.ParseUint(parts[0], 16, 32); err == nil {
+			parts[0] = fmt.Sprintf("%04x", domain)
+			value = strings.Join(parts, ":")
+		}
+	}
+	return value
+}

--- a/internal/hw/types.go
+++ b/internal/hw/types.go
@@ -1,0 +1,92 @@
+package hw
+
+import "time"
+
+const SchemaVersion = 1
+
+const (
+	CaptureScopeInferenceHost = "inference_host"
+	CaptureMethodDetected     = "detected"
+)
+
+type HardwareSnapshot struct {
+	SchemaVersion   int                  `json:"schema_version"`
+	CapturedAt      time.Time            `json:"captured_at"`
+	Capture         HardwareCapture      `json:"capture"`
+	Architecture    Architecture         `json:"architecture"`
+	OperatingSystem OperatingSystem      `json:"operating_system"`
+	Environment     ExecutionEnvironment `json:"environment"`
+	CPU             CPU                  `json:"cpu"`
+	Memory          SystemMemory         `json:"memory"`
+	Accelerators    []Accelerator        `json:"accelerators"`
+}
+
+type HardwareCapture struct {
+	Scope    string        `json:"scope"`
+	Method   string        `json:"method"`
+	Detector *DetectorInfo `json:"detector"`
+}
+
+type DetectorInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type Architecture struct {
+	Name    string  `json:"name"`
+	RawName *string `json:"raw_name"`
+}
+
+type OperatingSystem struct {
+	Family    string  `json:"family"`
+	Name      *string `json:"name"`
+	Version   *string `json:"version"`
+	Kernel    *string `json:"kernel"`
+	RawFamily *string `json:"raw_family,omitempty"`
+}
+
+type ExecutionEnvironment struct {
+	Kind    string  `json:"kind"`
+	Name    *string `json:"name"`
+	Version *string `json:"version"`
+	RawKind *string `json:"raw_kind,omitempty"`
+}
+
+type CPU struct {
+	Vendor             *string `json:"vendor"`
+	Model              *string `json:"model"`
+	SocketCount        *int    `json:"socket_count"`
+	PhysicalCoreCount  *int    `json:"physical_core_count"`
+	LogicalThreadCount *int    `json:"logical_thread_count"`
+}
+
+type SystemMemory struct {
+	CapacityBytes uint64 `json:"capacity_bytes"`
+}
+
+type Accelerator struct {
+	Index           int               `json:"index"`
+	Kind            string            `json:"kind"`
+	RawKind         *string           `json:"raw_kind,omitempty"`
+	Vendor          *string           `json:"vendor"`
+	Model           *string           `json:"model"`
+	Architecture    *string           `json:"architecture"`
+	Memory          AcceleratorMemory `json:"memory"`
+	Driver          *Driver           `json:"driver"`
+	PowerLimitWatts *float64          `json:"power_limit_watts"`
+}
+
+type AcceleratorMemory struct {
+	Kind          string  `json:"kind"`
+	CapacityBytes *uint64 `json:"capacity_bytes"`
+}
+
+type Driver struct {
+	Name    *string `json:"name"`
+	Version *string `json:"version"`
+}
+
+type detectedAccelerator struct {
+	identity string
+	value    Accelerator
+}

--- a/internal/hw/validate.go
+++ b/internal/hw/validate.go
@@ -1,0 +1,91 @@
+package hw
+
+import (
+	"fmt"
+	"math"
+	"strings"
+)
+
+func (s HardwareSnapshot) Validate() error {
+	if s.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("schema_version must be %d", SchemaVersion)
+	}
+	if s.CapturedAt.IsZero() {
+		return fmt.Errorf("captured_at is required")
+	}
+	if s.Capture.Scope != CaptureScopeInferenceHost {
+		return fmt.Errorf("capture.scope must be %q", CaptureScopeInferenceHost)
+	}
+	if s.Capture.Method != CaptureMethodDetected {
+		return fmt.Errorf("capture.method must be %q", CaptureMethodDetected)
+	}
+	if s.Capture.Detector == nil || strings.TrimSpace(s.Capture.Detector.Name) == "" || strings.TrimSpace(s.Capture.Detector.Version) == "" {
+		return fmt.Errorf("capture.detector name and version are required")
+	}
+	if err := validateNamedValue("architecture", s.Architecture.Name, s.Architecture.RawName,
+		"x86_64", "arm64", "armv7", "ppc64le", "riscv64", "s390x", "other"); err != nil {
+		return err
+	}
+	if err := validateNamedValue("operating_system.family", s.OperatingSystem.Family, s.OperatingSystem.RawFamily,
+		"linux", "macos", "windows", "freebsd", "other"); err != nil {
+		return err
+	}
+	if err := validateNamedValue("environment.kind", s.Environment.Kind, s.Environment.RawKind,
+		"native", "container", "virtual_machine", "wsl", "other", "unknown"); err != nil {
+		return err
+	}
+	if s.Memory.CapacityBytes == 0 {
+		return fmt.Errorf("memory.capacity_bytes must be positive")
+	}
+	for name, value := range map[string]*int{
+		"cpu.socket_count":         s.CPU.SocketCount,
+		"cpu.physical_core_count":  s.CPU.PhysicalCoreCount,
+		"cpu.logical_thread_count": s.CPU.LogicalThreadCount,
+	} {
+		if value != nil && *value <= 0 {
+			return fmt.Errorf("%s must be positive", name)
+		}
+	}
+	if s.CPU.PhysicalCoreCount != nil && s.CPU.LogicalThreadCount != nil && *s.CPU.LogicalThreadCount < *s.CPU.PhysicalCoreCount {
+		return fmt.Errorf("cpu.logical_thread_count must be greater than or equal to physical_core_count")
+	}
+
+	for i, accelerator := range s.Accelerators {
+		path := fmt.Sprintf("accelerators[%d]", i)
+		if accelerator.Index != i {
+			return fmt.Errorf("%s.index must be %d", path, i)
+		}
+		if err := validateNamedValue(path+".kind", accelerator.Kind, accelerator.RawKind, "gpu", "npu", "other"); err != nil {
+			return err
+		}
+		switch accelerator.Memory.Kind {
+		case "dedicated", "unified", "shared_system", "unknown":
+		default:
+			return fmt.Errorf("%s.memory.kind is invalid", path)
+		}
+		if accelerator.Memory.CapacityBytes != nil && *accelerator.Memory.CapacityBytes == 0 {
+			return fmt.Errorf("%s.memory.capacity_bytes must be positive", path)
+		}
+		if accelerator.PowerLimitWatts != nil && (*accelerator.PowerLimitWatts <= 0 || math.IsNaN(*accelerator.PowerLimitWatts) || math.IsInf(*accelerator.PowerLimitWatts, 0)) {
+			return fmt.Errorf("%s.power_limit_watts must be positive and finite", path)
+		}
+	}
+	return nil
+}
+
+func validateNamedValue(path, value string, raw *string, allowed ...string) error {
+	valid := false
+	for _, candidate := range allowed {
+		if value == candidate {
+			valid = true
+			break
+		}
+	}
+	if !valid {
+		return fmt.Errorf("%s is invalid", path)
+	}
+	if value == "other" && (raw == nil || strings.TrimSpace(*raw) == "") {
+		return fmt.Errorf("%s raw value is required for other", path)
+	}
+	return nil
+}

--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -293,6 +293,18 @@ func (s *Server) handleAPIVersion(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleAPIHardware serves the hardware snapshot captured at process startup.
+func (s *Server) handleAPIHardware(w http.ResponseWriter, r *http.Request) {
+	if s.hardware == nil {
+		shared.SendResponse(w, r, http.StatusServiceUnavailable, "hardware detection unavailable")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(s.hardware); err != nil {
+		s.proxylog.Warnf("failed to encode hardware snapshot: %v", err)
+	}
+}
+
 // handleAPICapture returns the stored request/response capture for a metric ID.
 func (s *Server) handleAPICapture(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.Atoi(r.PathValue("id"))

--- a/internal/server/apigroup_test.go
+++ b/internal/server/apigroup_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mostlygeek/llama-swap/internal/cache"
 	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/hw"
 	"github.com/mostlygeek/llama-swap/internal/shared"
 	"github.com/mostlygeek/llama-swap/internal/store"
 )
@@ -289,6 +290,47 @@ func TestServer_APIVersion(t *testing.T) {
 	}
 	if got["version"] != "1.2.3" || got["commit"] != "deadbeef" || got["build_date"] != "2026-05-19" {
 		t.Errorf("body = %v", got)
+	}
+}
+
+func TestServer_APIHardware(t *testing.T) {
+	s := newTestServer(newStubRouter(nil, ""), newStubRouter(nil, ""))
+	s.hardware = &hw.HardwareSnapshot{
+		SchemaVersion: hw.SchemaVersion,
+		CapturedAt:    time.Date(2026, time.August, 3, 12, 0, 0, 0, time.UTC),
+		Capture: hw.HardwareCapture{
+			Scope:    hw.CaptureScopeInferenceHost,
+			Method:   hw.CaptureMethodDetected,
+			Detector: &hw.DetectorInfo{Name: "llama-swap", Version: "246"},
+		},
+		Architecture:    hw.Architecture{Name: "x86_64"},
+		OperatingSystem: hw.OperatingSystem{Family: "linux"},
+		Environment:     hw.ExecutionEnvironment{Kind: "unknown"},
+		Memory:          hw.SystemMemory{CapacityBytes: 1024},
+		Accelerators:    []hw.Accelerator{},
+	}
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/hardware", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var got hw.HardwareSnapshot
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.SchemaVersion != 1 || got.Memory.CapacityBytes != 1024 || got.Accelerators == nil {
+		t.Errorf("body = %+v", got)
+	}
+}
+
+func TestServer_APIHardwareUnavailable(t *testing.T) {
+	s := newTestServer(newStubRouter(nil, ""), newStubRouter(nil, ""))
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/hardware", nil))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusServiceUnavailable)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mostlygeek/llama-swap/internal/chain"
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/event"
+	"github.com/mostlygeek/llama-swap/internal/hw"
 	"github.com/mostlygeek/llama-swap/internal/logmon"
 	"github.com/mostlygeek/llama-swap/internal/perf"
 	"github.com/mostlygeek/llama-swap/internal/router"
@@ -35,6 +36,7 @@ type Server struct {
 	metrics  *metricsMonitor
 	store    *store.Store
 	build    BuildInfo
+	hardware *hw.HardwareSnapshot
 
 	profileMu     sync.RWMutex
 	activeProfile string
@@ -153,7 +155,7 @@ type BuildInfo struct {
 	Date    string
 }
 
-func New(cfg config.Config, muxlog *logmon.Monitor, proxylog *logmon.Monitor, upstreamlog *logmon.Monitor, perfMon *perf.Monitor, st *store.Store, build BuildInfo) (*Server, error) {
+func New(cfg config.Config, muxlog *logmon.Monitor, proxylog *logmon.Monitor, upstreamlog *logmon.Monitor, perfMon *perf.Monitor, st *store.Store, build BuildInfo, hardware *hw.HardwareSnapshot) (*Server, error) {
 	var local router.LocalRouter
 	var err error
 
@@ -190,6 +192,7 @@ func New(cfg config.Config, muxlog *logmon.Monitor, proxylog *logmon.Monitor, up
 		metrics:     newMetricsMonitor(proxylog, cfg.MetricsMaxInMemory, cfg.CaptureBuffer, st),
 		store:       st,
 		build:       build,
+		hardware:    hardware,
 		local:       local,
 		peer:        peer,
 		shutdownCtx: shutdownCtx,
@@ -304,6 +307,7 @@ func (s *Server) routes() {
 	mux.Handle("GET /api/metrics/stats", apiChain.ThenFunc(s.handleAPIActivityStats))
 	mux.Handle("GET /api/performance", apiChain.ThenFunc(s.handleAPIPerformance))
 	mux.Handle("GET /api/version", apiChain.ThenFunc(s.handleAPIVersion))
+	mux.Handle("GET /api/hardware", apiChain.ThenFunc(s.handleAPIHardware))
 	mux.Handle("GET /api/captures/{id}", apiChain.ThenFunc(s.handleAPICapture))
 
 	s.mux = mux

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -132,7 +132,7 @@ func TestServer_New_GroupConfig(t *testing.T) {
 		t.Fatalf("store.New: %v", err)
 	}
 	defer st.Close()
-	s, err := New(cfg, discard, discard, discard, nil, st, BuildInfo{})
+	s, err := New(cfg, discard, discard, discard, nil, st, BuildInfo{}, nil)
 	if err != nil {
 		t.Fatalf("New (group): %v", err)
 	}
@@ -162,7 +162,7 @@ func TestServer_New_MatrixConfig(t *testing.T) {
 		t.Fatalf("store.New: %v", err)
 	}
 	defer st.Close()
-	s, err := New(cfg, discard, discard, discard, nil, st, BuildInfo{})
+	s, err := New(cfg, discard, discard, discard, nil, st, BuildInfo{}, nil)
 	if err != nil {
 		t.Fatalf("New (matrix): %v", err)
 	}

--- a/llama-swap.go
+++ b/llama-swap.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/event"
+	"github.com/mostlygeek/llama-swap/internal/hw"
 	"github.com/mostlygeek/llama-swap/internal/logmon"
 	"github.com/mostlygeek/llama-swap/internal/perf"
 	"github.com/mostlygeek/llama-swap/internal/process"
@@ -128,6 +129,19 @@ func main() {
 	applyLogSettings(cfg)
 	proxyLog.Debugf("PID: %d", os.Getpid())
 
+	// Hardware describes the inference host and remains stable for the life of
+	// this process, including config reloads. Detection is best effort so an
+	// unavailable platform probe never prevents llama-swap from starting.
+	var hardwareSnapshot *hw.HardwareSnapshot
+	detectCtx, detectCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	detectedHardware, detectErr := hw.Detect(detectCtx, version)
+	detectCancel()
+	if detectErr != nil {
+		proxyLog.Warnf("hardware detection unavailable: %v", detectErr)
+	} else {
+		hardwareSnapshot = &detectedHardware
+	}
+
 	// On Windows, bind the process tree to a Job Object so every upstream
 	// process is reaped when llama-swap exits — even on a forced kill. No-op
 	// elsewhere. Non-fatal: a failure just falls back to per-process teardown.
@@ -157,7 +171,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	initialSrv, err := server.New(cfg, muxLog, proxyLog, upstreamLog, perfMon, initialStore, buildInfo)
+	initialSrv, err := server.New(cfg, muxLog, proxyLog, upstreamLog, perfMon, initialStore, buildInfo, hardwareSnapshot)
 	if err != nil {
 		slog.Error("failed to create server", "error", err)
 		initialStore.Close()
@@ -227,7 +241,7 @@ func main() {
 			}
 		}
 
-		newSrv, err := server.New(newCfg, muxLog, proxyLog, upstreamLog, perfMon, newStore, buildInfo)
+		newSrv, err := server.New(newCfg, muxLog, proxyLog, upstreamLog, perfMon, newStore, buildInfo, hardwareSnapshot)
 		if err != nil {
 			proxyLog.Warnf("failed to build new server during reload: %v", err)
 			if storeChanged {

--- a/ui-svelte/src/App.svelte
+++ b/ui-svelte/src/App.svelte
@@ -39,6 +39,7 @@
     "/activity": wrap({ asyncComponent: () => import("./routes/Activity.svelte"), loadingComponent: RouteLoading }),
     "/settings": wrap({ asyncComponent: () => import("./routes/Settings.svelte"), loadingComponent: RouteLoading }),
     "/performance": wrap({ asyncComponent: () => import("./routes/Performance.svelte"), loadingComponent: RouteLoading }),
+    "/hardware": wrap({ asyncComponent: () => import("./routes/Hardware.svelte"), loadingComponent: RouteLoading }),
     "*": wrap({ asyncComponent: () => import("./routes/Activity.svelte"), loadingComponent: RouteLoading }),
   };
 
@@ -50,6 +51,7 @@
     "/logs": "Logs",
     "/settings": "Settings",
     "/performance": "Performance",
+    "/hardware": "Hardware",
   };
 
   let sectionTitle = $derived.by(() => {

--- a/ui-svelte/src/components/AppSidebar.svelte
+++ b/ui-svelte/src/components/AppSidebar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { link } from "svelte-spa-router";
-  import { FerrisWheel, Boxes, Activity, ScrollText, Gauge, Sun, Moon, Monitor, ChevronRight, Settings } from "@lucide/svelte";
+  import { FerrisWheel, Boxes, Activity, ScrollText, Gauge, Cpu, Sun, Moon, Monitor, ChevronRight, Settings } from "@lucide/svelte";
   import * as Sidebar from "$lib/components/ui/sidebar/index.js";
   import * as Collapsible from "$lib/components/ui/collapsible/index.js";
   import { Button } from "$lib/components/ui/button/index.js";
@@ -193,6 +193,17 @@
               </Sidebar.MenuButton>
             </Sidebar.MenuItem>
           {/if}
+
+          <Sidebar.MenuItem>
+            <Sidebar.MenuButton isActive={isActive("/hardware", $currentRoute)} tooltipContent="Hardware">
+              {#snippet child({ props })}
+                <a href="/hardware" use:link {...props}>
+                  <Cpu />
+                  <span>Hardware</span>
+                </a>
+              {/snippet}
+            </Sidebar.MenuButton>
+          </Sidebar.MenuItem>
         </Sidebar.Menu>
       </Sidebar.GroupContent>
     </Sidebar.Group>

--- a/ui-svelte/src/lib/format.test.ts
+++ b/ui-svelte/src/lib/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { formatDuration, formatSpeed, formatFileSize, formatRelativeTime } from "./format";
+import { formatDuration, formatSpeed, formatFileSize, formatCapacity, formatRelativeTime } from "./format";
 
 describe("formatDuration", () => {
   it("defaults to seconds with 2 decimals", () => {
@@ -41,6 +41,17 @@ describe("formatFileSize", () => {
 
   it("formats megabytes", () => {
     expect(formatFileSize(5 * 1024 * 1024)).toBe("5.0 MB");
+  });
+});
+
+describe("formatCapacity", () => {
+  it("formats binary hardware capacities", () => {
+    expect(formatCapacity(24 * 1024 ** 3)).toBe("24.0 GiB");
+    expect(formatCapacity(1.5 * 1024 ** 4)).toBe("1.50 TiB");
+  });
+
+  it("handles unavailable capacities", () => {
+    expect(formatCapacity(0)).toBe("Not detected");
   });
 });
 

--- a/ui-svelte/src/lib/format.ts
+++ b/ui-svelte/src/lib/format.ts
@@ -28,6 +28,20 @@ export function formatFileSize(bytes: number): string {
   return (bytes / (1024 * 1024)).toFixed(1) + " MB";
 }
 
+/** Format a hardware capacity using binary units through TiB. */
+export function formatCapacity(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "Not detected";
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  const precision = unit < 2 || value >= 100 ? 0 : value >= 10 ? 1 : 2;
+  return `${value.toFixed(precision)} ${units[unit]}`;
+}
+
 /** Format a timestamp as a relative time or local timestamp when older than a day. */
 export function formatRelativeTime(timestamp: string): string {
   const now = new Date();

--- a/ui-svelte/src/lib/types.ts
+++ b/ui-svelte/src/lib/types.ts
@@ -184,6 +184,71 @@ export interface VersionInfo {
   version: string;
 }
 
+export interface HardwareSnapshot {
+  schema_version: number;
+  captured_at: string;
+  capture: HardwareCapture;
+  architecture: HardwareArchitecture;
+  operating_system: HardwareOperatingSystem;
+  environment: HardwareEnvironment;
+  cpu: HardwareCPU;
+  memory: HardwareMemory;
+  accelerators: HardwareAccelerator[];
+}
+
+export interface HardwareCapture {
+  scope: "inference_host";
+  method: "detected" | "detected_and_edited" | "manual";
+  detector: { name: string; version: string } | null;
+}
+
+export interface HardwareArchitecture {
+  name: string;
+  raw_name?: string | null;
+}
+
+export interface HardwareOperatingSystem {
+  family: string;
+  name: string | null;
+  version: string | null;
+  kernel: string | null;
+  raw_family?: string | null;
+}
+
+export interface HardwareEnvironment {
+  kind: string;
+  name: string | null;
+  version: string | null;
+  raw_kind?: string | null;
+}
+
+export interface HardwareCPU {
+  vendor: string | null;
+  model: string | null;
+  socket_count: number | null;
+  physical_core_count: number | null;
+  logical_thread_count: number | null;
+}
+
+export interface HardwareMemory {
+  capacity_bytes: number;
+}
+
+export interface HardwareAccelerator {
+  index: number;
+  kind: "gpu" | "npu" | "other";
+  raw_kind?: string | null;
+  vendor: string | null;
+  model: string | null;
+  architecture: string | null;
+  memory: {
+    kind: "dedicated" | "unified" | "shared_system" | "unknown";
+    capacity_bytes: number | null;
+  };
+  driver: { name: string | null; version: string | null } | null;
+  power_limit_watts: number | null;
+}
+
 export type ScreenWidth = "xs" | "sm" | "md" | "lg" | "xl" | "2xl";
 
 export type TextContentPart = {

--- a/ui-svelte/src/routes/Hardware.svelte
+++ b/ui-svelte/src/routes/Hardware.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { getHardware } from "../stores/api";
+  import type { HardwareAccelerator, HardwareSnapshot } from "../lib/types";
+  import { formatCapacity } from "../lib/format";
+  import { copyText } from "../lib/clipboard";
+  import { Check, Copy } from "@lucide/svelte";
+  import { Button } from "$lib/components/ui/button/index.js";
+  import { Tabs, TabsContent, TabsList, TabsTrigger } from "$lib/components/ui/tabs/index.js";
+
+  let hardware = $state<HardwareSnapshot | null>(null);
+  let loading = $state(true);
+  let error = $state("");
+  let copied = $state(false);
+
+  onMount(async () => {
+    try {
+      hardware = await getHardware();
+    } catch (cause) {
+      error = cause instanceof Error ? cause.message : "Hardware detection unavailable";
+    } finally {
+      loading = false;
+    }
+  });
+
+  function shown(value: string | number | null | undefined): string {
+    return value === null || value === undefined || value === "" ? "Not detected" : String(value);
+  }
+
+  function titleCase(value: string): string {
+    return value.replaceAll("_", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+  }
+
+  function osLabel(snapshot: HardwareSnapshot): string {
+    return [snapshot.operating_system.name ?? titleCase(snapshot.operating_system.family), snapshot.operating_system.version]
+      .filter(Boolean)
+      .join(" ");
+  }
+
+  function acceleratorTitle(accelerator: HardwareAccelerator): string {
+    return accelerator.model ?? `${titleCase(accelerator.kind)} ${accelerator.index + 1}`;
+  }
+
+  function environmentLabel(snapshot: HardwareSnapshot): string {
+    return `${titleCase(snapshot.environment.kind)}${snapshot.environment.name ? ` (${snapshot.environment.name})` : ""}${snapshot.environment.version ? ` ${snapshot.environment.version}` : ""}`;
+  }
+
+  function driverLabel(accelerator: HardwareAccelerator): string {
+    return accelerator.driver
+      ? [accelerator.driver.name, accelerator.driver.version].filter(Boolean).join(" ") || "Not detected"
+      : "Not detected";
+  }
+
+  function acceleratorSummary(accelerator: HardwareAccelerator): string[] {
+    return [
+      `Accelerator ${accelerator.index + 1}: ${acceleratorTitle(accelerator)}`,
+      `  Type: ${titleCase(accelerator.kind)}`,
+      `  Vendor: ${shown(accelerator.vendor)}`,
+      `  Architecture: ${shown(accelerator.architecture)}`,
+      `  Memory: ${accelerator.memory.capacity_bytes ? formatCapacity(accelerator.memory.capacity_bytes) : "Not detected"} (${titleCase(accelerator.memory.kind)})`,
+      `  Driver: ${driverLabel(accelerator)}`,
+      `  Power Limit: ${accelerator.power_limit_watts === null ? "Not detected" : `${accelerator.power_limit_watts} W`}`,
+    ];
+  }
+
+  function hardwareSummary(snapshot: HardwareSnapshot): string {
+    const acceleratorLines = snapshot.accelerators.length === 0
+      ? ["No accelerators were detected or exposed to this process."]
+      : snapshot.accelerators.flatMap((accelerator, index) => [
+          ...(index > 0 ? [""] : []),
+          ...acceleratorSummary(accelerator),
+        ]);
+
+    return [
+      "Hardware Summary",
+      "",
+      "System",
+      `  Operating System: ${osLabel(snapshot)}`,
+      `  Kernel: ${shown(snapshot.operating_system.kernel)}`,
+      `  Architecture: ${snapshot.architecture.name}`,
+      `  Environment: ${environmentLabel(snapshot)}`,
+      `  System Memory: ${formatCapacity(snapshot.memory.capacity_bytes)}`,
+      "",
+      "CPU",
+      `  Model: ${shown(snapshot.cpu.model)}`,
+      `  Vendor: ${shown(snapshot.cpu.vendor)}`,
+      `  Sockets: ${shown(snapshot.cpu.socket_count)}`,
+      `  Physical Cores: ${shown(snapshot.cpu.physical_core_count)}`,
+      `  Logical Threads: ${shown(snapshot.cpu.logical_thread_count)}`,
+      "",
+      `Accelerators (${snapshot.accelerators.length})`,
+      ...acceleratorLines,
+    ].join("\n");
+  }
+
+  let summary = $derived(hardware ? hardwareSummary(hardware) : "");
+
+  async function copySummary() {
+    if (await copyText(summary)) {
+      copied = true;
+      window.setTimeout(() => (copied = false), 2000);
+    }
+  }
+</script>
+
+<div class="p-2">
+  <div class="mt-4 mb-4">
+    <h3 class="text-lg font-semibold">Hardware</h3>
+    <p class="text-sm text-muted-foreground">
+      This is an experimental feature. Please share feedback in <a
+        class="underline hover:text-foreground"
+        href="https://github.com/mostlygeek/llama-swap/issues/977">issue 977</a
+      >.
+    </p>
+  </div>
+
+  {#if loading}
+    <div class="rounded-lg border p-6 text-sm text-muted-foreground">Loading hardware profile…</div>
+  {:else if error || !hardware}
+    <div class="rounded-lg border border-destructive/50 p-6">
+      <h4 class="font-semibold">Hardware detection unavailable</h4>
+      <p class="mt-1 text-sm text-muted-foreground">{error || "No hardware snapshot was captured at startup."}</p>
+    </div>
+  {:else}
+    <Tabs value="overview">
+      <TabsList variant="line">
+        <TabsTrigger value="overview">Overview</TabsTrigger>
+        <TabsTrigger value="summary">Text</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="overview" class="mt-4">
+        <div class="grid gap-4 lg:grid-cols-2">
+          <section class="rounded-lg border p-4">
+            <h4 class="mb-3 text-sm font-semibold text-muted-foreground">System</h4>
+            <dl class="grid grid-cols-[minmax(8rem,auto)_1fr] gap-x-4 gap-y-2 text-sm">
+              <dt class="text-muted-foreground">Operating System</dt><dd>{osLabel(hardware)}</dd>
+              <dt class="text-muted-foreground">Kernel</dt><dd>{shown(hardware.operating_system.kernel)}</dd>
+              <dt class="text-muted-foreground">Architecture</dt><dd>{hardware.architecture.name}</dd>
+              <dt class="text-muted-foreground">Environment</dt><dd>{environmentLabel(hardware)}</dd>
+              <dt class="text-muted-foreground">System Memory</dt><dd>{formatCapacity(hardware.memory.capacity_bytes)}</dd>
+            </dl>
+          </section>
+
+          <section class="rounded-lg border p-4">
+            <h4 class="mb-3 text-sm font-semibold text-muted-foreground">CPU</h4>
+            <dl class="grid grid-cols-[minmax(8rem,auto)_1fr] gap-x-4 gap-y-2 text-sm">
+              <dt class="text-muted-foreground">Model</dt><dd>{shown(hardware.cpu.model)}</dd>
+              <dt class="text-muted-foreground">Vendor</dt><dd>{shown(hardware.cpu.vendor)}</dd>
+              <dt class="text-muted-foreground">Sockets</dt><dd>{shown(hardware.cpu.socket_count)}</dd>
+              <dt class="text-muted-foreground">Physical Cores</dt><dd>{shown(hardware.cpu.physical_core_count)}</dd>
+              <dt class="text-muted-foreground">Logical Threads</dt><dd>{shown(hardware.cpu.logical_thread_count)}</dd>
+            </dl>
+          </section>
+        </div>
+
+        <section class="mt-4 rounded-lg border p-4">
+          <div class="mb-3 flex items-baseline justify-between gap-4">
+            <h4 class="text-sm font-semibold text-muted-foreground">Accelerators</h4>
+            <span class="text-xs text-muted-foreground">{hardware.accelerators.length} detected</span>
+          </div>
+          {#if hardware.accelerators.length === 0}
+            <p class="text-sm text-muted-foreground">No accelerators were detected or exposed to this process.</p>
+          {:else}
+            <div class="grid gap-3 lg:grid-cols-2 2xl:grid-cols-3">
+              {#each hardware.accelerators as accelerator (accelerator.index)}
+                <article class="rounded-md border bg-muted/20 p-3">
+                  <div class="mb-3">
+                    <h5 class="font-medium">{acceleratorTitle(accelerator)}</h5>
+                    <p class="text-xs text-muted-foreground">{shown(accelerator.vendor)} · {titleCase(accelerator.kind)}</p>
+                  </div>
+                  <dl class="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-sm">
+                    <dt class="text-muted-foreground">Architecture</dt><dd>{shown(accelerator.architecture)}</dd>
+                    <dt class="text-muted-foreground">Memory</dt>
+                    <dd>{accelerator.memory.capacity_bytes ? formatCapacity(accelerator.memory.capacity_bytes) : "Not detected"} ({titleCase(accelerator.memory.kind)})</dd>
+                    <dt class="text-muted-foreground">Driver</dt><dd>{driverLabel(accelerator)}</dd>
+                    <dt class="text-muted-foreground">Power Limit</dt>
+                    <dd>{accelerator.power_limit_watts === null ? "Not detected" : `${accelerator.power_limit_watts} W`}</dd>
+                  </dl>
+                </article>
+              {/each}
+            </div>
+          {/if}
+        </section>
+      </TabsContent>
+
+      <TabsContent value="summary" class="mt-4">
+        <section class="rounded-lg border p-4">
+          <div class="mb-3 flex items-center justify-between gap-4">
+            <p class="text-sm text-muted-foreground">Plain text formatted for sharing in bug reports and support requests.</p>
+            <Button variant="outline" size="sm" onclick={copySummary} title="Copy hardware summary">
+              {#if copied}
+                <Check /> Copied
+              {:else}
+                <Copy /> Copy
+              {/if}
+            </Button>
+          </div>
+          <textarea
+            class="min-h-112 w-full resize-y rounded-md border bg-muted/20 p-3 font-mono text-sm leading-5"
+            aria-label="Hardware text summary"
+            readonly
+            value={summary}
+          ></textarea>
+        </section>
+      </TabsContent>
+    </Tabs>
+  {/if}
+</div>

--- a/ui-svelte/src/stores/api.test.ts
+++ b/ui-svelte/src/stores/api.test.ts
@@ -5,6 +5,7 @@ import {
   activityRevision,
   fetchPlaygroundModels,
   fetchProfiles,
+  getHardware,
   handleAPIEventMessage,
   hasListedModels,
   inFlightRequests,
@@ -24,6 +25,30 @@ afterEach(() => {
   playgroundModels.set([]);
   profiles.set([]);
   activeProfile.set(null);
+});
+
+describe("hardware api", () => {
+  it("fetches the hardware snapshot", async () => {
+    const snapshot = {
+      schema_version: 1,
+      captured_at: "2026-08-03T12:00:00Z",
+      capture: { scope: "inference_host", method: "detected", detector: { name: "llama-swap", version: "246" } },
+      architecture: { name: "x86_64" },
+      operating_system: { family: "linux", name: "Ubuntu", version: "24.04", kernel: "6.8" },
+      environment: { kind: "native", name: null, version: null },
+      cpu: { vendor: "AMD", model: "Ryzen", socket_count: 1, physical_core_count: 16, logical_thread_count: 32 },
+      memory: { capacity_bytes: 1024 },
+      accelerators: [],
+    };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => snapshot }));
+    await expect(getHardware()).resolves.toEqual(snapshot);
+    expect(fetch).toHaveBeenCalledWith("/api/hardware");
+  });
+
+  it("rejects unavailable hardware", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+    await expect(getHardware()).rejects.toThrow("Failed to fetch hardware: 503");
+  });
 });
 
 describe("api store event handling", () => {

--- a/ui-svelte/src/stores/api.ts
+++ b/ui-svelte/src/stores/api.ts
@@ -14,6 +14,7 @@ import type {
   Profile,
   ProfileState,
   PlaygroundModelType,
+  HardwareSnapshot,
 } from "../lib/types";
 import { connectionState } from "./theme";
 
@@ -480,4 +481,12 @@ export async function fetchPerformance(after?: string): Promise<PerformanceRespo
     console.error("Failed to fetch performance data:", error);
     return null;
   }
+}
+
+export async function getHardware(): Promise<HardwareSnapshot> {
+  const response = await fetch("/api/hardware");
+  if (!response.ok) {
+    throw new Error(`Failed to fetch hardware: ${response.status}`);
+  }
+  return await response.json() as HardwareSnapshot;
 }


### PR DESCRIPTION
Detect the hardware available to the inference host and expose it through the API and UI.

- Detect operating system, CPU, memory, and accelerator details
- Provide a hardware snapshot endpoint with platform-specific collectors
- Show an overview and copyable text summary in the UI

update: #977