### PR TITLE
Support argv-based vLLM startup in `vllm-wrapper`

### DIFF
--- a/cmd/vllm-wrapper/README.md
+++ b/cmd/vllm-wrapper/README.md
@@ -97,14 +97,19 @@ Configure your model's `cmdStop` to invoke `vllm-wrapper sleep`:
 ```yaml
 models:
   my-vllm-model:
-    cmdStop: vllm-wrapper sleep --vllm-url http://127.0.0.1:8000
-    # Optional flag:
+    cmdStop: |
+      vllm-wrapper sleep
+      --vllm-url http://127.0.0.1:8000
+      --stop-pid ${PID}
+    # Optional flags:
     #   --sleep-level: sleep level to use (default: 1)
+    #   --stop-pid: PID of the serve proxy to terminate after a successful sleep request
 ```
 
 When llama-swap stops the model, it will:
 1. Send a sleep request to the vLLM daemon (POST to `/sleep` with JSON `{"level": 1}`).
-2. Exit with status 0, leaving the vLLM daemon running but asleep.
+2. If `--stop-pid` is provided, send SIGTERM to the specified `vllm-wrapper serve` process after the sleep request succeeds.
+3. Exit with status 0, leaving the vLLM daemon running but asleep while allowing llama-swap to complete the unload operation.
 
 ## Example Configuration
 
@@ -114,7 +119,7 @@ Here is a complete example using vLLM with sleep mode, demonstrating cold start 
 models:
   qwen-7b-chat:
     cmd: vllm-wrapper serve --vllm-url http://127.0.0.1:8000 --listen :${PORT} --start-cmd "docker run --rm -p 8000:8000 ... --enable-sleep-mode"
-    cmdStop: vllm-wrapper sleep --vllm-url http://127.0.0.1:8000
+    cmdStop: vllm-wrapper sleep --vllm-url http://127.0.0.1:8000 --stop-pid ${PID}
     # You may also want to set a TTL to automatically unload after a period of inactivity:
     ttl: 3600   # unload after 1 hour of inactivity
 ```
@@ -220,7 +225,8 @@ sudo -u llama env \
 ### sleep subcommand
 
 1. Sends a POST request to `${vllm-url}/sleep` with a JSON body `{"level": <level>}` where `<level>` is the sleep level (default 1).
-2. Upon receiving a successful response (HTTP 200), exits with status 0.
+2. If `--stop-pid` is provided, sends SIGTERM to the specified `vllm-wrapper serve` process after the sleep request succeeds.
+3. Exits with status 0, leaving the vLLM daemon running in sleep mode.
 
 ## Notes
 

--- a/cmd/vllm-wrapper/README.md
+++ b/cmd/vllm-wrapper/README.md
@@ -159,6 +159,8 @@ cmd: |
   --vllm-url http://127.0.0.1:18000
   --listen :${PORT}
   --wait-timeout 5m
+  --journal-unit: vllm-qwen.service
+  # optional systemd user unit whose new journal entries are forwarded to the wrapper's stdout, making vLLM logs available through llama-swap's upstream log stream.
   --
   systemd-run
   --user

--- a/cmd/vllm-wrapper/README.md
+++ b/cmd/vllm-wrapper/README.md
@@ -15,7 +15,7 @@ When using vLLM with llama-swap, you can leverage vLLM's sleep mode to drastical
 
 - vLLM server must be started with `--enable-sleep-mode`.
 - The vLLM server must be reachable at the URL provided to the wrapper.
-- To enable automatic start‑if‑not‑running, provide either a `--start-cmd` flag with a shell command (e.g., `docker run ...`) or pass the daemon executable and arguments after `--`. The argv-based method is preferred for native vLLM installations; `--start-cmd` is retained for backward compatibility.
+- To enable automatic start‑if‑not‑running, provide the daemon executable and arguments after `--`.
 
 ## Installation
 
@@ -35,30 +35,7 @@ go install ./cmd/vllm-wrapper
 
 ### As a model's `cmd`
 
-#### With `--start-cmd` (shell string)
-
-Configure your model in `config.yaml` with a `cmd` that invokes `vllm-wrapper serve`:
-
-```yaml
-models:
-  my-vllm-model:
-    cmd: vllm-wrapper serve --vllm-url http://127.0.0.1:8000 --listen :${PORT} --start-cmd "docker run --rm -p 8000:8000 ... --enable-sleep-mode"
-    # Optional flags:
-    #   --sleep-level: sleep level to use when sleeping (default: 1)
-    #   --health-path: health check path (default: /health)
-    #   --wait-timeout: timeout waiting for daemon to become healthy (default: 120s)
-```
-
-When llama-swap starts the model, it will:
-1. Check if the vLLM daemon is healthy by querying `${vllm-url}${health-path}` (default `/health`).
-2. If healthy and awake, proceed to step 4.
-3. If not healthy, attempt to wake the daemon by calling `${vllm-url}/wake_up`.
-4. If wake‑up fails (e.g., connection refused), execute the `--start-cmd` to start the daemon.
-5. Wait for the daemon to become healthy (polling the health path).
-6. Start a reverse proxy from the port assigned by llama-swap (via `${PORT}`) to `${vllm-url}`.
-7. Stay in the foreground as a proxy, allowing llama-swap to consider the model as running.
-
-#### With argv-based startup (after `--`)
+#### Daemon startup
 
 For native vLLM installations or when `llama-swap` splits the command into separate arguments, use the `--` separator. Everything after `--` is treated as the daemon executable and its arguments, launched directly without `sh -c`:
 
@@ -79,8 +56,6 @@ models:
       --max-model-len ${context_size}
       --enable-sleep-mode
 ```
-
-Precedence: if both `--start-cmd` and arguments after `--` are provided, the argv-based command takes priority. The `--start-cmd` fallback is used only when no positional arguments follow `--`.
 
 Benefits of argv-based startup:
 - Enables native vLLM without Docker.
@@ -118,7 +93,17 @@ Here is a complete example using vLLM with sleep mode, demonstrating cold start 
 ```yaml
 models:
   qwen-7b-chat:
-    cmd: vllm-wrapper serve --vllm-url http://127.0.0.1:8000 --listen :${PORT} --start-cmd "docker run --rm -p 8000:8000 ... --enable-sleep-mode"
+    cmd: |
+      vllm-wrapper serve
+      --vllm-url http://127.0.0.1:8000
+      --listen :${PORT}
+      --
+      ${vllm}
+      serve
+      ${model_path}
+      --host 127.0.0.1
+      --port 8000
+      --enable-sleep-mode
     cmdStop: vllm-wrapper sleep --vllm-url http://127.0.0.1:8000 --stop-pid ${PID}
     # You may also want to set a TTL to automatically unload after a period of inactivity:
     ttl: 3600   # unload after 1 hour of inactivity
@@ -211,15 +196,13 @@ sudo -u llama env \
     -o cat
 ```
 
-
-
 ## How it works
 
 ### serve subcommand
 
 1. **Health check**: Sends a GET request to `${vllm-url}${health-path}` (default `/health`). If the response is HTTP 200, the daemon is considered healthy and awake, and we proceed to step 4.
 2. **Wake up**: If the health check fails (non‑200 or connection error), send a POST request to `${vllm-url}/wake_up`. If the wake‑up succeeds (HTTP 200 or 204), proceed to step 4.
-3. **Start daemon**: If the wake‑up fails (indicating the daemon is not running), use the command specified after `--` (argv-based, launched via `exec.Command`), or fall back to `--start-cmd` (run via `sh -c`). The wrapper starts the command as a child process, then waits for the daemon to become healthy by polling the health path.
+3. **Start daemon**: If the wake‑up fails (indicating the daemon is not running), use the command specified after `--` (argv-based, launched via `exec.Command`). The wrapper starts the command as a child process, then waits for the daemon to become healthy by polling the health path.
 4. **Reverse proxy**: Once the daemon is healthy, start an HTTP server listening on `${PORT}` (or the address provided to `--listen`) that proxies all requests to the vLLM upstream URL. The proxy preserves streaming responses by setting `X-Accel-Buffering: no`.
 
 ### sleep subcommand
@@ -234,7 +217,7 @@ sudo -u llama env \
 - It is designed to be simple and robust.
 - For production use, ensure the vLLM daemon is properly managed (e.g., restarted if it crashes) outside of this wrapper.
 - The wrapper does not handle TLS certificates; if your vLLM server uses HTTPS, provide the appropriate URL and ensure the system's root CAs are configured.
-- On SIGTERM/SIGINT, the wrapper exits cleanly and does **not** kill the vLLM daemon, allowing it to be slept later.
+- On SIGTERM, the wrapper sends a sleep request to vLLM (using the configured sleep level) before shutting down, then exits cleanly without killing the vLLM daemon.
 
 ## Building
 

--- a/cmd/vllm-wrapper/README.md
+++ b/cmd/vllm-wrapper/README.md
@@ -119,6 +119,93 @@ models:
     ttl: 3600   # unload after 1 hour of inactivity
 ```
 
+## Systemd setup for native vLLM startup
+
+`llama-swap` runs as the system service user `llama`, while vLLM is started as a transient user service with `systemd-run --user`.
+
+Enable the user systemd manager:
+
+```bash
+sudo loginctl enable-linger llama
+
+uid=$(id -u llama)
+sudo systemctl start "user@${uid}.service"
+```
+
+Expose the user D-Bus session to `llama.service`:
+
+```bash
+sudo mkdir -p /etc/systemd/system/llama.service.d
+
+sudo tee /etc/systemd/system/llama.service.d/user-bus.conf >/dev/null <<EOF
+[Unit]
+Wants=user@${uid}.service
+After=user@${uid}.service
+
+[Service]
+Environment=XDG_RUNTIME_DIR=/run/user/${uid}
+Environment=DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${uid}/bus
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl restart llama.service
+```
+
+Use `systemd-run` in the `llama-swap` model command:
+
+```yaml
+cmd: |
+  vllm-wrapper serve
+  --vllm-url http://127.0.0.1:18000
+  --listen :${PORT}
+  --wait-timeout 5m
+  --
+  systemd-run
+  --user
+  --unit=vllm-qwen
+  --collect
+  --property=Restart=no
+  --property=StandardOutput=journal
+  --property=StandardError=journal
+  --setenv=HF_HOME
+  --setenv=VLLM_SERVER_DEV_MODE
+  --
+  ${vllm}
+  serve
+  ${model}
+  --port 18000
+  --enable-sleep-mode
+```
+
+Environment variables required by vLLM must be passed explicitly with `--setenv`.
+
+Check the service status:
+
+```bash
+uid=$(id -u llama)
+
+sudo -u llama env \
+  XDG_RUNTIME_DIR="/run/user/${uid}" \
+  DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${uid}/bus" \
+  systemctl --user status vllm-qwen.service
+```
+
+Follow the vLLM logs:
+
+```bash
+uid=$(id -u llama)
+
+sudo -u llama env \
+  XDG_RUNTIME_DIR="/run/user/${uid}" \
+  DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/${uid}/bus" \
+  journalctl --user \
+    -u vllm-qwen.service \
+    -f \
+    -o cat
+```
+
+
+
 ## How it works
 
 ### serve subcommand

--- a/cmd/vllm-wrapper/README.md
+++ b/cmd/vllm-wrapper/README.md
@@ -75,7 +75,7 @@ models:
       serve
       ${model_path}
       --host 127.0.0.1
-      --port 8001
+      --port 8000
       --max-model-len ${context_size}
       --enable-sleep-mode
 ```

--- a/cmd/vllm-wrapper/README.md
+++ b/cmd/vllm-wrapper/README.md
@@ -15,7 +15,7 @@ When using vLLM with llama-swap, you can leverage vLLM's sleep mode to drastical
 
 - vLLM server must be started with `--enable-sleep-mode`.
 - The vLLM server must be reachable at the URL provided to the wrapper.
-- To enable automatic start‑if‑not‑running, provide a `--start-cmd` flag with a command that launches the vLLM server (e.g., a `docker run` command that includes `--enable-sleep-mode`). The wrapper will start the daemon if it is not reachable, then wait for it to become healthy.
+- To enable automatic start‑if‑not‑running, provide either a `--start-cmd` flag with a shell command (e.g., `docker run ...`) or pass the daemon executable and arguments after `--`. The argv-based method is preferred for native vLLM installations; `--start-cmd` is retained for backward compatibility.
 
 ## Installation
 
@@ -34,6 +34,8 @@ go install ./cmd/vllm-wrapper
 ## Usage in llama-swap
 
 ### As a model's `cmd`
+
+#### With `--start-cmd` (shell string)
 
 Configure your model in `config.yaml` with a `cmd` that invokes `vllm-wrapper serve`:
 
@@ -55,6 +57,38 @@ When llama-swap starts the model, it will:
 5. Wait for the daemon to become healthy (polling the health path).
 6. Start a reverse proxy from the port assigned by llama-swap (via `${PORT}`) to `${vllm-url}`.
 7. Stay in the foreground as a proxy, allowing llama-swap to consider the model as running.
+
+#### With argv-based startup (after `--`)
+
+For native vLLM installations or when `llama-swap` splits the command into separate arguments, use the `--` separator. Everything after `--` is treated as the daemon executable and its arguments, launched directly without `sh -c`:
+
+```yaml
+models:
+  my-vllm-model:
+    cmd: |
+      vllm-wrapper serve
+      --vllm-url http://127.0.0.1:8000
+      --listen :${PORT}
+      --wait-timeout 600s
+      --
+      ${vllm}
+      serve
+      ${model_path}
+      --host 127.0.0.1
+      --port 8001
+      --max-model-len ${context_size}
+      --enable-sleep-mode
+```
+
+Precedence: if both `--start-cmd` and arguments after `--` are provided, the argv-based command takes priority. The `--start-cmd` fallback is used only when no positional arguments follow `--`.
+
+Benefits of argv-based startup:
+- Enables native vLLM without Docker.
+- Supports vLLM executables defined through llama-swap macros.
+- Allows readable multiline commands in YAML.
+- Preserves individual vLLM options (can be commented out).
+- Avoids shell parsing overhead.
+- Correctly preserves arguments containing spaces.
 
 ### As a model's `cmdStop`
 
@@ -91,7 +125,7 @@ models:
 
 1. **Health check**: Sends a GET request to `${vllm-url}${health-path}` (default `/health`). If the response is HTTP 200, the daemon is considered healthy and awake, and we proceed to step 4.
 2. **Wake up**: If the health check fails (non‑200 or connection error), send a POST request to `${vllm-url}/wake_up`. If the wake‑up succeeds (HTTP 200 or 204), proceed to step 4.
-3. **Start daemon**: If the wake‑up fails (indicating the daemon is not running), execute the command specified by `--start-cmd` (run via `sh -c`). The wrapper starts the command as a child process, then waits for the daemon to become healthy by polling the health path.
+3. **Start daemon**: If the wake‑up fails (indicating the daemon is not running), use the command specified after `--` (argv-based, launched via `exec.Command`), or fall back to `--start-cmd` (run via `sh -c`). The wrapper starts the command as a child process, then waits for the daemon to become healthy by polling the health path.
 4. **Reverse proxy**: Once the daemon is healthy, start an HTTP server listening on `${PORT}` (or the address provided to `--listen`) that proxies all requests to the vLLM upstream URL. The proxy preserves streaming responses by setting `X-Accel-Buffering: no`.
 
 ### sleep subcommand

--- a/cmd/vllm-wrapper/main.go
+++ b/cmd/vllm-wrapper/main.go
@@ -186,10 +186,12 @@ func sleepCmd(args []string) {
 	var (
 		vllmURL    string
 		sleepLevel int
+		stopPID    int
 	)
 	fs := flag.NewFlagSet("sleep", flag.ExitOnError)
 	fs.StringVar(&vllmURL, "vllm-url", "", "Base URL of vLLM server (e.g., http://127.0.0.1:8000)")
 	fs.IntVar(&sleepLevel, "sleep-level", 1, "Sleep level to use (default 1)")
+	fs.IntVar(&stopPID, "stop-pid", 0, "PID of the serve proxy to terminate after vLLM successfully enters sleep mode")
 	fs.Parse(args)
 
 	if vllmURL == "" {
@@ -216,6 +218,13 @@ func sleepCmd(args []string) {
 	}
 
 	log.Printf("Successfully put vLLM to sleep (level %d)", sleepLevel)
+
+	if stopPID > 0 {
+		if err := syscall.Kill(stopPID, syscall.SIGTERM); err != nil {
+			log.Fatalf("Failed to stop serve proxy process %d: %v", stopPID, err)
+		}
+		log.Printf("Sent SIGTERM to serve proxy process %d", stopPID)
+	}
 }
 
 // wakeUpVLLM sends a POST to /wake_up to wake the vLLM daemon.

--- a/cmd/vllm-wrapper/main.go
+++ b/cmd/vllm-wrapper/main.go
@@ -55,6 +55,7 @@ func serveCmd(args []string) {
 		startCmd    string
 		healthPath  string
 		waitTimeout time.Duration
+		journalUnit string
 	)
 	fs := flag.NewFlagSet("serve", flag.ExitOnError)
 	fs.StringVar(&vllmURL, "vllm-url", "", "Base URL of vLLM server (e.g., http://127.0.0.1:8000)")
@@ -63,6 +64,7 @@ func serveCmd(args []string) {
 	fs.StringVar(&startCmd, "start-cmd", "", "Command to start the vLLM daemon if not running (e.g., 'docker run ...')")
 	fs.StringVar(&healthPath, "health-path", "/health", "Health check path (default /health)")
 	fs.DurationVar(&waitTimeout, "wait-timeout", 120*time.Second, "Timeout waiting for daemon to become healthy")
+	fs.StringVar(&journalUnit, "journal-unit", "", "User systemd unit whose logs should be forwarded to stdout")
 	fs.Parse(args)
 	startArgs := fs.Args()
 
@@ -78,6 +80,14 @@ func serveCmd(args []string) {
 
 	// Ensure vLLM URL does not have trailing slash.
 	vllmURL = strings.TrimRight(vllmURL, "/")
+
+	journalCtx, stopJournal := context.WithCancel(context.Background())
+	defer stopJournal()
+	if journalUnit != "" {
+		if err := startJournalForwarder(journalCtx, journalUnit); err != nil {
+			log.Printf("Warning: failed to forward logs from %s: %v", journalUnit, err)
+		}
+	}
 
 	// Step 1: Ensure the daemon is running and awake.
 	// First, check if we can reach the daemon (liveness).
@@ -266,6 +276,34 @@ func checkHealthy(vllmURL string, healthPath string) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
+	return nil
+}
+
+// startJournalForwarder forwards new log entries from a user systemd unit to stdout.
+func startJournalForwarder(ctx context.Context, unit string) error {
+	cmd := exec.CommandContext(
+		ctx,
+		"journalctl",
+		"--user-unit="+unit,
+		"--follow",
+		"--lines=0",
+		"--output=cat",
+		"--no-pager",
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start journalctl for %s: %w", unit, err)
+	}
+
+	go func() {
+		err := cmd.Wait()
+		if ctx.Err() == nil && err != nil {
+			log.Printf("Journal forwarding for %s stopped: %v", unit, err)
+		}
+	}()
+
 	return nil
 }
 

--- a/cmd/vllm-wrapper/main.go
+++ b/cmd/vllm-wrapper/main.go
@@ -52,7 +52,6 @@ func serveCmd(args []string) {
 		vllmURL     string
 		listenAddr  string
 		sleepLevel  int
-		startCmd    string
 		healthPath  string
 		waitTimeout time.Duration
 		journalUnit string
@@ -61,7 +60,6 @@ func serveCmd(args []string) {
 	fs.StringVar(&vllmURL, "vllm-url", "", "Base URL of vLLM server (e.g., http://127.0.0.1:8000)")
 	fs.StringVar(&listenAddr, "listen", "", "Address to listen on (e.g., :$PORT)")
 	fs.IntVar(&sleepLevel, "sleep-level", 1, "Sleep level to use when sleeping (default 1)")
-	fs.StringVar(&startCmd, "start-cmd", "", "Command to start the vLLM daemon if not running (e.g., 'docker run ...')")
 	fs.StringVar(&healthPath, "health-path", "/health", "Health check path (default /health)")
 	fs.DurationVar(&waitTimeout, "wait-timeout", 120*time.Second, "Timeout waiting for daemon to become healthy")
 	fs.StringVar(&journalUnit, "journal-unit", "", "User systemd unit whose logs should be forwarded to stdout")
@@ -74,8 +72,8 @@ func serveCmd(args []string) {
 	if listenAddr == "" {
 		log.Fatalf("--listen is required")
 	}
-	if startCmd == "" && len(startArgs) == 0 {
-		log.Fatalf("--start-cmd or a command after -- is required")
+	if len(startArgs) == 0 {
+		log.Fatalf("a daemon command after -- is required")
 	}
 
 	// Ensure vLLM URL does not have trailing slash.
@@ -97,7 +95,7 @@ func serveCmd(args []string) {
 		if err := wakeUpVLLM(vllmURL); err != nil {
 			// Wake up failed (e.g., connection refused), assume daemon not running, try to start it.
 			log.Printf("Wake up failed: %v, attempting to start daemon", err)
-			if err := startDaemon(startCmd, startArgs, vllmURL, healthPath, waitTimeout); err != nil {
+			if err := startDaemon(startArgs, vllmURL, healthPath, waitTimeout); err != nil {
 				log.Fatalf("Failed to start daemon: %v", err)
 			}
 		} else {
@@ -171,7 +169,18 @@ func serveCmd(args []string) {
 	// Wait for interrupt signal to gracefully shutdown.
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	<-c
+	sig := <-c
+	signal.Stop(c)
+
+	if sig == syscall.SIGTERM {
+		log.Printf("SIGTERM received, putting vLLM to sleep (level %d)", sleepLevel)
+		if err := sleepVLLM(vllmURL, sleepLevel); err != nil {
+			log.Printf("Warning: failed to put vLLM to sleep: %v", err)
+		} else {
+			log.Printf("Successfully put vLLM to sleep (level %d)", sleepLevel)
+		}
+	}
+
 	log.Println("Shutting down vllm-wrapper serve...")
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -225,6 +234,27 @@ func sleepCmd(args []string) {
 		}
 		log.Printf("Sent SIGTERM to serve proxy process %d", stopPID)
 	}
+}
+
+// sleepVLLM sends a POST to /sleep to put the vLLM daemon to sleep.
+func sleepVLLM(vllmURL string, sleepLevel int) error {
+	body := map[string]int{"level": sleepLevel}
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("failed to marshal sleep request: %w", err)
+	}
+
+	resp, err := http.Post(vllmURL+"/sleep", "application/json", strings.NewReader(string(jsonBody)))
+	if err != nil {
+		return fmt.Errorf("failed to send sleep request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("vLLM sleep request failed with status %d: %s", resp.StatusCode, resp.Status)
+	}
+
+	return nil
 }
 
 // wakeUpVLLM sends a POST to /wake_up to wake the vLLM daemon.
@@ -317,14 +347,8 @@ func startJournalForwarder(ctx context.Context, unit string) error {
 }
 
 // startDaemon executes the start command and waits for the vLLM daemon to become healthy.
-func startDaemon(startCmd string, startArgs []string, vllmURL string, healthPath string, waitTimeout time.Duration) error {
-	var cmd *exec.Cmd
-	if len(startArgs) > 0 {
-		cmd = exec.Command(startArgs[0], startArgs[1:]...)
-	} else {
-		// Keep --start-cmd for backward compatibility.
-		cmd = exec.Command("sh", "-c", startCmd)
-	}
+func startDaemon(startArgs []string, vllmURL string, healthPath string, waitTimeout time.Duration) error {
+	cmd := exec.Command(startArgs[0], startArgs[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {

--- a/cmd/vllm-wrapper/main.go
+++ b/cmd/vllm-wrapper/main.go
@@ -64,6 +64,7 @@ func serveCmd(args []string) {
 	fs.StringVar(&healthPath, "health-path", "/health", "Health check path (default /health)")
 	fs.DurationVar(&waitTimeout, "wait-timeout", 120*time.Second, "Timeout waiting for daemon to become healthy")
 	fs.Parse(args)
+	startArgs := fs.Args()
 
 	if vllmURL == "" {
 		log.Fatalf("--vllm-url is required")
@@ -71,8 +72,8 @@ func serveCmd(args []string) {
 	if listenAddr == "" {
 		log.Fatalf("--listen is required")
 	}
-	if startCmd == "" {
-		log.Fatalf("--start-cmd is required")
+	if startCmd == "" && len(startArgs) == 0 {
+		log.Fatalf("--start-cmd or a command after -- is required")
 	}
 
 	// Ensure vLLM URL does not have trailing slash.
@@ -86,7 +87,7 @@ func serveCmd(args []string) {
 		if err := wakeUpVLLM(vllmURL); err != nil {
 			// Wake up failed (e.g., connection refused), assume daemon not running, try to start it.
 			log.Printf("Wake up failed: %v, attempting to start daemon", err)
-			if err := startDaemon(startCmd, vllmURL, healthPath, waitTimeout); err != nil {
+			if err := startDaemon(startCmd, startArgs, vllmURL, healthPath, waitTimeout); err != nil {
 				log.Fatalf("Failed to start daemon: %v", err)
 			}
 		} else {
@@ -269,9 +270,14 @@ func checkHealthy(vllmURL string, healthPath string) error {
 }
 
 // startDaemon executes the start command and waits for the vLLM daemon to become healthy.
-func startDaemon(startCmd string, vllmURL string, healthPath string, waitTimeout time.Duration) error {
-	// Start the daemon command.
-	cmd := exec.Command("sh", "-c", startCmd)
+func startDaemon(startCmd string, startArgs []string, vllmURL string, healthPath string, waitTimeout time.Duration) error {
+	var cmd *exec.Cmd
+	if len(startArgs) > 0 {
+		cmd = exec.Command(startArgs[0], startArgs[1:]...)
+	} else {
+		// Keep --start-cmd for backward compatibility.
+		cmd = exec.Command("sh", "-c", startCmd)
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {

--- a/cmd/vllm-wrapper/main.go
+++ b/cmd/vllm-wrapper/main.go
@@ -126,7 +126,7 @@ func serveCmd(args []string) {
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
 		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: 30 * time.Second,
+		ResponseHeaderTimeout: 300 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		MaxIdleConns:          100,
 		MaxIdleConnsPerHost:   10,

--- a/cmd/vllm-wrapper/main_test.go
+++ b/cmd/vllm-wrapper/main_test.go
@@ -92,7 +92,7 @@ func TestSleepCommandMarshal(t *testing.T) {
 // quickly and the daemon does not become healthy.
 func TestStartDaemon(t *testing.T) {
 	// Use a start command that exits immediately (true) and a health URL that will not respond.
-	err := startDaemon("true", nil, "http://127.0.0.1:12345/health", "/health", 10*time.Millisecond)
+	err := startDaemon([]string{"true"}, "http://127.0.0.1:12345/health", "/health", 10*time.Millisecond)
 	if err == nil {
 		t.Fatalf("startDaemon expected error but got nil")
 	}
@@ -113,7 +113,7 @@ func TestStartDaemonArgv(t *testing.T) {
 		t.Fatalf("write helper script: %v", err)
 	}
 
-	err := startDaemon("", []string{script, "arg1", "arg2", "arg3"}, "http://127.0.0.1:12345/health", "/health", 100*time.Millisecond)
+	err := startDaemon([]string{script, "arg1", "arg2", "arg3"}, "http://127.0.0.1:12345/health", "/health", 100*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected error (health check fails)")
 	}
@@ -134,37 +134,4 @@ func TestStartDaemonArgv(t *testing.T) {
 	}
 }
 
-// TestStartDaemonArgvPrecedence verifies that argv-based startup takes precedence
-// over the legacy startCmd when both are provided.
-func TestStartDaemonArgvPrecedence(t *testing.T) {
-	tmpDir := t.TempDir()
-	argvFile := filepath.Join(tmpDir, "argv.txt")
 
-	script := filepath.Join(tmpDir, "write-argv.sh")
-	if err := os.WriteFile(script, []byte(
-		"#!/bin/bash\nprintf '%s\n' \"$@\" > \""+argvFile+"\"\nexit 0\n",
-	), 0755); err != nil {
-		t.Fatalf("write helper script: %v", err)
-	}
-
-	// Both startCmd and startArgs provided — argv should take precedence.
-	err := startDaemon("echo legacy", []string{script, "from-argv"}, "http://127.0.0.1:12345/health", "/health", 100*time.Millisecond)
-	if err == nil {
-		t.Fatal("expected error (health check fails)")
-	}
-
-	content, err := os.ReadFile(argvFile)
-	if err != nil {
-		t.Fatalf("read argv file: %v", err)
-	}
-	got := strings.Split(strings.TrimSpace(string(content)), "\n")
-	want := []string{"from-argv"}
-	if len(got) != len(want) {
-		t.Fatalf("argv length: got %d, want %d", len(got), len(want))
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("argv[%d]: got %q, want %q", i, got[i], want[i])
-		}
-	}
-}

--- a/cmd/vllm-wrapper/main_test.go
+++ b/cmd/vllm-wrapper/main_test.go
@@ -90,7 +90,7 @@ func TestSleepCommandMarshal(t *testing.T) {
 // quickly and the daemon does not become healthy.
 func TestStartDaemon(t *testing.T) {
 	// Use a start command that exits immediately (true) and a health URL that will not respond.
-	err := startDaemon("true", "http://127.0.0.1:12345/health", "/health", 10*time.Millisecond)
+	err := startDaemon("true", nil, "http://127.0.0.1:12345/health", "/health", 10*time.Millisecond)
 	if err == nil {
 		t.Fatalf("startDaemon expected error but got nil")
 	}

--- a/cmd/vllm-wrapper/main_test.go
+++ b/cmd/vllm-wrapper/main_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -96,5 +98,73 @@ func TestStartDaemon(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "daemon did not become healthy") {
 		t.Errorf("error expected to contain 'daemon did not become healthy', got %v", err)
+	}
+}
+
+// TestStartDaemonArgv verifies that multiple startArgs are passed as separate argv values.
+func TestStartDaemonArgv(t *testing.T) {
+	tmpDir := t.TempDir()
+	argvFile := filepath.Join(tmpDir, "argv.txt")
+
+	script := filepath.Join(tmpDir, "write-argv.sh")
+	if err := os.WriteFile(script, []byte(
+		"#!/bin/bash\nprintf '%s\n' \"$@\" > \""+argvFile+"\"\nexit 0\n",
+	), 0755); err != nil {
+		t.Fatalf("write helper script: %v", err)
+	}
+
+	err := startDaemon("", []string{script, "arg1", "arg2", "arg3"}, "http://127.0.0.1:12345/health", "/health", 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error (health check fails)")
+	}
+
+	content, err := os.ReadFile(argvFile)
+	if err != nil {
+		t.Fatalf("read argv file: %v", err)
+	}
+	got := strings.Split(strings.TrimSpace(string(content)), "\n")
+	want := []string{"arg1", "arg2", "arg3"}
+	if len(got) != len(want) {
+		t.Fatalf("argv length: got %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("argv[%d]: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestStartDaemonArgvPrecedence verifies that argv-based startup takes precedence
+// over the legacy startCmd when both are provided.
+func TestStartDaemonArgvPrecedence(t *testing.T) {
+	tmpDir := t.TempDir()
+	argvFile := filepath.Join(tmpDir, "argv.txt")
+
+	script := filepath.Join(tmpDir, "write-argv.sh")
+	if err := os.WriteFile(script, []byte(
+		"#!/bin/bash\nprintf '%s\n' \"$@\" > \""+argvFile+"\"\nexit 0\n",
+	), 0755); err != nil {
+		t.Fatalf("write helper script: %v", err)
+	}
+
+	// Both startCmd and startArgs provided — argv should take precedence.
+	err := startDaemon("echo legacy", []string{script, "from-argv"}, "http://127.0.0.1:12345/health", "/health", 100*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error (health check fails)")
+	}
+
+	content, err := os.ReadFile(argvFile)
+	if err != nil {
+		t.Fatalf("read argv file: %v", err)
+	}
+	got := strings.Split(strings.TrimSpace(string(content)), "\n")
+	want := []string{"from-argv"}
+	if len(got) != len(want) {
+		t.Fatalf("argv length: got %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("argv[%d]: got %q, want %q", i, got[i], want[i])
+		}
 	}
 }


### PR DESCRIPTION
## Description

This PR improves `vllm-wrapper` support for native vLLM installations and systemd-managed vLLM processes.

It introduces three related features:

1. Passing the vLLM startup command as separate arguments after `--`.
2. Forwarding logs from a systemd user unit through the wrapper with `--journal-unit`.
3. Terminating the active proxy after a successful sleep request with `--stop-pid`.

## Argv-based startup

The existing `--start-cmd` approach works reasonably well when the complete startup command is provided as a single shell string, for example when launching a Docker container:

```text
--start-cmd "docker run ... vllm serve ..."
```

However, it is not practical when vLLM is installed and launched directly on the host.

For example, a native vLLM command may look like this:

```text
${vllm} serve model ...
```

When used inside a multiline `llama-swap` configuration, the command is split into individual arguments before it reaches `vllm-wrapper`. As a result, only the first part can be passed to `--start-cmd`, while the remaining vLLM options are interpreted as arguments of the wrapper itself.

Quoting the command or using YAML multiline string operators does not solve the problem reliably because `llama-swap` performs its own command parsing before starting the wrapper.

This change allows the vLLM executable and all of its arguments to be passed after `--`:

```yaml
cmd: |
  /usr/local/bin/vllm-wrapper serve
  --vllm-url http://127.0.0.1:8001
  --listen :${PORT}
  --wait-timeout 600s
  --
  ${vllm}
  serve
  ${model_path}
  --host 127.0.0.1
  --port 8001
  --max-model-len ${context_size}

  # Options can be disabled without restructuring the command:
  # --enforce-eager

  --enable-sleep-mode
```

Everything remaining after wrapper flag parsing is treated as the daemon executable and its arguments:

```go
startArgs := fs.Args()
```

The process is then launched directly without going through `sh -c`:

```go
exec.Command(startArgs[0], startArgs[1:]...)
```

If both `--start-cmd` and arguments after `--` are provided, the argv-based command takes priority.

## Systemd journal forwarding

Native vLLM processes may be started as transient systemd user services so that they remain independent from the `llama-swap` proxy process.

When vLLM output is redirected to the systemd journal, it is no longer visible in the `llama-swap` upstream log stream.

The new optional `--journal-unit` flag starts a journal follower for the specified systemd user unit and forwards new journal entries to the wrapper's stdout:

```yaml
cmd: |
  /usr/local/bin/vllm-wrapper serve
  --vllm-url http://127.0.0.1:8001
  --listen :${PORT}
  --wait-timeout 600s
  --journal-unit=vllm-qwen.service
  --
  systemd-run
  --user
  --unit=vllm-qwen
  --collect
  --property=Restart=no
  --property=StandardOutput=journal
  --property=StandardError=journal
  --
  ${vllm}
  serve
  ${model_path}
  --port 8001
  --enable-sleep-mode
```

The resulting log path is:

```text
vLLM
  -> systemd journal
  -> journal follower in vllm-wrapper
  -> vllm-wrapper stdout
  -> llama-swap upstream logs
```

Only new journal entries are forwarded, so restarting the proxy does not replay the complete historical log.

The journal follower is stopped together with the proxy process and does not stop or otherwise affect the vLLM systemd unit.

## Proxy termination after sleep

The existing `sleep` command sends a request to the vLLM `/sleep` endpoint and exits successfully, but the separate `vllm-wrapper serve` proxy process continues running.

From the perspective of `llama-swap`, the model therefore remains in the stopping state because the process started through `cmd` has not exited.

The new optional `--stop-pid` flag allows the sleep command to terminate the active proxy after vLLM successfully enters sleep mode:

```yaml
cmdStop: |
  /usr/local/bin/vllm-wrapper sleep
  --vllm-url http://127.0.0.1:8001
  --stop-pid=${PID}
```

The operation is performed in this order:

1. Send `POST /sleep` to vLLM.
2. Verify that the sleep request completed successfully.
3. Send `SIGTERM` to the specified `vllm-wrapper serve` process.
4. Allow the proxy to shut down gracefully.
5. Leave the vLLM daemon running in sleep mode.

If the sleep request fails, the proxy process is not terminated.

This allows `llama-swap` to finish unloading the model while preserving the vLLM process for a later fast wake-up.

## Complete example

```yaml
cmd: |
  /usr/local/bin/vllm-wrapper serve
  --vllm-url http://127.0.0.1:8001
  --listen :${PORT}
  --wait-timeout 600s
  --journal-unit=vllm-qwen.service
  --
  systemd-run
  --user
  --unit=vllm-qwen
  --collect
  --property=Restart=no
  --property=StandardOutput=journal
  --property=StandardError=journal
  --
  ${vllm}
  serve
  ${model_path}
  --host 127.0.0.1
  --port 8001
  --max-model-len ${context_size}

  # --enforce-eager

  --enable-sleep-mode

cmdStop: |
  /usr/local/bin/vllm-wrapper sleep
  --vllm-url http://127.0.0.1:8001
  --stop-pid=${PID}
```

## Benefits

* Enables native vLLM startup without Docker.
* Supports vLLM executables defined through `llama-swap` macros.
* Allows readable multiline commands in `llama-swap`.
* Preserves individual vLLM arguments and values containing spaces.
* Allows individual vLLM options to be commented out.
* Avoids unnecessary shell parsing for argv-based startup.
* Supports vLLM processes managed as transient systemd user services.
* Makes systemd-managed vLLM logs available through the `llama-swap` upstream log stream.
* Allows `cmdStop` to complete without terminating the sleeping vLLM daemon.
* Keeps the existing `--start-cmd` behavior for backward compatibility.

## Backward compatibility

Existing Docker-based and shell-based configurations using:

```text
--start-cmd "..."
```

continue to work unchanged.

The new behavior is optional:

* argv-based startup is used only when a command is supplied after `--`;
* journal forwarding is enabled only when `--journal-unit` is provided;
* proxy termination is enabled only when `--stop-pid` is provided.

## Validation

The changes were tested with:

* `gofmt`
* `git diff --check`
* `go test ./cmd/vllm-wrapper`
* `go vet ./cmd/vllm-wrapper`
* `go build ./cmd/vllm-wrapper`
* direct command execution after `--`
* arguments containing spaces
* native vLLM startup through `${vllm}`
* the existing `--start-cmd` fallback
* journal forwarding from a systemd user unit
* proxy termination after a successful sleep request
* preservation of the proxy process when the sleep request fails
