### PR TITLE
feat: support generic task API for audio.cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
   - `/sdapi/v1/img2img`
   - `/sdapi/v1/loras` - requires `model` in request body to fetch the correct loras
 
-- ✅ audio.cpp supported extra endpoints ([audio.cpp](https://github.com/0xShug0/audio.cpp))
+- ✅ [audio.cpp](https://github.com/0xShug0/audio.cpp) supported [extra endpoints](https://github.com/0xShug0/audio.cpp/blob/main/app/server/README.md#post-v1tasksrun)
   - `/audioapi/v1/tasks/run`
 
 - ✅ llama-swap API

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
   - `/sdapi/v1/txt2img`
   - `/sdapi/v1/img2img`
   - `/sdapi/v1/loras` - requires `model` in request body to fetch the correct loras
+
+- ✅ audio.cpp supported extra endpoints ([audio.cpp](https://github.com/0xShug0/audio.cpp))
+  - `/audioapi/v1/tasks/run`
+
 - ✅ llama-swap API
   - `/ui` - web UI
   - `/upstream/:model_id` - direct access to upstream server ([demo](https://github.com/mostlygeek/llama-swap/pull/31))

--- a/internal/server/extras_test.go
+++ b/internal/server/extras_test.go
@@ -160,6 +160,20 @@ func TestServer_StripVersionPrefix(t *testing.T) {
 	}
 }
 
+func TestServer_StripAudioAPIPrefix(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/audioapi/v1/tasks/run", nil)
+	stripAudioAPIPrefix(r)
+	if r.URL.Path != "/v1/tasks/run" {
+		t.Errorf("path = %q, want /v1/tasks/run", r.URL.Path)
+	}
+
+	r2 := httptest.NewRequest(http.MethodGet, "/v1/tasks/run", nil)
+	stripAudioAPIPrefix(r2)
+	if r2.URL.Path != "/v1/tasks/run" {
+		t.Errorf("path = %q, want unchanged", r2.URL.Path)
+	}
+}
+
 func TestServer_CloseStreams(t *testing.T) {
 	s := newTestServer(newStubRouter(nil, ""), newStubRouter(nil, ""))
 	s.CloseStreams()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -101,6 +101,9 @@ var modelPostJSONRoutes = []string{
 	"/sdapi/v1/txt2img",
 	"/sdapi/v1/img2img",
 
+	// audio.cpp generic task API
+	"/audioapi/v1/tasks/run",
+
 	// versionless routes, the /v/ is stripped before the request is forwarded upstream
 	// see issue #728
 	"/v/chat/completions",
@@ -207,6 +210,7 @@ func New(cfg config.Config, muxlog *logmon.Monitor, proxylog *logmon.Monitor, up
 // router. The model is resolved once via shared.FetchContext.
 func (s *Server) localPeerHandler(w http.ResponseWriter, r *http.Request) {
 	stripVersionPrefix(r)
+	stripAudioAPIPrefix(r)
 
 	data, err := shared.FetchContext(r, s.cfg)
 	if err != nil {
@@ -231,6 +235,15 @@ func (s *Server) localPeerHandler(w http.ResponseWriter, r *http.Request) {
 func stripVersionPrefix(r *http.Request) {
 	if strings.HasPrefix(r.URL.Path, "/v/") {
 		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/v")
+	}
+}
+
+// stripAudioAPIPrefix rewrites /audioapi/... requests to their /... form
+// before forwarding upstream, so /audioapi/v1/tasks/run reaches the upstream
+// as /v1/tasks/run.
+func stripAudioAPIPrefix(r *http.Request) {
+	if strings.HasPrefix(r.URL.Path, "/audioapi") {
+		r.URL.Path = strings.TrimPrefix(r.URL.Path, "/audioapi")
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -123,6 +123,15 @@ func chatRequest(model string) *http.Request {
 	return req
 }
 
+// audioTaskRequest builds a JSON POST to the /audioapi/v1/tasks/run endpoint
+// carrying the given model field.
+func audioTaskRequest(model string) *http.Request {
+	body := strings.NewReader(`{"model":"` + model + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/audioapi/v1/tasks/run", body)
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
 func TestServer_New_GroupConfig(t *testing.T) {
 	discard := logmon.NewWriter(io.Discard)
 	cfg := config.Config{HealthCheckTimeout: 15}
@@ -236,6 +245,40 @@ func TestServer_UnknownModelReturns404(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Errorf("status=%d want 404 body=%q", w.Code, w.Body.String())
+	}
+}
+
+func TestServer_AudioAPIRoutesTaskRequest(t *testing.T) {
+	s := newTestServer(
+		newStubRouter([]string{"local-audio"}, "local audio response"),
+		newStubRouter(nil, ""),
+	)
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, audioTaskRequest("local-audio"))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%q", w.Code, w.Body.String())
+	}
+	if w.Body.String() != "local audio response" {
+		t.Errorf("body=%q want %q", w.Body.String(), "local audio response")
+	}
+}
+
+func TestServer_AudioAPIRewritesUpstreamPath(t *testing.T) {
+	var gotPath string
+	local := newStubRouter([]string{"m1"}, "")
+	local.serveHTTP = func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}
+	s := newTestServer(local, newStubRouter(nil, ""))
+
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, audioTaskRequest("m1"))
+
+	if gotPath != "/v1/tasks/run" {
+		t.Errorf("upstream path = %q, want /v1/tasks/run", gotPath)
 	}
 }
 


### PR DESCRIPTION
This PR enables llama-swap to route the [generic task API](https://github.com/0xShug0/audio.cpp/blob/main/app/server/README.md#post-v1tasksrun) from [audio.cpp](https://github.com/0xShug0/audio.cpp) 

audio.cpp provides OpenAI-compatible transcriptions and speech API, thus already supported by current main branch llama-swap. This further PR enables audio-related tasks like VAD or audio-gen to be routed to an audio.cpp backend.