### PR TITLE
router: add models endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
   - `v1/rerank`, `v1/reranking`, `/rerank`
   - `/infill` - for code infilling
   - `/completion` - for completion endpoint
+  - `/models` - list available models. same behavior as `v1/models`
   - `/props` - requires `?model={model_id}` query parameter to be provided. The autoload parameter is not supported and will be ignored.
 - ✅ SDAPI via [stable-diffusion.cpp's server](https://github.com/leejet/stable-diffusion.cpp/tree/master/examples/server)
   - `/sdapi/v1/txt2img`

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -267,6 +267,7 @@ func (s *Server) routes() {
 
 	// llama-swap API + custom endpoints.
 	mux.Handle("GET /v1/models", apiChain.ThenFunc(s.handleListModels))
+	mux.Handle("GET /models", apiChain.ThenFunc(s.handleListModels))
 	mux.Handle("GET /logs", apiChain.ThenFunc(s.handleLogs))
 	mux.Handle("GET /logs/stream", apiChain.ThenFunc(s.handleLogStream))
 	mux.Handle("GET /logs/stream/{logMonitorID...}", apiChain.ThenFunc(s.handleLogStream))


### PR DESCRIPTION
llama.cpp implements a /models endpoint that provides an identical response to /v1/models.
(see https://github.com/ggml-org/llama.cpp/blob/f9e832c10e9444cb168ddcb579cc62c154f3068b/tools/server/server.cpp#L238-L239)

Make llama-swap do the same to improve interoperability with
tools designed for interfacing with llama.cpp.

resolves: #999
