### PR TITLE
expose meta.n_ctx on models endpoint

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -173,8 +173,14 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 		for key, value := range internalMetadata {
 			llamaSwapMetadata[key] = value
 		}
-		if len(llamaSwapMetadata) > 0 {
-			rec.Meta = map[string]any{"llamaswap": llamaSwapMetadata}
+		if len(llamaSwapMetadata) > 0 || rec.ContextLength > 0 {
+			rec.Meta = make(map[string]any)
+			if len(llamaSwapMetadata) > 0 {
+				rec.Meta["llamaswap"] = llamaSwapMetadata
+			}
+			if rec.ContextLength > 0 {
+				rec.Meta["n_ctx"] = rec.ContextLength
+			}
 		}
 		return rec
 	}


### PR DESCRIPTION
Some tools are trying to auto-detect max context size for models
using llama.cpp's /models endpoint instead of /props since it is
exposed in both places.

Add the meta.n_ctx to the /models response to improve compatibility
with other tools.

resolves: #999
