### PR TITLE
internal/server: preserve percent-encoding in /upstream paths

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -425,6 +425,9 @@ func handleUpstreamRedirect(w http.ResponseWriter, r *http.Request) {
 // the model's process, bypassing model dispatch by body/query inspection.
 func (s *Server) handleUpstream(w http.ResponseWriter, r *http.Request) {
 	upstreamPath := r.PathValue("upstreamPath")
+	// Read the escaped path before URL.Path is rewritten below: EscapedPath
+	// only returns RawPath while it still decodes to Path.
+	escapedPath := r.URL.EscapedPath()
 
 	searchName, modelID, remainingPath, found := shared.FindModelInPath(s.cfg, "/"+upstreamPath)
 	if !found {
@@ -447,8 +450,12 @@ func (s *Server) handleUpstream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Strip the /upstream/<model> prefix before forwarding.
+	// Strip the /upstream/<model> prefix before forwarding. RawPath carries the
+	// client's original escaping through to the upstream: a %2F inside a single
+	// segment (e.g. ComfyUI's /userdata/{file}) has already been decoded into a
+	// path separator by both PathValue and URL.Path.
 	r.URL.Path = remainingPath
+	r.URL.RawPath = shared.EscapedPathSuffix(escapedPath, strings.Count(searchName, "/")+2)
 	// Pin the resolved model so the router skips body/query extraction.
 	*r = *r.WithContext(shared.SetContext(r.Context(), shared.ReqContextData{Model: searchName, ModelID: modelID, Metadata: make(map[string]string)}))
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -228,6 +228,78 @@ func TestServer_HandleUpstream(t *testing.T) {
 	})
 }
 
+// A percent-encoded separator inside a single path segment (ComfyUI addresses
+// user files as /userdata/workflows%2Fname.json) must survive the
+// /upstream/<model> prefix strip. ServeMux path values and url.URL.Path both
+// decode %2F, which would hand the upstream two segments instead of one.
+func TestServer_HandleUpstream_PreservesEncodedPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		models []string
+		target string
+		want   string
+	}{
+		{
+			name:   "encoded slash in segment",
+			models: []string{"m1"},
+			target: "/upstream/m1/api/userdata/workflows%2Fsdxl_simple_example.json?overwrite=false&full_info=true",
+			want:   "/api/userdata/workflows%2Fsdxl_simple_example.json",
+		},
+		{
+			name:   "encoded slash under multi-segment model name",
+			models: []string{"author/m1"},
+			target: "/upstream/author/m1/api/userdata/workflows%2Fsdxl.json",
+			want:   "/api/userdata/workflows%2Fsdxl.json",
+		},
+		{
+			name:   "other escapes preserved",
+			models: []string{"m1"},
+			target: "/upstream/m1/api/userdata/my%20file.json",
+			want:   "/api/userdata/my%20file.json",
+		},
+		{
+			name:   "unescaped path unchanged",
+			models: []string{"m1"},
+			target: "/upstream/m1/v1/chat/completions",
+			want:   "/v1/chat/completions",
+		},
+		{
+			name:   "bare model with trailing slash",
+			models: []string{"m1"},
+			target: "/upstream/m1/",
+			want:   "/",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			local := newStubRouter(tc.models, "")
+			var got string
+			local.serveHTTP = func(w http.ResponseWriter, r *http.Request) {
+				// EscapedPath is what httputil.ReverseProxy puts on the wire.
+				got = r.URL.EscapedPath()
+				w.WriteHeader(http.StatusOK)
+			}
+			s := newTestServer(local, newStubRouter(nil, ""))
+			models := make(map[string]config.ModelConfig, len(tc.models))
+			for _, id := range tc.models {
+				models[id] = config.ModelConfig{}
+			}
+			s.cfg = config.Config{Models: models}
+			s.routes()
+
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, httptest.NewRequest(http.MethodPost, tc.target, nil))
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (body=%q)", w.Code, w.Body.String())
+			}
+			if got != tc.want {
+				t.Errorf("upstream path = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func upstreamMetricsServer(t *testing.T, response string) *Server {
 	t.Helper()
 	cfg := config.Config{Models: map[string]config.ModelConfig{"m1": {}}}

--- a/internal/shared/http.go
+++ b/internal/shared/http.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -147,6 +148,11 @@ func ReplaceRequestModel(r *http.Request, model, replacement string) (*http.Requ
 			return r, nil
 		}
 
+		// Capture the client's escaping of everything after the model name
+		// before URL.Path is rewritten; EscapedPath falls back to re-encoding
+		// Path once RawPath no longer decodes to it.
+		escapedRemaining := EscapedPathSuffix(r.URL.EscapedPath(), strings.Count(model, "/")+2)
+
 		remainingPath := strings.TrimPrefix(upstreamPath, model)
 		rewrittenPath := replacement + remainingPath
 		if replacement == "" {
@@ -155,6 +161,12 @@ func ReplaceRequestModel(r *http.Request, model, replacement string) (*http.Requ
 		r.SetPathValue("upstreamPath", rewrittenPath)
 		r.URL.Path = "/upstream/" + rewrittenPath
 		r.URL.RawPath = ""
+		if replacement != "" && escapedRemaining != "" {
+			// Escape the substituted model name the way Go would, then splice
+			// the untouched remainder back on.
+			prefix := (&url.URL{Path: "/upstream/" + replacement}).EscapedPath()
+			r.URL.RawPath = prefix + escapedRemaining
+		}
 		return invalidateRequestContext(r), nil
 	}
 
@@ -326,6 +338,26 @@ func FindModelInPath(cfg config.Config, path string) (searchName, realName, rema
 	}
 
 	return
+}
+
+// EscapedPathSuffix drops the first n segments from an escaped URL path,
+// leaving the remainder's percent-encoding untouched. Both ServeMux path
+// values and url.URL.Path decode %2F into a literal "/", which splits a single
+// segment in two; rebuilding a path from either loses the distinction. Callers
+// use the result as url.URL.RawPath so the original encoding survives to the
+// upstream. Returns "" when the path has fewer than n segments, in which case
+// callers should leave RawPath empty and fall back to encoding Path.
+func EscapedPathSuffix(escapedPath string, n int) string {
+	rest := escapedPath
+	for range n {
+		rest = strings.TrimPrefix(rest, "/")
+		idx := strings.Index(rest, "/")
+		if idx < 0 {
+			return ""
+		}
+		rest = rest[idx:]
+	}
+	return rest
 }
 
 func SetContext(ctx context.Context, data ReqContextData) context.Context {

--- a/internal/shared/http_test.go
+++ b/internal/shared/http_test.go
@@ -782,6 +782,90 @@ func TestFindModelInPath_PeerNamespaces(t *testing.T) {
 	}
 }
 
+func TestEscapedPathSuffix(t *testing.T) {
+	tests := []struct {
+		path string
+		n    int
+		want string
+	}{
+		{"/upstream/m1/api/userdata/workflows%2Fsdxl.json", 2, "/api/userdata/workflows%2Fsdxl.json"},
+		{"/upstream/author/m1/api/x%2Fy", 3, "/api/x%2Fy"},
+		{"/upstream/m1/v1/chat/completions", 2, "/v1/chat/completions"},
+		{"/upstream/m1/", 2, "/"},
+		// No remainder at all: callers keep RawPath empty and fall back to
+		// encoding URL.Path.
+		{"/upstream/m1", 2, ""},
+		{"/upstream", 2, ""},
+		{"", 2, ""},
+		{"/upstream/m1/api", 0, "/upstream/m1/api"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := EscapedPathSuffix(tt.path, tt.n); got != tt.want {
+				t.Errorf("EscapedPathSuffix(%q, %d) = %q, want %q", tt.path, tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+// A pinned profile rewrites the model inside an /upstream path; the escaping of
+// everything after the model name must come through untouched.
+func TestReplaceRequestModel_UpstreamPreservesEncodedPath(t *testing.T) {
+	tests := []struct {
+		name        string
+		target      string
+		model       string
+		replacement string
+		wantPath    string
+		wantEscaped string
+	}{
+		{
+			name:        "encoded slash survives pin",
+			target:      "/upstream/public/api/userdata/workflows%2Fsdxl.json",
+			model:       "public",
+			replacement: "real",
+			wantPath:    "/upstream/real/api/userdata/workflows/sdxl.json",
+			wantEscaped: "/upstream/real/api/userdata/workflows%2Fsdxl.json",
+		},
+		{
+			name:        "multi-segment model name",
+			target:      "/upstream/author/public/api/x%2Fy",
+			model:       "author/public",
+			replacement: "real",
+			wantPath:    "/upstream/real/api/x/y",
+			wantEscaped: "/upstream/real/api/x%2Fy",
+		},
+		{
+			name:        "unescaped path unchanged",
+			target:      "/upstream/public/v1/chat/completions",
+			model:       "public",
+			replacement: "real",
+			wantPath:    "/upstream/real/v1/chat/completions",
+			wantEscaped: "/upstream/real/v1/chat/completions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.target, nil)
+			// Mirror what ServeMux does: path values arrive already decoded.
+			req.SetPathValue("upstreamPath", strings.TrimPrefix(req.URL.Path, "/upstream/"))
+
+			req, err := ReplaceRequestModel(req, tt.model, tt.replacement)
+			if err != nil {
+				t.Fatalf("ReplaceRequestModel: %v", err)
+			}
+			if req.URL.Path != tt.wantPath {
+				t.Errorf("URL.Path = %q, want %q", req.URL.Path, tt.wantPath)
+			}
+			if got := req.URL.EscapedPath(); got != tt.wantEscaped {
+				t.Errorf("EscapedPath() = %q, want %q", got, tt.wantEscaped)
+			}
+		})
+	}
+}
+
 func TestFetchContext_UpstreamPath_DoesNotReadBody(t *testing.T) {
 	cfg := config.Config{Models: map[string]config.ModelConfig{"m1": {}}}
 	body := `{"model":"should-not-matter"}`


### PR DESCRIPTION
A %2F inside a single path segment was decoded into a path separator before the request was forwarded, so upstreams that address resources that way saw two segments instead of one. ComfyUI's /userdata/{file} endpoint is one: POST /upstream/comfyui/api/userdata/workflows%2Ffoo.json arrived as /api/userdata/workflows/foo.json, missed the route, fell through to the static frontend handler and came back 405.

ServeMux path values and url.URL.Path are both already decoded, so rebuilding a path from either loses the distinction. Carry the client's original escaping over to url.URL.RawPath instead, which is what httputil.ReverseProxy puts on the wire.

- add shared.EscapedPathSuffix to strip the /upstream/<model> prefix from an escaped path while leaving the remainder untouched
- set URL.RawPath in handleUpstream, reading EscapedPath before URL.Path is rewritten
- fix the same loss in ReplaceRequestModel, which rebuilt URL.Path from the decoded path value and cleared RawPath on every profile pin
- cover encoded slashes, multi-segment model names and other escapes

fix: #986