### PR TITLE
internal/server,shared: preserve percent encoded in upstream

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -447,8 +447,11 @@ func (s *Server) handleUpstream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Strip the /upstream/<model> prefix before forwarding.
+	// Strip the /upstream/<model> prefix before forwarding. URL.Path is decoded,
+	// so retain the matching escaped suffix in RawPath for the reverse proxy.
+	escapedRemaining := shared.EscapedPathSuffix(r.URL.EscapedPath(), "/upstream/"+searchName)
 	r.URL.Path = remainingPath
+	r.URL.RawPath = escapedRemaining
 	// Pin the resolved model so the router skips body/query extraction.
 	*r = *r.WithContext(shared.SetContext(r.Context(), shared.ReqContextData{Model: searchName, ModelID: modelID, Metadata: make(map[string]string)}))
 

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -228,6 +228,61 @@ func TestServer_HandleUpstream(t *testing.T) {
 	})
 }
 
+func TestProxy_HandleUpstreamPreservesEscapedPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		models []string
+		target string
+		want   string
+	}{
+		{
+			name:   "encoded slash in resource path",
+			models: []string{"m1"},
+			target: "/upstream/m1/api/userdata/workflows%2Fexample.json",
+			want:   "/api/userdata/workflows%2Fexample.json",
+		},
+		{
+			name:   "multi-segment model name",
+			models: []string{"author/model"},
+			target: "/upstream/author/model/api/x%2Fy",
+			want:   "/api/x%2Fy",
+		},
+		{
+			name:   "encoded separator in multi-segment model name",
+			models: []string{"author/model"},
+			target: "/upstream/author%2Fmodel/api/x%2Fy",
+			want:   "/api/x%2Fy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			local := newStubRouter(tt.models, "")
+			var got string
+			local.serveHTTP = func(w http.ResponseWriter, r *http.Request) {
+				got = r.URL.EscapedPath()
+				w.WriteHeader(http.StatusOK)
+			}
+			s := newTestServer(local, newStubRouter(nil, ""))
+			models := make(map[string]config.ModelConfig, len(tt.models))
+			for _, model := range tt.models {
+				models[model] = config.ModelConfig{}
+			}
+			s.cfg = config.Config{Models: models}
+			s.routes()
+
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, httptest.NewRequest(http.MethodPost, tt.target, nil))
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200 (body=%q)", w.Code, w.Body.String())
+			}
+			if got != tt.want {
+				t.Errorf("upstream escaped path = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func upstreamMetricsServer(t *testing.T, response string) *Server {
 	t.Helper()
 	cfg := config.Config{Models: map[string]config.ModelConfig{"m1": {}}}

--- a/internal/shared/http.go
+++ b/internal/shared/http.go
@@ -11,8 +11,10 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/tidwall/gjson"
@@ -147,6 +149,10 @@ func ReplaceRequestModel(r *http.Request, model, replacement string) (*http.Requ
 			return r, nil
 		}
 
+		// Preserve the client's escaping of the path after the model name before
+		// URL.Path is rewritten below.
+		escapedRemaining := EscapedPathSuffix(r.URL.EscapedPath(), "/upstream/"+model)
+
 		remainingPath := strings.TrimPrefix(upstreamPath, model)
 		rewrittenPath := replacement + remainingPath
 		if replacement == "" {
@@ -155,6 +161,10 @@ func ReplaceRequestModel(r *http.Request, model, replacement string) (*http.Requ
 		r.SetPathValue("upstreamPath", rewrittenPath)
 		r.URL.Path = "/upstream/" + rewrittenPath
 		r.URL.RawPath = ""
+		if replacement != "" && escapedRemaining != "" {
+			prefix := (&url.URL{Path: "/upstream/" + replacement}).EscapedPath()
+			r.URL.RawPath = prefix + escapedRemaining
+		}
 		return invalidateRequestContext(r), nil
 	}
 
@@ -326,6 +336,37 @@ func FindModelInPath(cfg config.Config, path string) (searchName, realName, rema
 	}
 
 	return
+}
+
+// EscapedPathSuffix removes decodedPrefix from escapedPath while leaving the
+// remaining percent-encoding untouched. Decoded paths cannot identify the
+// boundary alone: a model name such as "author/model" may have arrived as the
+// single escaped segment "author%2Fmodel".
+func EscapedPathSuffix(escapedPath, decodedPrefix string) string {
+	rawIndex, prefixIndex := 0, 0
+	for rawIndex < len(escapedPath) && prefixIndex < len(decodedPrefix) {
+		end := rawIndex + 1
+		if escapedPath[rawIndex] == '%' {
+			end = rawIndex + 3
+		} else {
+			_, size := utf8.DecodeRuneInString(escapedPath[rawIndex:])
+			end = rawIndex + size
+		}
+		if end > len(escapedPath) {
+			return ""
+		}
+
+		decoded, err := url.PathUnescape(escapedPath[rawIndex:end])
+		if err != nil || !strings.HasPrefix(decodedPrefix[prefixIndex:], decoded) {
+			return ""
+		}
+		rawIndex = end
+		prefixIndex += len(decoded)
+	}
+	if prefixIndex != len(decodedPrefix) {
+		return ""
+	}
+	return escapedPath[rawIndex:]
 }
 
 func SetContext(ctx context.Context, data ReqContextData) context.Context {

--- a/internal/shared/http_test.go
+++ b/internal/shared/http_test.go
@@ -252,6 +252,22 @@ func TestReplaceRequestModel(t *testing.T) {
 	})
 }
 
+func TestProxy_ReplaceRequestModelUpstreamPreservesEscapedPath(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/upstream/author%2Fmodel/api/x%2Fy", nil)
+	r.SetPathValue("upstreamPath", strings.TrimPrefix(r.URL.Path, "/upstream/"))
+
+	updated, err := ReplaceRequestModel(r, "author/model", "target/model")
+	if err != nil {
+		t.Fatalf("ReplaceRequestModel: %v", err)
+	}
+	if got, want := updated.URL.Path, "/upstream/target/model/api/x/y"; got != want {
+		t.Errorf("URL.Path = %q, want %q", got, want)
+	}
+	if got, want := updated.URL.EscapedPath(), "/upstream/target/model/api/x%2Fy"; got != want {
+		t.Errorf("EscapedPath() = %q, want %q", got, want)
+	}
+}
+
 func TestExtractContext_GET(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -777,6 +793,43 @@ func TestFindModelInPath_PeerNamespaces(t *testing.T) {
 					tt.path, name, modelID, rest, found,
 					tt.wantName, tt.wantModel, tt.wantRest, tt.wantFound,
 				)
+			}
+		})
+	}
+}
+
+func TestProxy_EscapedPathSuffix(t *testing.T) {
+	tests := []struct {
+		escapedPath   string
+		decodedPrefix string
+		want          string
+	}{
+		{
+			escapedPath:   "/upstream/m1/api/userdata/workflows%2Fexample.json",
+			decodedPrefix: "/upstream/m1",
+			want:          "/api/userdata/workflows%2Fexample.json",
+		},
+		{
+			escapedPath:   "/upstream/author/model/api/x%2Fy",
+			decodedPrefix: "/upstream/author/model",
+			want:          "/api/x%2Fy",
+		},
+		{
+			escapedPath:   "/upstream/author%2Fmodel/api/x%2Fy",
+			decodedPrefix: "/upstream/author/model",
+			want:          "/api/x%2Fy",
+		},
+		{
+			escapedPath:   "/upstream/m1",
+			decodedPrefix: "/upstream/m1",
+			want:          "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.escapedPath, func(t *testing.T) {
+			if got := EscapedPathSuffix(tt.escapedPath, tt.decodedPrefix); got != tt.want {
+				t.Errorf("EscapedPathSuffix(%q, %q) = %q, want %q", tt.escapedPath, tt.decodedPrefix, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
fixes: #986
closes: #987