### PR TITLE
config,server: add defaultProfile to select a profile at startup

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -341,6 +341,11 @@
                 "additionalProperties": false
             }
         },
+        "defaultProfile": {
+            "type": "string",
+            "default": "",
+            "description": "Profile to activate on startup and after a configuration reload. Must name a key under profiles. An empty value starts with no profile active."
+        },
         "selectors": {
             "type": "object",
             "default": {},

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -175,7 +175,8 @@ upstream:
 
 # profiles: named model ID replacements switched at runtime through the UI or API
 # - optional, default: empty dictionary
-# - one profile or none is active; startup and configuration reload select none
+# - one profile or none is active; startup and configuration reload select the
+#   defaultProfile below, or none when it is unset
 # - pins are applied before aliases, filters, and routing
 # - targets may be a local model, fully qualified peer model, alias, setParamsByID alias, or selector
 # - an empty string or YAML null (~) disables the pin with a 404; it is not
@@ -187,6 +188,12 @@ profiles:
       "llm-code": "gpt-oss-120b"
       "llm-plan": "qwen-unlisted"
       "image-gen": ~
+
+# defaultProfile: profile to activate on startup and after a configuration reload
+# - optional, default: empty string, which starts with no profile active
+# - must name a key under profiles or the configuration fails to load
+# - the runtime selection is not persisted; restarts return to this profile
+defaultProfile: "coding"
 
 # selectors: virtual model IDs resolved to concrete targets per request
 # - optional, default: empty dictionary

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,6 +82,7 @@ llama-swap supports many more features to customize how you want to manage your 
 | `aliases` | serve a model with different names             |
 | `filters` | modify requests before sending to the upstream |
 | `profiles` | switch model ID replacements at runtime       |
+| `defaultProfile` | activate a profile on startup            |
 | `...`     | And many more tweaks                           |
 
 ## Full Configuration Example
@@ -254,7 +255,8 @@ apiKeys:
 
 # profiles: named model ID replacements switched at runtime through the UI or API
 # - optional, default: empty dictionary
-# - one profile or none is active; startup and configuration reload select none
+# - one profile or none is active; startup and configuration reload select the
+#   defaultProfile below, or none when it is unset
 # - pins are applied before aliases, filters, and routing
 # - targets may be a local model, fully qualified peer model, alias, setParamsByID alias, or selector
 # - an empty string or YAML null (~) disables the pin with a 404; it is not
@@ -266,6 +268,12 @@ profiles:
       "llm-code": "gpt-oss-120b"
       "llm-plan": "qwen-unlisted"
       "image-gen": ~
+
+# defaultProfile: profile to activate on startup and after a configuration reload
+# - optional, default: empty string, which starts with no profile active
+# - must name a key under profiles or the configuration fails to load
+# - the runtime selection is not persisted; restarts return to this profile
+defaultProfile: "coding"
 
 # selectors: virtual model IDs resolved to concrete targets per request
 # - optional, default: empty dictionary

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -146,6 +146,7 @@ type Config struct {
 	UnloadTimeout      int                       `yaml:"unloadTimeout"`
 	Models             map[string]ModelConfig    `yaml:"models"` /* key is model ID */
 	Profiles           map[string]ProfileConfig  `yaml:"profiles"`
+	DefaultProfile     string                    `yaml:"defaultProfile"`
 	Selectors          map[string]SelectorConfig `yaml:"selectors"`
 
 	// routing is the canonical source for swap/scheduling configuration.

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -325,6 +325,11 @@ func validateProfiles(config Config) error {
 			}
 		}
 	}
+	if config.DefaultProfile != "" {
+		if _, found := config.Profiles[config.DefaultProfile]; !found {
+			return fmt.Errorf("defaultProfile references unknown profile %q", config.DefaultProfile)
+		}
+	}
 	return nil
 }
 

--- a/internal/config/profile_test.go
+++ b/internal/config/profile_test.go
@@ -34,8 +34,11 @@ profiles:
       disabled-empty: ""
       disabled-null: ~
       local: peer-model
+defaultProfile: coding
 `))
 	require.NoError(t, err)
+
+	assert.Equal(t, "coding", cfg.DefaultProfile)
 
 	profile := cfg.Profiles["coding"]
 	assert.Equal(t, "Coding profile", profile.Description)
@@ -106,6 +109,16 @@ func TestConfig_Profiles_Validation(t *testing.T) {
       public: missing
 `,
 			wantErr: "references unknown model",
+		},
+		{
+			name: "unknown default profile",
+			profile: `profiles:
+  good:
+    pins:
+      public: model
+defaultProfile: missing
+`,
+			wantErr: "defaultProfile references unknown profile",
 		},
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -183,20 +183,21 @@ func New(cfg config.Config, muxlog *logmon.Monitor, proxylog *logmon.Monitor, up
 
 	shutdownCtx, shutdownFn := context.WithCancel(context.Background())
 	s := &Server{
-		cfg:         cfg,
-		muxlog:      muxlog,
-		proxylog:    proxylog,
-		upstreamlog: upstreamlog,
-		perf:        perfMon,
-		inflight:    newInflightTracker(),
-		metrics:     newMetricsMonitor(proxylog, cfg.MetricsMaxInMemory, cfg.CaptureBuffer, st),
-		store:       st,
-		build:       build,
-		hardware:    hardware,
-		local:       local,
-		peer:        peer,
-		shutdownCtx: shutdownCtx,
-		shutdownFn:  shutdownFn,
+		cfg:           cfg,
+		muxlog:        muxlog,
+		proxylog:      proxylog,
+		upstreamlog:   upstreamlog,
+		perf:          perfMon,
+		inflight:      newInflightTracker(),
+		metrics:       newMetricsMonitor(proxylog, cfg.MetricsMaxInMemory, cfg.CaptureBuffer, st),
+		store:         st,
+		build:         build,
+		hardware:      hardware,
+		activeProfile: cfg.DefaultProfile,
+		local:         local,
+		peer:          peer,
+		shutdownCtx:   shutdownCtx,
+		shutdownFn:    shutdownFn,
 	}
 	s.routes()
 	s.startPreload()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -174,6 +174,30 @@ func TestServer_New_MatrixConfig(t *testing.T) {
 	}
 }
 
+func TestServer_New_DefaultProfile(t *testing.T) {
+	discard := logmon.NewWriter(io.Discard)
+	cfg := config.Config{HealthCheckTimeout: 15}
+	cfg.Profiles = map[string]config.ProfileConfig{
+		"coding": {Pins: map[string]string{"llm-code": "model"}},
+	}
+	cfg.DefaultProfile = "coding"
+	st, err := store.New("")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer st.Close()
+	s, err := New(cfg, discard, discard, discard, nil, st, BuildInfo{}, nil)
+	if err != nil {
+		t.Fatalf("New (default profile): %v", err)
+	}
+	if got := s.ActiveProfile(); got != "coding" {
+		t.Fatalf("ActiveProfile()=%q want %q", got, "coding")
+	}
+	if err := s.Shutdown(time.Second); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
 func TestServer_RouteToLocalModel(t *testing.T) {
 	s := newTestServer(
 		newStubRouter([]string{"local-model"}, "local response"),


### PR DESCRIPTION
Closes #992

Profiles can only be activated at runtime through the UI or the API, so a restart or a configuration reload always lands on "no profile". Deployments that run unattended have no way to express which profile they want.

This adds an optional top-level `defaultProfile` naming a key under `profiles:`. It seeds the active profile when the server is built, so it applies on startup and on every configuration reload.

```yaml
profiles:
  coding:
    pins:
      llm-code: "gpt-oss-120b"

defaultProfile: "coding"
```

Changes:

- validate `defaultProfile` against the configured profiles at load time, as the last step of `validateProfiles`
- seed `Server.activeProfile` from the config in `New()`, so the profile is active for the very first request and `/v1/models` reflects its pins
- document the setting in `config-schema.json`, `config.example.yaml`, and `docs/configuration.md`
- tests for the load path and for the seeded server

Behaviour notes:

- omitting the setting or leaving it empty keeps the current behaviour, so existing configurations are unaffected
- an unknown name fails the load with `defaultProfile references unknown profile "..."`
- the runtime selection is still not persisted; switching in the UI lasts until the next restart or reload, and "None" remains selectable

The diff in `server.go` is one added struct field plus gofmt realignment.

AI disclosure: implemented by Opus.