### PR TITLE
ui-svelte,internal/server: show capability tags on Models page

### DIFF
--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -989,6 +989,55 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 	})
 }
 
+// TestServer_ModelStatus_Capabilities verifies the /api/events modelStatus
+// payload carries capability booleans and context_length for configured models.
+// The Models list reads both from this SSE payload.
+func TestServer_ModelStatus_Capabilities(t *testing.T) {
+	newServer := func(mc config.ModelConfig) *Server {
+		s := newTestServer(newStubRouter(nil, ""), newStubRouter(nil, ""))
+		s.cfg = config.Config{Models: map[string]config.ModelConfig{"m": mc}}
+		return s
+	}
+
+	t.Run("renders capabilities and context", func(t *testing.T) {
+		s := newServer(config.ModelConfig{
+			Capabilities: config.ModelCapConfig{
+				In:      []string{"text", "image"},
+				Tools:   true,
+				Context: 128000,
+			},
+		})
+		status := s.modelStatus()
+		if len(status) != 1 {
+			t.Fatalf("expected 1 model, got %d", len(status))
+		}
+		m := status[0]
+		if m.Id != "m" {
+			t.Errorf("id = %q, want m", m.Id)
+		}
+		if m.Capabilities == nil || m.Capabilities["vision"] != true {
+			t.Errorf("vision = %v", m.Capabilities)
+		}
+		if m.Capabilities["function_calling"] != true {
+			t.Errorf("function_calling = %v", m.Capabilities["function_calling"])
+		}
+		if m.ContextLength != 128000 {
+			t.Errorf("context_length = %d, want 128000", m.ContextLength)
+		}
+	})
+
+	t.Run("omits capabilities when empty", func(t *testing.T) {
+		s := newServer(config.ModelConfig{})
+		m := s.modelStatus()[0]
+		if m.Capabilities != nil {
+			t.Errorf("expected no capabilities, got %v", m.Capabilities)
+		}
+		if m.ContextLength != 0 {
+			t.Errorf("expected no context_length, got %d", m.ContextLength)
+		}
+	})
+}
+
 func stringSliceEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -19,14 +19,15 @@ import (
 
 // apiModel is one entry in the /api/events modelStatus payload.
 type apiModel struct {
-	Id           string         `json:"id"`
-	Name         string         `json:"name"`
-	Description  string         `json:"description"`
-	State        string         `json:"state"`
-	Unlisted     bool           `json:"unlisted"`
-	PeerID       string         `json:"peerID"`
-	Aliases      []string       `json:"aliases,omitempty"`
-	Capabilities map[string]any `json:"capabilities,omitempty"`
+	Id            string         `json:"id"`
+	Name          string         `json:"name"`
+	Description   string         `json:"description"`
+	State         string         `json:"state"`
+	Unlisted      bool           `json:"unlisted"`
+	PeerID        string         `json:"peerID"`
+	Aliases       []string       `json:"aliases,omitempty"`
+	Capabilities  map[string]any `json:"capabilities,omitempty"`
+	ContextLength int            `json:"context_length,omitempty"`
 }
 
 type apiProfile struct {
@@ -111,15 +112,16 @@ func (s *Server) modelStatus() []apiModel {
 		if st, ok := running[id]; ok {
 			state = string(st)
 		}
-		_, capsMap, _, _ := renderCapabilities(mc.Capabilities)
+		_, capsMap, _, ctxLen := renderCapabilities(mc.Capabilities)
 		models = append(models, apiModel{
-			Id:           id,
-			Name:         mc.Name,
-			Description:  mc.Description,
-			State:        state,
-			Unlisted:     mc.Unlisted,
-			Aliases:      mc.Aliases,
-			Capabilities: capsMap,
+			Id:            id,
+			Name:          mc.Name,
+			Description:   mc.Description,
+			State:         state,
+			Unlisted:      mc.Unlisted,
+			Aliases:       mc.Aliases,
+			Capabilities:  capsMap,
+			ContextLength: ctxLen,
 		})
 	}
 

--- a/ui-svelte/src/components/model/ModelDetailsTab.svelte
+++ b/ui-svelte/src/components/model/ModelDetailsTab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Model } from "../../lib/types";
+  import { capabilityLabels } from "../../lib/capabilities";
   import * as Card from "$lib/components/ui/card/index.js";
   import Tag from "../Tag.svelte";
 
@@ -8,16 +9,6 @@
   }
 
   let { model }: Props = $props();
-
-  const capabilityLabels: Record<string, string> = {
-    vision: "Vision",
-    audio_transcriptions: "Transcription",
-    audio_speech: "Speech",
-    image_generation: "Image Gen",
-    image_to_image: "Img→Img",
-    function_calling: "Function Calling",
-    reranker: "Reranker",
-  };
 
   let capabilities = $derived.by(() => {
     const caps = model?.capabilities ?? {};

--- a/ui-svelte/src/lib/capabilities.test.ts
+++ b/ui-svelte/src/lib/capabilities.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { formatContextLength, listCapabilityBadges, capabilityLabels, capabilityBadgeClass } from "./capabilities";
+import type { Model } from "./types";
+
+describe("formatContextLength", () => {
+  it("returns empty for zero or negative", () => {
+    expect(formatContextLength(0)).toBe("");
+    expect(formatContextLength(-1)).toBe("");
+  });
+
+  it("passes small values through as-is", () => {
+    expect(formatContextLength(512)).toBe("512");
+    expect(formatContextLength(999)).toBe("999");
+  });
+
+  it("formats thousands with a K suffix", () => {
+    expect(formatContextLength(1000)).toBe("1K");
+    expect(formatContextLength(8192)).toBe("8K");
+    expect(formatContextLength(128000)).toBe("128K");
+    expect(formatContextLength(200000)).toBe("200K");
+  });
+
+  it("rounds non-round thousands to the nearest K", () => {
+    expect(formatContextLength(32768)).toBe("33K");
+    expect(formatContextLength(131072)).toBe("131K");
+  });
+
+  it("formats whole millions with an M suffix", () => {
+    expect(formatContextLength(1_000_000)).toBe("1M");
+    expect(formatContextLength(10_000_000)).toBe("10M");
+  });
+
+  it("formats fractional millions with one decimal", () => {
+    expect(formatContextLength(1_500_000)).toBe("1.5M");
+    expect(formatContextLength(1_048_576)).toBe("1.0M");
+  });
+});
+
+describe("listCapabilityBadges", () => {
+  const base: Pick<Model, "capabilities" | "context_length"> = {};
+
+  it("returns nothing when no context and no capabilities", () => {
+    expect(listCapabilityBadges({ ...base })).toEqual([]);
+  });
+
+  it("puts the context badge last (rightmost)", () => {
+    const badges = listCapabilityBadges({
+      capabilities: { vision: true },
+      context_length: 128000,
+    });
+    expect(badges[badges.length - 1]).toEqual({ key: "context", label: "128K" });
+  });
+
+  it("lists capabilities in the canonical label order", () => {
+    const badges = listCapabilityBadges({
+      capabilities: {
+        function_calling: true,
+        vision: true,
+        reranker: true,
+        audio_speech: true,
+      },
+    });
+    expect(badges.map((b) => b.key)).toEqual([
+      "vision",
+      "audio_speech",
+      "function_calling",
+      "reranker",
+    ]);
+  });
+
+  it("uses the full Details-tab labels", () => {
+    const badges = listCapabilityBadges({
+      capabilities: { function_calling: true, image_generation: true },
+    });
+    expect(badges).toContainEqual({ key: "function_calling", label: "Function Calling" });
+    expect(badges).toContainEqual({ key: "image_generation", label: "Image Gen" });
+  });
+
+  it("ignores falsey capabilities", () => {
+    const badges = listCapabilityBadges({
+      capabilities: { vision: false, function_calling: true },
+    });
+    expect(badges.map((b) => b.key)).toEqual(["function_calling"]);
+  });
+
+  it("surfaces all reported capabilities, not a curated subset", () => {
+    const badges = listCapabilityBadges({
+      capabilities: { reranker: true, audio_speech: true, image_to_image: true },
+    });
+    expect(badges.map((b) => b.key)).toEqual(["audio_speech", "image_to_image", "reranker"]);
+  });
+
+  it("omits the context badge when context_length is missing or zero", () => {
+    expect(listCapabilityBadges({ capabilities: { vision: true } })).toEqual([
+      { key: "vision", label: "Vision" },
+    ]);
+    expect(
+      listCapabilityBadges({ context_length: 0, capabilities: { vision: true } }).map((b) => b.key),
+    ).toEqual(["vision"]);
+  });
+
+  it("keeps the canonical labels map covering all known keys", () => {
+    for (const key of [
+      "vision",
+      "audio_transcriptions",
+      "audio_speech",
+      "image_generation",
+      "image_to_image",
+      "function_calling",
+      "reranker",
+    ]) {
+      expect(capabilityLabels[key]).toBeTruthy();
+    }
+  });
+
+  it("gives every surfaced badge key a pastel color class", () => {
+    const badges = listCapabilityBadges({
+      context_length: 128000,
+      capabilities: {
+        vision: true,
+        audio_transcriptions: true,
+        audio_speech: true,
+        image_generation: true,
+        image_to_image: true,
+        function_calling: true,
+        reranker: true,
+      },
+    });
+    // 7 capabilities + context
+    expect(badges.length).toBe(8);
+    for (const badge of badges) {
+      expect(capabilityBadgeClass[badge.key], `missing color for ${badge.key}`).toBeTruthy();
+    }
+  });
+});

--- a/ui-svelte/src/lib/capabilities.ts
+++ b/ui-svelte/src/lib/capabilities.ts
@@ -1,0 +1,71 @@
+import type { Model } from "./types";
+
+// Canonical capability key -> human label. Shared by the model Details tab
+// and the Models list so labels live in exactly one place.
+export const capabilityLabels: Record<string, string> = {
+  vision: "Vision",
+  audio_transcriptions: "Transcription",
+  audio_speech: "Speech",
+  image_generation: "Image Gen",
+  image_to_image: "Img→Img",
+  function_calling: "Function Calling",
+  reranker: "Reranker",
+};
+
+export interface CapabilityBadge {
+  key: string;
+  label: string;
+}
+
+// Formats a token count as a compact context-window badge. Uses decimal units
+// (128000 -> "128K", 1000000 -> "1M") to match the conventional "128K context"
+// wording used by llama.cpp and OpenAI-compatible listings.
+export function formatContextLength(tokens: number): string {
+  if (tokens <= 0) return "";
+  if (tokens >= 1_000_000) {
+    const m = tokens / 1_000_000;
+    return Number.isInteger(m) ? `${m}M` : `${m.toFixed(1)}M`;
+  }
+  if (tokens >= 1_000) {
+    const k = tokens / 1_000;
+    return Number.isInteger(k) ? `${k}K` : `${Math.round(k)}K`;
+  }
+  return String(tokens);
+}
+
+// Muted pastel background/text classes per capability badge key, so each is
+// visually distinct on the Models list. Low-opacity backgrounds keep the look
+// soft; the 700/300 text shades keep contrast in light and dark mode.
+export const capabilityBadgeClass: Record<string, string> = {
+  vision: "bg-violet-500/15 text-violet-700 dark:text-violet-300",
+  audio_transcriptions: "bg-amber-500/15 text-amber-700 dark:text-amber-300",
+  audio_speech: "bg-rose-500/15 text-rose-700 dark:text-rose-300",
+  image_generation: "bg-fuchsia-500/15 text-fuchsia-700 dark:text-fuchsia-300",
+  image_to_image: "bg-orange-500/15 text-orange-700 dark:text-orange-300",
+  function_calling: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+  reranker: "bg-indigo-500/15 text-indigo-700 dark:text-indigo-300",
+  context: "bg-sky-500/15 text-sky-700 dark:text-sky-300",
+};
+
+// Returns the capability badges for a Models list row: every reported
+// capability in canonical order (mirroring the Details tab tag set), with the
+// context window last so it sits on the right of the group.
+export function listCapabilityBadges(
+  model: Pick<Model, "capabilities" | "context_length">,
+): CapabilityBadge[] {
+  const badges: CapabilityBadge[] = [];
+
+  const caps = model.capabilities ?? {};
+  for (const key of Object.keys(capabilityLabels)) {
+    if (caps[key as keyof Model["capabilities"]]) {
+      badges.push({ key, label: capabilityLabels[key] });
+    }
+  }
+
+  const ctx = model.context_length ?? 0;
+  if (ctx > 0) {
+    badges.push({ key: "context", label: formatContextLength(ctx) });
+  }
+
+  return badges;
+}

--- a/ui-svelte/src/lib/types.ts
+++ b/ui-svelte/src/lib/types.ts
@@ -23,6 +23,7 @@ export interface Model {
   playgroundType?: PlaygroundModelType;
   aliases?: string[];
   capabilities?: ModelCapabilities;
+  context_length?: number;
   // selector-only fields from the v1/models llamaswap metadata
   strategy?: string;
   targets?: string[];

--- a/ui-svelte/src/routes/ModelsDash.svelte
+++ b/ui-svelte/src/routes/ModelsDash.svelte
@@ -79,7 +79,7 @@
     {#if $showCapabilityTags}
       {@const badges = listCapabilityBadges(model)}
       {#if badges.length > 0}
-        <div class="flex items-center gap-1">
+        <div class="flex min-w-0 flex-wrap items-center gap-1">
           {#each badges as badge (badge.key)}
             <Tag class={`px-1.5 text-[0.625rem] ${capabilityBadgeClass[badge.key] ?? ""}`}>{badge.label}</Tag>
           {/each}

--- a/ui-svelte/src/routes/ModelsDash.svelte
+++ b/ui-svelte/src/routes/ModelsDash.svelte
@@ -11,7 +11,8 @@
     unloadAllModels,
   } from "../stores/api";
   import { statusDotColor } from "../stores/modelLoad";
-  import { showUnlistedModels as showUnlisted } from "../stores/modelDisplay";
+  import { showUnlistedModels as showUnlisted, showCapabilityTags } from "../stores/modelDisplay";
+  import { listCapabilityBadges, capabilityBadgeClass } from "../lib/capabilities";
   import type { Model } from "../lib/types";
   import ModelLoadButton from "../components/ModelLoadButton.svelte";
   import Tag from "../components/Tag.svelte";
@@ -75,6 +76,16 @@
         {/if}
       </div>
     </a>
+    {#if $showCapabilityTags}
+      {@const badges = listCapabilityBadges(model)}
+      {#if badges.length > 0}
+        <div class="flex items-center gap-1">
+          {#each badges as badge (badge.key)}
+            <Tag class={`px-1.5 text-[0.625rem] ${capabilityBadgeClass[badge.key] ?? ""}`}>{badge.label}</Tag>
+          {/each}
+        </div>
+      {/if}
+    {/if}
     <span class="text-muted-foreground text-xs uppercase tracking-wide">
       {model.state}
     </span>

--- a/ui-svelte/src/routes/ModelsDash.svelte
+++ b/ui-svelte/src/routes/ModelsDash.svelte
@@ -79,7 +79,7 @@
     {#if $showCapabilityTags}
       {@const badges = listCapabilityBadges(model)}
       {#if badges.length > 0}
-        <div class="flex min-w-0 flex-wrap items-center gap-1">
+        <div class="hidden min-w-0 flex-wrap items-center gap-1 sm:flex">
           {#each badges as badge (badge.key)}
             <Tag class={`px-1.5 text-[0.625rem] ${capabilityBadgeClass[badge.key] ?? ""}`}>{badge.label}</Tag>
           {/each}

--- a/ui-svelte/src/routes/Settings.svelte
+++ b/ui-svelte/src/routes/Settings.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { connectionState, themeName, themeMode, themes, type ThemeMode } from "../stores/theme";
   import { versionInfo } from "../stores/api";
+  import { showCapabilityTags } from "../stores/modelDisplay";
   import * as Select from "$lib/components/ui/select/index.js";
+  import * as Switch from "$lib/components/ui/switch/index.js";
+  import * as Label from "$lib/components/ui/label/index.js";
 
   const modes: { value: ThemeMode; label: string }[] = [
     { value: "light", label: "Light" },
@@ -49,6 +52,24 @@
           {/each}
         </Select.Content>
       </Select.Root>
+    </div>
+  </div>
+
+  <div class="rounded-lg border p-4 space-y-3 max-w-md mb-4">
+    <h4 class="text-sm font-semibold text-muted-foreground">Models page</h4>
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <Label.Root for="show-capability-tags" class="text-sm">Show capability tags</Label.Root>
+        <p class="text-muted-foreground text-xs">
+          Show all capability badges next to each model, mirroring the Details tab
+          (vision, tools, context window, and more).
+        </p>
+      </div>
+      <Switch.Root
+        id="show-capability-tags"
+        checked={$showCapabilityTags}
+        onCheckedChange={(v) => showCapabilityTags.set(v)}
+      />
     </div>
   </div>
 

--- a/ui-svelte/src/stores/modelDisplay.ts
+++ b/ui-svelte/src/stores/modelDisplay.ts
@@ -4,3 +4,10 @@ export const showUnlistedModels = persistentStore<boolean>(
   "models-dash-show-unlisted",
   false,
 );
+
+// Show a curated set of capability badges (context window, vision, tools) on
+// each Models list row. Off by default to keep the list dense.
+export const showCapabilityTags = persistentStore<boolean>(
+  "models-dash-show-capability-tags",
+  false,
+);


### PR DESCRIPTION
## Summary

Add an opt-in setting to surface capability badges next to each model on the Models list.
All capability tags from the Details tab are shown in canonical order, each with a distinct muted pastel color; the context window badge sits last (rightmost). 
Disabled by default to keep the list dense; toggle in Settings.

LLM Disclosure: Yes, GLM-5.2 helped along

Fixes #1006

## Changes

- add shared `capabilityLabels`, `capabilityBadgeClass`, `listCapabilityBadges` and `formatContextLength` helpers (`ui-svelte/src/lib/capabilities.ts`) with unit tests
- extract `ModelDetailsTab` labels into the shared module (DRY)
- add `showCapabilityTags` persistent store (`modelDisplay`)
- render badges in `ModelsDash` modelRow, before the state label
- add a "Models page" toggle to `Settings`
- expose `context_length` on the `modelStatus` SSE payload (`apiModel`) so the Models list can badge context window size (the value already existed on `/v1/models`; this only adds it to the SSE stream the list reads from)

## Screenshots
<img width="1231" height="1001" alt="librewolf_jI0q01RKoT" src="https://github.com/user-attachments/assets/ef91033e-9be5-41d4-91ca-12716e653058" />
<img width="745" height="729" alt="librewolf_X9hmpxU1k7" src="https://github.com/user-attachments/assets/2a944020-ca27-4c05-9fca-6670feedc9a6" />



## Notes

- Pure UI feature; no new config fields or behavior beyond the SSE plumbing above. The setting is GUI-only (localStorage), default off.
- Capability data stays declarative (operator asserts it under `capabilities:` in YAML); llama-swap does not verify the upstream actually supports a capability, same as today.