### PR TITLE
Fix #838: render ANSI colors in logs

### DIFF
--- a/ui/src/components/LogPanel.svelte
+++ b/ui/src/components/LogPanel.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { persistentStore } from "../stores/persistent";
+  import { isDarkMode } from "../stores/theme";
+  import { ansiToHtml } from "../lib/ansi";
   import { Type, WrapText, Search, SearchX, CircleX } from "@lucide/svelte";
   import { Button } from "$lib/components/ui/button/index.js";
   import { Input } from "$lib/components/ui/input/index.js";
@@ -68,6 +70,8 @@
     }
   });
 
+  let renderedLogs = $derived(ansiToHtml(filteredLogs, $isDarkMode));
+
   let preElement: HTMLPreElement;
   let userScrolledUp = $state(false);
 
@@ -111,6 +115,6 @@
     {/if}
   </Card.Header>
   <Card.Content class="bg-background min-h-0 flex-1 p-0 font-mono text-sm">
-    <pre bind:this={preElement} onscroll={handleScroll} class="{textWrapClass} {fontSizeClass} h-full overflow-auto p-4">{filteredLogs}</pre>
+    <pre bind:this={preElement} onscroll={handleScroll} class="{textWrapClass} {fontSizeClass} h-full overflow-auto p-4">{@html renderedLogs}</pre>
   </Card.Content>
 </Card.Root>

--- a/ui/src/lib/ansi.test.ts
+++ b/ui/src/lib/ansi.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { ansiToHtml } from "./ansi";
+
+describe("ansiToHtml", () => {
+  it("returns escaped plain text when no ANSI codes are present", () => {
+    expect(ansiToHtml("hello <world> & \"friends\"")).toBe("hello &lt;world&gt; &amp; &quot;friends&quot;");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(ansiToHtml("")).toBe("");
+  });
+
+  it("renders foreground color", () => {
+    expect(ansiToHtml("\x1b[32mgreen\x1b[0m")).toBe('<span style="color:#008700">green</span>');
+  });
+
+  it("renders bold combined with color", () => {
+    expect(ansiToHtml("\x1b[1;31merror\x1b[0m")).toBe('<span style="font-weight:600;color:#cd0000">error</span>');
+  });
+
+  it("merges consecutive chunks with the same style", () => {
+    expect(ansiToHtml("\x1b[32ma\x1b[32mb")).toBe('<span style="color:#008700">ab</span>');
+  });
+
+  it("renders plain text after reset", () => {
+    expect(ansiToHtml("\x1b[32mgreen\x1b[0mplain")).toBe('<span style="color:#008700">green</span>plain');
+  });
+
+  it("renders background color", () => {
+    expect(ansiToHtml("\x1b[41mred bg\x1b[0m")).toBe('<span style="background-color:#cd0000">red bg</span>');
+  });
+
+  it("renders bright colors", () => {
+    expect(ansiToHtml("\x1b[93mbright yellow\x1b[0m")).toBe('<span style="color:#cdcd00">bright yellow</span>');
+  });
+
+  it("renders 256-color foreground", () => {
+    expect(ansiToHtml("\x1b[38;5;196mred\x1b[0m")).toBe('<span style="color:rgb(255, 0, 0)">red</span>');
+  });
+
+  it("renders 256-color background from the base palette", () => {
+    expect(ansiToHtml("\x1b[48;5;4mblue\x1b[0m")).toBe('<span style="background-color:#0000ee">blue</span>');
+  });
+
+  it("renders truecolor foreground", () => {
+    expect(ansiToHtml("\x1b[38;2;10;20;30mcustom\x1b[0m")).toBe('<span style="color:rgb(10, 20, 30)">custom</span>');
+  });
+
+  it("renders italic and underline", () => {
+    expect(ansiToHtml("\x1b[3;4mstyled\x1b[0m")).toBe('<span style="font-style:italic;text-decoration:underline">styled</span>');
+  });
+
+  it("treats empty SGR as reset", () => {
+    expect(ansiToHtml("\x1b[32ma\x1b[mplain")).toBe('<span style="color:#008700">a</span>plain');
+  });
+
+  it("drops non-SGR CSI sequences", () => {
+    expect(ansiToHtml("\x1b[2Kline")).toBe("line");
+  });
+
+  it("closes open span at end of input without reset", () => {
+    expect(ansiToHtml("\x1b[32mgreen")).toBe('<span style="color:#008700">green</span>');
+  });
+
+  it("escapes HTML inside colored segments", () => {
+    expect(ansiToHtml("\x1b[32m<a>\x1b[0m")).toBe('<span style="color:#008700">&lt;a&gt;</span>');
+  });
+
+  it("handles a typical llama-server colored log line", () => {
+    const line = "\x1b[1;32m[server]\x1b[0m loading model";
+    expect(ansiToHtml(line)).toBe('<span style="font-weight:600;color:#008700">[server]</span> loading model');
+  });
+
+  describe("dark palette", () => {
+    it("renders brighter foreground colors", () => {
+      expect(ansiToHtml("\x1b[32mgreen\x1b[0m", true)).toBe('<span style="color:#50fa7b">green</span>');
+    });
+
+    it("renders brighter blue for timestamps", () => {
+      expect(ansiToHtml("\x1b[34mblue\x1b[0m", true)).toBe('<span style="color:#61afef">blue</span>');
+    });
+
+    it("renders brighter bright colors", () => {
+      expect(ansiToHtml("\x1b[93mbright yellow\x1b[0m", true)).toBe('<span style="color:#f5fc9e">bright yellow</span>');
+    });
+
+    it("renders 256-color base palette from the dark palette", () => {
+      expect(ansiToHtml("\x1b[48;5;4mblue\x1b[0m", true)).toBe('<span style="background-color:#61afef">blue</span>');
+    });
+
+    it("renders 256-color cube colors identically in both palettes", () => {
+      expect(ansiToHtml("\x1b[38;5;196mred\x1b[0m", true)).toBe('<span style="color:rgb(255, 0, 0)">red</span>');
+    });
+  });
+});

--- a/ui/src/lib/ansi.ts
+++ b/ui/src/lib/ansi.ts
@@ -1,0 +1,208 @@
+import { escapeHtml } from "./markdown";
+
+interface AnsiStyle {
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  strikethrough: boolean;
+  fg: string | null;
+  bg: string | null;
+}
+
+const DEFAULT_STYLE: AnsiStyle = {
+  bold: false,
+  italic: false,
+  underline: false,
+  strikethrough: false,
+  fg: null,
+  bg: null,
+};
+
+interface AnsiPalette {
+  colors: string[];
+  brightColors: string[];
+}
+
+// Classic terminal colors, darkened where needed for light backgrounds
+const LIGHT_PALETTE: AnsiPalette = {
+  colors: ["#000000", "#cd0000", "#008700", "#8a6d00", "#0000ee", "#cd00cd", "#008b8b", "#e5e5e5"],
+  brightColors: ["#7f7f7f", "#ff0000", "#00cd00", "#cdcd00", "#5c5cff", "#ff00ff", "#00cdcd", "#ffffff"],
+};
+
+// Brighter variants for dark backgrounds
+const DARK_PALETTE: AnsiPalette = {
+  colors: ["#767676", "#ff5555", "#50fa7b", "#f1fa8c", "#61afef", "#ff79c1", "#8be9fd", "#e5e5e5"],
+  brightColors: ["#969696", "#ff6e6e", "#69ff94", "#f5fc9e", "#7cc0ff", "#ff92d0", "#a4f5ff", "#ffffff"],
+};
+
+function color256(n: number, palette: AnsiPalette): string {
+  if (n < 16) {
+    return n < 8 ? palette.colors[n] : palette.brightColors[n - 8];
+  }
+  if (n < 232) {
+    const i = n - 16;
+    const to255 = (v: number) => (v === 0 ? 0 : v * 40 + 55);
+    const r = to255(Math.floor(i / 36));
+    const g = to255(Math.floor((i % 36) / 6));
+    const b = to255(i % 6);
+    return `rgb(${r}, ${g}, ${b})`;
+  }
+  const v = (n - 232) * 10 + 8;
+  return `rgb(${v}, ${v}, ${v})`;
+}
+
+function applySgr(prev: AnsiStyle, params: number[], palette: AnsiPalette): AnsiStyle {
+  let style = prev;
+  const update = (patch: Partial<AnsiStyle>) => {
+    if (style === prev) {
+      style = { ...prev };
+    }
+    Object.assign(style, patch);
+  };
+
+  let i = 0;
+  while (i < params.length) {
+    const p = params[i];
+    if (p === 0) {
+      update({ ...DEFAULT_STYLE });
+    } else if (p === 1) {
+      update({ bold: true });
+    } else if (p === 3) {
+      update({ italic: true });
+    } else if (p === 4) {
+      update({ underline: true });
+    } else if (p === 9) {
+      update({ strikethrough: true });
+    } else if (p === 22) {
+      update({ bold: false });
+    } else if (p === 23) {
+      update({ italic: false });
+    } else if (p === 24) {
+      update({ underline: false });
+    } else if (p === 29) {
+      update({ strikethrough: false });
+    } else if (p >= 30 && p <= 37) {
+      update({ fg: palette.colors[p - 30] });
+    } else if (p === 39) {
+      update({ fg: null });
+    } else if (p >= 40 && p <= 47) {
+      update({ bg: palette.colors[p - 40] });
+    } else if (p === 49) {
+      update({ bg: null });
+    } else if (p >= 90 && p <= 97) {
+      update({ fg: palette.brightColors[p - 90] });
+    } else if (p >= 100 && p <= 107) {
+      update({ bg: palette.brightColors[p - 100] });
+    } else if (p === 38 || p === 48) {
+      const isFg = p === 38;
+      if (params[i + 1] === 5) {
+        const color = color256(params[i + 2] ?? 0, palette);
+        update(isFg ? { fg: color } : { bg: color });
+        i += 2;
+      } else if (params[i + 1] === 2) {
+        const r = params[i + 2] ?? 0;
+        const g = params[i + 3] ?? 0;
+        const b = params[i + 4] ?? 0;
+        const color = `rgb(${r}, ${g}, ${b})`;
+        update(isFg ? { fg: color } : { bg: color });
+        i += 4;
+      }
+    }
+    i++;
+  }
+  if (
+    style.bold === prev.bold &&
+    style.italic === prev.italic &&
+    style.underline === prev.underline &&
+    style.strikethrough === prev.strikethrough &&
+    style.fg === prev.fg &&
+    style.bg === prev.bg
+  ) {
+    return prev;
+  }
+  return style;
+}
+
+function styleIsDefault(style: AnsiStyle): boolean {
+  return (
+    !style.bold &&
+    !style.italic &&
+    !style.underline &&
+    !style.strikethrough &&
+    style.fg === null &&
+    style.bg === null
+  );
+}
+
+function styleToCss(style: AnsiStyle): string {
+  const parts: string[] = [];
+  if (style.bold) parts.push("font-weight:600");
+  if (style.italic) parts.push("font-style:italic");
+  const decoration: string[] = [];
+  if (style.underline) decoration.push("underline");
+  if (style.strikethrough) decoration.push("line-through");
+  if (decoration.length > 0) parts.push(`text-decoration:${decoration.join(" ")}`);
+  if (style.fg) parts.push(`color:${style.fg}`);
+  if (style.bg) parts.push(`background-color:${style.bg}`);
+  return parts.join(";");
+}
+
+const CSI_REGEX = /\x1b\[([0-9;?]*)([a-zA-Z])/g;
+
+/**
+ * Convert a string containing ANSI escape sequences into HTML. SGR
+ * (select graphic rendition) sequences become inline-styled spans;
+ * other CSI sequences are dropped. Text content is HTML-escaped.
+ * Strings without escape codes are returned escaped as-is.
+ * The `dark` flag selects a palette readable on the given background.
+ */
+export function ansiToHtml(text: string, dark: boolean = false): string {
+  if (!text.includes("\x1b[")) {
+    return escapeHtml(text);
+  }
+
+  const palette = dark ? DARK_PALETTE : LIGHT_PALETTE;
+  let html = "";
+  let lastIndex = 0;
+  let style: AnsiStyle = DEFAULT_STYLE;
+  let openStyle: AnsiStyle | null = null;
+
+  const closeSpan = () => {
+    if (openStyle !== null) {
+      html += "</span>";
+      openStyle = null;
+    }
+  };
+
+  const flush = (end: number) => {
+    if (end <= lastIndex) return;
+    const chunk = escapeHtml(text.slice(lastIndex, end));
+    lastIndex = end;
+    if (styleIsDefault(style)) {
+      closeSpan();
+      html += chunk;
+    } else if (openStyle === style) {
+      html += chunk;
+    } else {
+      closeSpan();
+      html += `<span style="${styleToCss(style)}">${chunk}`;
+      openStyle = style;
+    }
+  };
+
+  const regex = new RegExp(CSI_REGEX.source, "g");
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(text)) !== null) {
+    flush(match.index);
+    lastIndex = match.index + match[0].length;
+    if (match[2] === "m") {
+      const raw = match[1];
+      const params =
+        raw === "" ? [0] : raw.split(";").map((part) => (part === "" ? 0 : Number.parseInt(part, 10)));
+      style = applySgr(style, params, palette);
+    }
+  }
+  flush(text.length);
+  closeSpan();
+  return html;
+}


### PR DESCRIPTION
llama-server has recently added colored output, which is quite convenient. I was missing seeing these nice colors in llama-swap.

This PR fixes it, so the colors are rendered nicely:

<img width="1881" height="980" alt="Captura de pantalla_20260816_183726" src="https://github.com/user-attachments/assets/37c1c31f-2f29-4b8d-acb0-f2fbdbaac4e8" />

Note: llama-server defaults `--log-colors` to auto (TTY-only), so you need to add `--log-colors on` when starting llama-server  to see colors.