### PR TITLE
docker/unified: build audio.cpp as a deployment build

### DIFF
--- a/docker/unified/Dockerfile
+++ b/docker/unified/Dockerfile
@@ -15,6 +15,13 @@ ARG BACKEND=cuda
 
 FROM nvidia/cuda:12.9.1-devel-ubuntu24.04 AS builder-base-cuda
 
+# Compute capabilities compiled as SASS, shared by every CUDA build stage.
+# 60/61 are Pascal (P100, GTX 10xx, P40) -- the oldest architecture ggml still
+# supports -- through 89 (Ada). CMake emits PTX alongside SASS for each entry,
+# so architectures between and above the list (70 Volta, 80 Ampere, 90 Hopper,
+# 120 Blackwell) still run by JIT-compiling the nearest lower PTX; they just
+# pay a first-run JIT cost and miss arch-specific kernels. Add those numbers
+# here to compile them natively, at the cost of build time in every stage.
 ARG CMAKE_CUDA_ARCHITECTURES="60;61;75;86;89"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}
@@ -205,9 +212,12 @@ COPY --from=sd-build /install/bin/sd-server /usr/local/bin/
 COPY --from=sd-build /install/bin/sd-cli /usr/local/bin/
 COPY --from=sd-build /install/lib/ /usr/local/lib/
 
-# Copy audio.cpp binaries (statically linked)
+# Copy audio.cpp binaries (statically linked, model specs compiled in via
+# AUDIOCPP_DEPLOYMENT_BUILD). The on-disk spec catalog is installed too so
+# --model-spec-override has a path to point at.
 COPY --from=audio-build /install/bin/audiocpp_server /usr/local/bin/
 COPY --from=audio-build /install/bin/audiocpp_cli /usr/local/bin/
+COPY --from=audio-build /install/share/audiocpp/ /usr/local/share/audiocpp/
 
 # Copy llama.cpp binaries (statically linked)
 COPY --from=llama-build /install/bin/llama-server /usr/local/bin/
@@ -231,6 +241,14 @@ COPY --from=vllm-wrapper-build /install/bin/vllm-wrapper /usr/local/bin/
 RUN ldconfig
 
 COPY config.example.yaml /etc/llama-swap/config/config.yaml
+
+# audiocpp_server takes its own JSON config. Ship a starter with this image's
+# backend baked in -- the binary defaults to "cuda", so a vulkan image that
+# copies an unedited example would try to load every model on a backend it was
+# not built with.
+COPY audiocpp-server.example.json /etc/llama-swap/audiocpp-server.example.json
+RUN sed -i "s/__BACKEND__/${BACKEND}/" /etc/llama-swap/audiocpp-server.example.json && \
+    chown -R ${RUN_UID}:${RUN_UID} /etc/llama-swap
 
 # Version tracking
 RUN echo "llama.cpp: ${LLAMA_COMMIT_HASH}" > /versions.txt && \

--- a/docker/unified/Dockerfile
+++ b/docker/unified/Dockerfile
@@ -19,9 +19,10 @@ FROM nvidia/cuda:12.9.1-devel-ubuntu24.04 AS builder-base-cuda
 # 60/61 are Pascal (P100, GTX 10xx, P40) -- the oldest architecture ggml still
 # supports -- through 89 (Ada). CMake emits PTX alongside SASS for each entry,
 # so architectures between and above the list (70 Volta, 80 Ampere, 90 Hopper,
-# 120 Blackwell) still run by JIT-compiling the nearest lower PTX; they just
-# pay a first-run JIT cost and miss arch-specific kernels. Add those numbers
-# here to compile them natively, at the cost of build time in every stage.
+# 100 and 120 Blackwell) still run by JIT-compiling the nearest lower PTX; they
+# just pay a first-run JIT cost and miss arch-specific kernels. Add those
+# numbers here to compile them natively, at the cost of build time in every
+# stage.
 ARG CMAKE_CUDA_ARCHITECTURES="60;61;75;86;89"
 ENV DEBIAN_FRONTEND=noninteractive
 ENV CMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES}

--- a/docker/unified/README.md
+++ b/docker/unified/README.md
@@ -12,3 +12,52 @@ These scripts create a custom llama-swap container that contains:
 binary in the image. It expects a vLLM server started with `--enable-sleep-mode`
 that is reachable from the container; vLLM itself is not included in the image.
 
+## audio.cpp
+
+`audiocpp_server` needs its own JSON config listing the models it serves. The
+image ships a starter with the backend it was built for already set:
+
+```bash
+docker run --rm llama-swap:unified-cuda \
+  cat /etc/llama-swap/audiocpp-server.example.json > /path/to/models/audiocpp-server.json
+```
+
+Replace the example entries with your models, then point the `audio` entry in
+`config.yaml` at it (see `config.example.yaml`). Every model needs a `family`
+matching an audio.cpp model spec, and a `path` to the package inside the
+container.
+
+The `backend` field must match the image: `cuda` or `vulkan`. `audiocpp_server`
+defaults to `cuda` regardless of how it was compiled, so a vulkan image with an
+unset backend fails to load models.
+
+audio.cpp is compiled as a **deployment build**
+(`AUDIOCPP_DEPLOYMENT_BUILD=ON`), which compiles the `model_specs/*.json`
+catalog into the binaries. Without it the runtime can only use a spec embedded
+in a GGUF or found in a `model_specs/` directory near the working directory,
+neither of which a container of bare binaries has. The catalog is also
+installed at `/usr/local/share/audiocpp/model_specs` for `--model-spec-override`
+when a spec needs to be edited or pinned:
+
+```yaml
+cmd: |
+  audiocpp_server
+  --config /models/audiocpp-server.json
+  --model-spec-override /usr/local/share/audiocpp/model_specs
+  --port ${PORT}
+```
+
+### GPU support
+
+The CUDA image compiles SASS for compute capabilities `60;61;75;86;89`, so
+Pascal (P100, GTX 10xx, P40) and newer NVIDIA GPUs are supported. Architectures
+between and above those entries — Volta (70), Ampere (80), Hopper (90),
+Blackwell (120) — run by JIT-compiling the nearest lower PTX, which costs time
+on first load. Add the number to `CMAKE_CUDA_ARCHITECTURES` in the Dockerfile to
+compile one of them natively; the list is shared with llama.cpp, whisper.cpp,
+stable-diffusion.cpp and ik_llama.cpp, so each addition lengthens every build.
+
+The Vulkan image builds audio.cpp with `ENGINE_ENABLE_VULKAN=ON`. audio.cpp is
+tuned for CUDA, and the server prints a notice on startup that a non-CUDA
+backend may have lower performance and model coverage.
+

--- a/docker/unified/README.md
+++ b/docker/unified/README.md
@@ -18,8 +18,8 @@ that is reachable from the container; vLLM itself is not included in the image.
 image ships a starter with the backend it was built for already set:
 
 ```bash
-docker run --rm llama-swap:unified-cuda \
-  cat /etc/llama-swap/audiocpp-server.example.json > /path/to/models/audiocpp-server.json
+docker run --rm --entrypoint cat llama-swap:unified-cuda \
+  /etc/llama-swap/audiocpp-server.example.json > /path/to/models/audiocpp-server.json
 ```
 
 Replace the example entries with your models, then point the `audio` entry in
@@ -51,11 +51,12 @@ cmd: |
 
 The CUDA image compiles SASS for compute capabilities `60;61;75;86;89`, so
 Pascal (P100, GTX 10xx, P40) and newer NVIDIA GPUs are supported. Architectures
-between and above those entries — Volta (70), Ampere (80), Hopper (90),
-Blackwell (120) — run by JIT-compiling the nearest lower PTX, which costs time
-on first load. Add the number to `CMAKE_CUDA_ARCHITECTURES` in the Dockerfile to
-compile one of them natively; the list is shared with llama.cpp, whisper.cpp,
-stable-diffusion.cpp and ik_llama.cpp, so each addition lengthens every build.
+between and above those entries — Volta (70), Ampere (80), Hopper (90) and
+Blackwell (100 on datacenter parts, 120 on GeForce and RTX PRO) — run by
+JIT-compiling the nearest lower PTX, which costs time on first load. Add the
+number to `CMAKE_CUDA_ARCHITECTURES` in the Dockerfile to compile one of them
+natively; the list is shared with llama.cpp, whisper.cpp, stable-diffusion.cpp
+and ik_llama.cpp, so each addition lengthens every build.
 
 The Vulkan image builds audio.cpp with `ENGINE_ENABLE_VULKAN=ON`. audio.cpp is
 tuned for CUDA, and the server prints a notice on startup that a non-CUDA

--- a/docker/unified/audiocpp-server.example.json
+++ b/docker/unified/audiocpp-server.example.json
@@ -1,0 +1,26 @@
+{
+  "host": "127.0.0.1",
+  "backend": "__BACKEND__",
+  "device": 0,
+  "threads": 1,
+  "lazy_load": true,
+  "models": [
+    {
+      "id": "pocket-tts",
+      "family": "pocket_tts",
+      "path": "/models/pocket-tts",
+      "task": "tts",
+      "mode": "offline",
+      "default_voice_preset": {
+        "voice_id": "alba"
+      }
+    },
+    {
+      "id": "qwen3-asr",
+      "family": "qwen3_asr",
+      "path": "/models/Qwen3-ASR-0.6B",
+      "task": "asr",
+      "mode": "offline"
+    }
+  ]
+}

--- a/docker/unified/build-image.sh
+++ b/docker/unified/build-image.sh
@@ -274,6 +274,35 @@ if [[ "$BACKEND" == "cuda" ]]; then
 fi
 echo "All expected binaries verified: ${VERIFIED_LIST}"
 
+# audio.cpp must be a deployment build: the model_specs catalog is compiled into
+# the binaries, since the image ships no model_specs/ directory for the runtime
+# to discover. Without it every load of a package without an embedded spec fails
+# with "model spec not found for family ...". The compiled catalog is raw JSON in
+# .rodata, so grepping the binary for a known spec confirms it is there.
+if ! docker run --rm --entrypoint grep "${DOCKER_IMAGE_TAG}" \
+        -aq '"family": "pocket_tts"' /usr/local/bin/audiocpp_server; then
+    echo "ERROR: audiocpp_server was not built with AUDIOCPP_DEPLOYMENT_BUILD=ON;"
+    echo "       its compiled model spec catalog is missing."
+    exit 1
+fi
+
+# Run the binary so a missing runtime library is caught here rather than on a
+# user's first request. CUDA builds link libcuda.so.1, which the NVIDIA
+# container runtime only injects with --gpus; point at the stub copied into the
+# image so this works on a build machine with no GPU.
+SMOKE_ARGS=(--rm)
+if [[ "$BACKEND" == "cuda" ]]; then
+    SMOKE_ARGS+=(-e "LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:/usr/local/cuda/lib64")
+fi
+
+if ! docker run "${SMOKE_ARGS[@]}" --entrypoint audiocpp_server "${DOCKER_IMAGE_TAG}" --help >/dev/null; then
+    echo "ERROR: audiocpp_server --help failed; the binary or its runtime"
+    echo "       libraries are broken in the image."
+    exit 1
+fi
+
+echo "audio.cpp verified: deployment build (compiled model spec catalog), binary runs"
+
 echo ""
 echo "=========================================="
 echo "Building rootless image..."

--- a/docker/unified/config.example.yaml
+++ b/docker/unified/config.example.yaml
@@ -20,8 +20,11 @@ models:
 
   "audio":
     checkEndpoint: /health
-    # set "backend" in audiocpp-server.json (or pass --backend) to match the
-    # image: cuda or vulkan. audiocpp_server defaults to cuda.
+    # audiocpp_server takes its own JSON config listing the models it serves.
+    # Copy the starter shipped in the image -- it already has this image's
+    # backend set -- and replace the example models with your own:
+    #   docker run --rm <image> \
+    #     cat /etc/llama-swap/audiocpp-server.example.json > /models/audiocpp-server.json
     cmd: |
       audiocpp_server
       --config /models/audiocpp-server.json

--- a/docker/unified/config.example.yaml
+++ b/docker/unified/config.example.yaml
@@ -23,8 +23,8 @@ models:
     # audiocpp_server takes its own JSON config listing the models it serves.
     # Copy the starter shipped in the image -- it already has this image's
     # backend set -- and replace the example models with your own:
-    #   docker run --rm <image> \
-    #     cat /etc/llama-swap/audiocpp-server.example.json > /models/audiocpp-server.json
+    #   docker run --rm --entrypoint cat <image> \
+    #     /etc/llama-swap/audiocpp-server.example.json > /models/audiocpp-server.json
     cmd: |
       audiocpp_server
       --config /models/audiocpp-server.json

--- a/docker/unified/install-audio.sh
+++ b/docker/unified/install-audio.sh
@@ -5,8 +5,9 @@ set -e
 
 COMMIT_HASH="${1:-main}"
 BACKEND="${BACKEND:-cuda}"
+CUDA_ROOT="${CUDA_ROOT:-/usr/local/cuda}"
 
-mkdir -p /install/bin
+mkdir -p /install/bin /install/share/audiocpp
 
 # Clone and checkout (init-based so cache-mounted /src/audio.cpp/build dir doesn't break clone)
 echo "=== Cloning audio.cpp at ${COMMIT_HASH} ==="
@@ -20,12 +21,27 @@ git fetch --depth=1 origin "${COMMIT_HASH}"
 git checkout FETCH_HEAD
 
 # Common cmake flags
+#
+# AUDIOCPP_DEPLOYMENT_BUILD=ON is what audio.cpp calls a deployment build: it
+# compiles the model_specs/*.json catalog into the binaries. Without it a model
+# spec is only resolved from a GGUF that embeds one, or from a model_specs/
+# directory found by walking up from the process working directory. An image
+# that ships bare binaries has neither, so loading a safetensors package or a
+# GGUF written before embedded specs fails with
+# "model spec not found for family <family>".
+#
 # ENGINE_ENABLE_NATIVE_CPU=OFF builds portable CPU kernels so the image runs on
 # hosts other than the build machine (equivalent to GGML_NATIVE=OFF elsewhere).
+# This also keeps the build fully static: audio.cpp only switches to shared
+# libraries under ENGINE_ENABLE_CPU_ALL_VARIANTS, which would drop a third,
+# ABI-incompatible libggml*.so into the /usr/local/lib shared with whisper.cpp
+# and stable-diffusion.cpp. The check after the build enforces that.
 CMAKE_FLAGS=(
     -DCMAKE_BUILD_TYPE=Release
     -DCMAKE_C_COMPILER_LAUNCHER=ccache
     -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+    -DAUDIOCPP_DEPLOYMENT_BUILD=ON
+    -DAUDIOCPP_MODEL_SET=full
     -DENGINE_ENABLE_NATIVE_CPU=OFF
     -DENGINE_ENABLE_OPENMP=ON
     -DENGINE_BUILD_EXAMPLES=OFF
@@ -34,10 +50,16 @@ CMAKE_FLAGS=(
 )
 
 if [ "$BACKEND" = "cuda" ]; then
+    # docs/build/linux.md: set CUDAToolkit_ROOT *and* CMAKE_CUDA_COMPILER.
+    # CMake otherwise takes the first nvcc on PATH and the first CUDA libraries
+    # it finds, which can be two different toolkits. That mismatch links without
+    # a warning, so the linked runtime is verified after the build below.
     CMAKE_FLAGS+=(
         -DENGINE_ENABLE_CUDA=ON
         -DENGINE_ENABLE_CUDA_GRAPHS=ON
         -DENGINE_ENABLE_VULKAN=OFF
+        "-DCUDAToolkit_ROOT=${CUDA_ROOT}"
+        "-DCMAKE_CUDA_COMPILER=${CUDA_ROOT}/bin/nvcc"
         "-DCMAKE_CUDA_ARCHITECTURES=${CMAKE_CUDA_ARCHITECTURES:?CMAKE_CUDA_ARCHITECTURES must be set}"
         "-DCMAKE_CUDA_FLAGS=-allow-unsupported-compiler"
         "-DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath-link,/usr/local/cuda/lib64/stubs -lcuda"
@@ -57,13 +79,65 @@ echo "=== Building audio.cpp for ${BACKEND} ==="
 cmake -B build "${CMAKE_FLAGS[@]}"
 cmake --build build --config Release -j"$(nproc)" --target "${TARGETS[@]}"
 
+# Verify each binary got the backend it was configured for. A backend that
+# silently failed to enable still produces working binaries -- they just fall
+# back to CPU at runtime, on a user's machine, long after the build passed.
+verify_linkage() {
+    local bin="$1"
+    local needed
+    needed=$(readelf -d "$bin" | grep NEEDED || true)
+
+    case "$BACKEND" in
+        cuda)
+            if ! grep -qE 'libcudart\.so\.1[23]' <<<"$needed"; then
+                echo "FATAL: $bin is not linked against a CUDA 12/13 runtime." >&2
+                echo "       NEEDED entries:" >&2
+                echo "$needed" >&2
+                exit 1
+            fi
+            # A mixed build (new nvcc, old distro libcudart) links cleanly and
+            # then misbehaves at runtime -- docs/build/linux.md calls this out.
+            if grep -qE 'libcudart\.so\.11' <<<"$needed"; then
+                echo "FATAL: $bin links libcudart.so.11 (mixed CUDA toolkit build)." >&2
+                exit 1
+            fi
+            ;;
+        vulkan)
+            if ! grep -q 'libvulkan\.so' <<<"$needed"; then
+                echo "FATAL: $bin is not linked against libvulkan." >&2
+                echo "       NEEDED entries:" >&2
+                echo "$needed" >&2
+                exit 1
+            fi
+            ;;
+    esac
+
+    # audio.cpp vendors its own ggml fork. The runtime image already installs
+    # whisper.cpp's and stable-diffusion.cpp's libggml*.so into /usr/local/lib,
+    # so a shared audio.cpp build would either collide with them or need its own
+    # library directory. Keep it static and fail loudly if that ever changes.
+    if grep -qE 'libggml|libengine' <<<"$needed"; then
+        echo "FATAL: $bin expects audio.cpp shared libraries; only static builds" >&2
+        echo "       are installed here (see the CMAKE_FLAGS comment)." >&2
+        echo "$needed" >&2
+        exit 1
+    fi
+}
+
 for bin in "${TARGETS[@]}"; do
     if [ ! -f "build/bin/$bin" ]; then
         echo "FATAL: $bin not found in build/bin/" >&2
         exit 1
     fi
+    verify_linkage "build/bin/$bin"
     cp "build/bin/$bin" "/install/bin/"
 done
+
+# The specs are compiled into the binaries by AUDIOCPP_DEPLOYMENT_BUILD, but the
+# catalog is only a fallback: shipping it on disk as well gives users a concrete
+# path for --model-spec-override when they need to edit or pin a spec.
+rm -rf "/install/share/audiocpp/model_specs"
+cp -r model_specs "/install/share/audiocpp/model_specs"
 
 echo "=== audio.cpp build complete ==="
 ls -la /install/bin/


### PR DESCRIPTION
audio.cpp resolves a model spec from a GGUF that embeds one, from a
model_specs/ directory found by walking up from the working directory,
or from a catalog compiled into the binary by AUDIOCPP_DEPLOYMENT_BUILD.
The image ships only the binaries, so the first two never apply and any
package without an embedded spec fails to load with "model spec not
found for family <family>". Enable the deployment build and verify it
holds in the built image.

Also tighten the CUDA and Vulkan configuration against audio.cpp's
docs/build/linux.md, and give the server a starter config so it is
usable without hand-writing one.

- set AUDIOCPP_DEPLOYMENT_BUILD=ON and pin AUDIOCPP_MODEL_SET=full
- pass CUDAToolkit_ROOT and CMAKE_CUDA_COMPILER together, as the docs
  require, so nvcc and the CUDA libraries come from one toolkit
- assert after the build that each binary links a CUDA 12/13 runtime
  (cuda) or libvulkan (vulkan), and that it stayed static so it cannot
  collide with whisper.cpp/stable-diffusion.cpp libggml in /usr/local/lib
- install the spec catalog at /usr/local/share/audiocpp/model_specs for
  --model-spec-override
- ship audiocpp-server.example.json with the image's backend baked in;
  audiocpp_server defaults to cuda no matter what it was built for
- smoke test the deployment catalog and run the binary in build-image.sh
- document the compiled CUDA architectures: 60/61 (Pascal) through 89,
  with PTX JIT covering Volta, Ampere, Hopper and Blackwell