### PR TITLE
internal/matrix: add synthetic "undefined" fallback set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,29 +46,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  trigger-tap-update:
-    runs-on: ubuntu-latest
-    needs: goreleaser
-    steps:
-      - name: "Resolve tag to dispatch"
-        id: tag
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: "Trigger tap repository update"
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 #4.0.1
-        with:
-          token: ${{ secrets.TAP_REPO_PAT }}
-          repository: mostlygeek/homebrew-llama-swap
-          event-type: new-release
-          client-payload: |
-            {
-              "release": {
-                "tag_name": "${{ steps.tag.outputs.tag }}"
-              }
-            }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,29 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  trigger-tap-update:
+    runs-on: ubuntu-latest
+    needs: goreleaser
+    steps:
+      - name: "Resolve tag to dispatch"
+        id: tag
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: "Trigger tap repository update"
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 #4.0.1
+        with:
+          token: ${{ secrets.TAP_REPO_PAT }}
+          repository: mostlygeek/homebrew-llama-swap
+          event-type: new-release
+          client-payload: |
+            {
+              "release": {
+                "tag_name": "${{ steps.tag.outputs.tag }}"
+              }
+            }

--- a/config-schema.json
+++ b/config-schema.json
@@ -147,7 +147,7 @@
                 },
                 "sets": {
                     "type": "object",
-                    "description": "Named sets of concurrent model combinations. Values are DSL strings using & (AND), | (OR), () (grouping), and +ref (inline another set). Definition order is used for tie-breaking.",
+                    "description": "Named sets of concurrent model combinations. Values are DSL strings using & (AND), | (OR), () (grouping), +ref (inline another set), and +undefined (the models not named by any set leaf). Definition order is used for tie-breaking.",
                     "minProperties": 1,
                     "additionalProperties": {
                         "type": "string"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -639,6 +639,13 @@ routing:
         #   "(a | b) & (c | d)"  → [a,c], [a,d], [b,c], [b,d]
         #   "+llms & v"          → inline the llms set, then AND with v
         sets:
+          # +undefined includes every model not named by a leaf in any set.
+          # User-defined set names and vars take precedence as usual.
+          # Example catch-all shape:
+          # always: "task-small & embed-model"
+          # main: "+always & moe-medium & (dense-a | dense-b)"
+          # scratch: "+always & +undefined"
+
           # An LLM plus TTS. Vars and real model IDs may be mixed.
           # expands to: [g,v], [qwen-model,v], [m,v]
           standard: "(g | qwen-model | m) & v"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,33 @@ llama-swap supports many more features to customize how you want to manage your 
 | `profiles` | switch model ID replacements at runtime       |
 | `...`     | And many more tweaks                           |
 
+## Matrix catch-all models
+
+Matrix expressions can use the reserved reference `+undefined` for a catch-all
+set of models. A model is considered defined when its resolved real model ID
+appears as a leaf in any user-authored set. Vars are resolved before this check;
+set references such as `+base` are not leaves and do not define additional
+models themselves.
+
+The orphan model list is computed once at compile time and sorted by model ID,
+so the synthesized expression is deterministic. For example, if `a` is named
+by a leaf and `b` and `c` are not, `+undefined` behaves as `(b | c)`. If there
+are no orphan models, a `+undefined` term is dropped. This also propagates
+through references: a set that becomes empty can be dropped from a parent set
+that references it. A set defined as only `+undefined` therefore remains
+empty and is never selectable.
+
+A user-defined set literally named `undefined` always shadows the synthetic set,
+and no orphan synthesis occurs. When synthesis is used, llama-swap logs one of
+these messages after matrix compilation:
+
+- `matrix: synthesized set "undefined" = (modelA | modelB | ...)`
+- `matrix: synthesized set "undefined" is empty; +undefined terms dropped`
+- `matrix: set "undefined" is user-defined; orphan synthesis disabled`
+
+Editing `models:` changes which models are orphans. The synthesized set is
+recomputed on the next configuration reload by design.
+
 ## Full Configuration Example
 
 Check [config.example.yaml](https://github.com/mostlygeek/llama-swap/blob/main/config.example.yaml) for the most up to date reference for all example configurations. It has grown quite complex but your favorite local LLM can help with a local configuration.

--- a/internal/config/matrix.go
+++ b/internal/config/matrix.go
@@ -93,9 +93,13 @@ func ValidateMatrix(matrix *MatrixConfig, models map[string]ModelConfig) error {
 		})
 	}
 
+	modelIDs := make([]string, 0, len(models))
+	for modelID := range models {
+		modelIDs = append(modelIDs, modelID)
+	}
 	program, err := matrixdsl.Compile(definitions, func(ident string) (string, bool) {
 		return resolveMatrixModel(ident, matrix.Var, models)
-	})
+	}, modelIDs)
 	if err != nil {
 		return err
 	}

--- a/internal/config/matrix_undefined_test.go
+++ b/internal/config/matrix_undefined_test.go
@@ -1,0 +1,52 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateMatrix_UndefinedVarInteraction(t *testing.T) {
+	models := makeModels("a", "b")
+	matrix := MatrixConfig{
+		Var:  map[string]string{"alias": "a"},
+		Sets: OrderedSets{{Name: "main", DSL: "alias & +undefined"}},
+	}
+	require.NoError(t, ValidateMatrix(&matrix, models))
+	orphans, mode := matrix.Program().SynthesizedUndefined()
+	require.Equal(t, "synthesized", mode)
+	require.Equal(t, []string{"b"}, orphans)
+}
+
+func TestValidateMatrix_UndefinedTokenizerHostileModel(t *testing.T) {
+	models := makeModels("a", "qwen3:32b")
+	matrix := MatrixConfig{Sets: OrderedSets{{Name: "main", DSL: "a & +undefined"}}}
+	require.NoError(t, ValidateMatrix(&matrix, models))
+	result := matrix.Program().Solve("qwen3:32b", nil, nil)
+	require.Equal(t, "main", result.SetName)
+	require.Equal(t, []string{"a", "qwen3:32b"}, result.TargetSet)
+}
+
+func TestValidateMatrix_UndefinedEvictCosts(t *testing.T) {
+	models := makeModels("a", "b", "c")
+	matrix := MatrixConfig{
+		EvictCosts: map[string]int{"b": 7},
+		Sets:       OrderedSets{{Name: "main", DSL: "a & +undefined"}},
+	}
+	require.NoError(t, ValidateMatrix(&matrix, models))
+	costs := matrix.ResolvedEvictCosts()
+	require.Equal(t, 7, costs["b"])
+	require.NotContains(t, costs, "c")
+}
+
+func TestValidateMatrix_UndefinedShadowing(t *testing.T) {
+	models := makeModels("a", "b")
+	matrix := MatrixConfig{Sets: OrderedSets{
+		{Name: "undefined", DSL: "a"},
+		{Name: "scratch", DSL: "+undefined"},
+	}}
+	require.NoError(t, ValidateMatrix(&matrix, models))
+	_, mode := matrix.Program().SynthesizedUndefined()
+	require.Equal(t, "user-defined", mode)
+	require.Equal(t, "undefined", matrix.Program().Solve("a", nil, nil).SetName)
+}

--- a/internal/matrix/dsl.go
+++ b/internal/matrix/dsl.go
@@ -30,6 +30,7 @@ const (
 	nodeRef
 	nodeAnd
 	nodeOr
+	nodeEmpty
 )
 
 type node struct {

--- a/internal/matrix/dsl_test.go
+++ b/internal/matrix/dsl_test.go
@@ -178,7 +178,7 @@ func TestProgram_CompileErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := Compile(tt.defs, resolve)
+			_, err := Compile(tt.defs, resolve, nil)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.errMsg)
 		})
@@ -254,7 +254,7 @@ func compileIdentity(t *testing.T, definitions []Definition, models []string) *P
 	}
 	program, err := Compile(definitions, func(name string) (string, bool) {
 		return name, known[name]
-	})
+	}, nil)
 	require.NoError(t, err)
 	return program
 }

--- a/internal/matrix/program.go
+++ b/internal/matrix/program.go
@@ -26,9 +26,11 @@ type compiledSet struct {
 
 // Program is an immutable, compiled matrix DSL program.
 type Program struct {
-	sets      []compiledSet
-	modelBits map[string]int
-	words     int
+	sets            []compiledSet
+	modelBits       map[string]int
+	words           int
+	undefinedModels []string
+	undefinedMode   string
 }
 
 // Decision describes the selected matrix set and the running models it evicts.
@@ -42,7 +44,7 @@ type Decision struct {
 
 // Compile parses, validates, resolves, and links an ordered collection of DSL
 // definitions without expanding their Cartesian products.
-func Compile(definitions []Definition, resolve Resolver) (*Program, error) {
+func Compile(definitions []Definition, resolve Resolver, allModels []string) (*Program, error) {
 	if len(definitions) == 0 {
 		return nil, fmt.Errorf("matrix must define at least one set")
 	}
@@ -55,6 +57,8 @@ func Compile(definitions []Definition, resolve Resolver) (*Program, error) {
 		setNames[definition.Name] = true
 	}
 
+	seenModels := make(map[string]bool)
+	undefinedReferenced := false
 	for _, definition := range definitions {
 		root, err := parseDSL(definition.DSL)
 		if err != nil {
@@ -71,9 +75,15 @@ func Compile(definitions []Definition, resolve Resolver) (*Program, error) {
 					return fmt.Errorf("set %q: unknown var or model %q", definition.Name, n.name)
 				}
 				n.name = model
+				seenModels[model] = true
 			case nodeRef:
-				if !setNames[n.name] {
-					return fmt.Errorf("set %q references undefined set %q", definition.Name, n.name)
+				if n.name == "undefined" {
+					undefinedReferenced = true
+				}
+				if n.name != "undefined" || setNames["undefined"] {
+					if !setNames[n.name] {
+						return fmt.Errorf("set %q references undefined set %q", definition.Name, n.name)
+					}
 				}
 				if !seenRefs[n.name] {
 					seenRefs[n.name] = true
@@ -90,11 +100,45 @@ func Compile(definitions []Definition, resolve Resolver) (*Program, error) {
 		deps[definition.Name] = refs
 	}
 
+	program := &Program{}
+	if undefinedReferenced {
+		if setNames["undefined"] {
+			program.undefinedMode = "user-defined"
+		} else {
+			orphans := make([]string, 0, len(allModels))
+			for _, model := range allModels {
+				if !seenModels[model] {
+					orphans = append(orphans, model)
+				}
+			}
+			sort.Strings(orphans)
+			setNames["undefined"] = true
+			deps["undefined"] = nil
+			if len(orphans) == 0 {
+				roots["undefined"] = &node{kind: nodeEmpty}
+				program.undefinedMode = "empty"
+			} else {
+				children := make([]*node, len(orphans))
+				for i, model := range orphans {
+					children[i] = &node{kind: nodeLeaf, name: model}
+				}
+				roots["undefined"] = &node{kind: nodeOr, children: children}
+				program.undefinedModels = orphans
+				program.undefinedMode = "synthesized"
+			}
+		}
+	}
+
 	order, err := topologicalOrder(definitions, deps)
 	if err != nil {
 		return nil, err
 	}
 
+	if undefinedReferenced {
+		for _, name := range order {
+			roots[name] = simplifyEmptyRefs(roots[name], roots)
+		}
+	}
 	for _, root := range roots {
 		if err := walk(root, func(n *node) error {
 			if n.kind == nodeRef {
@@ -108,6 +152,9 @@ func Compile(definitions []Definition, resolve Resolver) (*Program, error) {
 
 	sets := make([]compiledSet, 0, len(order))
 	for _, name := range order {
+		if name == "undefined" && (program.undefinedMode == "synthesized" || program.undefinedMode == "empty") {
+			continue
+		}
 		sets = append(sets, compiledSet{
 			name: name,
 			dsl:  dslByName[name],
@@ -115,7 +162,7 @@ func Compile(definitions []Definition, resolve Resolver) (*Program, error) {
 		})
 	}
 
-	program := &Program{sets: sets}
+	program.sets = sets
 	program.computeSupport()
 	return program, nil
 }
@@ -136,6 +183,8 @@ func (p *Program) computeSupport() {
 			models = map[string]bool{n.name: true}
 		case nodeRef:
 			models = collect(n.ref)
+		case nodeEmpty:
+			models = make(map[string]bool)
 		default:
 			models = make(map[string]bool)
 			for _, child := range n.children {
@@ -181,6 +230,40 @@ func (p *Program) supportsAll(set *compiledSet, models []string) bool {
 		}
 	}
 	return true
+}
+
+func simplifyEmptyRefs(root *node, roots map[string]*node) *node {
+	if root.kind == nodeRef {
+		if target, ok := roots[root.name]; ok && target.kind == nodeEmpty {
+			return &node{kind: nodeEmpty}
+		}
+		return root
+	}
+	if root.kind == nodeLeaf || root.kind == nodeEmpty {
+		return root
+	}
+
+	children := root.children[:0]
+	for _, child := range root.children {
+		child = simplifyEmptyRefs(child, roots)
+		if child.kind == nodeEmpty {
+			continue
+		}
+		children = append(children, child)
+	}
+	root.children = children
+	if len(children) == 0 {
+		return &node{kind: nodeEmpty}
+	}
+	if len(children) == 1 {
+		return children[0]
+	}
+	return root
+}
+
+// SynthesizedUndefined reports the opt-in +undefined compilation result.
+func (p *Program) SynthesizedUndefined() ([]string, string) {
+	return append([]string(nil), p.undefinedModels...), p.undefinedMode
 }
 
 func topologicalOrder(definitions []Definition, deps map[string][]string) ([]string, error) {
@@ -417,6 +500,8 @@ func (e *evaluator) evaluate(root *node) []projectedState {
 
 	var states []projectedState
 	switch root.kind {
+	case nodeEmpty:
+		states = nil
 	case nodeLeaf:
 		mask := make(bitMask, e.words)
 		if bit, relevant := e.modelBits[root.name]; relevant {

--- a/internal/matrix/program_bench_test.go
+++ b/internal/matrix/program_bench_test.go
@@ -19,7 +19,7 @@ func BenchmarkProgram_SolveMultiSet(b *testing.B) {
 		definitions, known, costs := multiSetDefinitions(setCount, 10)
 		program, err := Compile(definitions, func(name string) (string, bool) {
 			return name, known[name]
-		})
+		}, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -87,7 +87,7 @@ func BenchmarkMatrix_Compile(b *testing.B) {
 			for b.Loop() {
 				program, err := Compile([]Definition{definition}, func(name string) (string, bool) {
 					return name, known[name]
-				})
+				}, nil)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/internal/matrix/program_undefined_test.go
+++ b/internal/matrix/program_undefined_test.go
@@ -1,0 +1,148 @@
+package matrix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func compileUndefinedTestProgram(t *testing.T, definitions []Definition, models []string) *Program {
+	t.Helper()
+	program, err := Compile(definitions, func(name string) (string, bool) {
+		for _, model := range models {
+			if name == model {
+				return model, true
+			}
+		}
+		return "", false
+	}, models)
+	require.NoError(t, err)
+	return program
+}
+
+func TestProgram_UndefinedSynthesis(t *testing.T) {
+	program := compileUndefinedTestProgram(t, []Definition{{Name: "main", DSL: "a & +undefined"}}, []string{"c", "a", "b"})
+	models, mode := program.SynthesizedUndefined()
+	require.Equal(t, "synthesized", mode)
+	require.Equal(t, []string{"b", "c"}, models)
+
+	decision := program.Solve("b", []string{"a"}, nil)
+	require.Equal(t, "main", decision.SetName)
+	require.Equal(t, []string{"a", "b"}, decision.TargetSet)
+}
+
+func TestProgram_UndefinedEmptyUnderAnd(t *testing.T) {
+	program := compileUndefinedTestProgram(t, []Definition{{Name: "main", DSL: "a & +undefined"}}, []string{"a"})
+	decision := program.Solve("a", nil, nil)
+	require.Equal(t, "main", decision.SetName)
+	require.Equal(t, []string{"a"}, decision.TargetSet)
+}
+
+func TestProgram_UndefinedEmptyOnly(t *testing.T) {
+	program := compileUndefinedTestProgram(t, []Definition{
+		{Name: "always", DSL: "a"},
+		{Name: "scratch", DSL: "+undefined"},
+	}, []string{"a"})
+	require.NotPanics(t, func() { program.Solve("a", nil, nil) })
+	require.Equal(t, "always", program.Solve("a", nil, nil).SetName)
+}
+
+func TestProgram_UndefinedSharedRef(t *testing.T) {
+	program := compileUndefinedTestProgram(t, []Definition{
+		{Name: "one", DSL: "a & +undefined"},
+		{Name: "two", DSL: "b & +undefined"},
+	}, []string{"a", "b", "c"})
+	models, _ := program.SynthesizedUndefined()
+	require.Equal(t, []string{"c"}, models)
+	require.Equal(t, []string{"a", "c"}, program.Solve("a", []string{"c"}, nil).TargetSet)
+	require.Equal(t, []string{"b", "c"}, program.Solve("b", []string{"c"}, nil).TargetSet)
+}
+
+func TestProgram_UndefinedTransitiveDrop(t *testing.T) {
+	program := compileUndefinedTestProgram(t, []Definition{
+		{Name: "scratch", DSL: "+undefined"},
+		{Name: "outer", DSL: "+scratch & x"},
+	}, []string{"x"})
+	require.Equal(t, "outer", program.Solve("x", nil, nil).SetName)
+	require.Equal(t, []string{"x"}, program.Solve("x", nil, nil).TargetSet)
+}
+
+func TestProgram_UndefinedTransitiveChain(t *testing.T) {
+	program := compileUndefinedTestProgram(t, []Definition{
+		{Name: "a1", DSL: "+undefined"},
+		{Name: "a2", DSL: "+a1"},
+		{Name: "a3", DSL: "+a2 & x"},
+	}, []string{"x"})
+	require.Equal(t, "a3", program.Solve("x", nil, nil).SetName)
+	require.Equal(t, []string{"x"}, program.Solve("x", nil, nil).TargetSet)
+}
+
+func TestProgram_UndefinedTransitiveNonEmpty(t *testing.T) {
+	program := compileUndefinedTestProgram(t, []Definition{
+		{Name: "scratch", DSL: "+undefined"},
+		{Name: "outer", DSL: "+scratch & x"},
+	}, []string{"x", "orphan"})
+	decision := program.Solve("orphan", nil, nil)
+	require.Contains(t, []string{"outer", "scratch"}, decision.SetName)
+	require.Contains(t, decision.TargetSet, "orphan")
+}
+
+func TestProgram_UndefinedNested(t *testing.T) {
+	program := compileUndefinedTestProgram(t, []Definition{{Name: "nested", DSL: "(x | +undefined) & y"}}, []string{"x", "y", "z"})
+	require.Equal(t, []string{"y", "z"}, program.Solve("z", nil, nil).TargetSet)
+
+	empty := compileUndefinedTestProgram(t, []Definition{{Name: "nested", DSL: "(x & +undefined) | y"}}, []string{"x", "y"})
+	require.Equal(t, []string{"x"}, empty.Solve("x", nil, nil).TargetSet)
+	require.Equal(t, []string{"y"}, empty.Solve("y", nil, nil).TargetSet)
+}
+
+func TestProgram_UndefinedBareLeaf(t *testing.T) {
+	program := compileUndefinedTestProgram(t, []Definition{{Name: "bare", DSL: "undefined"}}, []string{"undefined"})
+	_, mode := program.SynthesizedUndefined()
+	require.Equal(t, "", mode)
+	require.Equal(t, "bare", program.Solve("undefined", nil, nil).SetName)
+
+	_, err := Compile([]Definition{{Name: "bare", DSL: "undefined"}}, func(string) (string, bool) {
+		return "", false
+	}, []string{"a"})
+	require.EqualError(t, err, `set "bare": unknown var or model "undefined"`)
+}
+
+func TestProgram_UndefinedNeverSelectable(t *testing.T) {
+	program := compileUndefinedTestProgram(t, []Definition{{Name: "main", DSL: "a & +undefined"}}, []string{"a", "b"})
+	for _, target := range []string{"a", "b"} {
+		require.NotEqual(t, "undefined", program.Solve(target, nil, nil).SetName)
+	}
+}
+
+func TestProgram_UndefinedZeroUse(t *testing.T) {
+	program := compileUndefinedTestProgram(t, []Definition{{Name: "main", DSL: "a"}}, []string{"a", "b"})
+	models, mode := program.SynthesizedUndefined()
+	require.Equal(t, "", mode)
+	require.Empty(t, models)
+}
+
+func TestProgram_UndefinedDeterministic(t *testing.T) {
+	definitions := []Definition{{Name: "main", DSL: "a & +undefined"}}
+	first := compileUndefinedTestProgram(t, definitions, []string{"a", "c", "b"})
+	second := compileUndefinedTestProgram(t, definitions, []string{"b", "a", "c"})
+	firstModels, firstMode := first.SynthesizedUndefined()
+	secondModels, secondMode := second.SynthesizedUndefined()
+	require.Equal(t, firstModels, secondModels)
+	require.Equal(t, firstMode, secondMode)
+	for _, target := range []string{"a", "b", "c"} {
+		require.Equal(t, first.Solve(target, nil, nil), second.Solve(target, nil, nil))
+	}
+}
+
+func TestProgram_UndefinedShadowed(t *testing.T) {
+	program := compileUndefinedTestProgram(t, []Definition{{Name: "undefined", DSL: "a"}, {Name: "scratch", DSL: "+undefined"}}, []string{"a", "b"})
+	_, mode := program.SynthesizedUndefined()
+	require.Equal(t, "user-defined", mode)
+	require.Equal(t, "undefined", program.Solve("a", nil, nil).SetName)
+}
+
+func TestProgram_UndefinedUnreferencedShadowSet(t *testing.T) {
+	program := compileUndefinedTestProgram(t, []Definition{{Name: "undefined", DSL: "a"}}, []string{"a"})
+	require.Equal(t, "undefined", program.Solve("a", nil, nil).SetName)
+}

--- a/internal/router/matrix.go
+++ b/internal/router/matrix.go
@@ -3,6 +3,7 @@ package router
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/logmon"
@@ -22,6 +23,15 @@ func NewMatrix(conf config.Config, proxylog, upstreamlog *logmon.Monitor) (*Matr
 		if err := config.ValidateMatrix(mtx, conf.Models); err != nil {
 			return nil, fmt.Errorf("compiling matrix configuration: %w", err)
 		}
+	}
+	models, mode := mtx.Program().SynthesizedUndefined()
+	switch mode {
+	case "synthesized":
+		proxylog.Infof("matrix: synthesized set \"undefined\" = (%s)", strings.Join(models, " | "))
+	case "empty":
+		proxylog.Info("matrix: synthesized set \"undefined\" is empty; +undefined terms dropped")
+	case "user-defined":
+		proxylog.Info("matrix: set \"undefined\" is user-defined; orphan synthesis disabled")
 	}
 
 	swapper := &matrixSwapper{


### PR DESCRIPTION
# Problem
Compared to groups, matrix routing handles unspecified models less elegantly. In groups, when loading a model that is not encapsulated in a group, persistent groups are still retained. This allows for a set of models that will never be unloaded under any circumstances, even if you add a new model and do not define it in a group.

With matrices, achieving the same functionality requires adding every model into a set. This creates a onerous, error-prone workflow in order to create feature parity.

# Solution
Create a synthetic set named `undefined`. This set will contain all the models that are not defined in an expression. Then, at config compile time:

- Parse every set expression into a tree.
- While walking the trees, collect every model name that appears directly in an expression (var aliases translated to real model IDs first).
- Subtract that collection from the full `models:` list. Whatever remains is the orphan list. Sort it.
- Build a synthetic expression, `orphan1 | orphan2 | ...`, and wire every `+undefined` reference to point at it, the same way `+always` points at a set named `always`.
- Edge cases resolved at the same moment: zero orphans means the `+undefined` term is deleted from whatever expression contained it; a user set actually named `undefined` means step 3 and 4 never run and the references bind to that set instead.
- Log which of those happened.

# Tests
In addition to the tests written during development of this feature, I also did some empirical testing of this functionality. The feature works as intended based on my testing, with no impact to previous features or unrelated elements, including peered models.

#### Config snippet
```yaml
routing:
  router:
    use: matrix
    settings:
      matrix:
        sets:
          always:  "text-embedding & task-model & comfy-serve"
          main:    "+always & (qwen3.6-35b-a3b | gemma-4-26b-a4b) & (qwen3.8-27b | gemma-4-31b)"
          scratch: "+always & +undefined"
```
#### Log

Upon config save:
```
3:17PM [INFO] matrix: synthesized set "undefined" = (gemma-4-12b | gemma-4-26b-a4b-uncensored | gemma-4-e2b | gemma-4-e4b | gpt-oss-120b | gpt-oss-20b | laguna-s-2.1 | laguna-xs-2.1 | ling-3.0-flash | ling-3.0-tiny | muse-glimmer | nvidia-nemotron-3-nano-omni-30b-a3b | qwen3.5-122b-a10b | qwen3.5-122b-a10b-uncensored | qwen3.5-9b | qwen3.6-27b | qwen3.6-35b-a3b-uncensored)
```

Upon loading a model in set `main`:
```
3:20PM [DEBUG] matrix: starting swap for model gemma-4-26b-a4b, evicting []
3:20PM [DEBUG] matrix: model=gemma-4-26b-a4b already running in set=main dsl="+always & (qwen3.6-35b-a3b | gemma-4-26b-a4b) & (qwen3.8-27b | gemma-4-31b)"
```

Upon loading an `undefined` model:
```
3:23PM [DEBUG] matrix: starting swap for model ling-3.0-flash, evicting [gemma-4-26b-a4b]
3:23PM [INFO] matrix: model=ling-3.0-flash set=scratch dsl="+always & +undefined" evict=[gemma-4-26b-a4b] target=[comfy-serve ling-3.0-flash task-model text-embedding] cost=1
```

Upon loading another `undefined` model:
```
3:24PM [DEBUG] matrix: starting swap for model ling-3.0-tiny, evicting [ling-3.0-flash]
3:24PM [INFO] matrix: model=ling-3.0-tiny set=scratch dsl="+always & +undefined" evict=[ling-3.0-flash] target=[comfy-serve ling-3.0-tiny task-model text-embedding] cost=1
```
# Considerations
Naming: I'm not sure if `undefined` is the best term for this synthetic set. My logic was, "These models are undefined in sets". Open to other suggestions, or making it user-settable.