### PR TITLE
internal/matrix: add synthetic "undefined" fallback set

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -147,7 +147,7 @@
                 },
                 "sets": {
                     "type": "object",
-                    "description": "Named sets of concurrent model combinations. Values are DSL strings using & (AND), | (OR), () (grouping), and +ref (inline another set). Definition order is used for tie-breaking.",
+                    "description": "Named sets of concurrent model combinations. Values are DSL strings using & (AND), | (OR), () (grouping), +ref (inline another set), and +auto:orphans (each model that is not a leaf in a set). Definition order is used for tie-breaking.",
                     "minProperties": 1,
                     "additionalProperties": {
                         "type": "string"

--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -666,6 +666,13 @@ routing:
         #   "(a | b) & (c | d)"  → [a,c], [a,d], [b,c], [b,d]
         #   "+llms & v"          → inline the llms set, then AND with v
         sets:
+          # +auto:orphans includes each model that is not a leaf in a set.
+          # If you define a set with this name, llama-swap uses your set.
+          # Example of a catch-all set:
+          # always: "task-small & embed-model"
+          # main: "+always & moe-medium & (dense-a | dense-b)"
+          # scratch: "+always & +auto:orphans"
+
           # An LLM plus TTS. Vars and real model IDs may be mixed.
           # expands to: [g,v], [qwen-model,v], [m,v]
           standard: "(g | qwen-model | m) & v"

--- a/docs/kb/guides/routing/groups-and-matrix.md
+++ b/docs/kb/guides/routing/groups-and-matrix.md
@@ -119,6 +119,48 @@ Two things worth internalising:
 `evict_costs` (default 1) is how you express "this one is painful to reload".
 Give slow cold-starting backends a high cost.
 
+### Use `+auto:orphans` for the models that no set names
+
+A leaf is a model ID or a var in a set expression. The reserved reference
+`+auto:orphans` includes each model that is not a leaf in your sets. llama-swap
+changes a var to its model ID before this test. A reference such as `+base` is
+not a leaf and adds no models.
+
+The name of the set is `auto:orphans`. The first `+` is the usual syntax for a
+reference to a set. Only a reference name can contain a colon. A model name or a
+var name cannot contain a colon.
+
+llama-swap makes the orphan list one time, when it reads the configuration, and
+sorts the list by model ID. The expression is therefore always the same. For
+example, a leaf names `a`, but no leaf names `b` or `c`. Then `+auto:orphans`
+operates as `(b | c)`:
+
+```yaml
+sets:
+  always:  "task-small & embed-model"
+  main:    "+always & moe-medium & (dense-a | dense-b)"
+  scratch: "+always & +auto:orphans"
+```
+
+If there are no orphan models, llama-swap removes the `+auto:orphans` term. An
+empty term also moves through references. For example, the set `empty` resolves
+only to an empty `+auto:orphans`. The set `outer: "+empty & x"` then operates as
+`x`. llama-swap can never select a set that contains only an empty
+`+auto:orphans`.
+
+If you define a set with the name `auto:orphans`, llama-swap uses your set and
+does not make the automatic set.
+
+If a set refers to `+auto:orphans`, llama-swap writes one of these lines to the
+log at startup and at each reload of the configuration:
+
+- `matrix: synthesized set "auto:orphans" = (modelA | modelB | ...)`
+- `matrix: synthesized set "auto:orphans" is empty; +auto:orphans terms dropped`
+- `matrix: set "auto:orphans" is user-defined; orphan synthesis disabled`
+
+If you change `models:`, llama-swap makes a new orphan list at the next reload.
+This is the intended behavior.
+
 ## Which one?
 
 Use **group** if your setup is describable as "these run together, those swap

--- a/internal/config/matrix.go
+++ b/internal/config/matrix.go
@@ -93,9 +93,13 @@ func ValidateMatrix(matrix *MatrixConfig, models map[string]ModelConfig) error {
 		})
 	}
 
+	modelIDs := make([]string, 0, len(models))
+	for modelID := range models {
+		modelIDs = append(modelIDs, modelID)
+	}
 	program, err := matrixdsl.Compile(definitions, func(ident string) (string, bool) {
 		return resolveMatrixModel(ident, matrix.Var, models)
-	})
+	}, modelIDs)
 	if err != nil {
 		return err
 	}

--- a/internal/config/matrix_orphans_test.go
+++ b/internal/config/matrix_orphans_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestValidateMatrix_OrphansVarInteraction(t *testing.T) {
+	models := makeModels("a", "b")
+	matrix := MatrixConfig{
+		Var:  map[string]string{"alias": "a"},
+		Sets: OrderedSets{{Name: "main", DSL: "alias & +auto:orphans"}},
+	}
+	require.NoError(t, ValidateMatrix(&matrix, models))
+	orphans, mode := matrix.Program().SynthesizedOrphans()
+	require.Equal(t, "synthesized", mode)
+	require.Equal(t, []string{"b"}, orphans)
+}
+
+func TestValidateMatrix_OrphansTokenizerHostileModel(t *testing.T) {
+	models := makeModels("a", "qwen3:32b")
+	matrix := MatrixConfig{Sets: OrderedSets{{Name: "main", DSL: "a & +auto:orphans"}}}
+	require.NoError(t, ValidateMatrix(&matrix, models))
+	result := matrix.Program().Solve("qwen3:32b", nil, nil)
+	require.Equal(t, "main", result.SetName)
+	require.Equal(t, []string{"a", "qwen3:32b"}, result.TargetSet)
+}
+
+func TestValidateMatrix_OrphansEvictCosts(t *testing.T) {
+	models := makeModels("a", "b", "c")
+	matrix := MatrixConfig{
+		EvictCosts: map[string]int{"b": 7},
+		Sets:       OrderedSets{{Name: "main", DSL: "a & +auto:orphans"}},
+	}
+	require.NoError(t, ValidateMatrix(&matrix, models))
+	costs := matrix.ResolvedEvictCosts()
+	require.Equal(t, 7, costs["b"])
+	require.NotContains(t, costs, "c")
+}
+
+func TestValidateMatrix_OrphansYAML(t *testing.T) {
+	for _, tt := range []struct {
+		name, input, mode, set string
+	}{
+		{"generated", "sets:\n  main: 'a & +auto:orphans'\n", "synthesized", "main"},
+		{"shadowed", "sets:\n  auto:orphans: b\n  main: 'a & +auto:orphans'\n", "user-defined", "auto:orphans"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var matrix MatrixConfig
+			require.NoError(t, yaml.Unmarshal([]byte(tt.input), &matrix))
+			require.NoError(t, ValidateMatrix(&matrix, makeModels("a", "b")))
+			_, mode := matrix.Program().SynthesizedOrphans()
+			require.Equal(t, tt.mode, mode)
+			require.Equal(t, tt.set, matrix.Program().Solve("b", nil, nil).SetName)
+		})
+	}
+}
+
+func TestValidateMatrix_OrphansShadowing(t *testing.T) {
+	models := makeModels("a", "b")
+	matrix := MatrixConfig{Sets: OrderedSets{
+		{Name: "auto:orphans", DSL: "a"},
+		{Name: "scratch", DSL: "+auto:orphans"},
+	}}
+	require.NoError(t, ValidateMatrix(&matrix, models))
+	_, mode := matrix.Program().SynthesizedOrphans()
+	require.Equal(t, "user-defined", mode)
+	require.Equal(t, "auto:orphans", matrix.Program().Solve("a", nil, nil).SetName)
+}

--- a/internal/matrix/dsl.go
+++ b/internal/matrix/dsl.go
@@ -30,6 +30,7 @@ const (
 	nodeRef
 	nodeAnd
 	nodeOr
+	nodeEmpty
 )
 
 type node struct {
@@ -66,7 +67,9 @@ func tokenize(input string) ([]token, error) {
 		case '+':
 			i++
 			start := i
-			for i < len(runes) && isIdentChar(runes[i]) {
+			// Namespaced set references (e.g. +auto:orphans) allow colons.
+			// Bare model/var identifiers keep their existing grammar.
+			for i < len(runes) && (isIdentChar(runes[i]) || runes[i] == ':') {
 				i++
 			}
 			if i == start {

--- a/internal/matrix/dsl_test.go
+++ b/internal/matrix/dsl_test.go
@@ -46,6 +46,17 @@ func TestDSL_Tokenize(t *testing.T) {
 				{typ: tokEOF},
 			},
 		},
+		{
+			name: "namespaced reference", input: "+auto:orphans & x",
+			expect: []token{
+				{typ: tokRef, val: "auto:orphans"},
+				{typ: tokAnd, val: "&"},
+				{typ: tokIdent, val: "x"},
+				{typ: tokEOF},
+			},
+		},
+		{name: "bare namespaced name", input: "auto:orphans", errMsg: "unexpected character ':'"},
+		{name: "bare model with colon", input: "qwen3:32b", errMsg: "unexpected character ':'"},
 		{name: "empty ref", input: "+", errMsg: "expected set name after '+'"},
 		{name: "invalid character", input: "a @ b", errMsg: "unexpected character"},
 	}
@@ -178,7 +189,7 @@ func TestProgram_CompileErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := Compile(tt.defs, resolve)
+			_, err := Compile(tt.defs, resolve, nil)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.errMsg)
 		})
@@ -254,7 +265,7 @@ func compileIdentity(t *testing.T, definitions []Definition, models []string) *P
 	}
 	program, err := Compile(definitions, func(name string) (string, bool) {
 		return name, known[name]
-	})
+	}, nil)
 	require.NoError(t, err)
 	return program
 }

--- a/internal/matrix/model_set_test.go
+++ b/internal/matrix/model_set_test.go
@@ -1,0 +1,72 @@
+package matrix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProgram_OrphansCompileIsolation(t *testing.T) {
+	definitions := []Definition{
+		{Name: "first", DSL: "+" + OrphanSetName},
+		{Name: "second", DSL: "+" + OrphanSetName},
+	}
+	first := compileOrphansTestProgram(t, definitions, []string{"a"})
+	require.Len(t, first.sets, 2, "automatic root must not be selectable")
+	root := first.sets[0].root.ref
+	require.Same(t, root, first.sets[1].root.ref, "references share one generated root")
+
+	// Building another model list neither registers nor changes any named set.
+	other := buildModelSet([]string{"b"})
+	require.NotSame(t, root, other)
+	other.children[0].name = "changed"
+	require.Equal(t, []string{"a"}, first.Solve("a", nil, nil).TargetSet)
+
+	// A reload must recompute membership, without modifying the old program.
+	second := compileOrphansTestProgram(t, definitions, []string{"b"})
+	require.NotSame(t, root, second.sets[0].root.ref)
+	models, mode := first.SynthesizedOrphans()
+	require.Equal(t, "synthesized", mode)
+	require.Equal(t, []string{"a"}, models)
+	models[0] = "changed"
+	models, _ = first.SynthesizedOrphans()
+	require.Equal(t, []string{"a"}, models, "reporting must not expose mutable storage")
+	models, _ = second.SynthesizedOrphans()
+	require.Equal(t, []string{"b"}, models)
+}
+
+func TestProgram_BuildModelSet(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		models []string
+		want   [][]string
+	}{
+		{name: "empty"},
+		{name: "single", models: []string{"a"}, want: [][]string{{"a"}}},
+		{name: "sorted alternatives", models: []string{"z", "a"}, want: [][]string{{"a"}, {"z"}}},
+		{name: "resolved IDs bypass tokenizer", models: []string{"qwen3:32b", "org/model"}, want: [][]string{{"org/model"}, {"qwen3:32b"}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			original := append([]string(nil), tt.models...)
+			root := buildModelSet(tt.models)
+			require.Equal(t, original, tt.models, "builder must not mutate its input")
+
+			var combinations [][]string
+			for _, state := range newEvaluator(tt.models).evaluate(root) {
+				combinations = append(combinations, flattenWitness(state.witness))
+			}
+			require.Equal(t, tt.want, combinations)
+
+			program := &Program{sets: []compiledSet{{name: "generated", root: root}}}
+			program.computeSupport()
+			for _, model := range tt.models {
+				require.Equal(t, "generated", program.Solve(model, nil, nil).SetName)
+			}
+			if len(tt.models) == 0 {
+				require.Equal(t, nodeEmpty, root.kind)
+				require.Empty(t, program.modelBits)
+				require.Empty(t, program.Solve("unknown", nil, nil).SetName)
+			}
+		})
+	}
+}

--- a/internal/matrix/program.go
+++ b/internal/matrix/program.go
@@ -5,6 +5,9 @@ import (
 	"sort"
 )
 
+// OrphanSetName is the reserved reference target for automatic orphan models.
+const OrphanSetName = "auto:orphans"
+
 // Definition is one named matrix DSL expression.
 type Definition struct {
 	Name string
@@ -26,9 +29,11 @@ type compiledSet struct {
 
 // Program is an immutable, compiled matrix DSL program.
 type Program struct {
-	sets      []compiledSet
-	modelBits map[string]int
-	words     int
+	sets         []compiledSet
+	modelBits    map[string]int
+	words        int
+	orphanModels []string
+	orphanMode   string
 }
 
 // Decision describes the selected matrix set and the running models it evicts.
@@ -42,7 +47,7 @@ type Decision struct {
 
 // Compile parses, validates, resolves, and links an ordered collection of DSL
 // definitions without expanding their Cartesian products.
-func Compile(definitions []Definition, resolve Resolver) (*Program, error) {
+func Compile(definitions []Definition, resolve Resolver, allModels []string) (*Program, error) {
 	if len(definitions) == 0 {
 		return nil, fmt.Errorf("matrix must define at least one set")
 	}
@@ -55,6 +60,8 @@ func Compile(definitions []Definition, resolve Resolver) (*Program, error) {
 		setNames[definition.Name] = true
 	}
 
+	seenModels := make(map[string]bool)
+	orphansReferenced := false
 	for _, definition := range definitions {
 		root, err := parseDSL(definition.DSL)
 		if err != nil {
@@ -71,9 +78,15 @@ func Compile(definitions []Definition, resolve Resolver) (*Program, error) {
 					return fmt.Errorf("set %q: unknown var or model %q", definition.Name, n.name)
 				}
 				n.name = model
+				seenModels[model] = true
 			case nodeRef:
-				if !setNames[n.name] {
-					return fmt.Errorf("set %q references undefined set %q", definition.Name, n.name)
+				if n.name == OrphanSetName {
+					orphansReferenced = true
+				}
+				if n.name != OrphanSetName || setNames[OrphanSetName] {
+					if !setNames[n.name] {
+						return fmt.Errorf("set %q references undefined set %q", definition.Name, n.name)
+					}
 				}
 				if !seenRefs[n.name] {
 					seenRefs[n.name] = true
@@ -90,11 +103,44 @@ func Compile(definitions []Definition, resolve Resolver) (*Program, error) {
 		deps[definition.Name] = refs
 	}
 
+	program := &Program{}
+	// Orphan membership must be computed from resolved user-authored leaves,
+	// before any other automatic sets are synthesized. Keep this phase outside
+	// reference walks: it registers at most one shared root per Compile call.
+	// Future automatic-set registration must not replace OrphanSetName.
+	if orphansReferenced {
+		if setNames[OrphanSetName] {
+			program.orphanMode = "user-defined"
+		} else {
+			orphans := make([]string, 0, len(allModels))
+			for _, model := range allModels {
+				if !seenModels[model] {
+					orphans = append(orphans, model)
+				}
+			}
+			sort.Strings(orphans)
+			setNames[OrphanSetName] = true
+			deps[OrphanSetName] = nil
+			roots[OrphanSetName] = buildModelSet(orphans)
+			if len(orphans) == 0 {
+				program.orphanMode = "empty"
+			} else {
+				program.orphanModels = orphans
+				program.orphanMode = "synthesized"
+			}
+		}
+	}
+
 	order, err := topologicalOrder(definitions, deps)
 	if err != nil {
 		return nil, err
 	}
 
+	if orphansReferenced {
+		for _, name := range order {
+			roots[name] = simplifyEmptyRefs(roots[name], roots)
+		}
+	}
 	for _, root := range roots {
 		if err := walk(root, func(n *node) error {
 			if n.kind == nodeRef {
@@ -108,6 +154,9 @@ func Compile(definitions []Definition, resolve Resolver) (*Program, error) {
 
 	sets := make([]compiledSet, 0, len(order))
 	for _, name := range order {
+		if name == OrphanSetName && (program.orphanMode == "synthesized" || program.orphanMode == "empty") {
+			continue
+		}
 		sets = append(sets, compiledSet{
 			name: name,
 			dsl:  dslByName[name],
@@ -115,9 +164,25 @@ func Compile(definitions []Definition, resolve Resolver) (*Program, error) {
 		})
 	}
 
-	program := &Program{sets: sets}
+	program.sets = sets
 	program.computeSupport()
 	return program, nil
+}
+
+// buildModelSet constructs alternatives from already-resolved model IDs without
+// parsing DSL or changing the input slice. Membership, reference registration,
+// and the treatment of empty sets belong to the caller.
+func buildModelSet(models []string) *node {
+	if len(models) == 0 {
+		return &node{kind: nodeEmpty}
+	}
+	models = append([]string(nil), models...)
+	sort.Strings(models)
+	children := make([]*node, len(models))
+	for i, model := range models {
+		children[i] = &node{kind: nodeLeaf, name: model}
+	}
+	return &node{kind: nodeOr, children: children}
 }
 
 // computeSupport builds the program-wide model registry and, for each set, a
@@ -136,6 +201,8 @@ func (p *Program) computeSupport() {
 			models = map[string]bool{n.name: true}
 		case nodeRef:
 			models = collect(n.ref)
+		case nodeEmpty:
+			models = make(map[string]bool)
 		default:
 			models = make(map[string]bool)
 			for _, child := range n.children {
@@ -181,6 +248,40 @@ func (p *Program) supportsAll(set *compiledSet, models []string) bool {
 		}
 	}
 	return true
+}
+
+func simplifyEmptyRefs(root *node, roots map[string]*node) *node {
+	if root.kind == nodeRef {
+		if target, ok := roots[root.name]; ok && target.kind == nodeEmpty {
+			return &node{kind: nodeEmpty}
+		}
+		return root
+	}
+	if root.kind == nodeLeaf || root.kind == nodeEmpty {
+		return root
+	}
+
+	children := root.children[:0]
+	for _, child := range root.children {
+		child = simplifyEmptyRefs(child, roots)
+		if child.kind == nodeEmpty {
+			continue
+		}
+		children = append(children, child)
+	}
+	root.children = children
+	if len(children) == 0 {
+		return &node{kind: nodeEmpty}
+	}
+	if len(children) == 1 {
+		return children[0]
+	}
+	return root
+}
+
+// SynthesizedOrphans reports the opt-in +auto:orphans compilation result.
+func (p *Program) SynthesizedOrphans() ([]string, string) {
+	return append([]string(nil), p.orphanModels...), p.orphanMode
 }
 
 func topologicalOrder(definitions []Definition, deps map[string][]string) ([]string, error) {
@@ -417,6 +518,8 @@ func (e *evaluator) evaluate(root *node) []projectedState {
 
 	var states []projectedState
 	switch root.kind {
+	case nodeEmpty:
+		states = nil
 	case nodeLeaf:
 		mask := make(bitMask, e.words)
 		if bit, relevant := e.modelBits[root.name]; relevant {

--- a/internal/matrix/program_bench_test.go
+++ b/internal/matrix/program_bench_test.go
@@ -19,7 +19,7 @@ func BenchmarkProgram_SolveMultiSet(b *testing.B) {
 		definitions, known, costs := multiSetDefinitions(setCount, 10)
 		program, err := Compile(definitions, func(name string) (string, bool) {
 			return name, known[name]
-		})
+		}, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -87,7 +87,7 @@ func BenchmarkMatrix_Compile(b *testing.B) {
 			for b.Loop() {
 				program, err := Compile([]Definition{definition}, func(name string) (string, bool) {
 					return name, known[name]
-				})
+				}, nil)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/internal/matrix/program_orphans_test.go
+++ b/internal/matrix/program_orphans_test.go
@@ -1,0 +1,167 @@
+package matrix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func compileOrphansTestProgram(t *testing.T, definitions []Definition, models []string) *Program {
+	t.Helper()
+	program, err := Compile(definitions, func(name string) (string, bool) {
+		for _, model := range models {
+			if name == model {
+				return model, true
+			}
+		}
+		return "", false
+	}, models)
+	require.NoError(t, err)
+	return program
+}
+
+func TestProgram_OrphansSynthesis(t *testing.T) {
+	program := compileOrphansTestProgram(t, []Definition{{Name: "main", DSL: "a & +auto:orphans"}}, []string{"c", "a", "b"})
+	models, mode := program.SynthesizedOrphans()
+	require.Equal(t, "synthesized", mode)
+	require.Equal(t, []string{"b", "c"}, models)
+
+	decision := program.Solve("b", []string{"a"}, nil)
+	require.Equal(t, "main", decision.SetName)
+	require.Equal(t, []string{"a", "b"}, decision.TargetSet)
+}
+
+func TestProgram_OrphansEmptyUnderAnd(t *testing.T) {
+	program := compileOrphansTestProgram(t, []Definition{{Name: "main", DSL: "a & +auto:orphans"}}, []string{"a"})
+	decision := program.Solve("a", nil, nil)
+	require.Equal(t, "main", decision.SetName)
+	require.Equal(t, []string{"a"}, decision.TargetSet)
+}
+
+func TestProgram_OrphansEmptyOnly(t *testing.T) {
+	program := compileOrphansTestProgram(t, []Definition{
+		{Name: "always", DSL: "a"},
+		{Name: "scratch", DSL: "+auto:orphans"},
+	}, []string{"a"})
+	require.NotPanics(t, func() { program.Solve("a", nil, nil) })
+	require.Equal(t, "always", program.Solve("a", nil, nil).SetName)
+}
+
+func TestProgram_OrphansSharedRef(t *testing.T) {
+	program := compileOrphansTestProgram(t, []Definition{
+		{Name: "one", DSL: "a & +auto:orphans"},
+		{Name: "two", DSL: "b & +auto:orphans"},
+	}, []string{"a", "b", "c"})
+	models, _ := program.SynthesizedOrphans()
+	require.Equal(t, []string{"c"}, models)
+	require.Equal(t, []string{"a", "c"}, program.Solve("a", []string{"c"}, nil).TargetSet)
+	require.Equal(t, []string{"b", "c"}, program.Solve("b", []string{"c"}, nil).TargetSet)
+}
+
+func TestProgram_OrphansTransitiveDrop(t *testing.T) {
+	program := compileOrphansTestProgram(t, []Definition{
+		{Name: "scratch", DSL: "+auto:orphans"},
+		{Name: "outer", DSL: "+scratch & x"},
+	}, []string{"x"})
+	require.Equal(t, "outer", program.Solve("x", nil, nil).SetName)
+	require.Equal(t, []string{"x"}, program.Solve("x", nil, nil).TargetSet)
+}
+
+func TestProgram_OrphansTransitiveChain(t *testing.T) {
+	program := compileOrphansTestProgram(t, []Definition{
+		{Name: "a1", DSL: "+auto:orphans"},
+		{Name: "a2", DSL: "+a1"},
+		{Name: "a3", DSL: "+a2 & x"},
+	}, []string{"x"})
+	require.Equal(t, "a3", program.Solve("x", nil, nil).SetName)
+	require.Equal(t, []string{"x"}, program.Solve("x", nil, nil).TargetSet)
+}
+
+func TestProgram_OrphansTransitiveNonEmpty(t *testing.T) {
+	program := compileOrphansTestProgram(t, []Definition{
+		{Name: "scratch", DSL: "+auto:orphans"},
+		{Name: "outer", DSL: "+scratch & x"},
+	}, []string{"x", "orphan"})
+	decision := program.Solve("orphan", nil, nil)
+	require.Contains(t, []string{"outer", "scratch"}, decision.SetName)
+	require.Contains(t, decision.TargetSet, "orphan")
+}
+
+func TestProgram_OrphansNested(t *testing.T) {
+	program := compileOrphansTestProgram(t, []Definition{{Name: "nested", DSL: "(x | +auto:orphans) & y"}}, []string{"x", "y", "z"})
+	require.Equal(t, []string{"y", "z"}, program.Solve("z", nil, nil).TargetSet)
+
+	empty := compileOrphansTestProgram(t, []Definition{{Name: "nested", DSL: "(x & +auto:orphans) | y"}}, []string{"x", "y"})
+	require.Equal(t, []string{"x"}, empty.Solve("x", nil, nil).TargetSet)
+	require.Equal(t, []string{"y"}, empty.Solve("y", nil, nil).TargetSet)
+}
+
+func TestProgram_UndefinedBareLeaf(t *testing.T) {
+	program := compileOrphansTestProgram(t, []Definition{{Name: "bare", DSL: "undefined"}}, []string{"undefined"})
+	_, mode := program.SynthesizedOrphans()
+	require.Equal(t, "", mode)
+	require.Equal(t, "bare", program.Solve("undefined", nil, nil).SetName)
+
+	_, err := Compile([]Definition{{Name: "bare", DSL: "undefined"}}, func(string) (string, bool) {
+		return "", false
+	}, []string{"a"})
+	require.EqualError(t, err, `set "bare": unknown var or model "undefined"`)
+}
+
+func TestProgram_OrphansReferenceValidation(t *testing.T) {
+	for _, name := range []string{"undefined", "auto:missing", "tag:vision"} {
+		t.Run(name, func(t *testing.T) {
+			_, err := Compile([]Definition{{Name: "main", DSL: "+" + name}}, func(id string) (string, bool) {
+				return id, true
+			}, []string{"a"})
+			require.EqualError(t, err, `set "main" references undefined set "`+name+`"`)
+		})
+	}
+	// The previous special name remains usable as an ordinary user set.
+	program := compileOrphansTestProgram(t, []Definition{
+		{Name: "undefined", DSL: "a"}, {Name: "main", DSL: "+undefined"},
+	}, []string{"a", "b"})
+	models, mode := program.SynthesizedOrphans()
+	require.Empty(t, mode)
+	require.Empty(t, models)
+	require.Equal(t, "undefined", program.Solve("a", nil, nil).SetName)
+}
+
+func TestProgram_OrphansNeverSelectable(t *testing.T) {
+	program := compileOrphansTestProgram(t, []Definition{{Name: "main", DSL: "a & +auto:orphans"}}, []string{"a", "b"})
+	for _, target := range []string{"a", "b"} {
+		require.NotEqual(t, "auto:orphans", program.Solve(target, nil, nil).SetName)
+	}
+}
+
+func TestProgram_OrphansZeroUse(t *testing.T) {
+	program := compileOrphansTestProgram(t, []Definition{{Name: "main", DSL: "a"}}, []string{"a", "b"})
+	models, mode := program.SynthesizedOrphans()
+	require.Equal(t, "", mode)
+	require.Empty(t, models)
+}
+
+func TestProgram_OrphansDeterministic(t *testing.T) {
+	definitions := []Definition{{Name: "main", DSL: "a & +auto:orphans"}}
+	first := compileOrphansTestProgram(t, definitions, []string{"a", "c", "b"})
+	second := compileOrphansTestProgram(t, definitions, []string{"b", "a", "c"})
+	firstModels, firstMode := first.SynthesizedOrphans()
+	secondModels, secondMode := second.SynthesizedOrphans()
+	require.Equal(t, firstModels, secondModels)
+	require.Equal(t, firstMode, secondMode)
+	for _, target := range []string{"a", "b", "c"} {
+		require.Equal(t, first.Solve(target, nil, nil), second.Solve(target, nil, nil))
+	}
+}
+
+func TestProgram_OrphansShadowed(t *testing.T) {
+	program := compileOrphansTestProgram(t, []Definition{{Name: "auto:orphans", DSL: "a"}, {Name: "scratch", DSL: "+auto:orphans"}}, []string{"a", "b"})
+	_, mode := program.SynthesizedOrphans()
+	require.Equal(t, "user-defined", mode)
+	require.Equal(t, "auto:orphans", program.Solve("a", nil, nil).SetName)
+}
+
+func TestProgram_OrphansUnreferencedShadowSet(t *testing.T) {
+	program := compileOrphansTestProgram(t, []Definition{{Name: "auto:orphans", DSL: "a"}}, []string{"a"})
+	require.Equal(t, "auto:orphans", program.Solve("a", nil, nil).SetName)
+}

--- a/internal/router/matrix.go
+++ b/internal/router/matrix.go
@@ -3,9 +3,11 @@ package router
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/matrix"
 	"github.com/mostlygeek/llama-swap/internal/process"
 )
 
@@ -22,6 +24,15 @@ func NewMatrix(conf config.Config, proxylog, upstreamlog *logmon.Monitor) (*Matr
 		if err := config.ValidateMatrix(mtx, conf.Models); err != nil {
 			return nil, fmt.Errorf("compiling matrix configuration: %w", err)
 		}
+	}
+	models, mode := mtx.Program().SynthesizedOrphans()
+	switch mode {
+	case "synthesized":
+		proxylog.Infof("matrix: synthesized set %q = (%s)", matrix.OrphanSetName, strings.Join(models, " | "))
+	case "empty":
+		proxylog.Infof("matrix: synthesized set %q is empty; +%s terms dropped", matrix.OrphanSetName, matrix.OrphanSetName)
+	case "user-defined":
+		proxylog.Infof("matrix: set %q is user-defined; orphan synthesis disabled", matrix.OrphanSetName)
 	}
 
 	swapper := &matrixSwapper{


### PR DESCRIPTION
Fixes #1025 

---
# Implementation
This implements the synthetic group as described in #1025:

Create a synthetic set named `undefined`. This set will contain all the models that are not defined in an expression. Then, at config compile time:

- Parse every set expression into a tree.
- While walking the trees, collect every model name that appears directly in an expression (var aliases translated to real model IDs first).
- Subtract that collection from the full `models:` list. Whatever remains is the orphan list. Sort it.
- Build a synthetic expression, `orphan1 | orphan2 | ...`, and wire every `+undefined` reference to point at it, the same way `+always` points at a set named `always`.
- Edge cases resolved at the same moment: zero orphans means the `+undefined` term is deleted from whatever expression contained it; a user set actually named `undefined` means step 3 and 4 never run and the references bind to that set instead.
- Log which of those happened.

# Tests
In addition to the tests written during development of this feature, I also did some empirical testing of this functionality. The feature works as intended based on my testing, with no impact to previous features or unrelated elements, including peered models.

#### Config snippet
```yaml
routing:
  router:
    use: matrix
    settings:
      matrix:
        sets:
          always:  "text-embedding & task-model & comfy-serve"
          main:    "+always & (qwen3.6-35b-a3b | gemma-4-26b-a4b) & (qwen3.8-27b | gemma-4-31b)"
          scratch: "+always & +undefined"
```
#### Log

Upon config save:
```
3:17PM [INFO] matrix: synthesized set "undefined" = (gemma-4-12b | gemma-4-26b-a4b-uncensored | gemma-4-e2b | gemma-4-e4b | gpt-oss-120b | gpt-oss-20b | laguna-s-2.1 | laguna-xs-2.1 | ling-3.0-flash | ling-3.0-tiny | muse-glimmer | nvidia-nemotron-3-nano-omni-30b-a3b | qwen3.5-122b-a10b | qwen3.5-122b-a10b-uncensored | qwen3.5-9b | qwen3.6-27b | qwen3.6-35b-a3b-uncensored)
```

Upon loading a model in set `main`:
```
3:20PM [DEBUG] matrix: starting swap for model gemma-4-26b-a4b, evicting []
3:20PM [DEBUG] matrix: model=gemma-4-26b-a4b already running in set=main dsl="+always & (qwen3.6-35b-a3b | gemma-4-26b-a4b) & (qwen3.8-27b | gemma-4-31b)"
```

Upon loading an `undefined` model:
```
3:23PM [DEBUG] matrix: starting swap for model ling-3.0-flash, evicting [gemma-4-26b-a4b]
3:23PM [INFO] matrix: model=ling-3.0-flash set=scratch dsl="+always & +undefined" evict=[gemma-4-26b-a4b] target=[comfy-serve ling-3.0-flash task-model text-embedding] cost=1
```

Upon loading another `undefined` model:
```
3:24PM [DEBUG] matrix: starting swap for model ling-3.0-tiny, evicting [ling-3.0-flash]
3:24PM [INFO] matrix: model=ling-3.0-tiny set=scratch dsl="+always & +undefined" evict=[ling-3.0-flash] target=[comfy-serve ling-3.0-tiny task-model text-embedding] cost=1
```
# Considerations
Naming: I'm not sure if `undefined` is the best term for this synthetic set. My logic was, "These models are undefined in sets". Open to other static name suggestions, or making it user-configurable.