### PR TITLE
internal/swaputil: OpenAI-compatible error bodies

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -62,7 +62,7 @@ type Process interface {
 
 	// ServeHTTP forwards requests to the underlying process
 	// Calling it when the process is not ready will result in a
-	// 503 response with a body indicating it is a llama-swap-error
+	// 503 response with an error body identifying llama-swap as the source
 	ServeHTTP(http.ResponseWriter, *http.Request)
 
 	// Logger returns the monitor that captures this process's stdout/stderr.

--- a/internal/process/process_command.go
+++ b/internal/process/process_command.go
@@ -750,7 +750,7 @@ func (p *ProcessCommand) State() ProcessState {
 func (p *ProcessCommand) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fn := p.handler.Load()
 	if fn == nil {
-		http.Error(w, fmt.Sprintf("llama-swap-error: [%s] process is not ready", p.id), http.StatusServiceUnavailable)
+		swaputil.SendResponse(w, r, http.StatusServiceUnavailable, fmt.Sprintf("[%s] process is not ready", p.id))
 		return
 	}
 	if p.config.Compat.IgnoreWebsockets && swaputil.IsWebSocketUpgrade(r) {

--- a/internal/process/process_command_test.go
+++ b/internal/process/process_command_test.go
@@ -174,8 +174,8 @@ func TestProcessCommand_StartStop(t *testing.T) {
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Errorf("before start: expected 503, got %d", rr.Code)
 	}
-	if body := rr.Body.String(); !strings.Contains(body, "llama-swap-error") {
-		t.Errorf("before start: expected body to contain %q, got %q", "llama-swap-error", body)
+	if body := rr.Body.String(); !strings.Contains(body, `"src":"llama-swap"`) || !strings.Contains(body, "process is not ready") {
+		t.Errorf("before start: expected llama-swap error envelope, got %q", body)
 	}
 
 	runErr := runAsync(t, p)
@@ -213,8 +213,8 @@ func TestProcessCommand_StartStop(t *testing.T) {
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Errorf("after stop: expected 503, got %d", rr.Code)
 	}
-	if body := rr.Body.String(); !strings.Contains(body, "llama-swap-error") {
-		t.Errorf("after stop: expected body to contain %q, got %q", "llama-swap-error", body)
+	if body := rr.Body.String(); !strings.Contains(body, `"src":"llama-swap"`) || !strings.Contains(body, "process is not ready") {
+		t.Errorf("after stop: expected llama-swap error envelope, got %q", body)
 	}
 }
 

--- a/internal/router/base_test.go
+++ b/internal/router/base_test.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +16,7 @@ import (
 	"github.com/mostlygeek/llama-swap/internal/logmon"
 	"github.com/mostlygeek/llama-swap/internal/process"
 	"github.com/mostlygeek/llama-swap/internal/router/scheduler"
+	"github.com/mostlygeek/llama-swap/internal/swaputil"
 )
 
 // These tests cover baseRouter's own machinery — the run loop, process
@@ -609,6 +611,15 @@ func TestBaseRouter_ConcurrencyLimitRejectsBeforeLoadingStream(t *testing.T) {
 	}
 	if strings.Contains(w.Body.String(), "llama-swap loading model") {
 		t.Fatalf("429 body contains loading stream: %q", w.Body.String())
+	}
+	// OpenAI clients read body["error"]["message"], so "error" must decode as
+	// an object rather than a bare string.
+	var envelope swaputil.ErrorEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("429 body is not an OpenAI error envelope: %v, body=%q", err, w.Body.String())
+	}
+	if envelope.Error.Message == "" || envelope.Error.Type != swaputil.ErrorTypeRateLimit {
+		t.Fatalf("429 error=%+v, want a rate_limit_error with a message", envelope.Error)
 	}
 
 	close(bProc.serveBlock)

--- a/internal/router/peer.go
+++ b/internal/router/peer.go
@@ -94,7 +94,7 @@ func NewPeer(cfg config.Config, logger *logmon.Monitor) (*Peer, error) {
 			if runtime.GOOS == "darwin" && strings.Contains(err.Error(), "connect: no route to host") {
 				errMsg += " (hint: on macOS, check System Settings > Privacy & Security > Local Network permissions)"
 			}
-			http.Error(w, errMsg, http.StatusBadGateway)
+			swaputil.SendResponse(w, r, http.StatusBadGateway, errMsg)
 		}
 
 		pp := &peerMember{

--- a/internal/swaputil/http.go
+++ b/internal/swaputil/http.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"html"
@@ -104,7 +103,9 @@ func SendError(w http.ResponseWriter, r *http.Request, err error) {
 	}
 }
 
-// SendResponse detects what content type the client prefers and returns an error response in that format.
+// SendResponse detects what content type the client prefers and returns an
+// error response in that format. JSON responses use the OpenAI-compatible
+// envelope, where "error" is an object rather than a string.
 func SendResponse(w http.ResponseWriter, r *http.Request, status int, message string) {
 	acceptHeader := r.Header.Get("Accept")
 	if strings.Contains(acceptHeader, "text/plain") {
@@ -123,12 +124,7 @@ func SendResponse(w http.ResponseWriter, r *http.Request, status int, message st
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	resp, err := json.Marshal(map[string]string{"src": "llama-swap", "error": message})
-	if err != nil {
-		w.Write([]byte(`{"src":"llama-swap", "error": "failed to marshal response"}`))
-		return
-	}
-	w.Write(resp)
+	w.Write(NewErrorEnvelope(status, message, "").JSON())
 }
 
 // FetchContext will attempt to get the model id from the context, then

--- a/internal/swaputil/http_test.go
+++ b/internal/swaputil/http_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -877,5 +879,116 @@ func TestFetchContext_UpstreamPath_DoesNotReadBody(t *testing.T) {
 	}
 	if string(got) != body {
 		t.Errorf("body was consumed: %q", string(got))
+	}
+}
+
+func TestSendResponse_JSONEnvelope(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	w := httptest.NewRecorder()
+	SendResponse(w, r, http.StatusBadRequest, "could not read request body")
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if got := w.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("Content-Type = %q, want application/json", got)
+	}
+
+	var envelope ErrorEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("body is not an OpenAI-style error envelope: %v, body=%s", err, w.Body.String())
+	}
+	if envelope.Error.Message != "could not read request body" {
+		t.Errorf("error.message = %q, want %q", envelope.Error.Message, "could not read request body")
+	}
+	if envelope.Error.Type != ErrorTypeInvalidRequest {
+		t.Errorf("error.type = %q, want %q", envelope.Error.Type, ErrorTypeInvalidRequest)
+	}
+	if envelope.Src != "llama-swap" {
+		t.Errorf("src = %q, want llama-swap", envelope.Src)
+	}
+}
+
+func TestSendResponse_TextFormats(t *testing.T) {
+	t.Run("plain", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("Accept", "text/plain")
+		w := httptest.NewRecorder()
+		SendResponse(w, r, http.StatusNotFound, "model not found")
+
+		if got := w.Header().Get("Content-Type"); got != "text/plain" {
+			t.Fatalf("Content-Type = %q, want text/plain", got)
+		}
+		if got, want := w.Body.String(), "llama-swap: model not found"; got != want {
+			t.Errorf("body = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("html", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("Accept", "text/html")
+		w := httptest.NewRecorder()
+		SendResponse(w, r, http.StatusNotFound, "model not found")
+
+		if got := w.Header().Get("Content-Type"); got != "text/html" {
+			t.Fatalf("Content-Type = %q, want text/html", got)
+		}
+		if !strings.Contains(w.Body.String(), "model not found") {
+			t.Errorf("body = %q, want it to contain the message", w.Body.String())
+		}
+	})
+}
+
+func TestSendError_HTTPErrorIsWrittenVerbatim(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	w := httptest.NewRecorder()
+	SendError(w, r, ConcurrencyLimitError{})
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", w.Code)
+	}
+	if got := w.Header().Get("Retry-After"); got != "1" {
+		t.Errorf("Retry-After = %q, want 1", got)
+	}
+
+	var envelope ErrorEnvelope
+	if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("body is not an OpenAI-style error envelope: %v, body=%s", err, w.Body.String())
+	}
+	if envelope.Error.Type != ErrorTypeRateLimit || envelope.Error.Code != "concurrency_limit" {
+		t.Errorf("error = %+v, want a rate_limit_error/concurrency_limit", envelope.Error)
+	}
+}
+
+func TestSendError_MapsSentinelErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{"no model in context", ErrNoModelInContext, http.StatusNotFound},
+		{"no peer model", ErrNoPeerModelFound, http.StatusNotFound},
+		{"no local model", ErrNoLocalModelFound, http.StatusNotFound},
+		{"no router", ErrNoRouterFound, http.StatusNotFound},
+		{"unknown", errors.New("boom"), http.StatusInternalServerError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			w := httptest.NewRecorder()
+			SendError(w, r, tc.err)
+
+			if w.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", w.Code, tc.wantStatus)
+			}
+			var envelope ErrorEnvelope
+			if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+				t.Fatalf("body is not an OpenAI-style error envelope: %v, body=%s", err, w.Body.String())
+			}
+			if envelope.Error.Message == "" || envelope.Error.Type == "" {
+				t.Errorf("error = %+v, want message and type set", envelope.Error)
+			}
+		})
 	}
 }

--- a/internal/swaputil/httperror.go
+++ b/internal/swaputil/httperror.go
@@ -6,6 +6,96 @@ import (
 	"strconv"
 )
 
+// Error types mirror the values the OpenAI API uses for error.type. Clients
+// branch on these to decide whether a request is retryable.
+const (
+	ErrorTypeInvalidRequest = "invalid_request_error"
+	ErrorTypeAuthentication = "authentication_error"
+	ErrorTypeRateLimit      = "rate_limit_error"
+	ErrorTypeServer         = "server_error"
+)
+
+// ErrorDetail is the object-valued "error" field of an OpenAI-compatible error
+// response. Clients written against the OpenAI API read it as
+// body["error"]["message"], so the field must never be a bare string.
+type ErrorDetail struct {
+	Message string  `json:"message"`
+	Type    string  `json:"type"`
+	Param   *string `json:"param"`
+	Code    string  `json:"code,omitempty"`
+}
+
+// ErrorEnvelope is the JSON body llama-swap returns for every error response.
+// "error" is the OpenAI-compatible object above; "src" marks llama-swap, rather
+// than an upstream inference server, as the origin of the error.
+type ErrorEnvelope struct {
+	Src   string      `json:"src"`
+	Error ErrorDetail `json:"error"`
+}
+
+// marshalFallback is written when an envelope somehow fails to marshal. It is
+// the same shape as a marshalled ErrorEnvelope so clients never see a body they
+// cannot parse.
+const marshalFallback = `{"src":"llama-swap","error":{"message":"failed to marshal response","type":"server_error","param":null,"code":"internal_error"}}`
+
+// NewErrorEnvelope builds an error envelope for an HTTP status. The error's
+// type and code are derived from status; a non-empty code overrides the derived
+// one for errors that have a more specific cause (e.g. a concurrency limit
+// rather than a generic rate limit).
+func NewErrorEnvelope(status int, message, code string) ErrorEnvelope {
+	errType, defaultCode := errorTypeForStatus(status)
+	if code == "" {
+		code = defaultCode
+	}
+	return ErrorEnvelope{
+		Src: "llama-swap",
+		Error: ErrorDetail{
+			Message: message,
+			Type:    errType,
+			Code:    code,
+		},
+	}
+}
+
+// JSON renders the envelope as an HTTP response body.
+func (e ErrorEnvelope) JSON() []byte {
+	b, err := json.Marshal(e)
+	if err != nil {
+		return []byte(marshalFallback)
+	}
+	return b
+}
+
+// errorTypeForStatus maps an HTTP status onto the OpenAI error type and a
+// default code for that status.
+func errorTypeForStatus(status int) (errType string, code string) {
+	switch status {
+	case http.StatusBadRequest:
+		return ErrorTypeInvalidRequest, "bad_request"
+	case http.StatusUnauthorized:
+		return ErrorTypeAuthentication, "unauthorized"
+	case http.StatusForbidden:
+		return ErrorTypeAuthentication, "forbidden"
+	case http.StatusNotFound:
+		return ErrorTypeInvalidRequest, "not_found"
+	case http.StatusConflict:
+		return ErrorTypeInvalidRequest, "conflict"
+	case http.StatusTooManyRequests:
+		return ErrorTypeRateLimit, "rate_limit_exceeded"
+	case http.StatusBadGateway:
+		return ErrorTypeServer, "bad_gateway"
+	case http.StatusServiceUnavailable:
+		return ErrorTypeServer, "service_unavailable"
+	case http.StatusGatewayTimeout:
+		return ErrorTypeServer, "gateway_timeout"
+	}
+
+	if status >= 400 && status < 500 {
+		return ErrorTypeInvalidRequest, "invalid_request"
+	}
+	return ErrorTypeServer, "internal_error"
+}
+
 // HTTPError is an error that carries a complete HTTP response. A producer (e.g.
 // a scheduler shedding a request) returns one of these; a renderer (e.g.
 // router.SendError) writes the status, headers, and body verbatim instead of
@@ -27,7 +117,7 @@ type ConcurrencyLimitError struct {
 	// Defaults to 1.
 	RetryAfter int
 
-	// Message overrides the JSON body's "error" field. Defaults to
+	// Message overrides the JSON body's error message. Defaults to
 	// "Too many requests".
 	Message string
 }
@@ -44,8 +134,7 @@ func (e ConcurrencyLimitError) Header() http.Header {
 }
 
 func (e ConcurrencyLimitError) Body() []byte {
-	b, _ := json.Marshal(map[string]string{"error": e.message()})
-	return b
+	return NewErrorEnvelope(e.StatusCode(), e.message(), "concurrency_limit").JSON()
 }
 
 func (e ConcurrencyLimitError) retryAfter() string {

--- a/internal/swaputil/httperror_test.go
+++ b/internal/swaputil/httperror_test.go
@@ -1,0 +1,127 @@
+package swaputil
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+// decodeEnvelope parses an error body and fails when "error" is not an object.
+func decodeEnvelope(t *testing.T, body []byte) gjson.Result {
+	t.Helper()
+	if !gjson.ValidBytes(body) {
+		t.Fatalf("body is not valid JSON: %s", body)
+	}
+	parsed := gjson.ParseBytes(body)
+	errValue := parsed.Get("error")
+	if !errValue.IsObject() {
+		t.Fatalf(`"error" is %s, want an object: %s`, errValue.Type, body)
+	}
+	return parsed
+}
+
+func TestErrorEnvelope_OpenAIShape(t *testing.T) {
+	body := NewErrorEnvelope(http.StatusNotFound, "model not found", "").JSON()
+	parsed := decodeEnvelope(t, body)
+
+	if got := parsed.Get("error.message").String(); got != "model not found" {
+		t.Errorf("error.message = %q, want %q", got, "model not found")
+	}
+	if got := parsed.Get("error.type").String(); got != ErrorTypeInvalidRequest {
+		t.Errorf("error.type = %q, want %q", got, ErrorTypeInvalidRequest)
+	}
+	if got := parsed.Get("error.code").String(); got != "not_found" {
+		t.Errorf("error.code = %q, want %q", got, "not_found")
+	}
+	if !parsed.Get("error.param").Exists() || parsed.Get("error.param").Type != gjson.Null {
+		t.Errorf("error.param = %v, want null", parsed.Get("error.param"))
+	}
+	if got := parsed.Get("src").String(); got != "llama-swap" {
+		t.Errorf("src = %q, want llama-swap", got)
+	}
+}
+
+func TestErrorEnvelope_TypesByStatus(t *testing.T) {
+	tests := []struct {
+		status   int
+		wantType string
+		wantCode string
+	}{
+		{http.StatusBadRequest, ErrorTypeInvalidRequest, "bad_request"},
+		{http.StatusUnauthorized, ErrorTypeAuthentication, "unauthorized"},
+		{http.StatusForbidden, ErrorTypeAuthentication, "forbidden"},
+		{http.StatusNotFound, ErrorTypeInvalidRequest, "not_found"},
+		{http.StatusConflict, ErrorTypeInvalidRequest, "conflict"},
+		{http.StatusTooManyRequests, ErrorTypeRateLimit, "rate_limit_exceeded"},
+		{http.StatusBadGateway, ErrorTypeServer, "bad_gateway"},
+		{http.StatusServiceUnavailable, ErrorTypeServer, "service_unavailable"},
+		{http.StatusGatewayTimeout, ErrorTypeServer, "gateway_timeout"},
+		{http.StatusInternalServerError, ErrorTypeServer, "internal_error"},
+		{http.StatusTeapot, ErrorTypeInvalidRequest, "invalid_request"},
+	}
+
+	for _, tc := range tests {
+		env := NewErrorEnvelope(tc.status, "boom", "")
+		if env.Error.Type != tc.wantType {
+			t.Errorf("status %d: type = %q, want %q", tc.status, env.Error.Type, tc.wantType)
+		}
+		if env.Error.Code != tc.wantCode {
+			t.Errorf("status %d: code = %q, want %q", tc.status, env.Error.Code, tc.wantCode)
+		}
+	}
+}
+
+func TestErrorEnvelope_CodeOverride(t *testing.T) {
+	env := NewErrorEnvelope(http.StatusTooManyRequests, "boom", "custom_code")
+	if env.Error.Code != "custom_code" {
+		t.Errorf("code = %q, want custom_code", env.Error.Code)
+	}
+	if env.Error.Type != ErrorTypeRateLimit {
+		t.Errorf("type = %q, want %q", env.Error.Type, ErrorTypeRateLimit)
+	}
+}
+
+func TestErrorEnvelope_MarshalFallbackIsValid(t *testing.T) {
+	var envelope ErrorEnvelope
+	if err := json.Unmarshal([]byte(marshalFallback), &envelope); err != nil {
+		t.Fatalf("marshalFallback does not decode into an ErrorEnvelope: %v", err)
+	}
+	if envelope.Src != "llama-swap" || envelope.Error.Message == "" || envelope.Error.Type != ErrorTypeServer {
+		t.Errorf("marshalFallback = %+v, want a filled llama-swap server error", envelope)
+	}
+}
+
+func TestConcurrencyLimitError_Body(t *testing.T) {
+	err := ConcurrencyLimitError{}
+	parsed := decodeEnvelope(t, err.Body())
+
+	if got := parsed.Get("error.message").String(); got != "Too many requests" {
+		t.Errorf("error.message = %q, want %q", got, "Too many requests")
+	}
+	if got := parsed.Get("error.type").String(); got != ErrorTypeRateLimit {
+		t.Errorf("error.type = %q, want %q", got, ErrorTypeRateLimit)
+	}
+	if got := parsed.Get("error.code").String(); got != "concurrency_limit" {
+		t.Errorf("error.code = %q, want %q", got, "concurrency_limit")
+	}
+	if got := err.StatusCode(); got != http.StatusTooManyRequests {
+		t.Errorf("StatusCode() = %d, want 429", got)
+	}
+	if got := err.Header().Get("Retry-After"); got != "1" {
+		t.Errorf("Retry-After = %q, want 1", got)
+	}
+}
+
+func TestConcurrencyLimitError_CustomMessageAndRetryAfter(t *testing.T) {
+	err := ConcurrencyLimitError{RetryAfter: 30, Message: "slow down"}
+	parsed := decodeEnvelope(t, err.Body())
+
+	if got := parsed.Get("error.message").String(); got != "slow down" {
+		t.Errorf("error.message = %q, want %q", got, "slow down")
+	}
+	if got := err.Header().Get("Retry-After"); got != "30" {
+		t.Errorf("Retry-After = %q, want 30", got)
+	}
+}


### PR DESCRIPTION
Error responses used a string-valued "error" field, so OpenAI clients
that read body["error"]["message"] hit a string where they expected an
object. Home Assistant's OpenAI-style conversation integration turns
that into an opaque 500 instead of a retryable "server busy" signal
when concurrencyLimit sheds a request.

Every JSON error body now uses the OpenAI envelope, with error.type and
error.code derived from the HTTP status:

  {"src":"llama-swap",
   "error":{"message":"Too many requests","type":"rate_limit_error",
            "param":null,"code":"concurrency_limit"}}

- add ErrorEnvelope/ErrorDetail and NewErrorEnvelope() in swaputil
- render SendResponse's JSON branch and ConcurrencyLimitError.Body()
  through the envelope, keeping status codes and Retry-After unchanged
- route the two remaining http.Error() call sites (process not ready,
  peer proxy failure) through SendResponse so they use the envelope too
- keep the top-level "src" marker and the text/plain and text/html
  response formats as they were

fix: #1037