### PR TITLE
internal: record client disconnects as 499, not 200 or 502

### DIFF
--- a/internal/process/process_command.go
+++ b/internal/process/process_command.go
@@ -38,17 +38,25 @@ type healthCheckKey struct{}
 // Real upstream failures keep the 502. See #1029.
 func newProxyErrorHandler(id string, proxyLogger *logmon.Monitor) func(http.ResponseWriter, *http.Request, error) {
 	return func(w http.ResponseWriter, r *http.Request, err error) {
-		if errors.Is(err, context.Canceled) || r.Context().Err() != nil {
-			proxyLogger.Debugf("<%s> client disconnected: %v", id, err)
-			swaputil.MarkClientClosed(w, r)
-			return
-		}
-		if _, ok := r.Context().Value(healthCheckKey{}).(bool); ok {
+		// Pick the log level first: a cancelled request is never an upstream
+		// fault, whether or not the sentinel ends up applying below.
+		switch {
+		case errors.Is(err, context.Canceled) || r.Context().Err() != nil:
+			proxyLogger.Debugf("<%s> request cancelled: %v", id, err)
+		case r.Context().Value(healthCheckKey{}) != nil:
 			proxyLogger.Debugf("<%s> health check not ready: %v", id, err)
-			w.WriteHeader(http.StatusBadGateway)
+		default:
+			proxyLogger.Warnf("<%s> proxy error: %v", id, err)
+		}
+
+		// Only a client that actually hung up gets the recorded-only sentinel.
+		// A request cancelled server-side (an operator cancelling it from the
+		// UI, or shutdown) still has a client waiting, and must be answered —
+		// otherwise net/http finalizes it as an empty 200, telling the caller
+		// the request succeeded.
+		if swaputil.MarkClientClosed(w, r) || swaputil.ResponseStarted(w) {
 			return
 		}
-		proxyLogger.Warnf("<%s> proxy error: %v", id, err)
 		w.WriteHeader(http.StatusBadGateway)
 	}
 }

--- a/internal/process/process_command.go
+++ b/internal/process/process_command.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -20,6 +21,37 @@ import (
 )
 
 var ErrStartAborted = fmt.Errorf("aborted")
+
+// healthCheckKey marks requests issued by the health check loop, which polls
+// the upstream through the same reverse proxy. Their failures are the expected
+// shape of a model still booting, so they must not be logged as proxy errors.
+type healthCheckKey struct{}
+
+// newProxyErrorHandler builds the ErrorHandler for a model's reverse proxy.
+//
+// httputil.ReverseProxy's default handler answers every failure with 502, so a
+// client hanging up mid-generation is logged as a Bad Gateway and sends
+// operators looking at an inference server that was healthy the whole time.
+// Cancellation is classified here, where the error is actually known: the
+// request is recorded with the client-closed sentinel rather than blamed on the
+// upstream, and at debug level because an impatient caller is normal traffic.
+// Real upstream failures keep the 502. See #1029.
+func newProxyErrorHandler(id string, proxyLogger *logmon.Monitor) func(http.ResponseWriter, *http.Request, error) {
+	return func(w http.ResponseWriter, r *http.Request, err error) {
+		if errors.Is(err, context.Canceled) || r.Context().Err() != nil {
+			proxyLogger.Debugf("<%s> client disconnected: %v", id, err)
+			swaputil.MarkClientClosed(w, r)
+			return
+		}
+		if _, ok := r.Context().Value(healthCheckKey{}).(bool); ok {
+			proxyLogger.Debugf("<%s> health check not ready: %v", id, err)
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		proxyLogger.Warnf("<%s> proxy error: %v", id, err)
+		w.WriteHeader(http.StatusBadGateway)
+	}
+}
 
 // cmdWaitDelay is the upper bound the runtime will wait for child I/O to
 // drain after the process exits before force-closing the stdout/stderr
@@ -431,6 +463,7 @@ func (p *ProcessCommand) doStart(startCtx context.Context, healthCheckTimeout ti
 		MaxIdleConnsPerHost:   10,
 		IdleConnTimeout:       time.Duration(p.config.Timeouts.IdleConn) * time.Second,
 	}
+	reverseProxy.ErrorHandler = newProxyErrorHandler(p.id, p.proxyLogger)
 	reverseProxy.ModifyResponse = func(resp *http.Response) error {
 		if strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "text/event-stream") {
 			resp.Header.Set("X-Accel-Buffering", "no")
@@ -536,7 +569,10 @@ func (p *ProcessCommand) doStart(startCtx context.Context, healthCheckTimeout ti
 			return abort(fmt.Errorf("health check timed out after %v", healthCheckTimeout))
 		}
 
-		req, _ := http.NewRequestWithContext(startCtx, "GET", p.config.CheckEndpoint, nil)
+		// Tagged so the proxy ErrorHandler logs a not-yet-listening upstream
+		// at debug rather than as a proxy error once per poll.
+		checkCtx := context.WithValue(startCtx, healthCheckKey{}, true)
+		req, _ := http.NewRequestWithContext(checkCtx, "GET", p.config.CheckEndpoint, nil)
 		rr := httptest.NewRecorder()
 		reverseProxy.ServeHTTP(rr, req)
 		resp := rr.Result()

--- a/internal/process/proxy_error_test.go
+++ b/internal/process/proxy_error_test.go
@@ -55,11 +55,13 @@ func (m *markerRecorder) WroteHeader() bool { return m.wroteHeader }
 // 502, blaming a healthy upstream. Cancellation must record the client-closed
 // sentinel instead, while genuine upstream failures keep their 502.
 func TestProcessCommand_ProxyErrorHandler(t *testing.T) {
-	t.Run("cancelled request records the sentinel without writing", func(t *testing.T) {
+	t.Run("client disconnect records the sentinel without writing", func(t *testing.T) {
 		logger := logmon.NewWriter(io.Discard)
 		handler := newProxyErrorHandler("m", logger)
 
-		ctx, cancel := context.WithCancel(context.Background())
+		// The client connection itself goes away.
+		clientCtx, cancel := context.WithCancel(context.Background())
+		ctx := swaputil.SetClientContext(clientCtx, clientCtx)
 		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
 		cancel()
 
@@ -93,6 +95,35 @@ func TestProcessCommand_ProxyErrorHandler(t *testing.T) {
 		}
 		if line := string(logger.GetHistory()); !strings.Contains(line, "proxy error") {
 			t.Errorf("upstream failure should be logged: %q", line)
+		}
+	})
+
+	// A request cancelled server-side (an operator cancelling it from the UI,
+	// or shutdown) still has a connected client. Recording it as a client
+	// disconnect would misattribute it, and returning without writing would
+	// let net/http finalize an empty 200 that tells the caller it succeeded.
+	t.Run("server-side cancel still answers the connected client", func(t *testing.T) {
+		logger := logmon.NewWriter(io.Discard)
+		handler := newProxyErrorHandler("m", logger)
+
+		// The client is alive; the inflight tracker's derived context is what
+		// gets cancelled, exactly as POST /api/inflight/{id}/cancel does.
+		clientCtx := context.Background()
+		ctx, cancel := context.WithCancel(swaputil.SetClientContext(clientCtx, clientCtx))
+		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+		cancel()
+
+		rec := newMarkerRecorder()
+		handler(rec, r, context.Canceled)
+
+		if rec.marked == swaputil.StatusClientClosedRequest {
+			t.Error("a server-side cancel must not be recorded as a client disconnect")
+		}
+		if rec.status != http.StatusBadGateway {
+			t.Errorf("status = %d, want %d: a connected client must get a real response", rec.status, http.StatusBadGateway)
+		}
+		if line := string(logger.GetHistory()); strings.Contains(line, "proxy error") {
+			t.Errorf("a cancel is not an upstream fault: %q", line)
 		}
 	})
 

--- a/internal/process/proxy_error_test.go
+++ b/internal/process/proxy_error_test.go
@@ -1,0 +1,135 @@
+package process
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/swaputil"
+)
+
+// markerRecorder stands in for the server package's response recorders: it
+// implements swaputil.StatusMarker so the proxy error handler can record a
+// status without writing it to the client.
+type markerRecorder struct {
+	http.ResponseWriter
+	status      int
+	marked      int
+	wroteHeader bool
+}
+
+func newMarkerRecorder() *markerRecorder {
+	return &markerRecorder{ResponseWriter: httptest.NewRecorder(), status: http.StatusOK}
+}
+
+func (m *markerRecorder) WriteHeader(code int) {
+	if m.wroteHeader {
+		return
+	}
+	m.wroteHeader = true
+	m.status = code
+	m.ResponseWriter.WriteHeader(code)
+}
+
+func (m *markerRecorder) Write(b []byte) (int, error) {
+	if !m.wroteHeader {
+		m.WriteHeader(http.StatusOK)
+	}
+	return m.ResponseWriter.Write(b)
+}
+
+func (m *markerRecorder) MarkStatus(code int) {
+	m.status = code
+	m.marked = code
+}
+
+func (m *markerRecorder) WroteHeader() bool { return m.wroteHeader }
+
+// TestProcessCommand_ProxyErrorHandler covers the secondary case in #1029: once
+// the model is loaded, a client hanging up mid-request used to surface as a
+// 502, blaming a healthy upstream. Cancellation must record the client-closed
+// sentinel instead, while genuine upstream failures keep their 502.
+func TestProcessCommand_ProxyErrorHandler(t *testing.T) {
+	t.Run("cancelled request records the sentinel without writing", func(t *testing.T) {
+		logger := logmon.NewWriter(io.Discard)
+		handler := newProxyErrorHandler("m", logger)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+		cancel()
+
+		rec := newMarkerRecorder()
+		handler(rec, r, context.Canceled)
+
+		if rec.marked != swaputil.StatusClientClosedRequest {
+			t.Errorf("marked status = %d, want %d", rec.marked, swaputil.StatusClientClosedRequest)
+		}
+		if rec.wroteHeader {
+			t.Error("nothing should be written to a client that already hung up")
+		}
+		if line := string(logger.GetHistory()); strings.Contains(line, "proxy error") {
+			t.Errorf("client disconnect should not be logged as a proxy error: %q", line)
+		}
+	})
+
+	t.Run("upstream failure still answers 502", func(t *testing.T) {
+		logger := logmon.NewWriter(io.Discard)
+		handler := newProxyErrorHandler("m", logger)
+
+		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+		rec := newMarkerRecorder()
+		handler(rec, r, fmt.Errorf("dial tcp 127.0.0.1:9999: connect: connection refused"))
+
+		if rec.status != http.StatusBadGateway {
+			t.Errorf("status = %d, want %d", rec.status, http.StatusBadGateway)
+		}
+		if !rec.wroteHeader {
+			t.Error("a real upstream failure must still be answered")
+		}
+		if line := string(logger.GetHistory()); !strings.Contains(line, "proxy error") {
+			t.Errorf("upstream failure should be logged: %q", line)
+		}
+	})
+
+	t.Run("health check poll is not logged as a proxy error", func(t *testing.T) {
+		logger := logmon.NewWriter(io.Discard)
+		handler := newProxyErrorHandler("m", logger)
+
+		ctx := context.WithValue(context.Background(), healthCheckKey{}, true)
+		r := httptest.NewRequest(http.MethodGet, "/health", nil).WithContext(ctx)
+		rec := newMarkerRecorder()
+		handler(rec, r, fmt.Errorf("dial tcp 127.0.0.1:9999: connect: connection refused"))
+
+		// The loop keys off the 502 to decide the model is not ready yet.
+		if rec.status != http.StatusBadGateway {
+			t.Errorf("status = %d, want %d", rec.status, http.StatusBadGateway)
+		}
+		if line := string(logger.GetHistory()); strings.Contains(line, "proxy error") {
+			t.Errorf("a booting upstream should not log a proxy error per poll: %q", line)
+		}
+	})
+
+	t.Run("response already started keeps its status", func(t *testing.T) {
+		logger := logmon.NewWriter(io.Discard)
+		handler := newProxyErrorHandler("m", logger)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+		cancel()
+
+		// A streamed response that already flushed headers before the client
+		// left: marking it 499 would misreport bytes the client did receive.
+		rec := newMarkerRecorder()
+		rec.Write([]byte("data: {}\n\n"))
+		handler(rec, r, context.Canceled)
+
+		if rec.status != http.StatusOK {
+			t.Errorf("status = %d, want %d", rec.status, http.StatusOK)
+		}
+	})
+}

--- a/internal/router/base.go
+++ b/internal/router/base.go
@@ -552,20 +552,40 @@ func (b *baseRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// reclaims it. release() must run even when waitForCompletion times out:
 	// otherwise a still-streaming goroutine flushes a finalized response and
 	// panics on the recycled *bufio.Writer.
-	finishLoading := func() {
+	//
+	// A non-nil streamErr is framed into the stream first, while writes still
+	// reach the client: the 200 is already committed, so this is the only way
+	// the error can be reported at all.
+	finishLoading := func(streamErr error) {
 		cancelLoad()
 		if lw != nil {
 			lw.waitForCompletion(1 * time.Second)
+			if streamErr != nil {
+				lw.sendError(streamErr)
+			}
 			lw.release()
+		}
+	}
+
+	// reportError sends err as a normal error response, for the paths where no
+	// loading stream was live to carry it in-band. When one was, finishLoading
+	// has already framed it into the stream and a second report would append a
+	// bare JSON line that SSE parsers discard.
+	reportError := func(err error) {
+		if lw == nil {
+			swaputil.SendError(w, req, err)
 		}
 	}
 
 	var resp scheduler.HandlerResp
 	select {
 	case resp = <-hr.Respond:
-		finishLoading()
+		// Pass the dispatch error in so it is framed into the stream before
+		// release fences the writer; a nil error just ends the stream.
+		finishLoading(resp.Err)
 	case <-req.Context().Done():
-		finishLoading()
+		// The client is gone, so there is nobody to report to.
+		finishLoading(nil)
 		// Notify the scheduler so it can prune this request from its queue
 		// and swap waiters. Without this, a queued request whose client left
 		// would sit in the scheduler until drainQueue eventually starts a
@@ -576,13 +596,14 @@ func (b *baseRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 		return
 	case <-b.shutdownCtx.Done():
-		finishLoading()
-		swaputil.SendError(w, req, fmt.Errorf("%s is shutting down", b.name))
+		shutdownErr := fmt.Errorf("%s is shutting down", b.name)
+		finishLoading(shutdownErr)
+		reportError(shutdownErr)
 		return
 	}
 
 	if resp.Err != nil {
-		swaputil.SendError(w, req, resp.Err)
+		reportError(resp.Err)
 		return
 	}
 	resp.HandleFunc(w, req)

--- a/internal/router/base_test.go
+++ b/internal/router/base_test.go
@@ -3,6 +3,7 @@ package router
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -625,6 +626,43 @@ func TestBaseRouter_ConcurrencyLimitRejectsBeforeLoadingStream(t *testing.T) {
 	close(bProc.serveBlock)
 	for name, ch := range map[string]chan struct{}{"b": bDone, "a1": aDone1, "a2": aDone2} {
 		waitSignal(t, ch, name+" request finish")
+	}
+}
+
+// TestBaseRouter_DispatchErrorFramedIntoLoadingStream covers the second half of
+// #1029. Once the loading stream has committed its 200, an error can only reach
+// the client in-band: swaputil.SendError's status is dropped and its JSON body
+// lands as a bare line that every SSE parser discards, leaving the caller with
+// a truncated stream, no [DONE], and no reason.
+func TestBaseRouter_DispatchErrorFramedIntoLoadingStream(t *testing.T) {
+	sendLoading := true
+	conf := config.Config{
+		HealthCheckTimeout: 5,
+		Models:             map[string]config.ModelConfig{"a": {SendLoadingState: &sendLoading}},
+	}
+	a := newFakeProcess("a")
+	a.ensureErr = fmt.Errorf("upstream command exited prematurely")
+
+	b := newTestBaseWithConfig(t, conf, map[string]process.Process{"a": a}, &stubPlanner{})
+
+	w := httptest.NewRecorder()
+	b.ServeHTTP(w, newStreamRequest("a"))
+
+	body := w.Body.String()
+	// The loading text is streamed a few characters per frame, so reassemble it.
+	if content := extractStreamedContent(body); !strings.Contains(content, "llama-swap loading model") {
+		t.Fatalf("loading stream did not start, so this is not the path under test: %q", content)
+	}
+	for _, line := range strings.Split(strings.TrimRight(body, "\n"), "\n") {
+		if line != "" && !strings.HasPrefix(line, "data: ") {
+			t.Errorf("line %q is not an SSE field; a client would silently ignore it", line)
+		}
+	}
+	if !strings.Contains(body, "upstream command exited prematurely") {
+		t.Errorf("dispatch error never reached the client: %q", body)
+	}
+	if !strings.HasSuffix(strings.TrimRight(body, "\n"), "data: [DONE]") {
+		t.Errorf("stream not terminated with [DONE]: %q", body)
 	}
 }
 

--- a/internal/router/helpers_test.go
+++ b/internal/router/helpers_test.go
@@ -54,6 +54,10 @@ type fakeProcess struct {
 
 	autoReady bool
 
+	// ensureErr, when non-nil, makes EnsureReady fail with it, driving the
+	// dispatch-error path without needing a real process to die.
+	ensureErr error
+
 	// serveBlock, when non-nil, makes ServeHTTP receive from it before
 	// writing its response. Tests use this to hold a request in-flight.
 	// Closing the channel releases every blocked ServeHTTP caller.
@@ -223,6 +227,12 @@ func (f *fakeProcess) EnsureReady(ctx context.Context, _ time.Duration) error {
 
 	f.opMu.Lock()
 	f.mu.Lock()
+	if f.ensureErr != nil {
+		err := f.ensureErr
+		f.mu.Unlock()
+		f.opMu.Unlock()
+		return err
+	}
 	switch f.state {
 	case process.StateReady:
 		f.mu.Unlock()

--- a/internal/router/loading.go
+++ b/internal/router/loading.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/swaputil"
 )
 
 var loadingPaths = []string{
@@ -252,23 +253,14 @@ func (s *loadingWriter) sendData(data string) {
 // failure-reported-as-success shape as #1029. Framing the error keeps it
 // visible.
 //
+// The frame carries the same envelope as a non-streamed error body (#1038), so
+// a client sees one error shape either way. The status only selects the
+// envelope's type/code — 500 matches what this error would have been answered
+// with had the stream not already committed a 200.
+//
 // Must be called before release, while writes still reach the client.
 func (s *loadingWriter) sendError(err error) {
-	type errorBody struct {
-		Message string `json:"message"`
-		Type    string `json:"type"`
-	}
-	type errorMessage struct {
-		Error errorBody `json:"error"`
-	}
-
-	jsonData, marshalErr := json.Marshal(errorMessage{
-		Error: errorBody{Message: err.Error(), Type: "llama-swap"},
-	})
-	if marshalErr != nil {
-		s.logger.Errorf("<%s> Failed to marshal SSE error: %v", s.modelName, marshalErr)
-		return
-	}
+	jsonData := swaputil.NewErrorEnvelope(http.StatusInternalServerError, err.Error(), "").JSON()
 
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()

--- a/internal/router/loading.go
+++ b/internal/router/loading.go
@@ -241,6 +241,50 @@ func (s *loadingWriter) sendData(data string) {
 	}
 }
 
+// sendError streams err to the client as a terminating SSE error frame
+// followed by [DONE].
+//
+// Once the loading stream has committed its 200, a real status can no longer be
+// sent: swaputil.SendError's WriteHeader is dropped and its JSON body lands in
+// the stream as a bare line, which every SSE parser discards silently (the text
+// before the first colon is read as an unknown field name). The client is left
+// with a truncated stream, no [DONE], and no reason — the same
+// failure-reported-as-success shape as #1029. Framing the error keeps it
+// visible.
+//
+// Must be called before release, while writes still reach the client.
+func (s *loadingWriter) sendError(err error) {
+	type errorBody struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	}
+	type errorMessage struct {
+		Error errorBody `json:"error"`
+	}
+
+	jsonData, marshalErr := json.Marshal(errorMessage{
+		Error: errorBody{Message: err.Error(), Type: "llama-swap"},
+	})
+	if marshalErr != nil {
+		s.logger.Errorf("<%s> Failed to marshal SSE error: %v", s.modelName, marshalErr)
+		return
+	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if s.released {
+		return
+	}
+
+	if _, werr := fmt.Fprintf(s.writer, "data: %s\n\ndata: [DONE]\n\n", jsonData); werr != nil {
+		s.logger.Debugf("<%s> Failed to write SSE error (client likely disconnected): %v", s.modelName, werr)
+		return
+	}
+	if flusher, ok := s.writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
 // release fences the loadingWriter off from the underlying ResponseWriter.
 // After it returns, the streaming goroutine will not write to or flush the
 // writer again: any in-flight write completes under writeMu first, and later

--- a/internal/router/loading_test.go
+++ b/internal/router/loading_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/swaputil"
 )
 
 func TestLoadingWriter_SSEHeadersAndInitialMessage(t *testing.T) {
@@ -98,18 +99,19 @@ func TestLoadingWriter_SendError(t *testing.T) {
 		}
 	}
 
-	var msg struct {
-		Error struct {
-			Message string `json:"message"`
-			Type    string `json:"type"`
-		} `json:"error"`
-	}
+	// The frame must carry the same envelope as a non-streamed error body, so
+	// clients do not need a second shape for streamed failures.
+	var msg swaputil.ErrorEnvelope
 	first, _, _ := strings.Cut(chunk, "\n")
 	if err := json.Unmarshal([]byte(strings.TrimPrefix(first, "data: ")), &msg); err != nil {
 		t.Fatalf("error frame is not JSON: %v (%q)", err, first)
 	}
 	if msg.Error.Message != "upstream command exited prematurely" {
 		t.Errorf("message = %q, want the underlying error", msg.Error.Message)
+	}
+	want := swaputil.NewErrorEnvelope(http.StatusInternalServerError, "upstream command exited prematurely", "")
+	if msg.Error.Type != want.Error.Type || msg.Error.Code != want.Error.Code || msg.Src != want.Src {
+		t.Errorf("envelope = %+v, want the shared shape %+v", msg, want)
 	}
 	if !strings.HasSuffix(strings.TrimRight(chunk, "\n"), "data: [DONE]") {
 		t.Errorf("stream not terminated with [DONE]: %q", chunk)

--- a/internal/router/loading_test.go
+++ b/internal/router/loading_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -70,6 +71,65 @@ func TestLoadingWriter_WritePassthrough(t *testing.T) {
 	body := w.Body.String()
 	if !strings.Contains(body, "hello") {
 		t.Errorf("Write passthrough failed, body: %s", body)
+	}
+}
+
+// TestLoadingWriter_SendError checks that an error arriving after the loading
+// stream committed its 200 is delivered as a frame the client can parse, and
+// terminates the stream. Writing it as a bare JSON line (what swaputil.SendError
+// used to leave behind) is silently dropped by every SSE parser.
+func TestLoadingWriter_SendError(t *testing.T) {
+	logger := logmon.NewWriter(io.Discard)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	lw := newLoadingWriter(logger, "test-model", w, req)
+	before := w.Body.Len()
+	lw.sendError(fmt.Errorf("upstream command exited prematurely"))
+	chunk := w.Body.String()[before:]
+
+	// Every line must be a well-formed SSE field, or an SSE parser drops it.
+	for _, line := range strings.Split(strings.TrimRight(chunk, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, "data: ") {
+			t.Errorf("line %q is not an SSE field; a parser would ignore it", line)
+		}
+	}
+
+	var msg struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		} `json:"error"`
+	}
+	first, _, _ := strings.Cut(chunk, "\n")
+	if err := json.Unmarshal([]byte(strings.TrimPrefix(first, "data: ")), &msg); err != nil {
+		t.Fatalf("error frame is not JSON: %v (%q)", err, first)
+	}
+	if msg.Error.Message != "upstream command exited prematurely" {
+		t.Errorf("message = %q, want the underlying error", msg.Error.Message)
+	}
+	if !strings.HasSuffix(strings.TrimRight(chunk, "\n"), "data: [DONE]") {
+		t.Errorf("stream not terminated with [DONE]: %q", chunk)
+	}
+}
+
+// Once released, the streaming goroutine must not touch the writer — a write
+// against a finalized response panics on the recycled *bufio.Writer.
+func TestLoadingWriter_SendErrorAfterReleaseIsDropped(t *testing.T) {
+	logger := logmon.NewWriter(io.Discard)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	lw := newLoadingWriter(logger, "test-model", w, req)
+	lw.release()
+
+	before := w.Body.Len()
+	lw.sendError(fmt.Errorf("too late"))
+	if w.Body.Len() != before {
+		t.Errorf("sendError wrote %d bytes after release", w.Body.Len()-before)
 	}
 }
 

--- a/internal/router/peer.go
+++ b/internal/router/peer.go
@@ -90,15 +90,21 @@ func NewPeer(cfg config.Config, logger *logmon.Monitor) (*Peer, error) {
 		}
 
 		reverseProxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-			// A client that hung up is not a peer failure: record the
-			// client-closed sentinel instead of blaming the peer with a 502
-			// (#1029). Nothing is sent — the client is already gone.
+			// A cancelled request is not a peer failure, so keep it out of the
+			// warning stream whether or not the sentinel applies below.
 			if errors.Is(err, context.Canceled) || r.Context().Err() != nil {
-				logger.Debugf("peer %s: client disconnected: %v", peerID, err)
-				swaputil.MarkClientClosed(w, r)
+				logger.Debugf("peer %s: request cancelled: %v", peerID, err)
+			} else {
+				logger.Warnf("peer %s: proxy error: %v", peerID, err)
+			}
+
+			// Only a client that actually hung up gets the recorded-only
+			// sentinel (#1029). A request cancelled server-side still has a
+			// client waiting for an answer.
+			if swaputil.MarkClientClosed(w, r) || swaputil.ResponseStarted(w) {
 				return
 			}
-			logger.Warnf("peer %s: proxy error: %v", peerID, err)
+
 			errMsg := fmt.Sprintf("peer proxy error: %v", err)
 			if runtime.GOOS == "darwin" && strings.Contains(err.Error(), "connect: no route to host") {
 				errMsg += " (hint: on macOS, check System Settings > Privacy & Security > Local Network permissions)"
@@ -216,15 +222,16 @@ func (r *Peer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Cancel the proxy request when the client disconnects or shutdown times out.
-	// AfterFunc links both parent contexts to our child without a goroutine leak.
-	ctx, cancel := context.WithCancel(context.Background())
-	stopReq := context.AfterFunc(req.Context(), cancel)
+	// Deriving from the request covers the client half directly and keeps the
+	// request's context values — notably the client context that tells a real
+	// disconnect apart from a server-side cancel. AfterFunc links the unrelated
+	// shutdown context in without a goroutine leak.
+	ctx, cancel := context.WithCancel(req.Context())
 	stopShutdown := context.AfterFunc(r.shutdownCtx, cancel)
 	req = req.WithContext(ctx)
 
 	pp.reverseProxy.ServeHTTP(w, req)
 
 	stopShutdown()
-	stopReq()
 	cancel()
 }

--- a/internal/router/peer.go
+++ b/internal/router/peer.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -89,6 +90,14 @@ func NewPeer(cfg config.Config, logger *logmon.Monitor) (*Peer, error) {
 		}
 
 		reverseProxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+			// A client that hung up is not a peer failure: record the
+			// client-closed sentinel instead of blaming the peer with a 502
+			// (#1029). Nothing is sent — the client is already gone.
+			if errors.Is(err, context.Canceled) || r.Context().Err() != nil {
+				logger.Debugf("peer %s: client disconnected: %v", peerID, err)
+				swaputil.MarkClientClosed(w, r)
+				return
+			}
 			logger.Warnf("peer %s: proxy error: %v", peerID, err)
 			errMsg := fmt.Sprintf("peer proxy error: %v", err)
 			if runtime.GOOS == "darwin" && strings.Contains(err.Error(), "connect: no route to host") {

--- a/internal/server/inflight.go
+++ b/internal/server/inflight.go
@@ -344,6 +344,18 @@ func (w *inflightResponseWriter) Write(data []byte) (int, error) {
 	return n, err
 }
 
+// MarkStatus forwards a recorded-only status to the wrapped writer. The
+// tracker records bytes and headers rather than a status code, so there is
+// nothing to update here.
+func (w *inflightResponseWriter) MarkStatus(code int) {
+	if marker, ok := w.ResponseWriter.(swaputil.StatusMarker); ok {
+		marker.MarkStatus(code)
+	}
+}
+
+// WroteHeader reports whether a response status reached the client.
+func (w *inflightResponseWriter) WroteHeader() bool { return w.wroteHeader }
+
 func (w *inflightResponseWriter) Flush() {
 	if !w.wroteHeader {
 		w.WriteHeader(http.StatusOK)

--- a/internal/server/log.go
+++ b/internal/server/log.go
@@ -235,6 +235,12 @@ func CreateRequestLogMiddleware(proxylog *logmon.Monitor) chain.Middleware {
 			start := time.Now()
 			ip, method, path, proto, ua := clientIP(r), r.Method, r.URL.Path, r.Proto, r.UserAgent()
 
+			// This is the outermost middleware, so the context here is still
+			// the connection's own. Remember it before anything downstream
+			// derives a cancellable child, so a request cancelled server-side
+			// is not later reported as a client that hung up.
+			r = swaputil.WithClientContext(r)
+
 			rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 			next.ServeHTTP(rec, r)
 

--- a/internal/server/log.go
+++ b/internal/server/log.go
@@ -161,6 +161,14 @@ type statusRecorder struct {
 }
 
 func (sr *statusRecorder) WriteHeader(code int) {
+	// net/http commits the first status and ignores every later one, so the
+	// access log has to do the same. Handlers do call WriteHeader after a
+	// response has started — a shutdown or dispatch error arriving once the
+	// loading stream has already sent its 200 — and recording the second code
+	// would report a status the client never received.
+	if sr.wroteHeader {
+		return
+	}
 	sr.status = code
 	sr.wroteHeader = true
 	sr.ResponseWriter.WriteHeader(code)
@@ -183,9 +191,14 @@ func (sr *statusRecorder) Write(b []byte) (int, error) {
 }
 
 func (sr *statusRecorder) Flush() {
-	if f, ok := sr.ResponseWriter.(http.Flusher); ok {
-		f.Flush()
+	f, ok := sr.ResponseWriter.(http.Flusher)
+	if !ok {
+		return
 	}
+	// Flushing commits net/http's implicit 200 and puts it on the wire, so the
+	// client has started receiving a response even if nothing wrote a header.
+	sr.wroteHeader = true
+	f.Flush()
 }
 
 // Hijack forwards to the underlying ResponseWriter so httputil.ReverseProxy can

--- a/internal/server/log.go
+++ b/internal/server/log.go
@@ -155,16 +155,28 @@ var requestLogPathSkips = []string{"/wol-health", "/api/performance", "/metrics"
 // is forwarded so httputil.ReverseProxy can upgrade websocket connections.
 type statusRecorder struct {
 	http.ResponseWriter
-	status int
-	size   int
+	status      int
+	size        int
+	wroteHeader bool
 }
 
 func (sr *statusRecorder) WriteHeader(code int) {
 	sr.status = code
+	sr.wroteHeader = true
 	sr.ResponseWriter.WriteHeader(code)
 }
 
+// MarkStatus records code for the access log without writing to the client.
+// This is the outermost recorder, so there is nothing further to forward to.
+func (sr *statusRecorder) MarkStatus(code int) { sr.status = code }
+
+// WroteHeader reports whether a response status reached the client.
+func (sr *statusRecorder) WroteHeader() bool { return sr.wroteHeader }
+
 func (sr *statusRecorder) Write(b []byte) (int, error) {
+	// An implicit 200 from net/http still counts as a response the client
+	// started receiving, so it must not be overwritten by a late sentinel.
+	sr.wroteHeader = true
 	n, err := sr.ResponseWriter.Write(b)
 	sr.size += n
 	return n, err
@@ -225,6 +237,16 @@ func CreateRequestLogMiddleware(proxylog *logmon.Monitor) chain.Middleware {
 
 			rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
 			next.ServeHTTP(rec, r)
+
+			// Cancellation branches (a client hanging up during a cold model
+			// load, for one) return without writing anything, which would
+			// otherwise be logged as the seeded 200. net/http cancels the
+			// request context when the client disconnects or when the
+			// top-level ServeHTTP returns; this middleware is inside that
+			// call, so a done context here means the client really left.
+			// Deriving it once covers every such branch, including ones added
+			// later. See #1029.
+			swaputil.MarkClientClosed(rec, r)
 
 			proxylog.Infof("Request %s \"%s %s %s\" %d %d \"%s\" %v",
 				ip, method, path, proto, rec.status, rec.size, ua, time.Since(start))

--- a/internal/server/log_test.go
+++ b/internal/server/log_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"net"
 	"net/http"
@@ -139,6 +140,83 @@ func TestServer_RequestLogMiddleware(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestServer_RequestLogMiddleware_ClientClosed covers #1029: a client that
+// hangs up before anything is written (e.g. during a cold model load) used to
+// be logged as the seeded 200, hiding aborted requests from status-code
+// monitoring. It must be logged as 499 instead — but only when no response had
+// started.
+func TestServer_RequestLogMiddleware_ClientClosed(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler http.HandlerFunc
+		want    string
+		notWant string
+	}{
+		{
+			// The cold-load cancellation branches in baseRouter.ServeHTTP:
+			// they return without touching the ResponseWriter.
+			name:    "no response written is logged as 499",
+			handler: func(w http.ResponseWriter, r *http.Request) {},
+			want:    "499 0",
+			notWant: "200 0",
+		},
+		{
+			// A response already on the wire keeps the status the client
+			// actually received, even though it hung up mid-stream.
+			name: "response already started keeps its status",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("partial"))
+			},
+			want:    "200 7",
+			notWant: "499",
+		},
+		{
+			// An implicit 200 from a bare Write counts as started too.
+			name: "implicit 200 from Write keeps its status",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte("partial"))
+			},
+			want:    "200 7",
+			notWant: "499",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			proxylog := logmon.NewWriter(io.Discard)
+			ctx, cancel := context.WithCancel(context.Background())
+			r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil).WithContext(ctx)
+			r.RemoteAddr = "192.168.1.1:5000"
+			// The client goes away while the handler is still waiting.
+			cancel()
+
+			CreateRequestLogMiddleware(proxylog)(c.handler).ServeHTTP(httptest.NewRecorder(), r)
+
+			line := string(proxylog.GetHistory())
+			if !strings.Contains(line, c.want) {
+				t.Errorf("log line %q missing %q", line, c.want)
+			}
+			if strings.Contains(line, c.notWant) {
+				t.Errorf("log line %q should not contain %q", line, c.notWant)
+			}
+		})
+	}
+
+	t.Run("live client keeps the seeded 200", func(t *testing.T) {
+		proxylog := logmon.NewWriter(io.Discard)
+		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+		r.RemoteAddr = "192.168.1.1:5000"
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+		CreateRequestLogMiddleware(proxylog)(handler).ServeHTTP(httptest.NewRecorder(), r)
+
+		if line := string(proxylog.GetHistory()); !strings.Contains(line, "200 0") {
+			t.Errorf("log line %q should report 200 for a connected client", line)
+		}
+	})
 }
 
 // TestServer_RequestLogMiddleware_WebSocketUpgrade verifies that the access-log

--- a/internal/server/log_test.go
+++ b/internal/server/log_test.go
@@ -205,6 +205,57 @@ func TestServer_RequestLogMiddleware_ClientClosed(t *testing.T) {
 		})
 	}
 
+	// A streaming handler can commit the implicit 200 by flushing alone. The
+	// client has started receiving that response, so a later disconnect must
+	// not rewrite the log line to 499.
+	t.Run("cancellation after Flush keeps the flushed status", func(t *testing.T) {
+		proxylog := logmon.NewWriter(io.Discard)
+		ctx, cancel := context.WithCancel(context.Background())
+		r := httptest.NewRequest(http.MethodGet, "/logs/stream", nil).WithContext(ctx)
+		r.RemoteAddr = "192.168.1.1:5000"
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Establish the stream, then the client goes away mid-stream.
+			w.(http.Flusher).Flush()
+			cancel()
+		})
+		CreateRequestLogMiddleware(proxylog)(handler).ServeHTTP(httptest.NewRecorder(), r)
+
+		line := string(proxylog.GetHistory())
+		if !strings.Contains(line, "200 0") {
+			t.Errorf("log line %q should keep the flushed 200", line)
+		}
+		if strings.Contains(line, "499") {
+			t.Errorf("log line %q must not report 499 after a flushed response", line)
+		}
+	})
+
+	// base.go calls SendError after the loading stream has already sent its
+	// 200 (shutdown, or a dispatch error). net/http drops that second header,
+	// so the client keeps the 200 and the log must report what it received.
+	t.Run("WriteHeader after a started response keeps the first status", func(t *testing.T) {
+		proxylog := logmon.NewWriter(io.Discard)
+		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+		r.RemoteAddr = "192.168.1.1:5000"
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("data: loading\n\n"))
+			// Something fails after the stream has started.
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+
+		rec := httptest.NewRecorder()
+		CreateRequestLogMiddleware(proxylog)(handler).ServeHTTP(rec, r)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("client received %d, want %d", rec.Code, http.StatusOK)
+		}
+		if line := string(proxylog.GetHistory()); !strings.Contains(line, "200 15") {
+			t.Errorf("log line %q should report the 200 the client received", line)
+		}
+	})
+
 	t.Run("live client keeps the seeded 200", func(t *testing.T) {
 		proxylog := logmon.NewWriter(io.Discard)
 		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -608,9 +608,17 @@ func (w *responseBodyCopier) WroteHeader() bool { return w.wroteHeader }
 
 // Flush forwards to the underlying writer so streaming responses still flush.
 func (w *responseBodyCopier) Flush() {
-	if f, ok := w.ResponseWriter.(http.Flusher); ok {
-		f.Flush()
+	f, ok := w.ResponseWriter.(http.Flusher)
+	if !ok {
+		return
 	}
+	// Flushing commits the implicit 200, so the response has started even if
+	// nothing wrote a header. Recorded here for the same reason as in
+	// statusRecorder: the client-closed sentinel must not overwrite it.
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	f.Flush()
 }
 
 // Hijack forwards to the underlying writer so httputil.ReverseProxy can take

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -104,6 +104,12 @@ func (mp *metricsMonitor) warnf(format string, args ...any) {
 	}
 }
 
+func (mp *metricsMonitor) debugf(format string, args ...any) {
+	if mp.logger != nil {
+		mp.logger.Debugf(format, args...)
+	}
+}
+
 func (mp *metricsMonitor) Close() error {
 	return nil
 }
@@ -144,6 +150,18 @@ func (mp *metricsMonitor) record(modelID string, r *http.Request, recorder *resp
 		}
 		tm = stored
 		mp.emitMetric(tm)
+	}
+
+	// A client that hangs up is normal traffic, not a server fault: record the
+	// entry so the abort is visible, but at debug level and without the
+	// synthesized upstream error message the failure path below would attach.
+	// No capture is stored — there is no response to inspect, and a client
+	// retrying in a loop would otherwise flood the capture store. See #1029.
+	if recorder.Status() == swaputil.StatusClientClosedRequest {
+		mp.debugf("metrics: client disconnected before response, path=%s", r.URL.Path)
+		tm.ErrorMsg = "client disconnected before response"
+		queueAndEmit()
+		return
 	}
 
 	if recorder.Status() != http.StatusOK {
@@ -575,6 +593,18 @@ func (w *responseBodyCopier) WriteHeader(statusCode int) {
 	w.status = statusCode
 	w.ResponseWriter.WriteHeader(statusCode)
 }
+
+// MarkStatus records code for metrics without writing to the client, and
+// forwards to the wrapped writer so the access-log recorder agrees.
+func (w *responseBodyCopier) MarkStatus(code int) {
+	w.status = code
+	if marker, ok := w.ResponseWriter.(swaputil.StatusMarker); ok {
+		marker.MarkStatus(code)
+	}
+}
+
+// WroteHeader reports whether a response status reached the client.
+func (w *responseBodyCopier) WroteHeader() bool { return w.wroteHeader }
 
 // Flush forwards to the underlying writer so streaming responses still flush.
 func (w *responseBodyCopier) Flush() {

--- a/internal/server/metrics_middleware.go
+++ b/internal/server/metrics_middleware.go
@@ -76,6 +76,9 @@ func CreateMetricsMiddleware(mm *metricsMonitor, cfg config.Config) chain.Middle
 
 			recorder := newBodyCopier(w)
 			next.ServeHTTP(recorder, r)
+			// A request abandoned before any response was written must not be
+			// filed as a successful (empty-body) metric. See #1029.
+			swaputil.MarkClientClosed(recorder, r)
 			mm.record(data.ModelID, r, recorder, cf, reqBody, reqHeaders)
 		})
 	}

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -256,6 +256,55 @@ func TestServer_MetricsMiddleware_ClientClosed(t *testing.T) {
 	}
 }
 
+// TestServer_MetricsMiddleware_ServerSideCancelIsNotClientClosed guards the
+// distinction #1029's fix depends on. The inflight middleware derives a
+// cancellable context that POST /api/inflight/{id}/cancel fires, so testing
+// "is this request's context done?" would report an operator cancelling a
+// request from the UI as a client that hung up.
+func TestServer_MetricsMiddleware_ServerSideCancelIsNotClientClosed(t *testing.T) {
+	mm := newTestMetricsMonitor(t, logmon.NewWriter(io.Discard), 10, 0)
+	cfg := config.Config{Models: map[string]config.ModelConfig{"m": {}}}
+
+	proxylog := logmon.NewWriter(io.Discard)
+	// The handler stands in for a dispatch that is cancelled mid-flight and
+	// answers the still-connected client, as the proxy ErrorHandler does.
+	handler := chain.New(
+		CreateRequestLogMiddleware(proxylog),
+		CreateMetricsMiddleware(mm, cfg),
+	).ThenFunc(func(w http.ResponseWriter, r *http.Request) {
+		derived, cancel := context.WithCancel(r.Context())
+		defer cancel()
+		cancel() // the operator cancels it
+		r = r.WithContext(derived)
+		if swaputil.MarkClientClosed(w, r) {
+			return
+		}
+		w.WriteHeader(http.StatusBadGateway)
+	})
+
+	body := `{"model":"m","messages":[{"role":"user","content":"hi"}]}`
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r.RemoteAddr = "192.168.1.1:5000"
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("client got %d, want %d: a connected client must be answered", w.Code, http.StatusBadGateway)
+	}
+	entries := metricsEntries(t, mm)
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	if entries[0].RespStatusCode == swaputil.StatusClientClosedRequest {
+		t.Error("a server-side cancel must not be recorded as a client disconnect")
+	}
+	if line := string(proxylog.GetHistory()); strings.Contains(line, "499") {
+		t.Errorf("access log %q should not report 499 for a connected client", line)
+	}
+}
+
 func TestMetricsMonitor_RecordFailedRequestCapture(t *testing.T) {
 	mm := newTestMetricsMonitor(t, logmon.NewWriter(io.Discard), 10, 5)
 	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"io"
 	"math"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mostlygeek/llama-swap/internal/chain"
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/logmon"
 	"github.com/mostlygeek/llama-swap/internal/swaputil"
@@ -186,6 +188,71 @@ func TestMetricsMonitor_RecordMetadata(t *testing.T) {
 	}
 	if entries[0].Metadata["trace"] != "abc" {
 		t.Errorf("trace = %q, want abc", entries[0].Metadata["trace"])
+	}
+}
+
+// TestMetricsMonitor_RecordClientClosed covers #1029: a client that hangs up
+// before a response is written must not be filed as a successful (empty-body)
+// metric. It is recorded with the 499 sentinel and a client-cancelled
+// ErrorMsg, and skips the capture the upstream-failure path would store.
+func TestMetricsMonitor_RecordClientClosed(t *testing.T) {
+	mm := newTestMetricsMonitor(t, logmon.NewWriter(io.Discard), 10, 5)
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	w := httptest.NewRecorder()
+	copier := newBodyCopier(w)
+	// Nothing is ever written: this is the cold-load cancellation shape.
+	copier.MarkStatus(swaputil.StatusClientClosedRequest)
+
+	mm.record("m", r, copier, captureAll, []byte("req"), nil)
+
+	entries := metricsEntries(t, mm)
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.RespStatusCode != swaputil.StatusClientClosedRequest {
+		t.Errorf("status = %d, want %d", entry.RespStatusCode, swaputil.StatusClientClosedRequest)
+	}
+	if entry.ErrorMsg != "client disconnected before response" {
+		t.Errorf("error_msg = %q, want client-cancelled message", entry.ErrorMsg)
+	}
+	if entry.HasCapture {
+		t.Error("a cancelled request has no response to capture")
+	}
+}
+
+// TestServer_MetricsMiddleware_ClientClosed checks the middleware derives the
+// sentinel for a handler that returns without writing, and that the marker
+// propagates outward to the access-log recorder so both agree.
+func TestServer_MetricsMiddleware_ClientClosed(t *testing.T) {
+	mm := newTestMetricsMonitor(t, logmon.NewWriter(io.Discard), 10, 0)
+	cfg := config.Config{Models: map[string]config.ModelConfig{"m": {}}}
+
+	proxylog := logmon.NewWriter(io.Discard)
+	handler := chain.New(
+		CreateRequestLogMiddleware(proxylog),
+		CreateMetricsMiddleware(mm, cfg),
+	).ThenFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	body := `{"model":"m","messages":[{"role":"user","content":"hi"}]}`
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body)).WithContext(ctx)
+	r.Header.Set("Content-Type", "application/json")
+	r.RemoteAddr = "192.168.1.1:5000"
+	cancel()
+
+	handler.ServeHTTP(httptest.NewRecorder(), r)
+
+	entries := metricsEntries(t, mm)
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	if entries[0].RespStatusCode != swaputil.StatusClientClosedRequest {
+		t.Errorf("activity status = %d, want %d", entries[0].RespStatusCode, swaputil.StatusClientClosedRequest)
+	}
+	if line := string(proxylog.GetHistory()); !strings.Contains(line, "499 0") {
+		t.Errorf("access log %q should report 499", line)
 	}
 }
 

--- a/internal/swaputil/http.go
+++ b/internal/swaputil/http.go
@@ -78,6 +78,43 @@ func ShouldIgnoreWebsocket(r *http.Request, cfg config.Config) bool {
 	return ok && mc.Compat.IgnoreWebsockets
 }
 
+// StatusClientClosedRequest mirrors nginx's non-standard 499 "Client Closed
+// Request". llama-swap records it when a client disconnects before any
+// response was written, so an abandoned request is not filed as a success (a
+// cancelled cold-start load) or blamed on the upstream (a 502 from the reverse
+// proxy). It is never written to the connection — the client is already gone —
+// so it only ever appears in the access log and the activity store.
+const StatusClientClosedRequest = 499
+
+// StatusMarker is implemented by the response recorders in the middleware
+// chain. It lets a status be recorded for logging and metrics without writing
+// anything to the client.
+type StatusMarker interface {
+	// MarkStatus records code as the response status without writing it to
+	// the connection. Recorders that wrap another writer forward the call so
+	// every recorder in the chain agrees on the status.
+	MarkStatus(code int)
+	// WroteHeader reports whether a response status has already been written.
+	WroteHeader() bool
+}
+
+// MarkClientClosed records StatusClientClosedRequest on w when r's context
+// reports that the client went away before any response status was written. It
+// reports whether the sentinel was recorded.
+//
+// Nothing is sent to the client: the connection is already gone, and on a
+// streamed response the upstream may have flushed headers long ago, where a
+// late WriteHeader would only produce "superfluous response.WriteHeader" spam.
+// A response that already started is left with the status it really had.
+func MarkClientClosed(w http.ResponseWriter, r *http.Request) bool {
+	marker, ok := w.(StatusMarker)
+	if !ok || marker.WroteHeader() || r.Context().Err() == nil {
+		return false
+	}
+	marker.MarkStatus(StatusClientClosedRequest)
+	return true
+}
+
 func SendError(w http.ResponseWriter, r *http.Request, err error) {
 	var httpErr HTTPError
 	if errors.As(err, &httpErr) {

--- a/internal/swaputil/http.go
+++ b/internal/swaputil/http.go
@@ -98,17 +98,58 @@ type StatusMarker interface {
 	WroteHeader() bool
 }
 
-// MarkClientClosed records StatusClientClosedRequest on w when r's context
-// reports that the client went away before any response status was written. It
+// clientCtxKey carries the connection's own context past middleware that derive
+// cancellable child contexts from it.
+type clientCtxKey struct{}
+
+// SetClientContext returns ctx carrying clientCtx as the client connection's
+// context, so a later cancellation can be attributed correctly.
+func SetClientContext(ctx, clientCtx context.Context) context.Context {
+	return context.WithValue(ctx, clientCtxKey{}, clientCtx)
+}
+
+// WithClientContext returns r with its current context remembered as the client
+// connection's own. Call it before any middleware derives a cancellable child
+// context, so a request aborted server-side is not mistaken for a client that
+// hung up.
+func WithClientContext(r *http.Request) *http.Request {
+	return r.WithContext(SetClientContext(r.Context(), r.Context()))
+}
+
+// ClientContext returns the client connection's context as remembered by
+// WithClientContext, falling back to ctx itself when none was recorded.
+func ClientContext(ctx context.Context) context.Context {
+	if clientCtx, ok := ctx.Value(clientCtxKey{}).(context.Context); ok {
+		return clientCtx
+	}
+	return ctx
+}
+
+// ResponseStarted reports whether a response status has already reached the
+// client, in which case an error handler has nothing useful left to send.
+func ResponseStarted(w http.ResponseWriter) bool {
+	marker, ok := w.(StatusMarker)
+	return ok && marker.WroteHeader()
+}
+
+// MarkClientClosed records StatusClientClosedRequest on w when the client
+// connection itself went away before any response status was written. It
 // reports whether the sentinel was recorded.
 //
-// Nothing is sent to the client: the connection is already gone, and on a
+// The test is deliberately the client's own context rather than the request's:
+// middleware derive cancellable children from it (the inflight tracker, which
+// an operator can cancel from the UI, and the peer router's shutdown link), and
+// a request killed server-side still has a live client that must be answered
+// normally. Blaming that client would be the same misattribution this sentinel
+// exists to fix.
+//
+// When it does apply, nothing is sent: the connection is already gone, and on a
 // streamed response the upstream may have flushed headers long ago, where a
 // late WriteHeader would only produce "superfluous response.WriteHeader" spam.
-// A response that already started is left with the status it really had.
+// A response that already started keeps the status it really had.
 func MarkClientClosed(w http.ResponseWriter, r *http.Request) bool {
 	marker, ok := w.(StatusMarker)
-	if !ok || marker.WroteHeader() || r.Context().Err() == nil {
+	if !ok || marker.WroteHeader() || ClientContext(r.Context()).Err() == nil {
 		return false
 	}
 	marker.MarkStatus(StatusClientClosedRequest)

--- a/internal/swaputil/http.go
+++ b/internal/swaputil/http.go
@@ -157,11 +157,8 @@ func MarkClientClosed(w http.ResponseWriter, r *http.Request) bool {
 }
 
 func SendError(w http.ResponseWriter, r *http.Request, err error) {
-	// A response that already started cannot carry a status any more, and its
-	// body would be appended to whatever the client is mid-way through reading
-	// — corrupting a stream rather than reporting the error. Callers that can
-	// still report in-band (the loading stream frames it as SSE) do so before
-	// reaching here; for the rest, dropping it is the lesser harm.
+	// Guarded here as well as in SendResponse because the HTTPError branch
+	// below writes its own body rather than delegating. See SendResponse.
 	if ResponseStarted(w) {
 		return
 	}
@@ -194,6 +191,15 @@ func SendError(w http.ResponseWriter, r *http.Request, err error) {
 // error response in that format. JSON responses use the OpenAI-compatible
 // envelope, where "error" is an object rather than a string.
 func SendResponse(w http.ResponseWriter, r *http.Request, status int, message string) {
+	// A response that already started cannot carry a status any more, and this
+	// body would be appended to whatever the client is mid-way through reading
+	// — corrupting a stream rather than reporting the error. Callers that can
+	// still report in-band (the loading stream frames it as SSE) do so before
+	// reaching here; for the rest, dropping it is the lesser harm.
+	if ResponseStarted(w) {
+		return
+	}
+
 	acceptHeader := r.Header.Get("Accept")
 	if strings.Contains(acceptHeader, "text/plain") {
 		w.Header().Set("Content-Type", "text/plain")

--- a/internal/swaputil/http.go
+++ b/internal/swaputil/http.go
@@ -157,6 +157,15 @@ func MarkClientClosed(w http.ResponseWriter, r *http.Request) bool {
 }
 
 func SendError(w http.ResponseWriter, r *http.Request, err error) {
+	// A response that already started cannot carry a status any more, and its
+	// body would be appended to whatever the client is mid-way through reading
+	// — corrupting a stream rather than reporting the error. Callers that can
+	// still report in-band (the loading stream frames it as SSE) do so before
+	// reaching here; for the rest, dropping it is the lesser harm.
+	if ResponseStarted(w) {
+		return
+	}
+
 	var httpErr HTTPError
 	if errors.As(err, &httpErr) {
 		for k, v := range httpErr.Header() {


### PR DESCRIPTION
A client that hangs up before a response is written was logged and
recorded as a successful 200 with a 0-byte body: the cancellation
branches return without touching the ResponseWriter, so the access log's
seeded 200 was what got reported, and the metrics path filed it through
the "empty body, recording minimal metrics" success arm. Aborted
requests were invisible to status-code monitoring. Once the model was
loaded, the same hangup surfaced as a 502, blaming a healthy upstream.

Add swaputil.StatusClientClosedRequest (nginx's non-standard 499) as the
sentinel. It is recorded only, never written to the connection: the
client is already gone, and on a streamed response a late WriteHeader
would just log "superfluous response.WriteHeader".

- add StatusMarker/MarkClientClosed to swaputil; the response recorders
  implement it and forward outward so log and metrics agree
- derive the sentinel in the access-log and metrics middleware, which
  covers every cancellation branch instead of each one separately
- classify cancellation in the model and peer proxy ErrorHandlers so a
  client hangup no longer reports 502
- record cancelled requests with a client-disconnected ErrorMsg at debug
  level and without a capture, since an impatient caller is normal
  traffic rather than a server fault
- tag health check polls so a booting upstream is not logged as a proxy
  error once per second

A response that already started keeps the status the client actually
received.

fix: #1029

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VCGTebifzJFZnDbcHJDeQd