### PR TITLE
internal/server: rate limit sendBuffer full warnings

### DIFF
--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -417,6 +417,10 @@ const (
 	msgTypeProfile     messageType = "profileChanged"
 )
 
+// sendDropReportInterval is how often handleAPIEvents reports messages that
+// were dropped because the send buffer was full.
+const sendDropReportInterval = 5 * time.Second
+
 type messageEnvelope struct {
 	Type messageType `json:"type"`
 	Data string      `json:"data"`
@@ -444,13 +448,39 @@ func (s *Server) handleAPIEvents(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithCancel(r.Context())
 	defer cancel()
 
+	// Dropped messages are counted and reported at most once per interval.
+	// Logging every drop floods the logs because each warning becomes a log
+	// event that is sent over this same buffer, which drops again.
+	dropped := newSuppressionCounter(sendDropReportInterval)
+	cancelled := newSuppressionCounter(sendDropReportInterval)
+	reportDropped := func(n int) {
+		s.proxylog.Warnf("handleAPIEvents sendBuffer full, %d messages suppressed", n)
+	}
+	reportCancelled := func(n int) {
+		s.proxylog.Warnf("handleAPIEvents send suppressed due to context done, %d messages suppressed", n)
+	}
+	// runs after the event handlers below are unsubscribed so any remaining
+	// counts are reported before the connection goes away
+	defer func() {
+		if n, ok := dropped.Flush(); ok {
+			reportDropped(n)
+		}
+		if n, ok := cancelled.Flush(); ok {
+			reportCancelled(n)
+		}
+	}()
+
 	send := func(msg messageEnvelope) {
 		select {
 		case sendBuffer <- msg:
 		case <-ctx.Done():
-			s.proxylog.Warn("handleAPIEvents send suppressed due to context done")
+			if n, ok := cancelled.Add(); ok {
+				reportCancelled(n)
+			}
 		default:
-			s.proxylog.Warn("handleAPIEvents sendBuffer full, dropped message")
+			if n, ok := dropped.Add(); ok {
+				reportDropped(n)
+			}
 		}
 	}
 	sendModels := func() {

--- a/internal/server/suppress.go
+++ b/internal/server/suppress.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"sync"
+	"time"
+)
+
+// suppressionCounter counts repeated events and rate limits reporting them so
+// a burst produces a single summary instead of one log line per event. It is
+// safe for concurrent use.
+type suppressionCounter struct {
+	mu       sync.Mutex
+	interval time.Duration
+	count    int
+	last     time.Time
+
+	// now is swappable for testing
+	now func() time.Time
+}
+
+func newSuppressionCounter(interval time.Duration) *suppressionCounter {
+	c := &suppressionCounter{
+		interval: interval,
+		now:      time.Now,
+	}
+	c.last = c.now()
+	return c
+}
+
+// Add records one suppressed event. It returns the number of events suppressed
+// since the last report and true when the reporting interval has elapsed. The
+// counter is reset whenever it returns true.
+func (c *suppressionCounter) Add() (int, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.count++
+	now := c.now()
+	if now.Sub(c.last) < c.interval {
+		return 0, false
+	}
+
+	count := c.count
+	c.count = 0
+	c.last = now
+	return count, true
+}
+
+// Flush returns any events counted but not yet reported, and true when there
+// are any. Use it to report the remainder when the counter goes away.
+func (c *suppressionCounter) Flush() (int, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.count == 0 {
+		return 0, false
+	}
+
+	count := c.count
+	c.count = 0
+	c.last = c.now()
+	return count, true
+}

--- a/internal/server/suppress_test.go
+++ b/internal/server/suppress_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func newTestSuppressionCounter(interval time.Duration, now *time.Time) *suppressionCounter {
+	c := newSuppressionCounter(interval)
+	c.now = func() time.Time { return *now }
+	c.last = *now
+	return c
+}
+
+func TestServer_SuppressionCounter_ReportsOncePerInterval(t *testing.T) {
+	now := time.Unix(0, 0)
+	c := newTestSuppressionCounter(5*time.Second, &now)
+
+	// events within the interval are counted but not reported
+	for i := 0; i < 100; i++ {
+		if n, ok := c.Add(); ok {
+			t.Fatalf("Add() reported %d after %d events, want no report", n, i)
+		}
+	}
+
+	now = now.Add(5 * time.Second)
+	n, ok := c.Add()
+	if !ok {
+		t.Fatal("Add() did not report after the interval elapsed")
+	}
+	if n != 101 {
+		t.Errorf("reported count = %d, want 101", n)
+	}
+
+	// the count resets after reporting
+	if n, ok := c.Add(); ok {
+		t.Errorf("Add() reported %d immediately after a report, want no report", n)
+	}
+	now = now.Add(5 * time.Second)
+	if n, ok := c.Add(); !ok || n != 2 {
+		t.Errorf("Add() = (%d, %v), want (2, true)", n, ok)
+	}
+}
+
+func TestServer_SuppressionCounter_FlushRemainder(t *testing.T) {
+	now := time.Unix(0, 0)
+	c := newTestSuppressionCounter(5*time.Second, &now)
+
+	if n, ok := c.Flush(); ok {
+		t.Errorf("Flush() = (%d, true) with nothing counted, want (0, false)", n)
+	}
+
+	c.Add()
+	c.Add()
+	n, ok := c.Flush()
+	if !ok || n != 2 {
+		t.Errorf("Flush() = (%d, %v), want (2, true)", n, ok)
+	}
+
+	if n, ok := c.Flush(); ok {
+		t.Errorf("second Flush() = (%d, true), want (0, false)", n)
+	}
+}
+
+func TestServer_SuppressionCounter_ConcurrentAddCountsEveryEvent(t *testing.T) {
+	now := time.Unix(0, 0)
+	c := newTestSuppressionCounter(time.Hour, &now)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				c.Add()
+			}
+		}()
+	}
+	wg.Wait()
+
+	n, ok := c.Flush()
+	if !ok || n != 1000 {
+		t.Errorf("Flush() = (%d, %v), want (1000, true)", n, ok)
+	}
+}


### PR DESCRIPTION
The SSE handler logged a warning for every message dropped when its send
buffer was full. Each warning is itself a log event that gets sent over
the same buffer, so a full buffer amplified into a continuous stream of
warnings that grew container logs to hundreds of GB.

Count the drops instead and report them at most once every 5 seconds as
"sendBuffer full, nnn messages suppressed". Any remaining count is
reported when the connection closes.

- add suppressionCounter, a small rate limited event counter
- use it for both the buffer full and context done drop paths
- add tests for counting, interval reporting and flushing

fix: #1042