### PR TITLE
ui: ignore IME composition Enter in keydown handlers

### DIFF
--- a/ui/src/components/AppSidebar.svelte
+++ b/ui/src/components/AppSidebar.svelte
@@ -11,6 +11,7 @@
   import { showUnlistedModels } from "../stores/modelDisplay";
   import { modelsMenuOpen } from "../stores/sidebar";
   import type { Model } from "../lib/types";
+  import { isComposingKey } from "../lib/ime";
   import ConnectionStatus from "./ConnectionStatus.svelte";
 
   function handleTitleChange(newTitle: string): void {
@@ -19,7 +20,7 @@
   }
 
   function handleKeyDown(e: KeyboardEvent): void {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !isComposingKey(e)) {
       e.preventDefault();
       const target = e.currentTarget as HTMLElement;
       handleTitleChange(target.textContent || "(set title)");

--- a/ui/src/components/playground/ChatInterface.svelte
+++ b/ui/src/components/playground/ChatInterface.svelte
@@ -4,6 +4,7 @@
   import { streamChatCompletion, type Endpoint } from "../../lib/chatApi";
   import { playgroundStores } from "../../stores/playgroundActivity";
   import type { ChatMessage, ContentPart } from "../../lib/types";
+  import { isSubmitEnter } from "../../lib/ime";
   import ChatMessageComponent from "./ChatMessage.svelte";
   import ModelSelector from "./ModelSelector.svelte";
   import ExpandableTextarea from "./ExpandableTextarea.svelte";
@@ -247,7 +248,7 @@
   }
 
   function handleKeyDown(event: KeyboardEvent) {
-    if (event.key === "Enter" && !event.shiftKey) {
+    if (isSubmitEnter(event)) {
       event.preventDefault();
       sendMessage();
     }

--- a/ui/src/components/playground/ChatMessage.svelte
+++ b/ui/src/components/playground/ChatMessage.svelte
@@ -8,6 +8,7 @@
   import type { ContentPart } from "../../lib/types";
   import { formatDuration } from "../../lib/format";
   import { copyText } from "../../lib/clipboard";
+  import { isSubmitEnter } from "../../lib/ime";
 
   interface Props {
     role: "user" | "assistant" | "system";
@@ -91,7 +92,7 @@
   }
 
   function handleKeyDown(event: KeyboardEvent) {
-    if (event.key === "Enter" && !event.shiftKey) {
+    if (isSubmitEnter(event)) {
       event.preventDefault();
       saveEdit();
     } else if (event.key === "Escape") {

--- a/ui/src/components/playground/ImageInterface.svelte
+++ b/ui/src/components/playground/ImageInterface.svelte
@@ -9,6 +9,7 @@
   import ExpandableTextarea from "./ExpandableTextarea.svelte";
   import EmptyState from "../EmptyState.svelte";
   import type { ImageApiMode, SdApiLora, SdApiLoraRef } from "../../lib/types";
+  import { isSubmitEnter } from "../../lib/ime";
   import { Button } from "$lib/components/ui/button/index.js";
   import { Input } from "$lib/components/ui/input/index.js";
   import { Textarea } from "$lib/components/ui/textarea/index.js";
@@ -161,7 +162,7 @@
   }
 
   function handleKeyDown(event: KeyboardEvent) {
-    if (event.key === "Enter" && !event.shiftKey) {
+    if (isSubmitEnter(event)) {
       event.preventDefault();
       generate();
     }

--- a/ui/src/components/playground/RerankInterface.svelte
+++ b/ui/src/components/playground/RerankInterface.svelte
@@ -2,6 +2,7 @@
   import { hasListedModels } from "../../stores/api";
   import { createPlaygroundInterface } from "../../lib/playgroundInterface";
   import { rerank } from "../../lib/rerankApi";
+  import { isSubmitEnter } from "../../lib/ime";
   import { playgroundStores } from "../../stores/playgroundActivity";
   import ModelSelector from "./ModelSelector.svelte";
   import EmptyState from "../EmptyState.svelte";
@@ -232,7 +233,7 @@
   }
 
   function handleKeyDown(e: KeyboardEvent) {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (isSubmitEnter(e)) {
       e.preventDefault();
       submit();
     }

--- a/ui/src/components/playground/SpeechInterface.svelte
+++ b/ui/src/components/playground/SpeechInterface.svelte
@@ -11,6 +11,7 @@
   import * as Select from "$lib/components/ui/select/index.js";
   import { RefreshCw, Download } from "@lucide/svelte";
   import { playgroundSessionHeaders } from "../../lib/playgroundSession";
+  import { isSubmitEnter } from "../../lib/ime";
 
   const iface = createPlaygroundInterface("playground-speech-model", playgroundStores.speechGenerating);
   const selectedModelStore = iface.selectedModel;
@@ -211,7 +212,7 @@
   }
 
   function handleKeyDown(event: KeyboardEvent) {
-    if (event.key === "Enter" && !event.shiftKey) {
+    if (isSubmitEnter(event)) {
       event.preventDefault();
       generate();
     }

--- a/ui/src/lib/ime.test.ts
+++ b/ui/src/lib/ime.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { isComposingKey, isSubmitEnter } from "./ime";
+
+// Shorthand for the subset of KeyboardEvent the helpers read.
+function key(
+  overrides: Partial<Pick<KeyboardEvent, "key" | "shiftKey" | "isComposing" | "keyCode">> = {},
+) {
+  return { key: "Enter", shiftKey: false, isComposing: false, keyCode: 13, ...overrides };
+}
+
+describe("isComposingKey", () => {
+  it("is true while a composition session is active", () => {
+    expect(isComposingKey(key({ isComposing: true }))).toBe(true);
+  });
+
+  it("is true for the legacy composing keyCode", () => {
+    expect(isComposingKey(key({ keyCode: 229 }))).toBe(true);
+  });
+
+  it("is false for a normal keypress", () => {
+    expect(isComposingKey(key())).toBe(false);
+  });
+});
+
+describe("isSubmitEnter", () => {
+  it("submits on a plain Enter", () => {
+    expect(isSubmitEnter(key())).toBe(true);
+  });
+
+  it("does not submit on the Enter that confirms an IME conversion", () => {
+    expect(isSubmitEnter(key({ isComposing: true }))).toBe(false);
+    expect(isSubmitEnter(key({ isComposing: true, keyCode: 229 }))).toBe(false);
+  });
+
+  it("does not submit when only the legacy composing keyCode is set", () => {
+    expect(isSubmitEnter(key({ keyCode: 229 }))).toBe(false);
+  });
+
+  it("does not submit on Shift+Enter, which inserts a newline", () => {
+    expect(isSubmitEnter(key({ shiftKey: true }))).toBe(false);
+  });
+
+  it("ignores other keys", () => {
+    expect(isSubmitEnter(key({ key: "a", keyCode: 65 }))).toBe(false);
+    expect(isSubmitEnter(key({ key: "Escape", keyCode: 27 }))).toBe(false);
+  });
+});

--- a/ui/src/lib/ime.ts
+++ b/ui/src/lib/ime.ts
@@ -1,0 +1,22 @@
+// Helpers for telling an IME conversion-confirming Enter apart from an Enter
+// that means "submit".
+//
+// Browsers deliver the Enter that confirms a Japanese/Chinese/Korean IME
+// conversion as an ordinary keydown - same key, same target. There are only
+// two signals that distinguish it:
+//   - isComposing: the standard one, true for keydowns inside a composition
+//     session.
+//   - keyCode === 229: the legacy "composing" value engines still set. Kept as
+//     a backstop for engines that don't set isComposing on the confirming key.
+
+export function isComposingKey(event: Pick<KeyboardEvent, "isComposing" | "keyCode">): boolean {
+  return event.isComposing || event.keyCode === 229;
+}
+
+// True when a keydown is a plain Enter meant to submit. Shift+Enter (newline)
+// and IME conversion-confirm Enters are both false.
+export function isSubmitEnter(
+  event: Pick<KeyboardEvent, "key" | "shiftKey" | "isComposing" | "keyCode">,
+): boolean {
+  return event.key === "Enter" && !event.shiftKey && !isComposingKey(event);
+}


### PR DESCRIPTION
I have fixed an issue where pressing Enter to confirm an IME conversion would accidentally send a message, making it difficult to type using an IME in CJK languages.

### Cause:
The original handler did not check either `isComposing` or `keyCode === 229`; it made its determination based solely on `event.key === "Enter" && !event.shiftKey`.

### Changes:
- Added a new helper(ui/src/lib/ime.ts)
- Replaced code in 6 locations
- Added unit tests

Changed the behavior so that pressing Enter to confirm an IME conversion no longer sends a message.
Pressing Enter when there is no active IME conversion session will send a message.

### Verification:
I used `make test-ui` to confirm there were no errors.
A line break occurs when you press Shift+Enter, whether you’re using IME input or typing letters directly.

```
 Test Files  11 passed (11)
      Tests  184 passed (184)
   Start at  22:28:15
   Duration  384ms (transform 565ms, setup 0ms, import 1.06s, tests 142ms, environment 0ms)
```

I also confirmed that the issue has been resolved in Chrome and Safari.
There is no change in behavior in Firefox.

https://github.com/user-attachments/assets/1407e89f-4919-407f-a53d-e5fb1589da4a



Fixes #1044