### PR TITLE
cli: add -validate flag to check config and exit

### DIFF
--- a/llama-swap.go
+++ b/llama-swap.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -63,6 +64,20 @@ func configStorePath(cfg config.Config) string {
 	return strings.TrimSpace(cfg.Store.Path)
 }
 
+// runValidate loads the configuration from the given sources and prints a
+// short human-readable result to out. It returns 0 when the config loads
+// without error and 1 otherwise. It does not start the server, detect
+// hardware, or open a listener.
+func runValidate(configPath, configDir string, out io.Writer) int {
+	cfg, err := config.LoadConfigSources(configPath, configDir)
+	if err != nil {
+		fmt.Fprintf(out, "config validation failed: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(out, "config is valid: %d model(s), %d peer(s)\n", len(cfg.Models), len(cfg.Peers))
+	return 0
+}
+
 func main() {
 	flagConfig := flag.String("config", "", "path to config file")
 	flagConfigDir := flag.String("config-dir", "", "directory of *.yml/*.yaml config files (additive to -config)")
@@ -71,6 +86,7 @@ func main() {
 	flagKeyFile := flag.String("tls-key-file", "", "TLS key file")
 	flagVersion := flag.Bool("version", false, "show version and exit")
 	flagWatchConfig := flag.Bool("watch-config", false, "reload config on file change")
+	flagValidate := flag.Bool("validate", false, "validate the config file and exit (without starting the server)")
 	flag.Parse()
 
 	if *flagVersion {
@@ -81,6 +97,11 @@ func main() {
 	if *flagConfig == "" && *flagConfigDir == "" {
 		slog.Error("at least one of -config or -config-dir must be provided")
 		os.Exit(1)
+	}
+
+	if *flagValidate {
+		code := runValidate(*flagConfig, *flagConfigDir, os.Stdout)
+		os.Exit(code)
 	}
 
 	useTLS := *flagCertFile != "" || *flagKeyFile != ""

--- a/llama-swap_test.go
+++ b/llama-swap_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunValidate_ValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+models:
+  model1:
+    cmd: server --port ${PORT}
+    proxy: http://localhost:8080
+`), 0644))
+
+	var buf strings.Builder
+	code := runValidate(configPath, "", &buf)
+
+	assert.Equal(t, 0, code)
+	assert.NotEmpty(t, buf.String())
+	assert.Contains(t, buf.String(), "config is valid")
+}
+
+func TestRunValidate_BrokenConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+models:
+  model1:
+    cmd: server --port ${PORT} ${UNKNOWN_MACRO}
+    proxy: http://localhost:8080
+`), 0644))
+
+	var buf strings.Builder
+	code := runValidate(configPath, "", &buf)
+
+	assert.Equal(t, 1, code)
+	assert.NotEmpty(t, buf.String())
+	assert.Contains(t, buf.String(), "failed")
+}
+
+func TestRunValidate_ConfigDir(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.yml"), []byte(`
+models:
+  model1:
+    cmd: server --port ${PORT}
+    proxy: http://localhost:8080
+`), 0644))
+
+	var buf strings.Builder
+	code := runValidate("", dir, &buf)
+
+	assert.Equal(t, 0, code)
+	assert.NotEmpty(t, buf.String())
+	assert.Contains(t, buf.String(), "config is valid")
+}


### PR DESCRIPTION
Adds a -validate boolean flag that loads the config via the existing config.LoadConfigSources and exits without starting the server, detecting hardware, or binding a listener. Exits 0 when the config loads cleanly and 1 when it does not, printing a one-line result either way.

The logic lives in runValidate(configPath, configDir string, out io.Writer) int rather than inline in main() so it can be tested directly.

Closes #1034

