### PR TITLE
config,server: add startup profile hook

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -638,10 +638,15 @@
                             },
                             "default": [],
                             "description": "List of model IDs to load on startup. Model names must match keys in models. When preloading multiple models, define a group to prevent swapping."
+                        },
+                        "profile": {
+                            "type": "string",
+                            "default": "",
+                            "description": "Profile to activate on startup and after a configuration reload. Must name a key under profiles. An empty value starts with no profile active."
                         }
                     },
                     "additionalProperties": false,
-                    "description": "Actions to perform on startup. Only supported action is preload."
+                    "description": "Actions to perform on startup."
                 }
             },
             "additionalProperties": false,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -179,7 +179,8 @@ upstream:
 
 # profiles: named model ID replacements switched at runtime through the UI or API
 # - optional, default: empty dictionary
-# - one profile or none is active; startup and configuration reload select none
+# - one profile or none is active; hooks.on_startup.profile selects the profile
+#   used on startup and after a configuration reload
 # - pins are applied before aliases, filters, and routing
 # - targets may be a local model, fully qualified peer model, alias, setParamsByID alias, or selector
 # - an empty string or YAML null (~) disables the pin with a 404; it is not
@@ -491,8 +492,13 @@ models:
 hooks:
   # on_startup: a dictionary of actions to perform on startup
   # - optional, default: empty dictionary
-  # - the only supported action is preload
   on_startup:
+    # profile: profile to activate on startup and after a configuration reload
+    # - optional, default: empty string, which starts with no profile active
+    # - must name a key under profiles or the configuration fails to load
+    # - runtime selection is not persisted; restarts and reloads return to this profile
+    profile: "coding"
+
     # preload: a list of model ids to load on startup
     # - optional, default: empty list
     # - model names must match keys in the models sections

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,6 +94,7 @@ type HooksConfig struct {
 
 type HookOnStartup struct {
 	Preload []string `yaml:"preload"`
+	Profile string   `yaml:"profile"`
 }
 
 type Store struct {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -331,6 +331,11 @@ func validateProfiles(config Config) error {
 			}
 		}
 	}
+	if profile := config.Hooks.OnStartup.Profile; profile != "" {
+		if _, found := config.Profiles[profile]; !found {
+			return fmt.Errorf("hooks.on_startup.profile references unknown profile %q", profile)
+		}
+	}
 	return nil
 }
 

--- a/internal/config/profile_test.go
+++ b/internal/config/profile_test.go
@@ -34,8 +34,12 @@ profiles:
       disabled-empty: ""
       disabled-null: ~
       local: peer-model
+hooks:
+  on_startup:
+    profile: coding
 `))
 	require.NoError(t, err)
+	assert.Equal(t, "coding", cfg.Hooks.OnStartup.Profile)
 
 	profile := cfg.Profiles["coding"]
 	assert.Equal(t, "Coding profile", profile.Description)
@@ -106,6 +110,18 @@ func TestConfig_Profiles_Validation(t *testing.T) {
       public: missing
 `,
 			wantErr: "references unknown model",
+		},
+		{
+			name: "unknown startup profile",
+			profile: `profiles:
+  good:
+    pins:
+      public: model
+hooks:
+  on_startup:
+    profile: missing
+`,
+			wantErr: "hooks.on_startup.profile references unknown profile",
 		},
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -186,20 +186,21 @@ func New(cfg config.Config, muxlog *logmon.Monitor, proxylog *logmon.Monitor, up
 
 	shutdownCtx, shutdownFn := context.WithCancel(context.Background())
 	s := &Server{
-		cfg:         cfg,
-		muxlog:      muxlog,
-		proxylog:    proxylog,
-		upstreamlog: upstreamlog,
-		perf:        perfMon,
-		inflight:    newInflightTracker(),
-		metrics:     newMetricsMonitor(proxylog, cfg.MetricsMaxInMemory, cfg.CaptureBuffer, st),
-		store:       st,
-		build:       build,
-		hardware:    hardware,
-		local:       local,
-		peer:        peer,
-		shutdownCtx: shutdownCtx,
-		shutdownFn:  shutdownFn,
+		cfg:           cfg,
+		muxlog:        muxlog,
+		proxylog:      proxylog,
+		upstreamlog:   upstreamlog,
+		perf:          perfMon,
+		inflight:      newInflightTracker(),
+		metrics:       newMetricsMonitor(proxylog, cfg.MetricsMaxInMemory, cfg.CaptureBuffer, st),
+		store:         st,
+		build:         build,
+		hardware:      hardware,
+		activeProfile: cfg.Hooks.OnStartup.Profile,
+		local:         local,
+		peer:          peer,
+		shutdownCtx:   shutdownCtx,
+		shutdownFn:    shutdownFn,
 	}
 	s.routes()
 	s.startPreload()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -408,6 +408,31 @@ func TestServer_Preload(t *testing.T) {
 	}
 }
 
+// TestServer_New_OnStartupProfile verifies New activates the configured startup profile.
+func TestServer_New_OnStartupProfile(t *testing.T) {
+	discard := logmon.NewWriter(io.Discard)
+	cfg := config.Config{HealthCheckTimeout: 15}
+	cfg.Profiles = map[string]config.ProfileConfig{
+		"coding": {Pins: map[string]string{"llm-code": "model"}},
+	}
+	cfg.Hooks.OnStartup.Profile = "coding"
+	st, err := store.New("")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer st.Close()
+	s, err := New(cfg, discard, discard, discard, nil, st, BuildInfo{}, nil)
+	if err != nil {
+		t.Fatalf("New (startup profile): %v", err)
+	}
+	if got := s.ActiveProfile(); got != "coding" {
+		t.Fatalf("ActiveProfile()=%q want %q", got, "coding")
+	}
+	if err := s.Shutdown(time.Second); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
 func TestServer_Shutdown_StopsRoutersAndIsIdempotent(t *testing.T) {
 	local := newStubRouter([]string{"local-model"}, "")
 	peer := newStubRouter(nil, "")


### PR DESCRIPTION
An optional `hooks.on_startup.profile` setting for activating a profile on startup and after a configuration reload:

```yaml
profiles:
  coding:
    pins:
      llm-code: "gpt-oss-120b"

hooks:
  on_startup:
    profile: "coding"
```

Another attempt to close #992 after unsuccessful #993 ;)