### PR TITLE
cmd/wol-proxy: add -api-key option for use in health checks

### DIFF
--- a/cmd/wol-proxy/README.md
+++ b/cmd/wol-proxy/README.md
@@ -19,7 +19,10 @@ $ ./wol-proxy -mac BA:DC:0F:FE:E0:00 -upstream http://192.168.1.13:8080 \
     # altenerative listening port
     -listen localhost:9999 \
     # seconds to hold requests waiting for upstream to be ready
-    -timeout 30
+    -timeout 30 \
+    # API key sent as Bearer token to the upstream SSE endpoint
+    # (can also be set via the LLAMA_SWAP_API_KEY env var; the flag wins if both are set)
+    -api-key <key>
 ```
 
 ## API

--- a/cmd/wol-proxy/wol-proxy.go
+++ b/cmd/wol-proxy/wol-proxy.go
@@ -29,7 +29,7 @@ var (
 	flagListen   = flag.String("listen", ":8080", "listen address to listen on")
 	flagLog      = flag.String("log", "info", "log level (debug, info, warn, error)")
 	flagTimeout  = flag.Int("timeout", 60, "seconds requests wait for upstream response before failing")
-	flagAPIKey   = flag.String("api-key", "", "API key sent as Bearer token to the upstream SSE endpoint")
+	flagAPIKey   = flag.String("api-key", "", "API key sent as Bearer token to the upstream SSE endpoint (falls back to LLAMA_SWAP_API_KEY env var)")
 )
 
 func main() {
@@ -84,7 +84,12 @@ func main() {
 		}
 	}
 
-	proxy := newProxy(upstreamURL)
+	apiKey := *flagAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("LLAMA_SWAP_API_KEY")
+	}
+
+	proxy := newProxy(upstreamURL, apiKey)
 	server := &http.Server{
 		Addr:    *flagListen,
 		Handler: proxy,
@@ -120,7 +125,7 @@ type proxyServer struct {
 	status        upstreamStatus
 }
 
-func newProxy(url *url.URL) *proxyServer {
+func newProxy(url *url.URL, apiKey string) *proxyServer {
 	p := httputil.NewSingleHostReverseProxy(url)
 	proxy := &proxyServer{
 		upstreamProxy: p,
@@ -156,8 +161,8 @@ func newProxy(url *url.URL) *proxyServer {
 			req.Header.Set("Accept", "text/event-stream")
 			req.Header.Set("Cache-Control", "no-cache")
 			req.Header.Set("Connection", "keep-alive")
-			if *flagAPIKey != "" {
-				req.Header.Set("Authorization", "Bearer "+*flagAPIKey)
+			if apiKey != "" {
+				req.Header.Set("Authorization", "Bearer "+apiKey)
 			}
 
 			resp, err := client.Do(req)

--- a/cmd/wol-proxy/wol-proxy.go
+++ b/cmd/wol-proxy/wol-proxy.go
@@ -29,6 +29,7 @@ var (
 	flagListen   = flag.String("listen", ":8080", "listen address to listen on")
 	flagLog      = flag.String("log", "info", "log level (debug, info, warn, error)")
 	flagTimeout  = flag.Int("timeout", 60, "seconds requests wait for upstream response before failing")
+	flagAPIKey   = flag.String("api-key", "", "API key sent as Bearer token to the upstream SSE endpoint")
 )
 
 func main() {
@@ -155,6 +156,9 @@ func newProxy(url *url.URL) *proxyServer {
 			req.Header.Set("Accept", "text/event-stream")
 			req.Header.Set("Cache-Control", "no-cache")
 			req.Header.Set("Connection", "keep-alive")
+			if *flagAPIKey != "" {
+				req.Header.Set("Authorization", "Bearer "+*flagAPIKey)
+			}
 
 			resp, err := client.Do(req)
 			if err != nil {


### PR DESCRIPTION
add a -api-key option that the user can optionally provide to give
wol-proxy a private api key it will use for authenticating its
health checks against the llama-swap server.

This is api key is not used as part of any client request, and
clients connecting to the wol-proxy will still need to provide their
own api keys matching one of the ones in the destination llama-swap's
config.yaml

Fixes: #1051 