### PR TITLE
expose context_window on models endpoint

### DIFF
--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -26,6 +26,7 @@ type modelRecord struct {
 	Capabilities        map[string]any `json:"capabilities,omitempty"`
 	SupportedParameters []string       `json:"supported_parameters,omitempty"`
 	ContextLength       int            `json:"context_length,omitempty"`
+	ContextWindow       int            `json:"context_window,omitempty"`
 	Meta                map[string]any `json:"meta,omitempty"`
 	Status              map[string]any `json:"status"`
 }
@@ -38,6 +39,7 @@ var cappedMetadataKeys = map[string]struct{}{
 	"capabilities":         {},
 	"supported_parameters": {},
 	"context_length":       {},
+	"context_window":       {},
 }
 
 // renderCapabilities converts a model's capabilities config into additional
@@ -163,6 +165,9 @@ func (s *Server) handleListModels(w http.ResponseWriter, r *http.Request) {
 			Status:      map[string]any{"value": status},
 		}
 		rec.Architecture, rec.Capabilities, rec.SupportedParameters, rec.ContextLength = renderCapabilities(caps)
+		// context_window mirrors context_length for OpenAI-compatible gateways
+		// (e.g. Bifrost) that read the context size from this field name.
+		rec.ContextWindow = rec.ContextLength
 		if !caps.Empty() {
 			metadata = filterCappedMetadata(metadata)
 		}

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -816,6 +816,9 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 		if m.ContextLength != 100000 {
 			t.Errorf("context_length = %d", m.ContextLength)
 		}
+		if m.ContextWindow != 100000 {
+			t.Errorf("context_window = %d", m.ContextWindow)
+		}
 	})
 
 	t.Run("in_only", func(t *testing.T) {
@@ -839,6 +842,9 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 		}
 		if m.ContextLength != 0 {
 			t.Error("should not have context_length")
+		}
+		if m.ContextWindow != 0 {
+			t.Error("should not have context_window")
 		}
 	})
 
@@ -891,6 +897,9 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 		if m.ContextLength != 32768 {
 			t.Errorf("context_length = %d", m.ContextLength)
 		}
+		if m.ContextWindow != 32768 {
+			t.Errorf("context_window = %d", m.ContextWindow)
+		}
 		if m.Architecture != nil {
 			t.Error("should not have architecture")
 		}
@@ -937,6 +946,9 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 		if m.ContextLength != 0 {
 			t.Error("should not have context_length")
 		}
+		if m.ContextWindow != 0 {
+			t.Error("should not have context_window")
+		}
 	})
 
 	t.Run("metadata_precedence", func(t *testing.T) {
@@ -946,6 +958,7 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 				"architecture":   "should-be-dropped",
 				"custom_field":   "should-remain",
 				"capabilities":   "also-dropped",
+				"context_window": "also-dropped",
 				"other_metadata": "also-remain",
 			},
 		}))
@@ -962,6 +975,9 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 		if _, ok := meta["custom_field"]; !ok {
 			t.Error("custom_field should remain in metadata")
 		}
+		if _, ok := meta["context_window"]; ok {
+			t.Error("context_window should be filtered from metadata when caps are set")
+		}
 	})
 
 	t.Run("metadata_passthrough_no_caps", func(t *testing.T) {
@@ -970,6 +986,7 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 				"architecture":   "preserved",
 				"context_length": 4096,
 				"capabilities":   "preserved",
+				"context_window": 8192,
 				"custom_field":   "preserved",
 			},
 		}))
@@ -985,6 +1002,9 @@ func TestServer_HandleListModels_Capabilities(t *testing.T) {
 		}
 		if _, ok := meta["context_length"]; !ok {
 			t.Error("context_length should be preserved in metadata when caps is empty")
+		}
+		if _, ok := meta["context_window"]; !ok {
+			t.Error("context_window should be preserved in metadata when caps is empty")
 		}
 	})
 }


### PR DESCRIPTION
Some OpenAI-compatible gateways read the context size from a **context_window** field on the models endpoint (e.g. Bifrost, following GROQ's convention) instead of **context_length**. 

llama-swap only exposed the latter, so such gateways silently dropped the context size configured in model capabilities.

Add context_window to the /v1/models and /models responses, mirroring the capabilities-based context_length value, so both field names carry the same number. The field is renderer-owned like context_length: a context_window key in a model's metadata block is dropped when capabilities are rendered, matching the existing behavior.

Tests assert the mirrored value alongside context_length, including the metadata precedence and passthrough cases.

---
Replaces #1062 (closed when the head repository was reworked).