### PR TITLE
filters: set-if-undefined params via "?" key suffix

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -508,7 +508,7 @@
                                 "type": "object",
                                 "additionalProperties": true,
                                 "default": {},
-                                "description": "Dictionary of parameters to set/override in requests. Useful for enforcing specific parameter values. A key ending in '?' (e.g. 'max_tokens?') is a soft default: it is only applied when the request does not already contain that parameter. Protected params like 'model' cannot be overridden. Values can be strings, numbers, booleans, arrays, or objects."
+                                "description": "Dictionary of parameters to set/override in requests. Useful for enforcing specific parameter values. A key ending in '?' (e.g. 'max_tokens?') is set-if-undefined: it is only applied when the request does not already contain that parameter. Protected params like 'model' cannot be overridden. Values can be strings, numbers, booleans, arrays, or objects."
                             },
                             "setParamsByID": {
                                 "type": "object",
@@ -517,7 +517,7 @@
                                     "additionalProperties": true
                                 },
                                 "default": {},
-                                "description": "Dictionary mapping requested model IDs (or aliases) to parameters to set/override in requests. Applied after setParams and can override those values. Useful with aliases to vary behaviour depending on which alias the client used (e.g. different reasoning_effort per alias). A parameter key ending in '?' (e.g. 'max_tokens?') is a soft default: it is only applied when the request does not already contain that parameter. Keys support ${MODEL_ID} macro substitution. Protected params like 'model' cannot be overridden."
+                                "description": "Dictionary mapping requested model IDs (or aliases) to parameters to set/override in requests. Applied after setParams and can override those values. Useful with aliases to vary behaviour depending on which alias the client used (e.g. different reasoning_effort per alias). A parameter key ending in '?' (e.g. 'max_tokens?') is set-if-undefined: it is only applied when the request does not already contain that parameter. Keys support ${MODEL_ID} macro substitution. Protected params like 'model' cannot be overridden."
                             }
                         },
                         "additionalProperties": false,
@@ -712,7 +712,7 @@
                                 "type": "object",
                                 "additionalProperties": true,
                                 "default": {},
-                                "description": "Dictionary of parameters to set/override in requests to this peer. Useful for injecting provider-specific settings. A key ending in '?' (e.g. 'max_tokens?') is a soft default: it is only applied when the request does not already contain that parameter. Protected params like 'model' cannot be overridden. Values can be strings, numbers, booleans, arrays, or objects."
+                                "description": "Dictionary of parameters to set/override in requests to this peer. Useful for injecting provider-specific settings. A key ending in '?' (e.g. 'max_tokens?') is set-if-undefined: it is only applied when the request does not already contain that parameter. Protected params like 'model' cannot be overridden. Values can be strings, numbers, booleans, arrays, or objects."
                             }
                         },
                         "additionalProperties": false,

--- a/config-schema.json
+++ b/config-schema.json
@@ -508,7 +508,7 @@
                                 "type": "object",
                                 "additionalProperties": true,
                                 "default": {},
-                                "description": "Dictionary of parameters to set/override in requests. Useful for enforcing specific parameter values. Protected params like 'model' cannot be overridden. Values can be strings, numbers, booleans, arrays, or objects."
+                                "description": "Dictionary of parameters to set/override in requests. Useful for enforcing specific parameter values. A key ending in '?' (e.g. 'max_tokens?') is a soft default: it is only applied when the request does not already contain that parameter. Protected params like 'model' cannot be overridden. Values can be strings, numbers, booleans, arrays, or objects."
                             },
                             "setParamsByID": {
                                 "type": "object",
@@ -517,7 +517,7 @@
                                     "additionalProperties": true
                                 },
                                 "default": {},
-                                "description": "Dictionary mapping requested model IDs (or aliases) to parameters to set/override in requests. Applied after setParams and can override those values. Useful with aliases to vary behaviour depending on which alias the client used (e.g. different reasoning_effort per alias). Keys support ${MODEL_ID} macro substitution. Protected params like 'model' cannot be overridden."
+                                "description": "Dictionary mapping requested model IDs (or aliases) to parameters to set/override in requests. Applied after setParams and can override those values. Useful with aliases to vary behaviour depending on which alias the client used (e.g. different reasoning_effort per alias). A parameter key ending in '?' (e.g. 'max_tokens?') is a soft default: it is only applied when the request does not already contain that parameter. Keys support ${MODEL_ID} macro substitution. Protected params like 'model' cannot be overridden."
                             }
                         },
                         "additionalProperties": false,
@@ -712,7 +712,7 @@
                                 "type": "object",
                                 "additionalProperties": true,
                                 "default": {},
-                                "description": "Dictionary of parameters to set/override in requests to this peer. Useful for injecting provider-specific settings. Protected params like 'model' cannot be overridden. Values can be strings, numbers, booleans, arrays, or objects."
+                                "description": "Dictionary of parameters to set/override in requests to this peer. Useful for injecting provider-specific settings. A key ending in '?' (e.g. 'max_tokens?') is a soft default: it is only applied when the request does not already contain that parameter. Protected params like 'model' cannot be overridden. Values can be strings, numbers, booleans, arrays, or objects."
                             }
                         },
                         "additionalProperties": false,

--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -339,7 +339,7 @@ models:
       # - protected params like "model" cannot be overridden
       # - values can be strings, numbers, booleans, arrays, or objects
       # - always runs for the model
-      # - a key ending in "?" is a soft default: only applied when the
+      # - a key ending in "?" is set-if-undefined: only applied when the
       #   request does not already contain that parameter
       setParams:
         # Example: enforce specific sampling parameters

--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -339,10 +339,14 @@ models:
       # - protected params like "model" cannot be overridden
       # - values can be strings, numbers, booleans, arrays, or objects
       # - always runs for the model
+      # - a key ending in "?" is a soft default: only applied when the
+      #   request does not already contain that parameter
       setParams:
         # Example: enforce specific sampling parameters
         temperature: 0.7
         top_p: 0.9
+        # Example: default max_tokens, requests that set it win
+        max_tokens?: 4096
 
       # setParamsByID: a dictionary of parameters to set based the model ID
       # - optional, default: empty dictionary

--- a/docs/kb/guides/api-integration/filters-and-request-rewriting.md
+++ b/docs/kb/guides/api-integration/filters-and-request-rewriting.md
@@ -2,9 +2,9 @@
 title: Rewriting requests with filters
 summary: Use stripParams, setParams and setParamsByID while preserving the protected model parameter.
 category: guides
-tags: [filters, strip-params, set-params, aliases, sampling]
+tags: [filters, strip-params, set-params, soft-defaults, aliases, sampling]
 config_keys: [models.*.filters, models.*.filters.stripParams, models.*.filters.setParams, models.*.filters.setParamsByID, peers.*.filters]
-updated: 2026-08-25
+updated: 2026-09-01
 ---
 
 # Rewriting requests with filters
@@ -47,6 +47,17 @@ models:
 Runs on every request to the model and overrides whatever the client sent.
 Values may be strings, numbers, booleans, arrays or objects. `model` and other
 protected params cannot be overridden.
+
+A key ending in `?` is a **soft default** instead: it applies only when the
+request does not already carry that parameter, so a client that sends its own
+value wins. Works in `setParams` and `setParamsByID` alike — see
+`guides/api-integration/soft-defaults`.
+
+```yaml
+      setParams:
+        temperature: 0.7    # forced
+        max_tokens?: 4096   # only if the request didn't set max_tokens
+```
 
 For peers this is how you inject provider-specific settings:
 
@@ -93,9 +104,10 @@ reload — with different parameters applied.
 1. Profile pins resolve the requested ID
 2. Aliases resolve
 3. `stripParams` removes keys
-4. `setParams` applies
-5. `setParamsByID` applies, overriding `setParams`
-6. The request is proxied
+4. Soft defaults (`key?`) check which parameters the request carries
+5. `setParams` applies
+6. `setParamsByID` applies, overriding `setParams`
+7. The request is proxied
 
 ## When not to use filters
 
@@ -105,5 +117,6 @@ only rewrite the request body; they cannot change how the server was started.
 
 ## Related
 
+- `guides/api-integration/soft-defaults` — set a parameter only if the request didn't
 - `reference/config/models` — the annotated `filters` block
 - `reference/config/peers` — peer filters

--- a/docs/kb/guides/api-integration/filters-and-request-rewriting.md
+++ b/docs/kb/guides/api-integration/filters-and-request-rewriting.md
@@ -2,7 +2,7 @@
 title: Rewriting requests with filters
 summary: Use stripParams, setParams and setParamsByID while preserving the protected model parameter.
 category: guides
-tags: [filters, strip-params, set-params, soft-defaults, aliases, sampling]
+tags: [filters, strip-params, set-params, set-if-undefined, aliases, sampling]
 config_keys: [models.*.filters, models.*.filters.stripParams, models.*.filters.setParams, models.*.filters.setParamsByID, peers.*.filters]
 updated: 2026-09-01
 ---
@@ -48,10 +48,10 @@ Runs on every request to the model and overrides whatever the client sent.
 Values may be strings, numbers, booleans, arrays or objects. `model` and other
 protected params cannot be overridden.
 
-A key ending in `?` is a **soft default** instead: it applies only when the
-request does not already carry that parameter, so a client that sends its own
+A key ending in `?` is **set-if-undefined** instead: it applies only when the
+body does not already carry that parameter, so a client that sends its own
 value wins. Works in `setParams` and `setParamsByID` alike — see
-`guides/api-integration/soft-defaults`.
+`guides/api-integration/set-if-undefined`.
 
 ```yaml
       setParams:
@@ -104,10 +104,13 @@ reload — with different parameters applied.
 1. Profile pins resolve the requested ID
 2. Aliases resolve
 3. `stripParams` removes keys
-4. Soft defaults (`key?`) check which parameters the request carries
-5. `setParams` applies
-6. `setParamsByID` applies, overriding `setParams`
-7. The request is proxied
+4. `setParams` applies
+5. `setParamsByID` applies, overriding `setParams`
+6. The request is proxied
+
+Filters apply like a pipe: `stripParams | setParams | setParamsByID`. A
+set-if-undefined key (`key?`) checks the body at its own stage, so a stripped
+key counts as undefined and a key an earlier stage set counts as defined.
 
 ## When not to use filters
 
@@ -117,6 +120,6 @@ only rewrite the request body; they cannot change how the server was started.
 
 ## Related
 
-- `guides/api-integration/soft-defaults` — set a parameter only if the request didn't
+- `guides/api-integration/set-if-undefined` — set a parameter only if the request didn't
 - `reference/config/models` — the annotated `filters` block
 - `reference/config/peers` — peer filters

--- a/docs/kb/guides/api-integration/set-if-undefined.md
+++ b/docs/kb/guides/api-integration/set-if-undefined.md
@@ -1,18 +1,18 @@
 ---
-title: Soft defaults — set a parameter only if the request didn't
+title: Set-if-undefined — set a parameter only if the request didn't
 summary: Append ? to a setParams or setParamsByID key to apply the value only when the request doesn't carry that parameter.
 category: guides
-tags: [filters, set-params, soft-defaults, aliases, sampling]
+tags: [filters, set-params, set-if-undefined, aliases, sampling]
 config_keys: [models.*.filters.setParams, models.*.filters.setParamsByID, peers.*.filters.setParams]
-updated: 2026-09-01
+updated: 2026-09-02
 ---
 
-# Soft defaults — set a parameter only if the request didn't
+# Set-if-undefined — set a parameter only if the request didn't
 
 `setParams` and `setParamsByID` normally force their values, overriding
-whatever the client sent. Appending `?` to a parameter key turns the value
-into a **soft default**: it is applied only when the request does not already
-carry that parameter.
+whatever the client sent. Appending `?` to a parameter key makes it
+**set-if-undefined**: the value is applied only when the request does not
+already carry that parameter.
 
 ```yaml
 models:
@@ -37,19 +37,19 @@ It works the same everywhere `setParams` works: model filters, per-alias
 
 ## Semantics
 
-- **Any value present in the request counts as sent** — including `0`,
-  `false`, `""` and `null`. The soft default only fills a genuinely missing
-  key.
-- **Stripped parameters count as not sent.** `stripParams` runs first, so
-  stripping a key and soft-setting it means "replace the client's value with
-  the default, but only because the strip removed it" — usually you want
-  either strip+set (force) or a soft default alone.
-- **A hard spelling wins over a soft one.** If the same block contains both
-  `max_tokens` and `max_tokens?`, the hard value is used and the soft one is
+Filters apply like a pipe — `stripParams | setParams | setParamsByID` — and a
+`?` key only fills what is undefined at its own stage:
+
+- **Any value present in the body counts as defined** — including `0`,
+  `false`, `""` and `null`. A `?` key only fills a genuinely missing key.
+- **Stripped parameters count as undefined.** `stripParams` runs first, so a
+  stripped key can be refilled by a later `?` key.
+- **A value set by an earlier stage counts as defined.** A `?` key in
+  `setParamsByID` is a no-op when `setParams` already set that key — only a
+  hard `setParamsByID` key overrides `setParams`.
+- **A hard spelling wins over a `?` one.** If the same block contains both
+  `max_tokens` and `max_tokens?`, the hard value is used and the `?` one is
   ignored.
-- **`setParamsByID` still overrides `setParams`.** A soft `setParamsByID`
-  value yields to the client, not to `setParams`: when the client didn't send
-  the key, the per-alias soft default wins over a plain `setParams` value.
 - **Keys are paths, as everywhere in filters.** A dotted key like
   `chat_template_kwargs.enable_thinking?` checks and sets the nested
   value; the presence check targets exactly the location the write

--- a/docs/kb/guides/api-integration/soft-defaults.md
+++ b/docs/kb/guides/api-integration/soft-defaults.md
@@ -1,0 +1,66 @@
+---
+title: Soft defaults — set a parameter only if the request didn't
+summary: Append ? to a setParams or setParamsByID key to apply the value only when the request doesn't carry that parameter.
+category: guides
+tags: [filters, set-params, soft-defaults, aliases, sampling]
+config_keys: [models.*.filters.setParams, models.*.filters.setParamsByID, peers.*.filters.setParams]
+updated: 2026-09-01
+---
+
+# Soft defaults — set a parameter only if the request didn't
+
+`setParams` and `setParamsByID` normally force their values, overriding
+whatever the client sent. Appending `?` to a parameter key turns the value
+into a **soft default**: it is applied only when the request does not already
+carry that parameter.
+
+```yaml
+models:
+  qwen:
+    filters:
+      setParamsByID:
+        "${MODEL_ID}:extraction":
+          temperature: 0.2      # forced — the client cannot change it
+          max_tokens?: 32768    # default — a request with max_tokens wins
+```
+
+A request to `qwen:extraction` without `max_tokens` gets 32768. A request
+that sets `max_tokens: 4096` keeps 4096. `temperature` stays 0.2 either way.
+
+This fills the gap between "the server has no opinion" (parameter absent from
+the config) and "the client has no say" (plain `setParams`): the server
+supplies a tuned value, the client can still deviate for a single request
+without anyone adding a new alias or copying the value into every client.
+
+It works the same everywhere `setParams` works: model filters, per-alias
+`setParamsByID` entries, and peer filters.
+
+## Semantics
+
+- **Any value present in the request counts as sent** — including `0`,
+  `false`, `""` and `null`. The soft default only fills a genuinely missing
+  key.
+- **Stripped parameters count as not sent.** `stripParams` runs first, so
+  stripping a key and soft-setting it means "replace the client's value with
+  the default, but only because the strip removed it" — usually you want
+  either strip+set (force) or a soft default alone.
+- **A hard spelling wins over a soft one.** If the same block contains both
+  `max_tokens` and `max_tokens?`, the hard value is used and the soft one is
+  ignored.
+- **`setParamsByID` still overrides `setParams`.** A soft `setParamsByID`
+  value yields to the client, not to `setParams`: when the client didn't send
+  the key, the per-alias soft default wins over a plain `setParams` value.
+- Protected params (`model`) cannot be set, with or without `?`.
+
+## When to use which
+
+| Spelling | Meaning |
+| --- | --- |
+| key absent from config | client decides, upstream server's own default applies |
+| `max_tokens?: 32768` | server suggests — request wins if it carries the key |
+| `max_tokens: 32768` | server enforces — request value is overwritten |
+
+## Related
+
+- `guides/api-integration/filters-and-request-rewriting` — the full filter
+  pipeline and order of operations

--- a/docs/kb/guides/api-integration/soft-defaults.md
+++ b/docs/kb/guides/api-integration/soft-defaults.md
@@ -50,6 +50,10 @@ It works the same everywhere `setParams` works: model filters, per-alias
 - **`setParamsByID` still overrides `setParams`.** A soft `setParamsByID`
   value yields to the client, not to `setParams`: when the client didn't send
   the key, the per-alias soft default wins over a plain `setParams` value.
+- **Keys are paths, as everywhere in filters.** A dotted key like
+  `chat_template_kwargs.enable_thinking?` checks and sets the nested
+  value; the presence check targets exactly the location the write
+  would modify, same as a hard `setParams` key.
 - Protected params (`model`) cannot be set, with or without `?`.
 
 ## When to use which

--- a/internal/config/filters.go
+++ b/internal/config/filters.go
@@ -17,13 +17,16 @@ type Filters struct {
 	// The "model" parameter can never be removed
 	StripParams string `yaml:"stripParams"`
 
-	// SetParams is a dictionary of parameters to set/override in requests
+	// SetParams is a dictionary of parameters to set/override in requests.
+	// A key ending in "?" (e.g. "max_tokens?") is a soft default: it is only
+	// applied when the request does not already carry that parameter.
 	// Protected params (like "model") cannot be set
 	SetParams map[string]any `yaml:"setParams"`
 
 	// SetParamsByID maps requested model IDs to parameters to set/override in requests.
 	// Useful with aliases: a single loaded model can behave differently depending on
 	// which alias the client used. Applied after SetParams, so it can override those values.
+	// Keys ending in "?" are soft defaults, as in SetParams.
 	// Protected params (like "model") cannot be set.
 	SetParamsByID map[string]map[string]any `yaml:"setParamsByID"`
 }
@@ -58,57 +61,76 @@ func (f Filters) SanitizedStripParams() []string {
 }
 
 // SanitizedSetParamsByID returns the params to set for the given requestedModelID,
-// with protected params removed and keys sorted for consistent iteration order.
-// Returns nil if the ID has no entry or all its params are protected.
-func (f Filters) SanitizedSetParamsByID(requestedModelID string) (map[string]any, []string) {
+// with protected params removed, the "?" soft-default suffix stripped from keys,
+// and keys sorted for consistent iteration order. Keys spelled with the suffix
+// are reported in soft. Returns nil if the ID has no entry or all its params
+// are protected.
+func (f Filters) SanitizedSetParamsByID(requestedModelID string) (map[string]any, []string, map[string]bool) {
 	if len(f.SetParamsByID) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	params, found := f.SetParamsByID[requestedModelID]
 	if !found || len(params) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
-	result := make(map[string]any, len(params))
-	keys := make([]string, 0, len(params))
-	for key, value := range params {
-		if slices.Contains(ProtectedParams, key) {
-			continue
-		}
-		result[key] = value
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	if len(result) == 0 {
-		return nil, nil
-	}
-	return result, keys
+	return sanitizeParams(params)
 }
 
-// SanitizedSetParams returns a copy of SetParams with protected params removed
-// and keys sorted for consistent iteration order
-func (f Filters) SanitizedSetParams() (map[string]any, []string) {
+// SanitizedSetParams returns a copy of SetParams with protected params removed,
+// the "?" soft-default suffix stripped from keys, and keys sorted for
+// consistent iteration order. Keys spelled with the suffix are reported in soft.
+func (f Filters) SanitizedSetParams() (map[string]any, []string, map[string]bool) {
 	if len(f.SetParams) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
+	return sanitizeParams(f.SetParams)
+}
 
-	result := make(map[string]any, len(f.SetParams))
-	keys := make([]string, 0, len(f.SetParams))
+// sanitizeParams removes protected params from raw and strips the "?" suffix
+// that marks a soft default (issue #1052), e.g. "max_tokens?": 32768. Soft
+// keys are returned (without the suffix) in soft; callers apply them only when
+// the request does not already carry the parameter. When the same key is
+// spelled both hard and soft, the hard spelling wins. Keys are sorted for
+// consistent iteration order.
+func sanitizeParams(raw map[string]any) (map[string]any, []string, map[string]bool) {
+	result := make(map[string]any, len(raw))
+	soft := make(map[string]bool)
 
-	for key, value := range f.SetParams {
-		// Skip protected params
-		if slices.Contains(ProtectedParams, key) {
+	// Hard keys first, so "key" wins over "key?"
+	for key, value := range raw {
+		if strings.HasSuffix(key, "?") || slices.Contains(ProtectedParams, key) {
 			continue
 		}
 		result[key] = value
-		keys = append(keys, key)
 	}
 
-	// Sort keys for consistent ordering
-	sort.Strings(keys)
+	for key, value := range raw {
+		if !strings.HasSuffix(key, "?") {
+			continue
+		}
+		key = strings.TrimSuffix(key, "?")
+		if key == "" || slices.Contains(ProtectedParams, key) {
+			continue
+		}
+		if _, isHard := result[key]; isHard {
+			continue
+		}
+		result[key] = value
+		soft[key] = true
+	}
 
 	if len(result) == 0 {
-		return nil, nil
+		return nil, nil, nil
+	}
+	if len(soft) == 0 {
+		soft = nil
 	}
 
-	return result, keys
+	keys := make([]string, 0, len(result))
+	for key := range result {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	return result, keys, soft
 }

--- a/internal/config/filters.go
+++ b/internal/config/filters.go
@@ -18,7 +18,7 @@ type Filters struct {
 	StripParams string `yaml:"stripParams"`
 
 	// SetParams is a dictionary of parameters to set/override in requests.
-	// A key ending in "?" (e.g. "max_tokens?") is a soft default: it is only
+	// A key ending in "?" (e.g. "max_tokens?") is set-if-undefined: it is only
 	// applied when the request does not already carry that parameter.
 	// Protected params (like "model") cannot be set
 	SetParams map[string]any `yaml:"setParams"`
@@ -26,7 +26,7 @@ type Filters struct {
 	// SetParamsByID maps requested model IDs to parameters to set/override in requests.
 	// Useful with aliases: a single loaded model can behave differently depending on
 	// which alias the client used. Applied after SetParams, so it can override those values.
-	// Keys ending in "?" are soft defaults, as in SetParams.
+	// Keys ending in "?" are set-if-undefined, as in SetParams.
 	// Protected params (like "model") cannot be set.
 	SetParamsByID map[string]map[string]any `yaml:"setParamsByID"`
 }
@@ -61,10 +61,10 @@ func (f Filters) SanitizedStripParams() []string {
 }
 
 // SanitizedSetParamsByID returns the params to set for the given requestedModelID,
-// with protected params removed, the "?" soft-default suffix stripped from keys,
-// and keys sorted for consistent iteration order. Keys spelled with the suffix
-// are reported in soft. Returns nil if the ID has no entry or all its params
-// are protected.
+// with protected params removed, the "?" set-if-undefined suffix stripped from
+// keys, and keys sorted for consistent iteration order. Keys spelled with the
+// suffix are reported in soft. Returns nil if the ID has no entry or all its
+// params are protected.
 func (f Filters) SanitizedSetParamsByID(requestedModelID string) (map[string]any, []string, map[string]bool) {
 	if len(f.SetParamsByID) == 0 {
 		return nil, nil, nil
@@ -77,7 +77,7 @@ func (f Filters) SanitizedSetParamsByID(requestedModelID string) (map[string]any
 }
 
 // SanitizedSetParams returns a copy of SetParams with protected params removed,
-// the "?" soft-default suffix stripped from keys, and keys sorted for
+// the "?" set-if-undefined suffix stripped from keys, and keys sorted for
 // consistent iteration order. Keys spelled with the suffix are reported in soft.
 func (f Filters) SanitizedSetParams() (map[string]any, []string, map[string]bool) {
 	if len(f.SetParams) == 0 {
@@ -87,9 +87,9 @@ func (f Filters) SanitizedSetParams() (map[string]any, []string, map[string]bool
 }
 
 // sanitizeParams removes protected params from raw and strips the "?" suffix
-// that marks a soft default (issue #1052), e.g. "max_tokens?": 32768. Soft
-// keys are returned (without the suffix) in soft; callers apply them only when
-// the request does not already carry the parameter. When the same key is
+// that marks a set-if-undefined key (issue #1052), e.g. "max_tokens?": 32768.
+// Such keys are returned (without the suffix) in soft; callers apply them only
+// when the body does not already carry the parameter. When the same key is
 // spelled both hard and soft, the hard spelling wins. Keys are sorted for
 // consistent iteration order.
 func sanitizeParams(raw map[string]any) (map[string]any, []string, map[string]bool) {

--- a/internal/config/filters_test.go
+++ b/internal/config/filters_test.go
@@ -69,6 +69,7 @@ func TestFilters_SanitizedSetParams(t *testing.T) {
 		setParams  map[string]any
 		wantParams map[string]any
 		wantKeys   []string
+		wantSoft   map[string]bool
 	}{
 		{
 			name:       "empty setParams",
@@ -131,12 +132,57 @@ func TestFilters_SanitizedSetParams(t *testing.T) {
 			},
 			wantKeys: []string{"provider", "transforms"},
 		},
+		{
+			name: "soft suffix stripped and reported",
+			setParams: map[string]any{
+				"max_tokens?": 32768,
+				"temperature": 0.2,
+			},
+			wantParams: map[string]any{
+				"max_tokens":  32768,
+				"temperature": 0.2,
+			},
+			wantKeys: []string{"max_tokens", "temperature"},
+			wantSoft: map[string]bool{"max_tokens": true},
+		},
+		{
+			name: "hard spelling wins over soft",
+			setParams: map[string]any{
+				"max_tokens":  4096,
+				"max_tokens?": 32768,
+			},
+			wantParams: map[string]any{
+				"max_tokens": 4096,
+			},
+			wantKeys: []string{"max_tokens"},
+		},
+		{
+			name: "protected param cannot be soft",
+			setParams: map[string]any{
+				"model?":      "should-be-filtered",
+				"temperature": 0.7,
+			},
+			wantParams: map[string]any{
+				"temperature": 0.7,
+			},
+			wantKeys: []string{"temperature"},
+		},
+		{
+			name: "bare question mark ignored",
+			setParams: map[string]any{
+				"?": 1,
+			},
+			wantParams: nil,
+			wantKeys:   nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := Filters{SetParams: tt.setParams}
-			gotParams, gotKeys := f.SanitizedSetParams()
+			gotParams, gotKeys, gotSoft := f.SanitizedSetParams()
+
+			assert.Equal(t, tt.wantSoft, gotSoft)
 
 			assert.Equal(t, len(tt.wantKeys), len(gotKeys), "keys length mismatch")
 			for i, key := range gotKeys {
@@ -169,6 +215,7 @@ func TestFilters_SanitizedSetParamsByID(t *testing.T) {
 		requestedModelID string
 		wantParams       map[string]any
 		wantKeys         []string
+		wantSoft         map[string]bool
 	}{
 		{
 			name:             "empty SetParamsByID returns nil",
@@ -260,21 +307,53 @@ func TestFilters_SanitizedSetParamsByID(t *testing.T) {
 			},
 			wantKeys: []string{"reasoning_effort"},
 		},
+		{
+			name: "soft suffix per alias",
+			setParamsByID: map[string]map[string]any{
+				"model1:extraction": {
+					"max_tokens?": 32768,
+					"temperature": 0.2,
+				},
+			},
+			requestedModelID: "model1:extraction",
+			wantParams: map[string]any{
+				"max_tokens":  32768,
+				"temperature": 0.2,
+			},
+			wantKeys: []string{"max_tokens", "temperature"},
+			wantSoft: map[string]bool{"max_tokens": true},
+		},
+		{
+			name: "hard spelling wins over soft",
+			setParamsByID: map[string]map[string]any{
+				"model1": {
+					"top_p":  0.9,
+					"top_p?": 0.5,
+				},
+			},
+			requestedModelID: "model1",
+			wantParams: map[string]any{
+				"top_p": 0.9,
+			},
+			wantKeys: []string{"top_p"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := Filters{SetParamsByID: tt.setParamsByID}
-			gotParams, gotKeys := f.SanitizedSetParamsByID(tt.requestedModelID)
+			gotParams, gotKeys, gotSoft := f.SanitizedSetParamsByID(tt.requestedModelID)
 
 			if tt.wantParams == nil {
 				assert.Nil(t, gotParams)
 				assert.Nil(t, gotKeys)
+				assert.Nil(t, gotSoft)
 				return
 			}
 
 			assert.Equal(t, tt.wantKeys, gotKeys)
 			assert.Equal(t, tt.wantParams, gotParams)
+			assert.Equal(t, tt.wantSoft, gotSoft)
 		})
 	}
 }

--- a/internal/config/model_config_test.go
+++ b/internal/config/model_config_test.go
@@ -220,7 +220,7 @@ models:
 	assert.Equal(t, []string{"top_k"}, stripParams)
 
 	// Check setParams
-	setParams, keys := modelConfig.Filters.SanitizedSetParams()
+	setParams, keys, _ := modelConfig.Filters.SanitizedSetParams()
 	assert.NotNil(t, setParams)
 	assert.Equal(t, []string{"stop", "temperature", "top_p"}, keys)
 	assert.Equal(t, 0.7, setParams["temperature"])

--- a/internal/server/filters.go
+++ b/internal/server/filters.go
@@ -145,19 +145,13 @@ func applyFilters(body []byte, requested, useModelName string, f config.Filters)
 	setParams, setKeys, setSoft := f.SanitizedSetParams()
 	byID, byIDKeys, byIDSoft := f.SanitizedSetParamsByID(requested)
 
-	// Soft defaults ("key?", issue #1052) yield to parameters the client sent.
-	// Snapshot which of them the request carries before any values are written,
-	// so a soft key still applies when an earlier filter set it, and stripped
-	// params count as not sent.
-	requestHas := make(map[string]bool, len(setSoft)+len(byIDSoft))
-	for _, soft := range []map[string]bool{setSoft, byIDSoft} {
-		for key := range soft {
-			requestHas[key] = gjson.GetBytes(body, key).Exists()
-		}
-	}
-
+	// Set-if-undefined keys ("key?", issue #1052) only fill parameters the body
+	// does not carry at that point in the pipeline. Filters apply like a pipe —
+	// stripParams | setParams | setParamsByID — so a stripped key counts as
+	// undefined, and a key an earlier stage set counts as defined (a "key?" in
+	// setParamsByID is a no-op when setParams already set it).
 	for _, key := range setKeys {
-		if setSoft[key] && requestHas[key] {
+		if setSoft[key] && gjson.GetBytes(body, key).Exists() {
 			continue
 		}
 		if body, err = sjson.SetBytes(body, key, setParams[key]); err != nil {
@@ -166,7 +160,7 @@ func applyFilters(body []byte, requested, useModelName string, f config.Filters)
 	}
 
 	for _, key := range byIDKeys {
-		if byIDSoft[key] && requestHas[key] {
+		if byIDSoft[key] && gjson.GetBytes(body, key).Exists() {
 			continue
 		}
 		if body, err = sjson.SetBytes(body, key, byID[key]); err != nil {

--- a/internal/server/filters.go
+++ b/internal/server/filters.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mostlygeek/llama-swap/internal/chain"
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/swaputil"
+	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
 )
 
@@ -141,15 +142,33 @@ func applyFilters(body []byte, requested, useModelName string, f config.Filters)
 		}
 	}
 
-	setParams, setKeys := f.SanitizedSetParams()
+	setParams, setKeys, setSoft := f.SanitizedSetParams()
+	byID, byIDKeys, byIDSoft := f.SanitizedSetParamsByID(requested)
+
+	// Soft defaults ("key?", issue #1052) yield to parameters the client sent.
+	// Snapshot which of them the request carries before any values are written,
+	// so a soft key still applies when an earlier filter set it, and stripped
+	// params count as not sent.
+	requestHas := make(map[string]bool, len(setSoft)+len(byIDSoft))
+	for _, soft := range []map[string]bool{setSoft, byIDSoft} {
+		for key := range soft {
+			requestHas[key] = gjson.GetBytes(body, key).Exists()
+		}
+	}
+
 	for _, key := range setKeys {
+		if setSoft[key] && requestHas[key] {
+			continue
+		}
 		if body, err = sjson.SetBytes(body, key, setParams[key]); err != nil {
 			return nil, fmt.Errorf("error setting parameter %s in request", key)
 		}
 	}
 
-	byID, byIDKeys := f.SanitizedSetParamsByID(requested)
 	for _, key := range byIDKeys {
+		if byIDSoft[key] && requestHas[key] {
+			continue
+		}
 		if body, err = sjson.SetBytes(body, key, byID[key]); err != nil {
 			return nil, fmt.Errorf("error setting parameter %s in request", key)
 		}

--- a/internal/server/filters_test.go
+++ b/internal/server/filters_test.go
@@ -104,6 +104,32 @@ func TestServer_ApplyFilters(t *testing.T) {
 		}
 	})
 
+	t.Run("soft keys are paths, consistent with the write target", func(t *testing.T) {
+		f := config.Filters{
+			SetParams: map[string]any{"chat_template_kwargs.enable_thinking?": true},
+		}
+
+		// Nested value present: the check finds it at the path the write
+		// would target, so the soft default yields.
+		out, err := applyFilters([]byte(`{"model":"m","chat_template_kwargs":{"enable_thinking":false}}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "chat_template_kwargs.enable_thinking").Bool(); got != false {
+			t.Errorf("enable_thinking = %v, want false (request value kept)", got)
+		}
+
+		// Absent: the soft default writes the nested location, exactly
+		// where a hard setParams key would write.
+		out, err = applyFilters([]byte(`{"model":"m"}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "chat_template_kwargs.enable_thinking").Bool(); got != true {
+			t.Errorf("enable_thinking = %v, want true (soft default applied)", got)
+		}
+	})
+
 	t.Run("soft setParamsByID yields to request but overrides setParams", func(t *testing.T) {
 		f := config.Filters{
 			SetParams:     map[string]any{"top_p": 0.5},

--- a/internal/server/filters_test.go
+++ b/internal/server/filters_test.go
@@ -41,7 +41,7 @@ func TestServer_ApplyFilters(t *testing.T) {
 		}
 	})
 
-	t.Run("soft default applied when request lacks the key", func(t *testing.T) {
+	t.Run("set-if-undefined applied when request lacks the key", func(t *testing.T) {
 		f := config.Filters{
 			SetParams: map[string]any{"max_tokens?": 32768},
 		}
@@ -54,7 +54,7 @@ func TestServer_ApplyFilters(t *testing.T) {
 		}
 	})
 
-	t.Run("request value wins over soft default", func(t *testing.T) {
+	t.Run("request value wins over set-if-undefined", func(t *testing.T) {
 		f := config.Filters{
 			SetParams: map[string]any{"max_tokens?": 32768},
 		}
@@ -104,13 +104,13 @@ func TestServer_ApplyFilters(t *testing.T) {
 		}
 	})
 
-	t.Run("soft keys are paths, consistent with the write target", func(t *testing.T) {
+	t.Run("set-if-undefined keys are paths, consistent with the write target", func(t *testing.T) {
 		f := config.Filters{
 			SetParams: map[string]any{"chat_template_kwargs.enable_thinking?": true},
 		}
 
 		// Nested value present: the check finds it at the path the write
-		// would target, so the soft default yields.
+		// would target, so the configured value yields.
 		out, err := applyFilters([]byte(`{"model":"m","chat_template_kwargs":{"enable_thinking":false}}`), "m", "", f)
 		if err != nil {
 			t.Fatalf("applyFilters: %v", err)
@@ -119,39 +119,58 @@ func TestServer_ApplyFilters(t *testing.T) {
 			t.Errorf("enable_thinking = %v, want false (request value kept)", got)
 		}
 
-		// Absent: the soft default writes the nested location, exactly
+		// Absent: the configured value writes the nested location, exactly
 		// where a hard setParams key would write.
 		out, err = applyFilters([]byte(`{"model":"m"}`), "m", "", f)
 		if err != nil {
 			t.Fatalf("applyFilters: %v", err)
 		}
 		if got := gjson.GetBytes(out, "chat_template_kwargs.enable_thinking").Bool(); got != true {
-			t.Errorf("enable_thinking = %v, want true (soft default applied)", got)
+			t.Errorf("enable_thinking = %v, want true (set-if-undefined applied)", got)
 		}
 	})
 
-	t.Run("soft setParamsByID yields to request but overrides setParams", func(t *testing.T) {
+	t.Run("set-if-undefined setParamsByID is a no-op when setParams already set the key", func(t *testing.T) {
+		// Filters apply like a pipe: stripParams | setParams | setParamsByID.
+		// A "?" key only fills what is undefined at its stage, so a value an
+		// earlier stage set counts as defined.
 		f := config.Filters{
 			SetParams:     map[string]any{"top_p": 0.5},
 			SetParamsByID: map[string]map[string]any{"alias": {"top_p?": 0.1}},
 		}
 
-		// Request without top_p: the soft byID value overrides setParams.
-		out, err := applyFilters([]byte(`{"model":"alias"}`), "alias", "", f)
-		if err != nil {
-			t.Fatalf("applyFilters: %v", err)
+		for _, body := range []string{`{"model":"alias"}`, `{"model":"alias","top_p":0.9}`} {
+			out, err := applyFilters([]byte(body), "alias", "", f)
+			if err != nil {
+				t.Fatalf("applyFilters(%s): %v", body, err)
+			}
+			if got := gjson.GetBytes(out, "top_p").Float(); got != 0.5 {
+				t.Errorf("top_p = %v, want 0.5 (setParams value, body %s)", got, body)
+			}
 		}
-		if got := gjson.GetBytes(out, "top_p").Float(); got != 0.1 {
-			t.Errorf("top_p = %v, want 0.1", got)
+	})
+
+	t.Run("pipe order: stripParams then setParams then setParamsByID", func(t *testing.T) {
+		// The example from issue #1052: strip removes the client value,
+		// setParams forces 1000, and both "?" entries are no-ops because
+		// setParams has already set the key.
+		f := config.Filters{
+			StripParams: "max_tokens",
+			SetParams:   map[string]any{"max_tokens": 1000},
+			SetParamsByID: map[string]map[string]any{
+				"my-model":      {"max_tokens?": 500},
+				"my-model:high": {"max_tokens?": 2000},
+			},
 		}
 
-		// Request with top_p: the soft byID value yields, setParams still applies.
-		out, err = applyFilters([]byte(`{"model":"alias","top_p":0.9}`), "alias", "", f)
-		if err != nil {
-			t.Fatalf("applyFilters: %v", err)
-		}
-		if got := gjson.GetBytes(out, "top_p").Float(); got != 0.5 {
-			t.Errorf("top_p = %v, want 0.5", got)
+		for _, requested := range []string{"my-model", "my-model:high"} {
+			out, err := applyFilters([]byte(`{"model":"m","max_tokens":999}`), requested, "", f)
+			if err != nil {
+				t.Fatalf("applyFilters(%s): %v", requested, err)
+			}
+			if got := gjson.GetBytes(out, "max_tokens").Int(); got != 1000 {
+				t.Errorf("max_tokens = %v, want 1000 (requested %s)", got, requested)
+			}
 		}
 	})
 

--- a/internal/server/filters_test.go
+++ b/internal/server/filters_test.go
@@ -41,6 +41,94 @@ func TestServer_ApplyFilters(t *testing.T) {
 		}
 	})
 
+	t.Run("soft default applied when request lacks the key", func(t *testing.T) {
+		f := config.Filters{
+			SetParams: map[string]any{"max_tokens?": 32768},
+		}
+		out, err := applyFilters([]byte(`{"model":"m"}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "max_tokens").Int(); got != 32768 {
+			t.Errorf("max_tokens = %v, want 32768", got)
+		}
+	})
+
+	t.Run("request value wins over soft default", func(t *testing.T) {
+		f := config.Filters{
+			SetParams: map[string]any{"max_tokens?": 32768},
+		}
+		out, err := applyFilters([]byte(`{"model":"m","max_tokens":64}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "max_tokens").Int(); got != 64 {
+			t.Errorf("max_tokens = %v, want 64", got)
+		}
+	})
+
+	t.Run("request null, zero and false count as sent", func(t *testing.T) {
+		f := config.Filters{
+			SetParams: map[string]any{
+				"max_tokens?": 32768,
+				"stream?":     true,
+				"stop?":       "</s>",
+			},
+		}
+		out, err := applyFilters([]byte(`{"model":"m","max_tokens":0,"stream":false,"stop":null}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "max_tokens").Int(); got != 0 {
+			t.Errorf("max_tokens = %v, want 0", got)
+		}
+		if got := gjson.GetBytes(out, "stream").Bool(); got != false {
+			t.Errorf("stream = %v, want false", got)
+		}
+		if got := gjson.GetBytes(out, "stop"); got.Type != gjson.Null {
+			t.Errorf("stop = %v, want null", got)
+		}
+	})
+
+	t.Run("stripped param counts as not sent", func(t *testing.T) {
+		f := config.Filters{
+			StripParams: "temperature",
+			SetParams:   map[string]any{"temperature?": 0.2},
+		}
+		out, err := applyFilters([]byte(`{"model":"m","temperature":0.7}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "temperature").Float(); got != 0.2 {
+			t.Errorf("temperature = %v, want 0.2", got)
+		}
+	})
+
+	t.Run("soft setParamsByID yields to request but overrides setParams", func(t *testing.T) {
+		f := config.Filters{
+			SetParams:     map[string]any{"top_p": 0.5},
+			SetParamsByID: map[string]map[string]any{"alias": {"top_p?": 0.1}},
+		}
+
+		// Request without top_p: the soft byID value overrides setParams.
+		out, err := applyFilters([]byte(`{"model":"alias"}`), "alias", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "top_p").Float(); got != 0.1 {
+			t.Errorf("top_p = %v, want 0.1", got)
+		}
+
+		// Request with top_p: the soft byID value yields, setParams still applies.
+		out, err = applyFilters([]byte(`{"model":"alias","top_p":0.9}`), "alias", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "top_p").Float(); got != 0.5 {
+			t.Errorf("top_p = %v, want 0.5", got)
+		}
+	})
+
 	t.Run("setParamsByID overrides setParams", func(t *testing.T) {
 		f := config.Filters{
 			SetParams:     map[string]any{"top_p": 0.5},


### PR DESCRIPTION
Implements the `?` suffix discussed in #1052.

A `setParams` / `setParamsByID` key ending in `?` is set-if-undefined: the
value is applied only when the request doesn't already carry that
parameter. Plain keys keep forcing their values, and a config that
doesn't use the suffix behaves exactly as before.

```yaml
setParamsByID:
  "qwen:extraction":
    temperature: 0.2      # hard, unchanged
    max_tokens?: 32768    # only if the request didn't set it
```

Semantics, as implemented and tested:

- Filters apply like a pipe — `stripParams | setParams | setParamsByID` —
  and a `?` key only fills what is undefined at its own stage. Stripped
  params count as undefined; a key an earlier stage set counts as
  defined, so a `?` key in `setParamsByID` is a no-op when `setParams`
  already set it.
- Any value in the request counts as defined — `0`, `false`, `""` and
  `null` included. `?` keys only fill genuinely missing parameters.
- The same key spelled hard and with `?` in one block: hard wins.
- Protected params (`model`) cannot be set, with or without `?`.
- Works for models and peers — same Filters code path.

Tested beyond the unit tests: built the branch and ran it end-to-end
against `simple-responder`, checking the echoed `request_body` for eight
cases — including the exact pipe example from the issue discussion
(client `max_tokens: 999` → stripped → `setParams` 1000 → both `?`
entries no-ops → upstream receives 1000). `llama-swap -validate` accepts
a config with `max_tokens?`, so the suffix survives the real YAML loader.

Changes:

- `internal/config/filters.go`: a shared `sanitizeParams` strips the
  suffix and reports set-if-undefined keys; also removes the duplication
  between `SanitizedSetParams` and `SanitizedSetParamsByID`
- `internal/server/filters.go`: skip a `?` key when the body already
  carries it at that stage
- tests for both packages; `config-schema.json`,
  `docs/config.example.yaml`, new kb article
  `guides/api-integration/set-if-undefined`, filters guide updated

fix: #1052
