### PR TITLE
ui,server: show model-load progress with a time-based ETA

### DIFF
--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -20,6 +20,17 @@ const (
 	StateShutdown ProcessState = ProcessState("shutdown")
 )
 
+// LoadInfo is a snapshot of a process's load timing, used by the UI to draw an
+// elapsed-vs-estimate progress bar while the process is starting.
+type LoadInfo struct {
+	// StartedAt is the unix-ms timestamp at which the current start began.
+	// Zero when the process is not in StateStarting.
+	StartedAt int64
+	// EstimateMs is the expected load duration derived from this process's
+	// previous successful loads. Zero when there is no history yet.
+	EstimateMs int64
+}
+
 type Process interface {
 	// Run starts the process blocks until the process is terminated.
 	// The timeout parameter controls how long to wait for the process to get
@@ -59,6 +70,10 @@ type Process interface {
 	// Note: this is a snapshot of the state at the time of the call
 	// and may change at any time after the call returns.
 	State() ProcessState
+
+	// LoadInfo returns the current load-timing snapshot. Like State it is a
+	// point-in-time read and may change immediately after returning.
+	LoadInfo() LoadInfo
 
 	// ServeHTTP forwards requests to the underlying process
 	// Calling it when the process is not ready will result in a

--- a/internal/process/process_command.go
+++ b/internal/process/process_command.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os/exec"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -131,7 +132,21 @@ type ProcessCommand struct {
 
 	lastUse  atomic.Int64 // unix nano timestamp of last ServeHTTP completion
 	inflight atomic.Int64 // current in-flight ServeHTTP calls
+
+	// loadStartedAt is the unix-ms timestamp of the in-flight start, or 0 when
+	// not starting. loadEstimateMs is the median of loadHistoryMs. Both are
+	// written only by run() and read by LoadInfo() via atomic load.
+	loadStartedAt  atomic.Int64
+	loadEstimateMs atomic.Int64
+	// loadHistoryMs holds the durations of the last successful loads (newest
+	// last, at most loadHistorySize entries). Owned exclusively by run().
+	loadHistoryMs []int64
 }
+
+// loadHistorySize bounds how many recent successful load durations feed the
+// estimate. Three absorbs a single cold-page-cache outlier without lagging when
+// the model/quant actually changes.
+const loadHistorySize = 3
 
 var _ Process = (*ProcessCommand)(nil)
 
@@ -161,6 +176,37 @@ func New(
 }
 
 func (p *ProcessCommand) Logger() *logmon.Monitor { return p.processLogger }
+
+func (p *ProcessCommand) LoadInfo() LoadInfo {
+	return LoadInfo{StartedAt: p.loadStartedAt.Load(), EstimateMs: p.loadEstimateMs.Load()}
+}
+
+// appendLoadHistory appends durMs and keeps only the most recent
+// loadHistorySize entries (newest last), so the estimate always reflects the
+// most recent loads rather than growing without bound.
+func appendLoadHistory(historyMs []int64, durMs int64) []int64 {
+	historyMs = append(historyMs, durMs)
+	if len(historyMs) > loadHistorySize {
+		historyMs = historyMs[len(historyMs)-loadHistorySize:]
+	}
+	return historyMs
+}
+
+// loadEstimate returns the median of the given load durations in ms, or 0 when
+// there are none. An even count averages the two middle values.
+func loadEstimate(historyMs []int64) int64 {
+	n := len(historyMs)
+	if n == 0 {
+		return 0
+	}
+	sorted := make([]int64, n)
+	copy(sorted, historyMs)
+	slices.Sort(sorted)
+	if n%2 == 1 {
+		return sorted[n/2]
+	}
+	return (sorted[n/2-1] + sorted[n/2]) / 2
+}
 
 // run is the single-writer goroutine that owns all mutable lifecycle state
 // (current ProcessState, the running *exec.Cmd, the active reverse-proxy
@@ -306,6 +352,11 @@ func (p *ProcessCommand) run() {
 				req.respond <- fmt.Errorf("[%s] could not be started in %s state", p.id, state)
 				continue
 			}
+			// Record the load-start timestamp BEFORE the setState that publishes
+			// it: setState emits ProcessStateChangeEvent, whose subscribers read
+			// the snapshot on another goroutine, so a write after setState would
+			// race the snapshot (see event.Emit).
+			p.loadStartedAt.Store(time.Now().UnixMilli())
 			setState(StateStarting)
 
 			startCtx, cancelStart := context.WithCancel(context.Background())
@@ -329,6 +380,20 @@ func (p *ProcessCommand) run() {
 					cmdCancel = res.cancel
 					fn := res.handlerFn
 					p.handler.Store(&fn)
+					// Record this successful load's duration and refresh the
+					// estimate before publishing StateReady (same ordering
+					// constraint as the start above). loadStartedAt is cleared
+					// last so the snapshot never carries a stale start time.
+					// Guard durMs > 0: a backward wall-clock step (e.g. NTP
+					// correction) mid-load would otherwise feed a negative
+					// sample into the median and skew later estimates.
+					if started := p.loadStartedAt.Load(); started > 0 {
+						if durMs := time.Now().UnixMilli() - started; durMs > 0 {
+							p.loadHistoryMs = appendLoadHistory(p.loadHistoryMs, durMs)
+							p.loadEstimateMs.Store(loadEstimate(p.loadHistoryMs))
+						}
+					}
+					p.loadStartedAt.Store(0)
 					setState(StateReady)
 					notifyWaiters(nil)
 					if req.block {
@@ -364,6 +429,10 @@ func (p *ProcessCommand) run() {
 						}()
 					}
 				} else {
+					// Failed start: a health-check timeout is not a load
+					// duration, so clear loadStartedAt (before setState) and
+					// leave the history untouched.
+					p.loadStartedAt.Store(0)
 					setState(StateStopped)
 					notifyWaiters(res.err)
 					req.respond <- res.err
@@ -381,6 +450,9 @@ func (p *ProcessCommand) run() {
 				if res.cmd != nil {
 					p.killProcess(res.cmd, res.cancel, res.cmdDone, stop.timeout)
 				}
+				// Aborted start: clear loadStartedAt before setState; an aborted
+				// load never feeds the history.
+				p.loadStartedAt.Store(0)
 				setState(StateStopped)
 				notifyWaiters(ErrStartAborted)
 				req.respond <- ErrStartAborted
@@ -396,6 +468,7 @@ func (p *ProcessCommand) run() {
 				// may block (e.g. taskkill on Windows is slow to spawn), and
 				// callers observing State() should see StateShutdown promptly
 				// rather than a stale StateStarting.
+				p.loadStartedAt.Store(0)
 				setState(StateShutdown)
 				res := <-resultCh
 				if res.cmd != nil {

--- a/internal/process/process_load_info_test.go
+++ b/internal/process/process_load_info_test.go
@@ -1,0 +1,208 @@
+package process
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+)
+
+// TestLoadEstimate pins the median-of-history math the ETA estimate is built
+// from: empty history yields no estimate, an even count averages the two middle
+// values, and an odd count takes the middle after sorting (so a slow outlier
+// does not drag the estimate up).
+func TestLoadEstimate(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []int64
+		want int64
+	}{
+		{"nil", nil, 0},
+		{"empty", []int64{}, 0},
+		{"single", []int64{5000}, 5000},
+		{"two averaged", []int64{5000, 9000}, 7000},
+		{"two averaged truncates toward zero", []int64{5000, 9001}, 7000}, // 14001/2 == 7000, not 7000.5
+		{"three median ignores outlier", []int64{5000, 9000, 100000}, 9000},
+		{"three median unsorted", []int64{9000, 5000, 7000}, 7000},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := loadEstimate(tt.in); got != tt.want {
+				t.Errorf("loadEstimate(%v) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLoadEstimate_DoesNotMutateInput guards the copy-before-sort in
+// loadEstimate: callers keep loadHistoryMs in insertion order so the newest
+// entries can be capped off the tail, which a sort-in-place would corrupt.
+func TestLoadEstimate_DoesNotMutateInput(t *testing.T) {
+	in := []int64{9000, 5000, 7000}
+	_ = loadEstimate(in)
+	want := []int64{9000, 5000, 7000}
+	for i := range want {
+		if in[i] != want[i] {
+			t.Fatalf("loadEstimate mutated its input: got %v, want %v", in, want)
+		}
+	}
+}
+
+// TestAppendLoadHistory pins the cap behavior the estimate depends on: the
+// helper keeps only the most recent loadHistorySize durations, in order, and
+// drops the OLDEST when full — a reversed slice direction (keeping the oldest)
+// would make the estimate stale forever, and length-only assertions miss it.
+func TestAppendLoadHistory(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []int64
+		dur  int64
+		want []int64
+	}{
+		{"nil grows", nil, 5000, []int64{5000}},
+		{"under cap appends", []int64{5000}, 9000, []int64{5000, 9000}},
+		{"fills to cap", []int64{5000, 9000}, 7000, []int64{5000, 9000, 7000}},
+		{"over cap drops oldest, keeps newest", []int64{5000, 9000, 7000}, 8000, []int64{9000, 7000, 8000}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := appendLoadHistory(tt.in, tt.dur); !slices.Equal(got, tt.want) {
+				t.Errorf("appendLoadHistory(%v, %d) = %v, want %v", tt.in, tt.dur, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestProcessCommand_LoadInfo_FirstLoadRecordsEstimate verifies the observable
+// contract after a successful load: StartedAt is cleared to 0 (the process is
+// no longer starting) and EstimateMs is populated from the load just recorded.
+func TestProcessCommand_LoadInfo_FirstLoadRecordsEstimate(t *testing.T) {
+	skipIfNoSimpleResponder(t)
+
+	cmd, port := simpleResponderCmd(t, "-silent")
+	p := newProcessCommand(t, config.ModelConfig{
+		Cmd:                cmd,
+		Proxy:              fmt.Sprintf("http://127.0.0.1:%d", port),
+		CheckEndpoint:      "/health",
+		HealthCheckTimeout: 10,
+	})
+	t.Cleanup(func() { p.Stop(testStopTimeout) }) //nolint: errcheck
+
+	// Before any load: no in-flight start, no history.
+	if li := p.LoadInfo(); li.StartedAt != 0 || li.EstimateMs != 0 {
+		t.Fatalf("before load: LoadInfo = %+v, want zero", li)
+	}
+
+	_ = runAsync(t, p)
+
+	li := p.LoadInfo()
+	if li.StartedAt != 0 {
+		t.Errorf("after ready: StartedAt = %d, want 0 (cleared once ready)", li.StartedAt)
+	}
+	if li.EstimateMs <= 0 {
+		t.Errorf("after ready: EstimateMs = %d, want > 0 (first load recorded)", li.EstimateMs)
+	}
+}
+
+// TestProcessCommand_LoadInfo_StartedAtSetWhileStarting proves StartedAt is
+// published while the process sits in StateStarting. The health check points at
+// a port nothing listens on, so the child runs but readiness never arrives and
+// the process stays starting long enough to observe.
+func TestProcessCommand_LoadInfo_StartedAtSetWhileStarting(t *testing.T) {
+	skipIfNoSimpleResponder(t)
+
+	cmd, _ := simpleResponderCmd(t, "-silent")
+	deadPort := getFreePort(t)
+	p := newProcessCommand(t, config.ModelConfig{
+		Cmd:                cmd,
+		Proxy:              fmt.Sprintf("http://127.0.0.1:%d", deadPort),
+		CheckEndpoint:      "/health",
+		HealthCheckTimeout: 15,
+	})
+	t.Cleanup(func() { p.Stop(testStopTimeout) }) //nolint: errcheck
+
+	go func() { _ = p.Run(10 * time.Second) }()
+	waitForState(t, p, StateStarting)
+
+	li := p.LoadInfo()
+	if li.StartedAt <= 0 {
+		t.Errorf("while starting: StartedAt = %d, want > 0", li.StartedAt)
+	}
+	if li.EstimateMs != 0 {
+		t.Errorf("while starting with no history: EstimateMs = %d, want 0", li.EstimateMs)
+	}
+}
+
+// TestProcessCommand_LoadInfo_ClearedOnFailedStart verifies a start that never
+// reaches readiness leaves no trace: StartedAt is cleared back to 0 and no
+// duration is fed into the estimate (a failed load is not a load time).
+func TestProcessCommand_LoadInfo_ClearedOnFailedStart(t *testing.T) {
+	skipIfNoSimpleResponder(t)
+
+	cmd, _ := simpleResponderCmd(t, "-silent")
+	deadPort := getFreePort(t)
+	p := newProcessCommand(t, config.ModelConfig{
+		Cmd:                cmd,
+		Proxy:              fmt.Sprintf("http://127.0.0.1:%d", deadPort),
+		CheckEndpoint:      "/health",
+		HealthCheckTimeout: 1,
+	})
+	t.Cleanup(func() { p.Stop(testStopTimeout) }) //nolint: errcheck
+
+	if err := p.Run(5 * time.Second); err == nil {
+		t.Fatal("Run: expected a failed start, got nil error")
+	}
+	waitForState(t, p, StateStopped)
+
+	li := p.LoadInfo()
+	if li.StartedAt != 0 {
+		t.Errorf("after failed start: StartedAt = %d, want 0", li.StartedAt)
+	}
+	if li.EstimateMs != 0 {
+		t.Errorf("after failed start: EstimateMs = %d, want 0 (failed load not recorded)", li.EstimateMs)
+	}
+}
+
+// TestProcessCommand_LoadInfo_HistoryIsCapped drives several successful load
+// cycles on one process and asserts the retained history never grows past
+// loadHistorySize, so the estimate always reflects only the most recent loads.
+func TestProcessCommand_LoadInfo_HistoryIsCapped(t *testing.T) {
+	skipIfNoSimpleResponder(t)
+
+	cmd, port := simpleResponderCmd(t, "-silent")
+	p := newProcessCommand(t, config.ModelConfig{
+		Cmd:                cmd,
+		Proxy:              fmt.Sprintf("http://127.0.0.1:%d", port),
+		CheckEndpoint:      "/health",
+		HealthCheckTimeout: 10,
+	})
+	t.Cleanup(func() { p.Stop(testStopTimeout) }) //nolint: errcheck
+
+	cycles := loadHistorySize + 2
+	for i := range cycles {
+		runErr := runAsync(t, p)
+		if err := p.Stop(testStopTimeout); err != nil {
+			t.Fatalf("cycle %d: Stop: %v", i, err)
+		}
+		select {
+		case <-runErr:
+		case <-time.After(testReturnTimeout):
+			t.Fatalf("cycle %d: Run did not return after Stop", i)
+		}
+		waitForState(t, p, StateStopped)
+	}
+
+	// Reading the unexported, non-atomic loadHistoryMs directly is safe here:
+	// it is mutated only inside run()'s success branch, strictly before that
+	// goroutine answers the Stop() we awaited above, so the channel round-trip
+	// establishes a happens-before with this read. (The cap direction itself is
+	// pinned purely by TestAppendLoadHistory.)
+	if got := len(p.loadHistoryMs); got != loadHistorySize {
+		t.Errorf("after %d cycles: history length = %d, want %d (capped)", cycles, got, loadHistorySize)
+	}
+	if li := p.LoadInfo(); li.EstimateMs <= 0 {
+		t.Errorf("after cycles: EstimateMs = %d, want > 0", li.EstimateMs)
+	}
+}

--- a/internal/router/base.go
+++ b/internal/router/base.go
@@ -360,6 +360,16 @@ func (b *baseRouter) ProcessLogger(modelID string) (*logmon.Monitor, bool) {
 	return nil, false
 }
 
+// LoadInfo returns the load-timing snapshot for the named model's process. Safe
+// without the run loop for the same reason as RunningModels: the processes map
+// keys are fixed at construction and LoadInfo() is a snapshot.
+func (b *baseRouter) LoadInfo(modelID string) (process.LoadInfo, bool) {
+	if p, ok := b.processes[modelID]; ok {
+		return p.LoadInfo(), true
+	}
+	return process.LoadInfo{}, false
+}
+
 // RunningModels returns the current state of every process that is not stopped
 // or shut down. The processes map keys are fixed at construction and State()
 // is a snapshot, so this is safe to call without the run loop.

--- a/internal/router/base_test.go
+++ b/internal/router/base_test.go
@@ -87,6 +87,27 @@ func TestBaseRouter_RunningModels(t *testing.T) {
 	}
 }
 
+// TestBaseRouter_LoadInfo checks the router forwards a process's load-timing
+// snapshot verbatim for a known model and reports not-found for an unknown one.
+func TestBaseRouter_LoadInfo(t *testing.T) {
+	loading := newFakeProcess("loading")
+	loading.loadInfo = process.LoadInfo{StartedAt: 1700000000123, EstimateMs: 42000}
+
+	b := newTestBase(t, map[string]process.Process{"loading": loading}, &stubPlanner{})
+
+	got, ok := b.LoadInfo("loading")
+	if !ok {
+		t.Fatal("LoadInfo(loading): ok=false, want true")
+	}
+	if got != loading.loadInfo {
+		t.Errorf("LoadInfo(loading) = %+v, want %+v", got, loading.loadInfo)
+	}
+
+	if _, ok := b.LoadInfo("nope"); ok {
+		t.Errorf("LoadInfo(nope): ok=true, want false for unknown model")
+	}
+}
+
 func TestBaseRouter_UnloadAll(t *testing.T) {
 	a := newFakeProcess("a")
 	a.markReady()

--- a/internal/router/helpers_test.go
+++ b/internal/router/helpers_test.go
@@ -85,6 +85,10 @@ type fakeProcess struct {
 	// "swap mid-request" anti-property.
 	inFlightServe       atomic.Int32
 	stoppedWhileServing atomic.Bool
+
+	// loadInfo is returned verbatim by LoadInfo(); tests preset it to exercise
+	// the load-timing plumbing.
+	loadInfo process.LoadInfo
 }
 
 func newFakeProcess(id string) *fakeProcess {
@@ -283,6 +287,8 @@ func (f *fakeProcess) WaitReady(ctx context.Context) error {
 }
 
 func (f *fakeProcess) Logger() *logmon.Monitor { return logmon.NewWriter(io.Discard) }
+
+func (f *fakeProcess) LoadInfo() process.LoadInfo { return f.loadInfo }
 
 func (f *fakeProcess) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	f.serveCalls.Add(1)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -53,4 +53,9 @@ type LocalRouter interface {
 	// modelID must be a real (non-alias) config key. Returns false when the
 	// model is not known to this router.
 	ProcessLogger(modelID string) (*logmon.Monitor, bool)
+
+	// LoadInfo returns the load-timing snapshot for the named model's process.
+	// modelID must be a real (non-alias) config key. Returns false when the
+	// model is not known to this router.
+	LoadInfo(modelID string) (process.LoadInfo, bool)
 }

--- a/internal/server/api_test.go
+++ b/internal/server/api_test.go
@@ -1058,6 +1058,50 @@ func TestServer_ModelStatus_Capabilities(t *testing.T) {
 	})
 }
 
+// TestServer_ModelStatus_LoadInfo verifies the /api/events modelStatus payload
+// carries the load-timing fields when the local router has them, and omits them
+// (json omitempty → absent/zero) when it does not.
+func TestServer_ModelStatus_LoadInfo(t *testing.T) {
+	t.Run("renders load timing while starting", func(t *testing.T) {
+		local := newStubRouter([]string{"m"}, "")
+		local.running = map[string]process.ProcessState{"m": process.StateStarting}
+		local.loadInfo = map[string]process.LoadInfo{
+			"m": {StartedAt: 1700000000123, EstimateMs: 42000},
+		}
+		s := newTestServer(local, newStubRouter(nil, ""))
+		s.cfg = config.Config{Models: map[string]config.ModelConfig{"m": {}}}
+
+		status := s.modelStatus()
+		if len(status) != 1 {
+			t.Fatalf("expected 1 model, got %d", len(status))
+		}
+		m := status[0]
+		if m.State != string(process.StateStarting) {
+			t.Errorf("state = %q, want %q", m.State, process.StateStarting)
+		}
+		if m.LoadStartedAt != 1700000000123 {
+			t.Errorf("loadStartedAt = %d, want 1700000000123", m.LoadStartedAt)
+		}
+		if m.EstLoadMs != 42000 {
+			t.Errorf("estLoadMs = %d, want 42000", m.EstLoadMs)
+		}
+	})
+
+	t.Run("omits load timing when router has none", func(t *testing.T) {
+		local := newStubRouter([]string{"m"}, "")
+		s := newTestServer(local, newStubRouter(nil, ""))
+		s.cfg = config.Config{Models: map[string]config.ModelConfig{"m": {}}}
+
+		m := s.modelStatus()[0]
+		if m.LoadStartedAt != 0 {
+			t.Errorf("loadStartedAt = %d, want 0", m.LoadStartedAt)
+		}
+		if m.EstLoadMs != 0 {
+			t.Errorf("estLoadMs = %d, want 0", m.EstLoadMs)
+		}
+	})
+}
+
 func stringSliceEqual(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/server/apigroup.go
+++ b/internal/server/apigroup.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mostlygeek/llama-swap/internal/config"
 	"github.com/mostlygeek/llama-swap/internal/event"
 	"github.com/mostlygeek/llama-swap/internal/perf"
+	"github.com/mostlygeek/llama-swap/internal/process"
 	"github.com/mostlygeek/llama-swap/internal/store"
 	"github.com/mostlygeek/llama-swap/internal/swaputil"
 )
@@ -28,6 +29,8 @@ type apiModel struct {
 	Aliases       []string       `json:"aliases,omitempty"`
 	Capabilities  map[string]any `json:"capabilities,omitempty"`
 	ContextLength int            `json:"context_length,omitempty"`
+	LoadStartedAt int64          `json:"loadStartedAt,omitempty"` // unix ms; only while state == starting
+	EstLoadMs     int64          `json:"estLoadMs,omitempty"`     // median of prior successful loads; 0 = unknown
 }
 
 type apiProfile struct {
@@ -113,6 +116,16 @@ func (s *Server) modelStatus() []apiModel {
 			state = string(st)
 		}
 		_, capsMap, _, ctxLen := renderCapabilities(mc.Capabilities)
+		// state (from RunningModels above) and li are read separately, so a load
+		// finishing between the two reads can yield state="starting" with
+		// li.StartedAt already 0 for a single snapshot. That is the benign
+		// direction — the UI treats a missing start time as elapsed 0 and the
+		// next snapshot corrects it; the reverse (ready + stale StartedAt) cannot
+		// happen because run() clears StartedAt before it publishes StateReady.
+		var li process.LoadInfo
+		if info, ok := s.local.LoadInfo(id); ok {
+			li = info
+		}
 		models = append(models, apiModel{
 			Id:            id,
 			Name:          mc.Name,
@@ -122,6 +135,8 @@ func (s *Server) modelStatus() []apiModel {
 			Aliases:       mc.Aliases,
 			Capabilities:  capsMap,
 			ContextLength: ctxLen,
+			LoadStartedAt: li.StartedAt,
+			EstLoadMs:     li.EstimateMs,
 		})
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -34,6 +34,7 @@ type stubRouter struct {
 	unloadModels  []string
 	unloadTimeout time.Duration
 	loggers       map[string]*logmon.Monitor
+	loadInfo      map[string]process.LoadInfo
 }
 
 func newStubRouter(models []string, response string) *stubRouter {
@@ -68,6 +69,10 @@ func (s *stubRouter) ProcessLogger(modelID string) (*logmon.Monitor, bool) {
 		}
 	}
 	return nil, false
+}
+func (s *stubRouter) LoadInfo(modelID string) (process.LoadInfo, bool) {
+	li, ok := s.loadInfo[modelID]
+	return li, ok
 }
 
 // newTestServer wires a Server with stub routers and a built mux.

--- a/ui/src/components/AppSidebar.svelte
+++ b/ui/src/components/AppSidebar.svelte
@@ -11,6 +11,7 @@
   import { showUnlistedModels } from "../stores/modelDisplay";
   import { modelsMenuOpen } from "../stores/sidebar";
   import type { Model } from "../lib/types";
+  import { statusDotAppearance, statusDotStyle, statusDotRingColor, type StatusDotKind } from "../lib/statusDot";
   import { isComposingKey } from "../lib/ime";
   import ConnectionStatus from "./ConnectionStatus.svelte";
 
@@ -44,17 +45,43 @@
     $models.filter((model) => model.peerID && ($showUnlistedModels || !model.unlisted)),
   );
 
-  type DotColor = "grey" | "yellow" | "green";
-  function statusDotColor(model: Model): DotColor {
-    if (model.state === "ready") return "green";
-    if (model.state === "starting" || model.state === "stopping") return "yellow";
-    return "grey";
-  }
+  // Wall clock driving the loading pie in each model's status dot. Only local
+  // models carry load timing (peers never do), so only they can keep the timer
+  // alive; the tick stops as soon as nothing local is starting.
+  let now = $state(Date.now());
+  const anyLocalModelStarting = $derived(
+    visibleLocalModels.some((model) => model.state === "starting"),
+  );
 
-  const dotClass: Record<DotColor, string> = {
-    grey: "bg-muted-foreground/40",
-    yellow: "bg-warning",
-    green: "bg-success",
+  $effect(() => {
+    if (!anyLocalModelStarting) {
+      return;
+    }
+
+    const tick = () => {
+      now = Date.now();
+    };
+    tick(); // seed immediately so the pie doesn't sit at a stale angle for 250ms
+
+    const id = setInterval(tick, 250);
+
+    return () => {
+      clearInterval(id);
+    };
+  });
+
+  // Flat interior colour per dot kind. Filling kinds keep the grey track as
+  // their background so the unfilled portion of the conic pie (inline style from
+  // statusDotStyle) shows through. No animate-pulse on any loading kind: the
+  // animated ring (statusDotRingColor) is now the single "loading" motion, so a
+  // second interior pulse would just fight it.
+  const dotClass: Record<StatusDotKind, string> = {
+    stopped: "bg-muted-foreground/40",
+    stopping: "bg-warning",
+    indeterminate: "bg-warning",
+    filling: "bg-muted-foreground/40",
+    overrun: "bg-muted-foreground/40",
+    ready: "bg-success",
   };
 </script>
 
@@ -64,8 +91,22 @@
       isActive={$currentRoute === `/models/${encodeURIComponent(model.id)}`}
     >
       {#snippet child({ props })}
+        {@const dot = statusDotAppearance(model, now)}
+        {@const ringColor = statusDotRingColor(dot)}
         <a href="/models/{encodeURIComponent(model.id)}" use:link {...props}>
-          <span class={`size-2 shrink-0 rounded-full ${dotClass[statusDotColor(model)]}`}></span>
+          <span class="relative inline-flex size-2 shrink-0">
+            {#if ringColor}
+              <span
+                class="absolute inset-0 rounded-full border animate-ping"
+                style={`border-color: ${ringColor}`}
+                aria-hidden="true"
+              ></span>
+            {/if}
+            <span
+              class={`relative size-2 rounded-full ${dotClass[dot.kind]}`}
+              style={statusDotStyle(dot)}
+            ></span>
+          </span>
           <span class="flex-1 truncate">{model.id}</span>
         </a>
       {/snippet}

--- a/ui/src/components/LoadProgressBar.svelte
+++ b/ui/src/components/LoadProgressBar.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  import type { Model } from "$lib/types";
+  import { computeLoadProgress, formatLoadProgressLabel } from "$lib/loadProgress";
+  import { formatDuration } from "$lib/format";
+  import { loadFillColor, loadLabelColor } from "$lib/statusDot";
+
+  let { model, className = "" } = $props<{ model: Model; className?: string }>();
+
+  let now = $state(Date.now());
+  // Seeded undefined (not model.state) so we don't read the prop non-reactively
+  // at init; the transition effect below records the real state on its first run
+  // before it can ever match starting→ready, so nothing spurious fires.
+  let prevState = $state<Model["state"] | undefined>(undefined);
+  let settled = $state(false);
+  let loadDurationMs = $state<number | null>(null);
+  // The last elapsed observed while starting. The server clears loadStartedAt
+  // to 0 (dropped by `omitempty`, so it arrives as undefined) *before* it
+  // publishes the ready snapshot, so by the starting→ready transition
+  // model.loadStartedAt is already gone. Capturing elapsed live here is the
+  // only way for the done-hold to report the real load duration.
+  let lastElapsedMs = $state(0);
+
+  // Timer effect: tick while starting, and remember the running elapsed so the
+  // done-hold can report it after loadStartedAt has been cleared.
+  $effect(() => {
+    if (model.state !== "starting") {
+      return;
+    }
+
+    const tick = () => {
+      now = Date.now();
+      lastElapsedMs = Math.max(0, now - (model.loadStartedAt ?? now));
+    };
+    tick(); // seed immediately so a sub-250ms load still records a duration
+
+    const id = setInterval(tick, 250);
+
+    return () => {
+      clearInterval(id);
+    };
+  });
+
+  // Detect the starting→ready transition exactly once. prevState is advanced on
+  // *every* run (not only the fallthrough), so a re-delivered ready snapshot —
+  // the store replaces every model object on each SSE tick — cannot re-trigger
+  // the done-hold and re-flash the bar.
+  $effect(() => {
+    const wasStarting = prevState === "starting";
+    prevState = model.state;
+    if (wasStarting && model.state === "ready") {
+      // Just finished loading: freeze the captured duration and show a 100%
+      // green bar for 600ms.
+      loadDurationMs = lastElapsedMs;
+      settled = true;
+
+      const id = setTimeout(() => {
+        settled = false;
+        loadDurationMs = null;
+      }, 600);
+
+      return () => {
+        clearTimeout(id);
+      };
+    }
+  });
+
+  let progress = $derived(computeLoadProgress(model, now));
+
+  // Peer models have no local load timing (LoadInfo is only populated for local
+  // models), so a peer would otherwise show a perpetual indeterminate bar —
+  // gate it here so every call site is consistent.
+  const showBar = $derived(!model.peerID && (!!progress || settled));
+  const pct = $derived(settled ? 100 : (progress?.pct ?? null));
+  // Bar-fill colour tells the same story as the sidebar dot: while estimating,
+  // warm amber→green with progress (inline color-mix, since the hue is
+  // per-frame and not a static class); flat amber once overrun so a near-green
+  // fill can't imply "almost done"; solid green on the done-hold.
+  const fillClass = $derived(
+    settled
+      ? "bg-success"
+      : progress?.mode === "overrun"
+        ? "bg-warning"
+        : "",
+  );
+  const fillStyle = $derived(
+    !settled && progress?.mode === "estimated" && pct !== null
+      ? `background-color: ${loadFillColor(pct)}`
+      : "",
+  );
+  const isPulsing = $derived(progress?.mode === "overrun");
+  const label = $derived(
+    settled
+      ? `Loaded in ${formatDuration(loadDurationMs ?? 0, { precision: 1 })}`
+      : progress
+        ? formatLoadProgressLabel(progress)
+        : "",
+  );
+  // Label colour tracks the fill so bar and text tell one story: green once
+  // done, amber when the estimate has been overrun, plain foreground otherwise.
+  const labelClass = $derived(
+    settled
+      ? "text-success font-medium"
+      : progress?.mode === "overrun"
+        ? "text-warning"
+        : "text-foreground/80",
+  );
+  // While estimating, warm the text along the same amber→green ramp as the bar
+  // but floored (loadLabelColor) so early amber stays legible as small text on a
+  // light background; other modes keep their flat class colour (green done,
+  // amber overrun, neutral indeterminate — no estimate to warm toward yet).
+  const labelStyle = $derived(
+    !settled && progress?.mode === "estimated" && pct !== null
+      ? `color: ${loadLabelColor(pct)}`
+      : "",
+  );
+</script>
+
+{#if showBar}
+  <div
+    role="progressbar"
+    aria-valuemin={0}
+    aria-valuemax={100}
+    aria-valuenow={pct !== null ? pct : undefined}
+    aria-label={`Loading ${model.name || model.id}`}
+    class="h-1.5 w-full overflow-hidden rounded-full bg-muted {className}"
+  >
+    {#if progress?.mode === "indeterminate"}
+      <div
+        class="h-full w-1/3 rounded-full bg-warning"
+        style="animation: ls-slide 1.2s linear infinite;"
+      ></div>
+    {:else}
+      <div
+        class="h-full rounded-full {fillClass} {isPulsing ? 'animate-pulse' : ''} transition-[width] duration-300"
+        style={`width: ${pct ?? 0}%${fillStyle ? `; ${fillStyle}` : ""}`}
+      ></div>
+    {/if}
+  </div>
+  <span class="text-xs tabular-nums {labelClass}" style={labelStyle}>{label}</span>
+{/if}
+
+<style>
+  /* Referenced from an inline style attribute, which Svelte does not rewrite,
+     so declare the keyframes global (the -global- prefix is stripped from the
+     emitted name) to keep the inline `ls-slide` reference valid. */
+  @keyframes -global-ls-slide {
+    from {
+      transform: translateX(-100%);
+    }
+    to {
+      transform: translateX(300%);
+    }
+  }
+</style>

--- a/ui/src/lib/loadProgress.test.ts
+++ b/ui/src/lib/loadProgress.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { computeLoadProgress, formatLoadProgressLabel, formatRemainingLabel } from "./loadProgress";
+
+describe("computeLoadProgress", () => {
+  const baseModel = {
+    state: "starting" as const,
+    loadStartedAt: 1000,
+    estLoadMs: 10000,
+  };
+
+  it("returns null for non-starting states", () => {
+    const states: Array<Parameters<typeof computeLoadProgress>[0]["state"]> = [
+      "ready",
+      "stopped",
+      "stopping",
+      "shutdown",
+      "unknown",
+    ];
+    for (const state of states) {
+      expect(
+        computeLoadProgress({ ...baseModel, state }, 5000),
+      ).toBeNull();
+    }
+  });
+
+  it("returns null when state is undefined", () => {
+    // Test with an object that has no state property at all
+    expect(
+      computeLoadProgress({ loadStartedAt: 1000, estLoadMs: 10000 } as any, 5000),
+    ).toBeNull();
+  });
+
+  it("handles indeterminate when estLoadMs is undefined", () => {
+    const result = computeLoadProgress(
+      { ...baseModel, estLoadMs: undefined },
+      6000,
+    );
+    expect(result).toEqual({
+      mode: "indeterminate",
+      elapsedMs: 5000,
+      pct: null,
+    });
+  });
+
+  it("handles indeterminate when estLoadMs is 0", () => {
+    const result = computeLoadProgress(
+      { ...baseModel, estLoadMs: 0 },
+      6000,
+    );
+    expect(result).toEqual({
+      mode: "indeterminate",
+      elapsedMs: 5000,
+      pct: null,
+    });
+  });
+
+  it("computes estimated progress correctly", () => {
+    // elapsed = 6000 - 1000 = 5000, ratio = 0.5, pct = 50, eta = 5000
+    const result = computeLoadProgress(baseModel, 6000);
+    expect(result).toEqual({
+      mode: "estimated",
+      elapsedMs: 5000,
+      pct: 50,
+      etaMs: 5000,
+    });
+  });
+
+  it("clamps at 95% when ratio is between 0.95 and 1", () => {
+    // elapsed = 9700, ratio = 0.97 -> round(97) actually exceeds the 95 cap,
+    // so this exercises the Math.min clamp (unlike a ratio of exactly 0.95,
+    // where round(95) makes the clamp a no-op).
+    const result = computeLoadProgress(baseModel, 10700);
+    expect(result).toEqual({
+      mode: "estimated",
+      elapsedMs: 9700,
+      pct: 95,
+      etaMs: 300,
+    });
+  });
+
+  it("treats ratio exactly 1 as overrun, not estimated", () => {
+    // elapsed = 10000 == estLoadMs, ratio = 1.0 -> the `ratio < 1` branch is
+    // false, so this is the overrun boundary.
+    const result = computeLoadProgress(baseModel, 11000);
+    expect(result).toEqual({
+      mode: "overrun",
+      elapsedMs: 10000,
+      pct: 95,
+      etaMs: 0,
+    });
+  });
+
+  it("clamps at 95% when ratio > 1 (overrun)", () => {
+    // elapsed = 10500, ratio = 1.05, mode = overrun, pct = 95, eta = 0
+    const result = computeLoadProgress(baseModel, 11500);
+    expect(result).toEqual({
+      mode: "overrun",
+      elapsedMs: 10500,
+      pct: 95,
+      etaMs: 0,
+    });
+  });
+
+  it("handles negative skew (now < loadStartedAt)", () => {
+    const result = computeLoadProgress(baseModel, 500);
+    expect(result).toEqual({
+      mode: "estimated",
+      elapsedMs: 0,
+      pct: 0,
+      etaMs: 10000,
+    });
+  });
+
+  it("handles now === loadStartedAt", () => {
+    const result = computeLoadProgress(baseModel, 1000);
+    expect(result).toEqual({
+      mode: "estimated",
+      elapsedMs: 0,
+      pct: 0,
+      etaMs: 10000,
+    });
+  });
+});
+
+describe("formatRemainingLabel", () => {
+  it("renders whole seconds", () => {
+    expect(formatRemainingLabel(5000)).toBe("~5s left");
+  });
+
+  it("rounds up so it never promises the load early", () => {
+    expect(formatRemainingLabel(4400)).toBe("~5s left");
+    expect(formatRemainingLabel(300)).toBe("~1s left");
+  });
+
+  it("floors at 1s instead of showing ~0s", () => {
+    expect(formatRemainingLabel(0)).toBe("~1s left");
+    expect(formatRemainingLabel(-50)).toBe("~1s left");
+  });
+});
+
+describe("formatLoadProgressLabel", () => {
+  it("formats indeterminate label", () => {
+    const label = formatLoadProgressLabel({
+      mode: "indeterminate",
+      elapsedMs: 5500,
+      pct: null,
+    });
+    expect(label).toBe("Loading… 5.5s");
+  });
+
+  it("formats estimated label as elapsed plus time remaining (seconds, not raw ms)", () => {
+    const label = formatLoadProgressLabel({
+      mode: "estimated",
+      elapsedMs: 5000,
+      pct: 50,
+      etaMs: 5000,
+    });
+    // Pinning the exact string catches a unit regression
+    // (e.g. "5000.0s · ~5000s left") a loose regex misses.
+    expect(label).toBe("Loading… 5.0s · ~5s left");
+  });
+
+  it("formats overrun label without a remaining estimate", () => {
+    const label = formatLoadProgressLabel({
+      mode: "overrun",
+      elapsedMs: 10500,
+      pct: 95,
+      etaMs: 0,
+    });
+    expect(label).toBe("Taking longer than usual… 10.5s");
+  });
+});

--- a/ui/src/lib/loadProgress.ts
+++ b/ui/src/lib/loadProgress.ts
@@ -1,0 +1,72 @@
+import type { Model } from "./types";
+import { formatDuration } from "./format";
+
+export type LoadProgressMode = "indeterminate" | "estimated" | "overrun";
+
+export interface LoadProgress {
+  mode: LoadProgressMode;
+  elapsedMs: number;
+  /** 0-95 while estimated/overrun; null when indeterminate. */
+  pct: number | null;
+  /** Remaining ms while estimated; 0 when overrun; undefined when indeterminate. */
+  etaMs?: number;
+}
+
+export const LOAD_PROGRESS_MAX_PCT = 95;
+
+/** Returns null unless the model is starting. Pure; `nowMs` is injected for testability. */
+export function computeLoadProgress(
+  model: Pick<Model, "state" | "loadStartedAt" | "estLoadMs">,
+  nowMs: number,
+): LoadProgress | null {
+  if (model.state !== "starting") {
+    return null;
+  }
+
+  const elapsedMs = Math.max(0, nowMs - (model.loadStartedAt ?? nowMs));
+
+  if (!model.estLoadMs || model.estLoadMs <= 0) {
+    return { mode: "indeterminate", elapsedMs, pct: null };
+  }
+
+  const ratio = elapsedMs / model.estLoadMs;
+
+  if (ratio < 1) {
+    return {
+      mode: "estimated",
+      elapsedMs,
+      pct: Math.min(LOAD_PROGRESS_MAX_PCT, Math.round(ratio * 100)),
+      etaMs: model.estLoadMs - elapsedMs,
+    };
+  }
+
+  return {
+    mode: "overrun",
+    elapsedMs,
+    pct: LOAD_PROGRESS_MAX_PCT,
+    etaMs: 0,
+  };
+}
+
+/**
+ * Formats remaining time as a coarse "~Ns left". Seconds are rounded *up* (and
+ * floored at 1s) so the label never promises the load sooner than the estimate
+ * does, and never shows a "~0s left" beat just before the estimate is crossed.
+ */
+export function formatRemainingLabel(etaMs: number): string {
+  const wholeSeconds = Math.max(1, Math.ceil(Math.max(0, etaMs) / 1000));
+  return `~${formatDuration(wholeSeconds * 1000, { precision: 0 })} left`;
+}
+
+/** Progress line shown under the load bar: elapsed at 0.1s, plus time remaining when known. */
+export function formatLoadProgressLabel(p: LoadProgress): string {
+  const elapsed = formatDuration(p.elapsedMs, { precision: 1 });
+  switch (p.mode) {
+    case "indeterminate":
+      return `Loading… ${elapsed}`;
+    case "estimated":
+      return `Loading… ${elapsed} · ${formatRemainingLabel(p.etaMs ?? 0)}`;
+    case "overrun":
+      return `Taking longer than usual… ${elapsed}`;
+  }
+}

--- a/ui/src/lib/statusDot.test.ts
+++ b/ui/src/lib/statusDot.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  statusDotAppearance,
+  loadFillColor,
+  loadLabelColor,
+  LOAD_LABEL_MIN_SUCCESS_PCT,
+  statusDotRingColor,
+  statusDotStyle,
+} from "./statusDot";
+
+describe("statusDotAppearance", () => {
+  const starting = { state: "starting" as const, loadStartedAt: 1000, estLoadMs: 10000 };
+
+  it("maps flat states without consulting the clock", () => {
+    expect(statusDotAppearance({ ...starting, state: "ready" }, 0)).toEqual({ kind: "ready", pct: null });
+    expect(statusDotAppearance({ ...starting, state: "stopping" }, 0)).toEqual({ kind: "stopping", pct: null });
+    for (const state of ["stopped", "shutdown", "unknown"] as const) {
+      expect(statusDotAppearance({ ...starting, state }, 0)).toEqual({ kind: "stopped", pct: null });
+    }
+  });
+
+  it("is indeterminate while starting without an estimate (e.g. a peer or first load)", () => {
+    expect(statusDotAppearance({ state: "starting", loadStartedAt: 1000 }, 6000)).toEqual({
+      kind: "indeterminate",
+      pct: null,
+    });
+    expect(statusDotAppearance({ ...starting, estLoadMs: 0 }, 6000)).toEqual({
+      kind: "indeterminate",
+      pct: null,
+    });
+  });
+
+  it("fills by elapsed/estimate while under the estimate", () => {
+    expect(statusDotAppearance(starting, 6000)).toEqual({ kind: "filling", pct: 50 });
+    expect(statusDotAppearance(starting, 1000)).toEqual({ kind: "filling", pct: 0 });
+  });
+
+  it("becomes overrun at the 95% cap once the estimate is passed", () => {
+    expect(statusDotAppearance(starting, 11500)).toEqual({ kind: "overrun", pct: 95 });
+  });
+});
+
+describe("loadFillColor", () => {
+  it("is pure warning at 0% and blends toward success with progress", () => {
+    expect(loadFillColor(0)).toBe("color-mix(in oklch, var(--warning), var(--success) 0%)");
+    expect(loadFillColor(50)).toBe("color-mix(in oklch, var(--warning), var(--success) 50%)");
+  });
+
+  it("clamps and rounds the mix percentage", () => {
+    expect(loadFillColor(-10)).toContain(" 0%)");
+    expect(loadFillColor(120)).toContain(" 95%)");
+    expect(loadFillColor(33.4)).toContain(" 33%)");
+  });
+});
+
+describe("loadLabelColor", () => {
+  it("floors the mix so early text is never the least-legible amber", () => {
+    // Below the floor, the label sits at the floor regardless of true progress,
+    // so bar (pure amber at 0%) and text (floored) deliberately differ.
+    expect(loadLabelColor(0)).toBe(loadFillColor(LOAD_LABEL_MIN_SUCCESS_PCT));
+    expect(loadLabelColor(LOAD_LABEL_MIN_SUCCESS_PCT - 15)).toBe(
+      loadFillColor(LOAD_LABEL_MIN_SUCCESS_PCT),
+    );
+  });
+
+  it("tracks true progress once past the floor", () => {
+    expect(loadLabelColor(LOAD_LABEL_MIN_SUCCESS_PCT + 20)).toBe(
+      loadFillColor(LOAD_LABEL_MIN_SUCCESS_PCT + 20),
+    );
+    expect(loadLabelColor(95)).toBe(loadFillColor(95));
+  });
+});
+
+describe("statusDotRingColor", () => {
+  it("rings every loading state and nothing else", () => {
+    expect(statusDotRingColor({ kind: "filling", pct: 50 })).toBe(loadFillColor(50));
+    expect(statusDotRingColor({ kind: "indeterminate", pct: null })).toBe("var(--warning)");
+    expect(statusDotRingColor({ kind: "overrun", pct: 95 })).toBe("var(--warning)");
+    for (const kind of ["ready", "stopped", "stopping"] as const) {
+      expect(statusDotRingColor({ kind, pct: null })).toBe("");
+    }
+  });
+
+  it("warms the filling ring with progress, matching the pie", () => {
+    expect(statusDotRingColor({ kind: "filling", pct: 0 })).toBe(loadFillColor(0));
+    expect(statusDotRingColor({ kind: "filling", pct: 80 })).toBe(loadFillColor(80));
+  });
+});
+
+describe("statusDotStyle", () => {
+  it("returns no inline style for flat kinds", () => {
+    expect(statusDotStyle({ kind: "ready", pct: null })).toBe("");
+    expect(statusDotStyle({ kind: "stopped", pct: null })).toBe("");
+    expect(statusDotStyle({ kind: "indeterminate", pct: null })).toBe("");
+  });
+
+  it("paints a conic pie in the blended colour while filling", () => {
+    expect(statusDotStyle({ kind: "filling", pct: 50 })).toBe(
+      "background-image: conic-gradient(color-mix(in oklch, var(--warning), var(--success) 50%) 50%, transparent 0)",
+    );
+  });
+
+  it("keeps the sector in plain warning amber on overrun", () => {
+    expect(statusDotStyle({ kind: "overrun", pct: 95 })).toBe(
+      "background-image: conic-gradient(var(--warning) 95%, transparent 0)",
+    );
+  });
+});

--- a/ui/src/lib/statusDot.ts
+++ b/ui/src/lib/statusDot.ts
@@ -1,0 +1,109 @@
+import type { Model } from "./types";
+import { computeLoadProgress, LOAD_PROGRESS_MAX_PCT } from "./loadProgress";
+
+/**
+ * Visual state of a model status dot. `filling` and `overrun` carry a fill
+ * percentage; every other kind is a flat colour chosen by the component.
+ */
+export type StatusDotKind = "stopped" | "stopping" | "indeterminate" | "filling" | "overrun" | "ready";
+
+export interface StatusDotAppearance {
+  kind: StatusDotKind;
+  /** Fill percentage (0-95) for `filling`/`overrun`; null for flat-colour kinds. */
+  pct: number | null;
+}
+
+/**
+ * Maps a model's state plus live load progress to a dot appearance. Pure;
+ * `nowMs` is injected for testability. A starting model with no estimate
+ * (including peers, which never carry load timing) is `indeterminate`.
+ */
+export function statusDotAppearance(
+  model: Pick<Model, "state" | "loadStartedAt" | "estLoadMs">,
+  nowMs: number,
+): StatusDotAppearance {
+  switch (model.state) {
+    case "ready":
+      return { kind: "ready", pct: null };
+    case "stopping":
+      return { kind: "stopping", pct: null };
+    case "starting": {
+      const progress = computeLoadProgress(model, nowMs);
+      if (!progress || progress.pct === null) {
+        return { kind: "indeterminate", pct: null };
+      }
+      return { kind: progress.mode === "overrun" ? "overrun" : "filling", pct: progress.pct };
+    }
+    default:
+      return { kind: "stopped", pct: null };
+  }
+}
+
+function clampPct(pct: number): number {
+  return Math.min(LOAD_PROGRESS_MAX_PCT, Math.max(0, Math.round(pct)));
+}
+
+/**
+ * Colour of the filled pie sector: pure `--warning` at 0%, blending toward
+ * `--success` as the load approaches its estimate, so the dot "warms" toward
+ * the solid green it snaps to on ready. Uses the raw theme variables rather
+ * than Tailwind's `--color-*` aliases, which `@theme inline` may not emit.
+ */
+export function loadFillColor(pct: number): string {
+  return `color-mix(in oklch, var(--warning), var(--success) ${clampPct(pct)}%)`;
+}
+
+/**
+ * Floor, in percent, applied to the *label text* colour ramp. The bar and dot
+ * paint pure `--warning` at 0%, but on a light background that bright amber
+ * (L≈0.77) is low-contrast as small text, so the label starts partway along the
+ * ramp — `--success` is darker (L≈0.6) and greener, so a higher floor both
+ * darkens and de-yellows the early text. The label still drifts to near-green
+ * as the load completes; it just never sits at the least-legible amber.
+ */
+export const LOAD_LABEL_MIN_SUCCESS_PCT = 40;
+
+/**
+ * Colour for the load-progress label: the same warm→green ramp as
+ * {@link loadFillColor}, but floored at {@link LOAD_LABEL_MIN_SUCCESS_PCT} so
+ * the text stays legible while the bar keeps the fuller 0→95 amber sweep.
+ */
+export function loadLabelColor(pct: number): string {
+  return loadFillColor(Math.max(LOAD_LABEL_MIN_SUCCESS_PCT, pct));
+}
+
+/**
+ * Colour of the animated "loading" ring drawn around the dot, or "" when the
+ * model is not loading (the caller then renders no ring). The ring is the
+ * unified loading affordance across all three starting sub-states, so the dot's
+ * interior no longer needs its own pulse. `filling` tracks the pie's warm→green
+ * hue; the flat-amber states (`indeterminate`, `overrun`) ring in plain warning
+ * to match their interior.
+ */
+export function statusDotRingColor(appearance: StatusDotAppearance): string {
+  switch (appearance.kind) {
+    case "filling":
+      return appearance.pct === null ? "var(--warning)" : loadFillColor(appearance.pct);
+    case "indeterminate":
+    case "overrun":
+      return "var(--warning)";
+    default:
+      return "";
+  }
+}
+
+/**
+ * Inline style for the dot. Filling kinds paint a conic pie (clockwise from
+ * 12 o'clock) over the component's grey track; the transparent remainder lets
+ * the track show through as the unfilled portion. Overrun keeps the sector in
+ * plain warning amber: the estimate has been passed, so the near-green hue
+ * would falsely suggest "almost done".
+ */
+export function statusDotStyle(appearance: StatusDotAppearance): string {
+  if (appearance.pct === null) {
+    return "";
+  }
+  const pct = clampPct(appearance.pct);
+  const color = appearance.kind === "overrun" ? "var(--warning)" : loadFillColor(pct);
+  return `background-image: conic-gradient(${color} ${pct}%, transparent 0)`;
+}

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -24,6 +24,10 @@ export interface Model {
   aliases?: string[];
   capabilities?: ModelCapabilities;
   context_length?: number;
+  /** Unix-ms when the current load began; present only while state === "starting". */
+  loadStartedAt?: number;
+  /** Estimated load duration in ms from this model's prior loads; absent when unknown. */
+  estLoadMs?: number;
   // selector-only fields from the v1/models llamaswap metadata
   strategy?: string;
   targets?: string[];

--- a/ui/src/routes/ModelDetail.svelte
+++ b/ui/src/routes/ModelDetail.svelte
@@ -4,6 +4,7 @@
   import { statusDotColor } from "../stores/modelLoad";
   import type { Model } from "../lib/types";
   import ModelLoadButton from "../components/ModelLoadButton.svelte";
+  import LoadProgressBar from "../components/LoadProgressBar.svelte";
   import * as Card from "$lib/components/ui/card/index.js";
   import { Tabs, TabsList, TabsTrigger, TabsContent } from "$lib/components/ui/tabs/index.js";
   import { ExternalLink } from "@lucide/svelte";
@@ -59,6 +60,7 @@
         {#if model.aliases && model.aliases.length > 0}
           <p class="text-muted-foreground text-xs">Aliases: {model.aliases.join(", ")}</p>
         {/if}
+        <LoadProgressBar {model} className="mt-1 max-w-md" />
       </Card.Header>
     </Card.Root>
 

--- a/ui/src/routes/ModelsDash.svelte
+++ b/ui/src/routes/ModelsDash.svelte
@@ -15,6 +15,7 @@
   import { listCapabilityBadges, capabilityBadgeClass } from "../lib/capabilities";
   import type { Model } from "../lib/types";
   import ModelLoadButton from "../components/ModelLoadButton.svelte";
+  import LoadProgressBar from "../components/LoadProgressBar.svelte";
   import Tag from "../components/Tag.svelte";
   import * as Card from "$lib/components/ui/card/index.js";
   import { Button } from "$lib/components/ui/button/index.js";
@@ -75,6 +76,7 @@
           · {model.aliases.join(", ")}
         {/if}
       </div>
+      <LoadProgressBar {model} className="mt-1" />
     </a>
     {#if $showCapabilityTags}
       {@const badges = listCapabilityBadges(model)}


### PR DESCRIPTION
Closes https://github.com/mostlygeek/llama-swap/issues/1079

Adds:
- a per-model progress bar when the model is loading, including remaining time
- the sidebar status dot is now filled in like a pie, changes color from amber to green, and is an animated ring
- ETA is median of last 3 successful loads, and each process tracks per-model load timing

Related:

-  https://github.com/mostlygeek/llama-swap/issues/871
- https://github.com/ggml-org/llama.cpp/issues/24822 (needs standalone)

Screenshots:
<img width="2067" height="588" alt="Screenshot 2026-09-02 at 1 05 58 AM" src="https://github.com/user-attachments/assets/be515abb-2a2c-4f06-bca7-de301291d296" />
<img width="2065" height="592" alt="Screenshot 2026-09-02 at 1 06 03 AM" src="https://github.com/user-attachments/assets/955206c3-a4b2-4bf7-9ee8-12475d951b81" />
<img width="2054" height="566" alt="Screenshot 2026-09-02 at 1 06 09 AM" src="https://github.com/user-attachments/assets/ac676046-791d-4c26-8f98-cb0975f04693" />
