### PR TITLE
Feature/unfied multiarch: add arm64 and cuda 13 builds to GitHub Actions workflow

### DIFF
--- a/.github/workflows/unified-docker-backend.yml
+++ b/.github/workflows/unified-docker-backend.yml
@@ -17,6 +17,11 @@ on:
         description: "cuda or vulkan"
         required: true
         type: string
+      platform:
+        description: "Target platform, linux/amd64 or linux/arm64"
+        required: false
+        type: string
+        default: "linux/amd64"
       projects:
         description: "JSON array of projects to build for this backend"
         required: true
@@ -43,15 +48,30 @@ on:
       ls_hash:
         required: true
         type: string
+      cuda_version:
+        description: "CUDA toolkit/runtime version as an nvidia/cuda image tag (CUDA only; default 12.9.1)"
+        required: false
+        type: string
+        default: ""
+      cuda_architectures:
+        description: "CUDA compute capabilities to compile natively, e.g. 80;86;89 (CUDA only; default 60;61;75;86;89)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
   packages: write
 
+# Each stage runs natively on a runner matching the target platform: amd64 on
+# ubuntu-latest, arm64 on the GitHub-hosted ubuntu-24.04-arm runner. Cross
+# compiling CUDA through QEMU is impractically slow, so there is no
+# cross-building -- the arch just selects the runner.
+
 jobs:
   base:
     name: base
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 60
     steps:
       - name: Checkout code
@@ -80,15 +100,26 @@ jobs:
           password: ${{ github.token }}
 
       # Skipped entirely when base-<backend>.Dockerfile has not changed.
+      # The base tag also depends on the CUDA version and architectures, so
+      # both must be set identically in every job that calls build-image.sh.
       - name: Build and publish builder base
+        env:
+          # Publish under the repo that triggers the build, so forks build
+          # their own images instead of pushing into the upstream namespace.
+          ARTIFACT_REPO: ghcr.io/${{ github.repository }}-build
+          CUDA_VERSION: ${{ inputs.cuda_version || '12.9.1' }}
+          # Empty means the script's default, which differs per platform
+          # (the aarch64 CUDA toolchain does not support sm_60/sm_61).
+          CMAKE_CUDA_ARCHITECTURES: ${{ inputs.cuda_architectures }}
+          PLATFORM: ${{ inputs.platform }}
         run: |
           chmod +x docker/unified/build-image.sh
           docker/unified/build-image.sh --${{ inputs.backend }} --stage=base
 
   artifacts:
-    name: build ${{ matrix.project }}
+    name: build ${{ matrix.project }} (${{ inputs.platform }})
     needs: base
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     # Each project gets a runner to itself. GitHub's hard cap is 360m; stop
     # short of it so an overrun is reported as a timeout on one project rather
     # than a silent cancellation of the whole build.
@@ -127,6 +158,10 @@ jobs:
       # both unchanged since a previous run published them.
       - name: Build and publish artifacts
         env:
+          ARTIFACT_REPO: ghcr.io/${{ github.repository }}-build
+          CUDA_VERSION: ${{ inputs.cuda_version || '12.9.1' }}
+          CMAKE_CUDA_ARCHITECTURES: ${{ inputs.cuda_architectures }}
+          PLATFORM: ${{ inputs.platform }}
           LLAMA_REF: ${{ inputs.llama_hash }}
           WHISPER_REF: ${{ inputs.whisper_hash }}
           SD_REF: ${{ inputs.sd_hash }}
@@ -138,9 +173,9 @@ jobs:
           docker/unified/build-image.sh --${{ inputs.backend }} --stage=${{ matrix.project }}
 
   assemble:
-    name: assemble
+    name: assemble (${{ inputs.platform }})
     needs: artifacts
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 90
     steps:
       - name: Checkout code
@@ -173,17 +208,42 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      # Tag shared by the assemble, push and rootless steps. Per-platform tag;
+      # unified-docker.yml merges the platforms into the arch-less multi-arch
+      # manifest. CUDA images include the version so multiple CUDA versions can
+      # coexist.
+      - name: Set image tags
+        env:
+          CUDA_VERSION: ${{ inputs.cuda_version || '12.9.1' }}
+        run: |
+          case "${{ inputs.platform }}" in
+            linux/arm64) ARCH="arm64" ;;
+            linux/amd64) ARCH="amd64" ;;
+            *) echo "ERROR: unsupported platform '${{ inputs.platform }}'" >&2; exit 1 ;;
+          esac
+          if [[ "${{ inputs.backend }}" == "cuda" ]]; then
+            echo "IMAGE_TAG=ghcr.io/${{ github.repository }}:unified-cuda-${CUDA_VERSION}-${ARCH}" >> "$GITHUB_ENV"
+          else
+            echo "IMAGE_TAG=ghcr.io/${{ github.repository }}:unified-${{ inputs.backend }}-${ARCH}" >> "$GITHUB_ENV"
+          fi
+          # Shared by the runtime and rootless pushes so their date tags match.
+          echo "DATE_TAG=$(date -u +%Y-%m-%d)" >> "$GITHUB_ENV"
+
       # Copies each project's published /install into the runtime image. The
       # compile stages are not part of this build's graph, so this is minutes.
       - name: Assemble unified Docker image
         env:
+          CUDA_VERSION: ${{ inputs.cuda_version || '12.9.1' }}
+          CMAKE_CUDA_ARCHITECTURES: ${{ inputs.cuda_architectures }}
           LLAMA_REF: ${{ inputs.llama_hash }}
           WHISPER_REF: ${{ inputs.whisper_hash }}
           SD_REF: ${{ inputs.sd_hash }}
           AUDIO_REF: ${{ inputs.audio_hash }}
           IK_LLAMA_REF: ${{ inputs.ik_llama_hash }}
           LS_VERSION: ${{ inputs.ls_hash }}
-          DOCKER_IMAGE_TAG: ghcr.io/mostlygeek/llama-swap:unified-${{ inputs.backend }}
+          PLATFORM: ${{ inputs.platform }}
+          DOCKER_IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          ARTIFACT_REPO: ghcr.io/${{ github.repository }}-build
           # When running under act, use the local builder that has warm ccache.
           # On GitHub Actions, BUILDX_BUILDER is unset so docker uses the builder
           # created by setup-buildx-action above.
@@ -195,14 +255,30 @@ jobs:
       - name: Push to GitHub Container Registry
         if: ${{ !env.ACT && inputs.push_to_ghcr }}
         run: |
-          BASE_TAG="ghcr.io/mostlygeek/llama-swap:unified-${{ inputs.backend }}"
-          DATE_TAG=$(date -u +%Y-%m-%d)
+          docker push "${IMAGE_TAG}"
+          docker tag "${IMAGE_TAG}" "${IMAGE_TAG}-${DATE_TAG}"
+          docker push "${IMAGE_TAG}-${DATE_TAG}"
 
-          docker push "${BASE_TAG}"
-          docker tag "${BASE_TAG}" "${BASE_TAG}-${DATE_TAG}"
-          docker push "${BASE_TAG}-${DATE_TAG}"
-
-          ROOTLESS_TAG="${BASE_TAG}-rootless"
-          docker push "${ROOTLESS_TAG}"
-          docker tag "${ROOTLESS_TAG}" "${ROOTLESS_TAG}-${DATE_TAG}"
-          docker push "${ROOTLESS_TAG}-${DATE_TAG}"
+      # The rootless image is the runtime image plus a non-root user, so it is
+      # built after that image is pushed rather than at the end of --assemble:
+      # as part of --assemble its FROM pointed at a tag no step had published
+      # yet, and the buildx container driver -- which cannot see the locally
+      # loaded image -- failed to resolve it.
+      - name: Build and push rootless image
+        if: ${{ !env.ACT && inputs.push_to_ghcr }}
+        env:
+          CUDA_VERSION: ${{ inputs.cuda_version || '12.9.1' }}
+          CMAKE_CUDA_ARCHITECTURES: ${{ inputs.cuda_architectures }}
+          LLAMA_REF: ${{ inputs.llama_hash }}
+          WHISPER_REF: ${{ inputs.whisper_hash }}
+          SD_REF: ${{ inputs.sd_hash }}
+          AUDIO_REF: ${{ inputs.audio_hash }}
+          IK_LLAMA_REF: ${{ inputs.ik_llama_hash }}
+          LS_VERSION: ${{ inputs.ls_hash }}
+          PLATFORM: ${{ inputs.platform }}
+          DOCKER_IMAGE_TAG: ${{ env.IMAGE_TAG }}
+          DATE_TAG: ${{ env.DATE_TAG }}
+          ARTIFACT_REPO: ghcr.io/${{ github.repository }}-build
+        run: |
+          chmod +x docker/unified/build-image.sh
+          docker/unified/build-image.sh --${{ inputs.backend }} --rootless

--- a/.github/workflows/unified-docker.yml
+++ b/.github/workflows/unified-docker.yml
@@ -31,7 +31,12 @@ on:
         required: false
         default: ""
       cuda_architectures:
-        description: "Override CUDA compute capabilities for all versions (default: 60;61;75;86;89 for CUDA 12, 86;89;120;121 for CUDA 13)"
+        description: >
+          Override CUDA compute capabilities. One list applies to every
+          version (e.g. 86;89;120;121); two comma-separated lists apply
+          positionally to 12.9.1 then 13.3.0,
+          e.g. 60;61;75;86;89,86;89;120;121
+          (defaults: 60;61;75;86;89 for CUDA 12, 86;89;120;121 for CUDA 13)
         required: false
         default: ""
       llama_swap_version:
@@ -143,6 +148,27 @@ jobs:
           # base, artifacts, assemble, and merge jobs.
           cuda_versions="${{ inputs.cuda_versions || '12.9.1,13.3.0' }}"
 
+          # One list applies to every version; two lists map positionally
+          # to 12.9.1 and 13.3.0. Anything else is a typo -- fail the run
+          # rather than silently build a version with the wrong archs.
+          arch_override="${{ inputs.cuda_architectures }}"
+          if [[ -n "${arch_override}" ]]; then
+            IFS=',' read -ra arch_lists <<< "${arch_override}"
+            case "${#arch_lists[@]}" in
+              1) arch_12="${arch_lists[0]}"; arch_13="${arch_lists[0]}" ;;
+              2) arch_12="${arch_lists[0]}"; arch_13="${arch_lists[1]}" ;;
+              *)
+                echo "ERROR: cuda_architectures must have 1 or 2 comma-separated lists, got ${#arch_lists[@]}" >&2
+                exit 1
+                ;;
+            esac
+          else
+            # CUDA 12 supports Pascal through Ada; CUDA 13 drops
+            # Pascal/Volta/Turing and adds Blackwell (120/121).
+            arch_12="60;61;75;86;89"
+            arch_13="86;89;120;121"
+          fi
+
           {
             echo "build_cuda=${build_cuda}"
             echo "build_vulkan=${build_vulkan}"
@@ -153,11 +179,8 @@ jobs:
             echo 'cuda_projects=["whisper","sd","audio","llama","ik-llama"]'
             echo 'vulkan_projects=["whisper","sd","audio","llama"]'
             echo "cuda_versions=${cuda_versions}"
-            # Per-version defaults: CUDA 12 supports Pascal through Ada;
-            # CUDA 13 drops Pascal/Volta/Turing and adds Blackwell (120/121).
-            # An explicit cuda_architectures input overrides both.
-            echo "cuda_arch_12=${{ inputs.cuda_architectures || '60;61;75;86;89' }}"
-            echo "cuda_arch_13=${{ inputs.cuda_architectures || '86;89;120;121' }}"
+            echo "cuda_arch_12=${arch_12}"
+            echo "cuda_arch_13=${arch_13}"
           } >> "$GITHUB_OUTPUT"
 
 # One backend call per version per platform so each chain (base -> projects ->

--- a/.github/workflows/unified-docker.yml
+++ b/.github/workflows/unified-docker.yml
@@ -27,7 +27,7 @@ on:
         required: false
         default: "main"
       cuda_versions:
-        description: "Comma-separated CUDA versions to build (e.g. 12.9.1,13.3.0)"
+        description: "Comma-separated CUDA versions to build (supported: 12.9.1, 13.3.0)"
         required: false
         default: ""
       cuda_architectures:
@@ -101,6 +101,8 @@ jobs:
       ik_llama_hash: ${{ steps.refs.outputs.ik_llama_hash }}
       ls_hash: ${{ steps.refs.outputs.ls_hash }}
       cuda_versions: ${{ steps.plan.outputs.cuda_versions }}
+      build_cuda_1291: ${{ steps.plan.outputs.build_cuda_1291 }}
+      build_cuda_1330: ${{ steps.plan.outputs.build_cuda_1330 }}
       cuda_arch_12: ${{ steps.plan.outputs.cuda_arch_12 }}
       cuda_arch_13: ${{ steps.plan.outputs.cuda_arch_13 }}
     steps:
@@ -145,8 +147,31 @@ jobs:
           fi
 
           # Multiple CUDA versions are built independently; each gets its own
-          # base, artifacts, assemble, and merge jobs.
+          # base, artifacts, assemble, and merge jobs. The request is parsed
+          # as exact comma-separated tokens: anything unsupported fails the
+          # run rather than silently skipping or substituting a version.
           cuda_versions="${{ inputs.cuda_versions || '12.9.1,13.3.0' }}"
+          build_1291=false; build_1330=false
+          IFS=',' read -ra ver_list <<< "${cuda_versions}"
+          for v in "${ver_list[@]}"; do
+            v="${v#"${v%%[![:space:]]*}"}"; v="${v%"${v##*[![:space:]]}"}"
+            case "${v}" in
+              12.9.1) build_1291=true ;;
+              13.3.0) build_1330=true ;;
+              *)
+                echo "ERROR: unsupported CUDA version '${v}' (supported: 12.9.1, 13.3.0)" >&2
+                exit 1
+                ;;
+            esac
+          done
+          if [[ "${build_1291}" == "false" && "${build_1330}" == "false" ]]; then
+            echo "ERROR: no CUDA versions selected" >&2
+            exit 1
+          fi
+          # Canonical list of the requested versions, in 12.9.1 then 13.3.0 order.
+          norm=""
+          if [[ "${build_1291}" == "true" ]]; then norm="12.9.1"; fi
+          if [[ "${build_1330}" == "true" ]]; then norm="${norm:+${norm},}13.3.0"; fi
 
           # One list applies to every version; two lists map positionally
           # to 12.9.1 and 13.3.0. Anything else is a typo -- fail the run
@@ -178,7 +203,9 @@ jobs:
             # ik_llama.cpp has no Vulkan build.
             echo 'cuda_projects=["whisper","sd","audio","llama","ik-llama"]'
             echo 'vulkan_projects=["whisper","sd","audio","llama"]'
-            echo "cuda_versions=${cuda_versions}"
+            echo "cuda_versions=${norm}"
+            echo "build_cuda_1291=${build_1291}"
+            echo "build_cuda_1330=${build_1330}"
             echo "cuda_arch_12=${arch_12}"
             echo "cuda_arch_13=${arch_13}"
           } >> "$GITHUB_OUTPUT"
@@ -191,7 +218,7 @@ jobs:
 
   cuda-1291:
     needs: setup
-    if: ${{ needs.setup.outputs.build_cuda == 'true' && contains(needs.setup.outputs.cuda_versions, '12.9.1') }}
+    if: ${{ needs.setup.outputs.build_cuda == 'true' && needs.setup.outputs.build_cuda_1291 == 'true' }}
     uses: ./.github/workflows/unified-docker-backend.yml
     permissions:
       contents: read
@@ -212,7 +239,7 @@ jobs:
 
   cuda-1291-arm64:
     needs: setup
-    if: ${{ needs.setup.outputs.build_cuda == 'true' && needs.setup.outputs.build_arm64 == 'true' && contains(needs.setup.outputs.cuda_versions, '12.9.1') }}
+    if: ${{ needs.setup.outputs.build_cuda == 'true' && needs.setup.outputs.build_arm64 == 'true' && needs.setup.outputs.build_cuda_1291 == 'true' }}
     uses: ./.github/workflows/unified-docker-backend.yml
     permissions:
       contents: read
@@ -236,7 +263,12 @@ jobs:
       - setup
       - cuda-1291
       - cuda-1291-arm64
-    if: ${{ needs.setup.outputs.build_cuda == 'true' && needs.setup.outputs.push_to_ghcr == 'true' && contains(needs.setup.outputs.cuda_versions, '12.9.1') }}
+    if: ${{ always()
+        && needs.cuda-1291.result == 'success'
+        && (needs.cuda-1291-arm64.result == 'skipped' || needs.cuda-1291-arm64.result == 'success')
+        && needs.setup.outputs.build_cuda == 'true'
+        && needs.setup.outputs.push_to_ghcr == 'true'
+        && needs.setup.outputs.build_cuda_1291 == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -278,7 +310,7 @@ jobs:
 
   cuda-1330:
     needs: setup
-    if: ${{ needs.setup.outputs.build_cuda == 'true' && contains(needs.setup.outputs.cuda_versions, '13.3.0') }}
+    if: ${{ needs.setup.outputs.build_cuda == 'true' && needs.setup.outputs.build_cuda_1330 == 'true' }}
     uses: ./.github/workflows/unified-docker-backend.yml
     permissions:
       contents: read
@@ -299,7 +331,7 @@ jobs:
 
   cuda-1330-arm64:
     needs: setup
-    if: ${{ needs.setup.outputs.build_cuda == 'true' && needs.setup.outputs.build_arm64 == 'true' && contains(needs.setup.outputs.cuda_versions, '13.3.0') }}
+    if: ${{ needs.setup.outputs.build_cuda == 'true' && needs.setup.outputs.build_arm64 == 'true' && needs.setup.outputs.build_cuda_1330 == 'true' }}
     uses: ./.github/workflows/unified-docker-backend.yml
     permissions:
       contents: read
@@ -323,7 +355,12 @@ jobs:
       - setup
       - cuda-1330
       - cuda-1330-arm64
-    if: ${{ needs.setup.outputs.build_cuda == 'true' && needs.setup.outputs.push_to_ghcr == 'true' && contains(needs.setup.outputs.cuda_versions, '13.3.0') }}
+    if: ${{ always()
+        && needs.cuda-1330.result == 'success'
+        && (needs.cuda-1330-arm64.result == 'skipped' || needs.cuda-1330-arm64.result == 'success')
+        && needs.setup.outputs.build_cuda == 'true'
+        && needs.setup.outputs.push_to_ghcr == 'true'
+        && needs.setup.outputs.build_cuda_1330 == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -406,7 +443,11 @@ jobs:
       - setup
       - vulkan
       - vulkan-arm64
-    if: ${{ needs.setup.outputs.build_vulkan == 'true' && needs.setup.outputs.push_to_ghcr == 'true' }}
+    if: ${{ always()
+        && needs.vulkan.result == 'success'
+        && (needs.vulkan-arm64.result == 'skipped' || needs.vulkan-arm64.result == 'success')
+        && needs.setup.outputs.build_vulkan == 'true'
+        && needs.setup.outputs.push_to_ghcr == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/unified-docker.yml
+++ b/.github/workflows/unified-docker.yml
@@ -26,6 +26,14 @@ on:
         description: "ik_llama.cpp commit hash, tag, or branch (CUDA only)"
         required: false
         default: "main"
+      cuda_versions:
+        description: "Comma-separated CUDA versions to build (e.g. 12.9.1,13.3.0)"
+        required: false
+        default: ""
+      cuda_architectures:
+        description: "Override CUDA compute capabilities for all versions (default: 60;61;75;86;89 for CUDA 12, 86;89;120;121 for CUDA 13)"
+        required: false
+        default: ""
       llama_swap_version:
         description: "llama-swap version (e.g. v198, latest, main)"
         required: false
@@ -37,6 +45,11 @@ on:
         default: true
       build_vulkan:
         description: "Build Vulkan image"
+        type: boolean
+        required: false
+        default: true
+      build_arm64:
+        description: "Also build the linux/arm64 images (amd64 is always built)"
         type: boolean
         required: false
         default: true
@@ -62,15 +75,17 @@ permissions:
 # base tag -- so anything unchanged is skipped, and one project overrunning no
 # longer discards the others.
 #
-# Each backend runs as its own call to unified-docker-backend.yml, so Vulkan
-# publishes as soon as its own projects finish rather than waiting on the
-# multi-hour CUDA compiles.
+# Each backend+version runs as its own call to unified-docker-backend.yml, so
+# Vulkan publishes as soon as its own projects finish rather than waiting on
+# the multi-hour CUDA compiles. Multiple CUDA versions build independently.
 jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
       build_cuda: ${{ steps.plan.outputs.build_cuda }}
       build_vulkan: ${{ steps.plan.outputs.build_vulkan }}
+      build_arm64: ${{ steps.plan.outputs.build_arm64 }}
+      platforms: ${{ steps.plan.outputs.platforms }}
       cuda_projects: ${{ steps.plan.outputs.cuda_projects }}
       vulkan_projects: ${{ steps.plan.outputs.vulkan_projects }}
       push_to_ghcr: ${{ steps.plan.outputs.push_to_ghcr }}
@@ -80,6 +95,9 @@ jobs:
       audio_hash: ${{ steps.refs.outputs.audio_hash }}
       ik_llama_hash: ${{ steps.refs.outputs.ik_llama_hash }}
       ls_hash: ${{ steps.refs.outputs.ls_hash }}
+      cuda_versions: ${{ steps.plan.outputs.cuda_versions }}
+      cuda_arch_12: ${{ steps.plan.outputs.cuda_arch_12 }}
+      cuda_arch_13: ${{ steps.plan.outputs.cuda_arch_13 }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # 6.0.2
@@ -105,31 +123,59 @@ jobs:
         run: |
           # schedule uses defaults (build both, push); workflow_dispatch respects inputs
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            build_cuda=true; build_vulkan=true; push=true
+            build_cuda=true; build_vulkan=true; build_arm64=true; push=true
           else
             build_cuda="${{ inputs.build_cuda }}"
             build_vulkan="${{ inputs.build_vulkan }}"
+            build_arm64="${{ inputs.build_arm64 }}"
             push="${{ inputs.push_to_ghcr }}"
           fi
+
+          # amd64 is always built; arm64 adds the second entry the merge jobs
+          # iterate over when folding the per-platform images together.
+          if [[ "${build_arm64}" == "true" ]]; then
+            platforms='["linux/amd64","linux/arm64"]'
+          else
+            platforms='["linux/amd64"]'
+          fi
+
+          # Multiple CUDA versions are built independently; each gets its own
+          # base, artifacts, assemble, and merge jobs.
+          cuda_versions="${{ inputs.cuda_versions || '12.9.1,13.3.0' }}"
 
           {
             echo "build_cuda=${build_cuda}"
             echo "build_vulkan=${build_vulkan}"
+            echo "build_arm64=${build_arm64}"
             echo "push_to_ghcr=${push}"
+            echo "platforms=${platforms}"
             # ik_llama.cpp has no Vulkan build.
             echo 'cuda_projects=["whisper","sd","audio","llama","ik-llama"]'
             echo 'vulkan_projects=["whisper","sd","audio","llama"]'
+            echo "cuda_versions=${cuda_versions}"
+            # Per-version defaults: CUDA 12 supports Pascal through Ada;
+            # CUDA 13 drops Pascal/Volta/Turing and adds Blackwell (120/121).
+            # An explicit cuda_architectures input overrides both.
+            echo "cuda_arch_12=${{ inputs.cuda_architectures || '60;61;75;86;89' }}"
+            echo "cuda_arch_13=${{ inputs.cuda_architectures || '86;89;120;121' }}"
           } >> "$GITHUB_OUTPUT"
 
-  cuda:
+# One backend call per version per platform so each chain (base -> projects ->
+# assemble) runs independently on native runners; a merge job then folds the
+# per-platform images into the arch-less multi-arch manifests.
+
+  # ── CUDA 12.9.1 ──────────────────────────────────────────────────────────
+
+  cuda-1291:
     needs: setup
-    if: ${{ needs.setup.outputs.build_cuda == 'true' }}
+    if: ${{ needs.setup.outputs.build_cuda == 'true' && contains(needs.setup.outputs.cuda_versions, '12.9.1') }}
     uses: ./.github/workflows/unified-docker-backend.yml
     permissions:
       contents: read
       packages: write
     with:
       backend: cuda
+      platform: linux/amd64
       projects: ${{ needs.setup.outputs.cuda_projects }}
       push_to_ghcr: ${{ needs.setup.outputs.push_to_ghcr == 'true' }}
       llama_hash: ${{ needs.setup.outputs.llama_hash }}
@@ -138,6 +184,159 @@ jobs:
       audio_hash: ${{ needs.setup.outputs.audio_hash }}
       ik_llama_hash: ${{ needs.setup.outputs.ik_llama_hash }}
       ls_hash: ${{ needs.setup.outputs.ls_hash }}
+      cuda_version: "12.9.1"
+      cuda_architectures: ${{ needs.setup.outputs.cuda_arch_12 }}
+
+  cuda-1291-arm64:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_cuda == 'true' && needs.setup.outputs.build_arm64 == 'true' && contains(needs.setup.outputs.cuda_versions, '12.9.1') }}
+    uses: ./.github/workflows/unified-docker-backend.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      backend: cuda
+      platform: linux/arm64
+      projects: ${{ needs.setup.outputs.cuda_projects }}
+      push_to_ghcr: ${{ needs.setup.outputs.push_to_ghcr == 'true' }}
+      llama_hash: ${{ needs.setup.outputs.llama_hash }}
+      whisper_hash: ${{ needs.setup.outputs.whisper_hash }}
+      sd_hash: ${{ needs.setup.outputs.sd_hash }}
+      audio_hash: ${{ needs.setup.outputs.audio_hash }}
+      ik_llama_hash: ${{ needs.setup.outputs.ik_llama_hash }}
+      ls_hash: ${{ needs.setup.outputs.ls_hash }}
+      cuda_version: "12.9.1"
+      cuda_architectures: ${{ needs.setup.outputs.cuda_arch_12 }}
+
+  cuda-1291-merge:
+    needs:
+      - setup
+      - cuda-1291
+      - cuda-1291-arm64
+    if: ${{ needs.setup.outputs.build_cuda == 'true' && needs.setup.outputs.push_to_ghcr == 'true' && contains(needs.setup.outputs.cuda_versions, '12.9.1') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      # Fails loudly if a requested platform's images are missing, rather than
+      # silently publishing a single-arch manifest after a failed build.
+      - name: Merge platform images into multi-arch manifests
+        env:
+          BASE_TAG: ghcr.io/${{ github.repository }}:unified-cuda-12.9.1
+          PLATFORMS: ${{ needs.setup.outputs.platforms }}
+        run: |
+          set -eu
+          DATE_TAG=$(date -u +%Y-%m-%d)
+          base_tags=()
+          rootless_tags=()
+          for platform in $(echo "${PLATFORMS}" | jq -r '.[]'); do
+            arch="${platform#linux/}"
+            for tag in "${BASE_TAG}-${arch}" "${BASE_TAG}-${arch}-rootless"; do
+              if ! docker buildx imagetools inspect "${tag}" >/dev/null 2>&1; then
+                echo "ERROR: ${tag} was not published; the ${platform} build must have failed." >&2
+                exit 1
+              fi
+            done
+            base_tags+=("${BASE_TAG}-${arch}")
+            rootless_tags+=("${BASE_TAG}-${arch}-rootless")
+          done
+          docker buildx imagetools create -t "${BASE_TAG}" "${base_tags[@]}"
+          docker buildx imagetools create -t "${BASE_TAG}-${DATE_TAG}" "${base_tags[@]}"
+          docker buildx imagetools create -t "${BASE_TAG}-rootless" "${rootless_tags[@]}"
+          docker buildx imagetools create -t "${BASE_TAG}-rootless-${DATE_TAG}" "${rootless_tags[@]}"
+
+  # ── CUDA 13.3.0 ──────────────────────────────────────────────────────────
+
+  cuda-1330:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_cuda == 'true' && contains(needs.setup.outputs.cuda_versions, '13.3.0') }}
+    uses: ./.github/workflows/unified-docker-backend.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      backend: cuda
+      platform: linux/amd64
+      projects: ${{ needs.setup.outputs.cuda_projects }}
+      push_to_ghcr: ${{ needs.setup.outputs.push_to_ghcr == 'true' }}
+      llama_hash: ${{ needs.setup.outputs.llama_hash }}
+      whisper_hash: ${{ needs.setup.outputs.whisper_hash }}
+      sd_hash: ${{ needs.setup.outputs.sd_hash }}
+      audio_hash: ${{ needs.setup.outputs.audio_hash }}
+      ik_llama_hash: ${{ needs.setup.outputs.ik_llama_hash }}
+      ls_hash: ${{ needs.setup.outputs.ls_hash }}
+      cuda_version: "13.3.0"
+      cuda_architectures: ${{ needs.setup.outputs.cuda_arch_13 }}
+
+  cuda-1330-arm64:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_cuda == 'true' && needs.setup.outputs.build_arm64 == 'true' && contains(needs.setup.outputs.cuda_versions, '13.3.0') }}
+    uses: ./.github/workflows/unified-docker-backend.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      backend: cuda
+      platform: linux/arm64
+      projects: ${{ needs.setup.outputs.cuda_projects }}
+      push_to_ghcr: ${{ needs.setup.outputs.push_to_ghcr == 'true' }}
+      llama_hash: ${{ needs.setup.outputs.llama_hash }}
+      whisper_hash: ${{ needs.setup.outputs.whisper_hash }}
+      sd_hash: ${{ needs.setup.outputs.sd_hash }}
+      audio_hash: ${{ needs.setup.outputs.audio_hash }}
+      ik_llama_hash: ${{ needs.setup.outputs.ik_llama_hash }}
+      ls_hash: ${{ needs.setup.outputs.ls_hash }}
+      cuda_version: "13.3.0"
+      cuda_architectures: ${{ needs.setup.outputs.cuda_arch_13 }}
+
+  cuda-1330-merge:
+    needs:
+      - setup
+      - cuda-1330
+      - cuda-1330-arm64
+    if: ${{ needs.setup.outputs.build_cuda == 'true' && needs.setup.outputs.push_to_ghcr == 'true' && contains(needs.setup.outputs.cuda_versions, '13.3.0') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Merge platform images into multi-arch manifests
+        env:
+          BASE_TAG: ghcr.io/${{ github.repository }}:unified-cuda-13.3.0
+          PLATFORMS: ${{ needs.setup.outputs.platforms }}
+        run: |
+          set -eu
+          DATE_TAG=$(date -u +%Y-%m-%d)
+          base_tags=()
+          rootless_tags=()
+          for platform in $(echo "${PLATFORMS}" | jq -r '.[]'); do
+            arch="${platform#linux/}"
+            for tag in "${BASE_TAG}-${arch}" "${BASE_TAG}-${arch}-rootless"; do
+              if ! docker buildx imagetools inspect "${tag}" >/dev/null 2>&1; then
+                echo "ERROR: ${tag} was not published; the ${platform} build must have failed." >&2
+                exit 1
+              fi
+            done
+            base_tags+=("${BASE_TAG}-${arch}")
+            rootless_tags+=("${BASE_TAG}-${arch}-rootless")
+          done
+          docker buildx imagetools create -t "${BASE_TAG}" "${base_tags[@]}"
+          docker buildx imagetools create -t "${BASE_TAG}-${DATE_TAG}" "${base_tags[@]}"
+          docker buildx imagetools create -t "${BASE_TAG}-rootless" "${rootless_tags[@]}"
+          docker buildx imagetools create -t "${BASE_TAG}-rootless-${DATE_TAG}" "${rootless_tags[@]}"
+
+  # ── Vulkan ───────────────────────────────────────────────────────────────
 
   vulkan:
     needs: setup
@@ -148,6 +347,7 @@ jobs:
       packages: write
     with:
       backend: vulkan
+      platform: linux/amd64
       projects: ${{ needs.setup.outputs.vulkan_projects }}
       push_to_ghcr: ${{ needs.setup.outputs.push_to_ghcr == 'true' }}
       llama_hash: ${{ needs.setup.outputs.llama_hash }}
@@ -156,3 +356,65 @@ jobs:
       audio_hash: ${{ needs.setup.outputs.audio_hash }}
       ik_llama_hash: ${{ needs.setup.outputs.ik_llama_hash }}
       ls_hash: ${{ needs.setup.outputs.ls_hash }}
+      cuda_version: ""
+      cuda_architectures: ""
+
+  vulkan-arm64:
+    needs: setup
+    if: ${{ needs.setup.outputs.build_vulkan == 'true' && needs.setup.outputs.build_arm64 == 'true' }}
+    uses: ./.github/workflows/unified-docker-backend.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      backend: vulkan
+      platform: linux/arm64
+      projects: ${{ needs.setup.outputs.vulkan_projects }}
+      push_to_ghcr: ${{ needs.setup.outputs.push_to_ghcr == 'true' }}
+      llama_hash: ${{ needs.setup.outputs.llama_hash }}
+      whisper_hash: ${{ needs.setup.outputs.whisper_hash }}
+      sd_hash: ${{ needs.setup.outputs.sd_hash }}
+      audio_hash: ${{ needs.setup.outputs.audio_hash }}
+      ik_llama_hash: ${{ needs.setup.outputs.ik_llama_hash }}
+      ls_hash: ${{ needs.setup.outputs.ls_hash }}
+
+  vulkan-merge:
+    needs:
+      - setup
+      - vulkan
+      - vulkan-arm64
+    if: ${{ needs.setup.outputs.build_vulkan == 'true' && needs.setup.outputs.push_to_ghcr == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Merge platform images into multi-arch manifests
+        env:
+          BASE_TAG: ghcr.io/${{ github.repository }}:unified-vulkan
+          PLATFORMS: ${{ needs.setup.outputs.platforms }}
+        run: |
+          set -eu
+          DATE_TAG=$(date -u +%Y-%m-%d)
+          base_tags=()
+          rootless_tags=()
+          for platform in $(echo "${PLATFORMS}" | jq -r '.[]'); do
+            arch="${platform#linux/}"
+            for tag in "${BASE_TAG}-${arch}" "${BASE_TAG}-${arch}-rootless"; do
+              if ! docker buildx imagetools inspect "${tag}" >/dev/null 2>&1; then
+                echo "ERROR: ${tag} was not published; the ${platform} build must have failed." >&2
+                exit 1
+              fi
+            done
+            base_tags+=("${BASE_TAG}-${arch}")
+            rootless_tags+=("${BASE_TAG}-${arch}-rootless")
+          done
+          docker buildx imagetools create -t "${BASE_TAG}" "${base_tags[@]}"
+          docker buildx imagetools create -t "${BASE_TAG}-${DATE_TAG}" "${base_tags[@]}"
+          docker buildx imagetools create -t "${BASE_TAG}-rootless" "${rootless_tags[@]}"
+          docker buildx imagetools create -t "${BASE_TAG}-rootless-${DATE_TAG}" "${rootless_tags[@]}"

--- a/docker/unified/README.md
+++ b/docker/unified/README.md
@@ -18,7 +18,8 @@ that is reachable from the container; vLLM itself is not included in the image.
 ./build-image.sh --cuda      # or --vulkan
 ```
 
-That compiles everything and assembles the image, same as before.
+That compiles everything and assembles the image, same as before, and derives
+the `-rootless` variant (same image with a non-root user) from it.
 
 ### Layout
 
@@ -29,6 +30,7 @@ The build is one Dockerfile per piece:
 | `base-<backend>.Dockerfile` | the builder base (compilers, CUDA/Vulkan SDK) |
 | `<project>.Dockerfile` | one upstream project, as a `scratch` image of `/install` |
 | `runtime.Dockerfile` | the final image, copying those `/install` trees in |
+| `rootless.Dockerfile` | the runtime image plus a non-root user (`-rootless`) |
 
 A project's build inputs are therefore exactly two files — its own Dockerfile
 and its install script — plus the tag of the base it compiles from. Nothing has
@@ -45,8 +47,8 @@ next night rebuilt everything again — one overrun kept every later run failing
 
 ```
 setup ── resolve every upstream ref once
-  ├─ cuda ─── base ── whisper sd audio llama ik-llama ── assemble ── push
-  └─ vulkan ─ base ── whisper sd audio llama ─────────── assemble ── push
+  ├─ cuda ─── base ── whisper sd audio llama ik-llama ── assemble ── push ── rootless
+  └─ vulkan ─ base ── whisper sd audio llama ─────────── assemble ── push ── rootless
 ```
 
 Each backend is a separate call to `unified-docker-backend.yml`, which holds
@@ -67,6 +69,7 @@ Which gives, concretely:
 | edit | rebuilds |
 |---|---|
 | `runtime.Dockerfile`, this README | nothing |
+| `rootless.Dockerfile` | nothing but the `-rootless` variant |
 | `install-sd.sh` or `sd.Dockerfile` | sd, both backends |
 | `base-cuda.Dockerfile` (e.g. `CMAKE_CUDA_ARCHITECTURES`, or setting the env var of the same name) | the CUDA base and all 5 CUDA projects; no Vulkan |
 | `CUDA_VERSION` env var | the CUDA base, all 5 CUDA projects, and the runtime image; no Vulkan |
@@ -83,7 +86,16 @@ recompiling anything.
 ./build-image.sh --cuda --stage=base      # build + push the builder base
 ./build-image.sh --cuda --stage=llama     # build + push one project's artifacts
 ./build-image.sh --cuda --assemble        # assemble from published images
+./build-image.sh --cuda --rootless        # rootless variant of DOCKER_IMAGE_TAG
 ```
+
+`--rootless` is a separate step and runs after the runtime image is pushed. Its
+`FROM` is the runtime image tag, and CI builds with a buildx container driver,
+which resolves `FROM` through the registry rather than the local image store —
+building it inside `--assemble` made it point at a tag no step had published
+yet. It still runs with the `docker` driver (`--builder default`), so it uses
+the image the assemble step already loaded and re-pulls from the registry only
+on a runner that does not have it.
 
 `--stage` and `--assemble` push to and read from `ARTIFACT_REPO` (default
 `ghcr.io/mostlygeek/llama-swap-build`), so they need registry credentials and a

--- a/docker/unified/build-image.sh
+++ b/docker/unified/build-image.sh
@@ -30,6 +30,11 @@
 #   ./build-image.sh --cuda --stage=base      # build + push the builder base
 #   ./build-image.sh --cuda --stage=whisper   # build + push one project's artifacts
 #   ./build-image.sh --cuda --assemble        # assemble the unified image
+#   ./build-image.sh --cuda --rootless        # build + push the rootless variant
+#
+# The rootless image is the published runtime image plus a non-root user, so
+# --rootless is its own CI step that runs after the runtime image has been
+# pushed: its FROM has to resolve a tag that only exists once that push did.
 #
 
 set -euo pipefail
@@ -39,10 +44,7 @@ NO_CACHE=false
 MODE="unified"
 STAGE_TARGET=""
 WHISPER_FFMPEG="${WHISPER_FFMPEG:-yes}"
-
-# CUDA compute capabilities compiled as SASS. Only the CUDA base reads it as a
-# build arg; the projects inherit it through the base image's ENV.
-CMAKE_CUDA_ARCHITECTURES="${CMAKE_CUDA_ARCHITECTURES:-60;61;75;86;89}"
+PLATFORM="${PLATFORM:-}"
 
 # CUDA toolkit and runtime version, matching nvidia/cuda image tags. The CUDA
 # builder base and the runtime image are both built from it, so the compiled
@@ -66,19 +68,25 @@ for arg in "$@"; do
         --cuda)    BACKEND="cuda" ;;
         --vulkan)  BACKEND="vulkan" ;;
         --no-cache) NO_CACHE=true ;;
+        --platform=*)
+            PLATFORM="${arg#*=}"
+            ;;
         --resolve)  MODE="resolve" ;;
         --assemble) MODE="assemble" ;;
+        --rootless) MODE="rootless" ;;
         --stage=*)
             MODE="stage"
             STAGE_TARGET="${arg#*=}"
             ;;
         --help|-h)
-            echo "Usage: ./build-image.sh --cuda|--vulkan [--no-cache]"
+            echo "Usage: ./build-image.sh --cuda|--vulkan [--no-cache] [--platform=linux/amd64|linux/arm64]"
             echo ""
             echo "Options:"
             echo "  --cuda      Build CUDA image (NVIDIA GPUs)"
             echo "  --vulkan    Build Vulkan image (AMD GPUs and compatible hardware)"
             echo "  --no-cache  Force rebuild without using Docker cache"
+            echo "  --platform=PLATFORM  Build for PLATFORM (linux/amd64 or linux/arm64);"
+            echo "                       defaults to the host architecture"
             echo "  --help, -h  Show this help message"
             echo ""
             echo "Split build (CI only):"
@@ -87,6 +95,8 @@ for arg in "$@"; do
             echo "  --stage=PROJECT  Build and push one project's artifacts image"
             echo "                   (${ALL_PROJECTS[*]})"
             echo "  --assemble       Assemble the unified image from published artifacts"
+            echo "  --rootless       Build and push the rootless variant of DOCKER_IMAGE_TAG"
+            echo "                   (DOCKER_IMAGE_TAG must be loaded locally or published)"
             echo ""
             echo "Environment variables:"
             echo "  DOCKER_IMAGE_TAG     Set custom image tag (default: llama-swap:unified-cuda or llama-swap:unified-vulkan)"
@@ -97,8 +107,9 @@ for arg in "$@"; do
             echo "  IK_LLAMA_REF         Pin ik_llama.cpp to a commit, tag, or branch (CUDA only)"
             echo "  LS_VERSION           Override llama-swap version (e.g., '170' or 'latest')"
             echo "  WHISPER_FFMPEG       Enable whisper.cpp FFmpeg support (default: yes)"
+            echo "  PLATFORM               Target platform (linux/amd64 or linux/arm64)"
             echo "  CMAKE_CUDA_ARCHITECTURES  CUDA compute capabilities to compile natively"
-            echo "                       (default: 60;61;75;86;89, CUDA only)"
+            echo "                       (default: amd64 60;61;75;86;89, arm64 80;86;89;121, CUDA only)"
             echo "  CUDA_VERSION         CUDA toolkit/runtime version as an nvidia/cuda image tag"
             echo "                       (default: 12.9.1, CUDA only)"
             echo "  ARTIFACT_REPO        Registry for base and artifacts images"
@@ -111,7 +122,7 @@ done
 if [[ -z "$BACKEND" ]]; then
     echo "Error: No backend specified. Please use --cuda or --vulkan."
     echo ""
-    echo "Usage: ./build-image.sh --cuda|--vulkan [--no-cache]"
+    echo "Usage: ./build-image.sh --cuda|--vulkan [--no-cache] [--platform=linux/amd64|linux/arm64]"
     exit 1
 fi
 
@@ -120,6 +131,36 @@ fi
 if [[ "$BACKEND" == "cuda" && ! "$CUDA_VERSION" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
     echo "ERROR: CUDA_VERSION '${CUDA_VERSION}' is not a valid nvidia/cuda version (e.g., 12.9.1)" >&2
     exit 1
+fi
+
+# The platform the image is built for: explicit --platform/PLATFORM (CI builds
+# each platform natively on matching runners), or the host architecture for
+# local builds. It is baked into the base and artifacts tags below so both
+# platforms can coexist in the registry.
+if [[ -n "$PLATFORM" ]]; then
+    case "$PLATFORM" in
+        linux/amd64) ARCH="amd64" ;;
+        linux/arm64) ARCH="arm64" ;;
+        *) echo "ERROR: unsupported platform '${PLATFORM}' (use linux/amd64 or linux/arm64)" >&2; exit 1 ;;
+    esac
+else
+    case "$(uname -m)" in
+        x86_64) ARCH="amd64" ;;
+        aarch64|arm64) ARCH="arm64" ;;
+        *) echo "ERROR: unsupported host architecture '$(uname -m)'" >&2; exit 1 ;;
+    esac
+fi
+
+# CUDA compute capabilities compiled as SASS. Only the CUDA base reads it as a
+# build arg; the projects inherit it through the base image's ENV. The default
+# depends on the platform: the nvidia/cuda aarch64 toolchain does not support
+# Pascal (60/61), so the arm64 set skips them and adds 121 (GB10, DGX Spark).
+if [[ -z "${CMAKE_CUDA_ARCHITECTURES:-}" ]]; then
+    if [[ "$ARCH" == "arm64" ]]; then
+        CMAKE_CUDA_ARCHITECTURES="80;86;89;121"
+    else
+        CMAKE_CUDA_ARCHITECTURES="60;61;75;86;89"
+    fi
 fi
 
 # --resolve emits machine-readable output only, so the progress chatter that
@@ -230,12 +271,13 @@ base_tag() {
     # the tag even though the Dockerfile is unchanged.
     h="$( {
         sha256sum "${SCRIPT_DIR}/base-${BACKEND}.Dockerfile"
+        echo "${ARCH}"
         if [[ "${BACKEND}" == "cuda" ]]; then
             echo "${CMAKE_CUDA_ARCHITECTURES}"
             echo "${CUDA_VERSION}"
         fi
     } | sha256sum | cut -c1-12)"
-    echo "${ARTIFACT_REPO}:base-${BACKEND}-${h}"
+    echo "${ARTIFACT_REPO}:base-${BACKEND}-${ARCH}-${h}"
 }
 
 # A project's artifacts are determined by the upstream commit plus its recipe:
@@ -250,7 +292,7 @@ artifact_tag() {
         echo "base=$(base_tag)"
         echo "WHISPER_FFMPEG=${WHISPER_FFMPEG}"
     } | sha256sum | cut -c1-8 )"
-    echo "${ARTIFACT_REPO}:art-${project}-${BACKEND}-${commit:0:12}-${recipe}"
+    echo "${ARTIFACT_REPO}:art-${project}-${BACKEND}-${ARCH}-${commit:0:12}-${recipe}"
 }
 
 image_exists() {
@@ -261,6 +303,7 @@ log "=========================================="
 case "$MODE" in
     stage)    log "llama-swap Build (${STAGE_TARGET}, ${BACKEND})" ;;
     assemble) log "llama-swap Unified Assemble (${BACKEND})" ;;
+    rootless) log "llama-swap Rootless Variant (${BACKEND})" ;;
     *)        log "llama-swap Unified Build (${BACKEND})" ;;
 esac
 log "=========================================="
@@ -361,7 +404,13 @@ if [[ "$NO_CACHE" == true ]]; then
     echo "Note: Building without cache"
 fi
 
+PLATFORM_ARGS=()
+if [[ -n "$PLATFORM" ]]; then
+    PLATFORM_ARGS+=(--platform="$PLATFORM")
+fi
+
 BASE_TAG="$(base_tag)"
+ROOTLESS_TAG="${DOCKER_IMAGE_TAG}-rootless"
 
 # ── Builders ──────────────────────────────────────────────────────────
 
@@ -381,6 +430,7 @@ build_base() {
         -f "${SCRIPT_DIR}/base-${BACKEND}.Dockerfile" \
         -t "${BASE_TAG}" \
         "${args[@]}" \
+        "${PLATFORM_ARGS[@]}" \
         "${CACHE_ARGS[@]}" \
         "${SCRIPT_DIR}"
 }
@@ -406,6 +456,7 @@ build_project() {
         --build-arg "AUDIO_COMMIT_HASH=${AUDIO_HASH}" \
         --build-arg "LLAMA_COMMIT_HASH=${LLAMA_HASH}" \
         --build-arg "IK_LLAMA_COMMIT_HASH=${IK_LLAMA_HASH}" \
+        "${PLATFORM_ARGS[@]}" \
         "${CACHE_ARGS[@]}" \
         "${SCRIPT_DIR}"
 }
@@ -438,7 +489,48 @@ build_runtime() {
     DOCKER_BUILDKIT=1 docker buildx build --load \
         -f "${SCRIPT_DIR}/runtime.Dockerfile" \
         -t "${DOCKER_IMAGE_TAG}" \
-        "${args[@]}" "${CACHE_ARGS[@]}" \
+        "${args[@]}" "${PLATFORM_ARGS[@]}" "${CACHE_ARGS[@]}" \
+        "${SCRIPT_DIR}"
+}
+
+# The rootless variant is the finished runtime image with a non-root user
+# layered on top of it.
+#
+# It builds with the docker (daemon) builder rather than the CI builder
+# deliberately: rootless.Dockerfile's FROM points at ${DOCKER_IMAGE_TAG}, which
+# only exists in the daemon's image store (a local --load) or in the registry
+# (after a push). A docker-container builder can resolve neither a locally
+# loaded tag nor one that has not been pushed yet, which is what broke CI.
+build_rootless() {
+    local output=("$@")
+    local tags=(-t "${ROOTLESS_TAG}")
+    if [[ -n "${ROOTLESS_DATE_TAG:-}" ]]; then
+        tags+=(-t "${ROOTLESS_DATE_TAG}")
+    fi
+
+    # Use the registry copy when there is no local one; the daemon pull and the
+    # registry credentials are already set up in CI.
+    if ! docker image inspect "${DOCKER_IMAGE_TAG}" >/dev/null 2>&1; then
+        if ! image_exists "${DOCKER_IMAGE_TAG}"; then
+            echo "ERROR: base image ${DOCKER_IMAGE_TAG} is neither loaded locally nor published." >&2
+            echo "  The rootless image is built on top of the runtime image, so that" >&2
+            echo "  image has to be built (--assemble) or pushed first." >&2
+            exit 1
+        fi
+        echo "${DOCKER_IMAGE_TAG} not loaded locally, pulling it from the registry..."
+    fi
+
+    echo ""
+    echo "=========================================="
+    echo "Building rootless image (${BACKEND})..."
+    echo "=========================================="
+    echo ""
+    DOCKER_BUILDKIT=1 docker buildx build --builder default "${output[@]}" \
+        -f "${SCRIPT_DIR}/rootless.Dockerfile" \
+        "${tags[@]}" \
+        --build-arg "BASE_IMAGE=${DOCKER_IMAGE_TAG}" \
+        "${PLATFORM_ARGS[@]}" \
+        "${CACHE_ARGS[@]}" \
         "${SCRIPT_DIR}"
 }
 
@@ -473,6 +565,29 @@ if [[ "$MODE" == "stage" ]]; then
 
     echo ""
     echo "Published: ${TARGET_TAG}"
+    exit 0
+fi
+
+# ── --rootless: publish the rootless variant of the runtime image ──────
+#
+# Its own CI step so it never depends on an image tag that a later step is
+# still responsible for publishing: the assemble job pushes the runtime image
+# first, then this runs.
+
+if [[ "$MODE" == "rootless" ]]; then
+    # Same date tag as the runtime image gets, so the pair always matches.
+    if [[ -n "${DATE_TAG:-}" ]]; then
+        ROOTLESS_DATE_TAG="${ROOTLESS_TAG}-${DATE_TAG}"
+    fi
+
+    echo ""
+    echo "Base image:  ${DOCKER_IMAGE_TAG}"
+    echo "Rootless:    ${ROOTLESS_TAG}"
+
+    build_rootless --push
+
+    echo ""
+    echo "Published: ${ROOTLESS_TAG}${ROOTLESS_DATE_TAG:+ ${ROOTLESS_DATE_TAG}}"
     exit 0
 fi
 
@@ -573,24 +688,13 @@ fi
 
 echo "audio.cpp verified: deployment build (compiled model spec catalog), binary runs"
 
-echo ""
-echo "=========================================="
-echo "Building rootless image..."
-echo "=========================================="
-echo ""
-
-ROOTLESS_TAG="${DOCKER_IMAGE_TAG}-rootless"
-docker buildx build --load -t "${ROOTLESS_TAG}" - <<EOF
-FROM ${DOCKER_IMAGE_TAG}
-USER root
-RUN groupadd --system --gid 10001 llama-swap && \\
-    useradd --system --uid 10001 --gid 10001 \\
-      --home /app --shell /sbin/nologin llama-swap && \\
-    chown -R 10001:10001 /etc/llama-swap /models
-USER 10001
-EOF
-
-echo "Rootless image built: ${ROOTLESS_TAG}"
+# Only the local unified build derives the rootless image here. CI builds it
+# with --rootless as a separate step, after the runtime image is pushed.
+ROOTLESS_BUILT=false
+if [[ "$MODE" == "unified" ]]; then
+    build_rootless --load
+    ROOTLESS_BUILT=true
+fi
 
 echo ""
 echo "=========================================="
@@ -599,9 +703,13 @@ echo "=========================================="
 echo ""
 echo "Image tags:"
 echo "  ${DOCKER_IMAGE_TAG}"
-echo "  ${ROOTLESS_TAG}"
+if [[ "$ROOTLESS_BUILT" == true ]]; then
+    echo "  ${ROOTLESS_TAG}"
+fi
 echo ""
 echo "Built with:"
+echo "  platform:             ${PLATFORM:-native}"
+echo "  architecture:         ${ARCH}"
 echo "  llama.cpp:            ${LLAMA_HASH}"
 echo "  whisper.cpp:          ${WHISPER_HASH}"
 echo "  stable-diffusion.cpp: ${SD_HASH}"

--- a/docker/unified/rootless.Dockerfile
+++ b/docker/unified/rootless.Dockerfile
@@ -1,0 +1,18 @@
+# Rootless variant of the unified image: the finished runtime image plus a
+# non-root user owning the config and model directories.
+#
+# Kept as its own Dockerfile so it can be built (and pushed) on top of an
+# already published runtime image, instead of being chained onto the end of
+# the assemble build -- that build ran before the runtime image existed in the
+# registry, so the FROM below could not resolve it.
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+USER root
+RUN groupadd --system --gid 10001 llama-swap && \
+    useradd --system --uid 10001 --gid 10001 \
+      --home /app --shell /sbin/nologin llama-swap && \
+    chown -R 10001:10001 /etc/llama-swap /models
+
+USER 10001


### PR DESCRIPTION
This PR adds the option to build CUDA 13 images and also to build all images for ARM64.

I needed to split the root and rootless build because rootless was using the newly pushed image as a base and on first run, there is no such image since it is pushed only after.

You can see the results here: https://github.com/tdamir/llama-swap/actions/runs/33618738872
Published images: https://github.com/tdamir/llama-swap/pkgs/container/llama-swap
Published dev images: https://github.com/tdamir/llama-swap/pkgs/container/llama-swap-build

I'm not sure how good and maintainable code is this. I'm not that much experienced in writing GitHub workflows. The AI helped me.