### PR TITLE
Replace config path argument with jq query support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Only use these technologies:
 - Use `make test-all` for commiting changes
 - Use the ./build subdirectory for testing binary builds
 - Only when the user asks use `make eval-docs-agent` to score the
-  Playground's Docs Agent against a local model after changing its system prompt, `docs/kb/` content, the MCP tool descriptions, or the docs search ranking. See `evals/docs-agent/README.md` for the tuning loop.
+  Help page's Docs Agent against a local model after changing its system prompt, `docs/kb/` content, the MCP tool descriptions, or the docs search ranking. See `evals/docs-agent/README.md` for the tuning loop.
 
 ### git commit rules
 

--- a/docs/kb/README.md
+++ b/docs/kb/README.md
@@ -1,6 +1,6 @@
 # llama-swap knowledge base
 
-Short, focused articles that the Playground's Docs agent can search and read.
+Short, focused articles that the Help page's Docs agent can search and read.
 Every file here is indexed at build time and served over MCP at `/api/mcp`, so an
 LLM running on your own hardware can answer questions about llama-swap using
 real text instead of guesswork.

--- a/docs/kb/guides/api-integration/mcp-endpoint.md
+++ b/docs/kb/guides/api-integration/mcp-endpoint.md
@@ -11,7 +11,7 @@ updated: 2026-09-04
 
 llama-swap serves its own documentation as an MCP server at `/api/mcp`. Any
 MCP client can point at a running instance and ask about llama-swap
-configuration — the same tools the web UI's Playground Docs tab uses.
+configuration — the same tools the web UI's Help page uses.
 
 ```
 http://localhost:8080/api/mcp

--- a/docs/kb/guides/api-integration/mcp-endpoint.md
+++ b/docs/kb/guides/api-integration/mcp-endpoint.md
@@ -95,8 +95,11 @@ it does not exist, or its value is the default, since defaults are omitted. `env
 and `$ENV` are not available: the process environment holds exactly the credentials
 that redaction keeps out of the result.
 
-Evaluation is capped at five seconds, and a result larger than 32KB is refused
-with a message asking for a narrower query rather than returned truncated.
+A query is bounded three ways, and each refusal explains itself so a client can
+retry with something narrower: evaluation is capped at five seconds, a result
+larger than 32KB is refused rather than returned truncated, and a query that
+builds a value too large to hold — `[range(0; 1000000000)]` and its relatives —
+is stopped while it is still building it.
 
 **`sys__*` — facts about the machine**
 

--- a/docs/kb/guides/api-integration/mcp-endpoint.md
+++ b/docs/kb/guides/api-integration/mcp-endpoint.md
@@ -4,7 +4,7 @@ summary: Point any MCP client at /api/mcp to search and read llama-swap's docume
 category: guides
 tags: [mcp, tools, agent, api, integration]
 config_keys: [apiKeys]
-updated: 2026-08-27
+updated: 2026-09-04
 ---
 
 # Connecting an MCP client to llama-swap
@@ -68,13 +68,35 @@ from, which keeps names unique once llama-swap starts proxying other MCP servers
 
 | tool | what it does |
 | --- | --- |
-| `config__get_config` | the configuration this instance is running right now, as YAML, with credentials redacted; pass `path` to scope it to a section like `models` or `models.qwen3` |
+| `config__get_config` | the configuration this instance is running right now, as YAML, with credentials redacted; pass a jq `query` to select part of it |
 
 `config__get_config` returns the *effective* config: defaults filled in, `${env.*}`
 and macro references already expanded. `apiKeys`, `peers.<id>.apiKey`, secret-looking
 `cmd`/`env` arguments, and any recognizable credential token are replaced with
 `[REDACTED]` before the result leaves the server. It is what lets an agent give advice
 about the setup actually in front of it.
+
+The `query` argument is a [jq](https://jqlang.org/manual/) expression, evaluated by
+[gojq](https://github.com/itchyny/gojq), so a client asks for exactly what it needs
+instead of reading the whole document and throwing most of it away:
+
+| query | what comes back |
+| --- | --- |
+| omitted, or `.` | the whole config |
+| `.models \| keys` | the configured model ids |
+| `.models.qwen3` | one model |
+| `.models["qwen3-8b"].ttl` | one field of a model whose id jq will not take bare |
+| `.models \| to_entries \| map({id: .key, ttl: .value.ttl})` | one field from every model |
+| `.models \| to_entries \| map(select(.value.ttl == null)) \| map(.key)` | the models with no `ttl` set |
+
+Results are YAML. A query producing more than one result returns them as several
+YAML documents separated by `---`. `null` means nothing is set at that key: either
+it does not exist, or its value is the default, since defaults are omitted. `env`
+and `$ENV` are not available: the process environment holds exactly the credentials
+that redaction keeps out of the result.
+
+Evaluation is capped at five seconds, and a result larger than 32KB is refused
+with a message asking for a narrower query rather than returned truncated.
 
 **`sys__*` — facts about the machine**
 
@@ -144,7 +166,7 @@ Only protocol problems — an unknown method, a header mismatch, a malformed bod
 - JSON-RPC batching is not supported. MCP removed it in revision 2025-06-18.
 - Results are size-capped so they fit a local model's context window.
   `docs__get_doc` says so when it truncates and tells you the `offset` to continue
-  from; `config__get_config` tells you to pass a `path` for the section you want.
+  from; `config__get_config` never truncates, it asks you for a narrower `query`.
 
 ## Related
 

--- a/evals/docs-agent/README.md
+++ b/evals/docs-agent/README.md
@@ -1,6 +1,7 @@
 # Docs Agent evaluation harness
 
-A headless driver and scored test suite for the Playground's Docs agent. It exists so that a strong coding agent — Claude Code,
+A headless driver and scored test suite for the Docs agent behind the UI's
+Help page. It exists so that a strong coding agent — Claude Code,
 Codex — can improve the Docs Agent's accuracy on a small local model by
 measuring, changing one thing, and measuring again.
 
@@ -93,8 +94,8 @@ reaches the binary through `//go:embed` in `reference_embed.go` — so they need
 
 Surface 5 currently reaches external MCP clients only. `agentTools.ts` calls
 `tools/list` and `tools/call` but never `server/discover`, so `mcpInstructions`
-never reaches the Playground. Improving it is still worthwhile for other MCP
-clients, but it will not move this score. The Playground's equivalent is
+never reaches the Help page. Improving it is still worthwhile for other MCP
+clients, but it will not move this score. The Help page's equivalent is
 surface 1.
 
 ## The protocol

--- a/evals/docs-agent/README.md
+++ b/evals/docs-agent/README.md
@@ -11,7 +11,7 @@ improvement to the score is an improvement to the product.
 ## One server serves everything
 
 ```bash
-go run . -config evals/config.yaml -listen :8080
+go run . -config evals/config.yaml -config-dir evals/docs-agent/fixture -listen :8080
 ```
 
 That single instance serves both halves:
@@ -19,6 +19,9 @@ That single instance serves both halves:
 - `/api/mcp` — the documentation tools, compiled from **your working tree**.
 - `/v1/chat/completions` — the agent model, which may be local or reached
   through a `peers:` block.
+
+`-config-dir` merges the model fixture in; see [The running-config
+fixture](#the-running-config-fixture). `run.sh` passes it for you.
 
 > **Do not point `--base-url` at a remote llama-swap you did not build.**
 > `/api/mcp` does not exist in releases and answers 404. The CLI refuses to
@@ -79,7 +82,7 @@ Change **one at a time**, and nothing outside this list.
 |---|---|---|---|
 | 1 | System prompt | `ui/src/lib/prompts/docsAgent.ts` | no |
 | 2 | Knowledge base | `docs/kb/**/*.md` | yes |
-| 3 | Tool descriptions and schemas | `internal/mcptools/{docs,config,sys}.go` | yes |
+| 3 | Tool descriptions and schemas | `internal/docagent/mcpprovider.go`, `internal/config/mcpprovider.go`, `internal/mcptools/sys.go` | yes |
 | 4 | Search ranking | `internal/reference/search.go` | yes |
 | 5 | MCP instructions | `internal/server/apimcp.go` (`mcpInstructions`) | yes |
 
@@ -210,12 +213,37 @@ refuses (exit 2) below `--min-score`, because judging answers that already fail
 regex checks wastes tokens, and it refuses a judge model equal to the agent
 model, because a model grading itself ratifies its own mistakes.
 
+## The running-config fixture
+
+`fixture/models.yaml` is a checked-in llama-swap config: 24 models with the
+nested blocks a real setup has — `capabilities`, `filters`, `timeouts`,
+`metadata`, model-scoped `macros` — plus two groups. `run.sh` merges it into
+the server with `-config-dir`, so `config__get_config` answers over the same
+models on every machine and cases about the running setup can be graded.
+
+It exists because the config tool takes a jq query. A query is only worth
+writing when the document is too large to read, and the whole fixture renders
+to roughly 10KB of YAML — several thousand tokens, most of a small model's
+context. `cases/configuration/running-config.yaml` asks for one nested field
+out of that; an agent that reads everything usually loses the field in the
+noise, so a pass means it queried for what it needed.
+
+Attaching with `--base-url` bypasses `run.sh`'s server startup, so start that
+server with `-config-dir evals/docs-agent/fixture` yourself or the
+running-config cases all fail.
+
+Editing rules are at the top of `fixture/models.yaml`. The short version: every
+name starts with `eval-` so it cannot collide with the config on the machine
+running the eval, and a value change there is a change to what the cases
+assert — grep the model id first.
+
 ## Adding cases
 
-Every assertion must be grounded in something `docs/kb/` actually says — check
-before you write it. A case asserting a fact the documentation does not contain
-tests the model's pretraining, not this agent, and it can never be fixed by any
-of the five surfaces.
+Every assertion must be grounded in something `docs/kb/` actually says, or —
+for a question about the running setup — in `fixture/models.yaml`. Check before
+you write it. A case asserting a fact neither source contains tests the model's
+pretraining, not this agent, and it can never be fixed by any of the five
+surfaces.
 
 Constraints to respect while editing:
 
@@ -226,8 +254,10 @@ Constraints to respect while editing:
   drops anything else, because these names are forwarded as OpenAI function
   names.
 - Run `gofmt -w` on any Go file you touch; CI fails on `gofmt -l`.
-- Do not assert on `config__get_config` output. It reflects whichever config
-  the server was started with, so such a case is machine-specific.
+- Assert on `config__get_config` output only for models, groups and values that
+  come from `fixture/models.yaml`. Everything else in that tool's output is
+  whatever config the person running the eval started the server with, so a case
+  built on it is machine-specific and will fail for someone else.
 
 ## Comparing models
 

--- a/evals/docs-agent/cases-holdout/configuration/running-config.yaml
+++ b/evals/docs-agent/cases-holdout/configuration/running-config.yaml
@@ -1,0 +1,40 @@
+# Held-out cases over the same fixture as
+# cases/configuration/running-config.yaml. Different models, different fields,
+# different wording. Do not tune against these; they exist to show whether a
+# gain on the training questions was real.
+
+- id: holdout-running-config-idle-unload
+  question: How long does eval-qwen3-coder-30b stay loaded on this server when nothing is using it?
+  tags: [config, running-config, holdout]
+  expect_regex: ["1800|30 min"]
+  expect_tools: [config__get_config]
+  max_iterations: 6
+  reference: |
+    `ttl: 1800`, so 30 minutes of inactivity.
+  rubric:
+    - Gives 1800 seconds or 30 minutes
+    - Names ttl as the setting
+
+- id: holdout-running-config-check-endpoint
+  question: What health check endpoint is configured for eval-phi4-14b on this server?
+  tags: [config, running-config, holdout]
+  expect_regex: ["/v1/models"]
+  expect_tools: [config__get_config]
+  max_iterations: 6
+  reference: |
+    `checkEndpoint: /v1/models`.
+  rubric:
+    - Gives /v1/models
+    - Names checkEndpoint as the setting
+
+- id: holdout-running-config-metadata-quant
+  question: What quantization does this server's config record in the metadata for eval-deepseek-v3-671b?
+  tags: [config, running-config, holdout]
+  expect_regex: ["UD-IQ1_S"]
+  expect_tools: [config__get_config]
+  max_iterations: 6
+  reference: |
+    `metadata.quant` is `UD-IQ1_S`.
+  rubric:
+    - Gives UD-IQ1_S
+    - Reads it from the model's metadata block

--- a/evals/docs-agent/cases/configuration/running-config.yaml
+++ b/evals/docs-agent/cases/configuration/running-config.yaml
@@ -105,3 +105,24 @@
   rubric:
     - Names all four models
     - Gives the right limit for each
+
+# Offered on the empty Help page, so it is a button a new user is likely to
+# press first. What it must not do is answer from the model's memory of some
+# other project: the only honest answer compares what the docs describe against
+# what this config sets. Nothing here asserts on the text -- which features are
+# unused depends on the config the eval was started with -- only that the agent
+# reads both before answering.
+- id: running-config-unused-features
+  question: What llama-swap features am I not using?
+  tags: [config, running-config, discovery]
+  expect_tools: [config__get_config]
+  expect_tools_any: [docs__list_docs, docs__search_docs]
+  max_iterations: 8
+  reference: |
+    A comparison of the documented features against this server's config: the
+    sections it never sets (groups, profiles, selectors, peers, hooks, filters,
+    capabilities, and so on) with a sentence on what each would do for it.
+  rubric:
+    - Names features that are genuinely absent from the running config
+    - Says what each one would do, rather than only listing key names
+    - Invents no feature llama-swap does not have

--- a/evals/docs-agent/cases/configuration/running-config.yaml
+++ b/evals/docs-agent/cases/configuration/running-config.yaml
@@ -1,0 +1,107 @@
+# Grounded in evals/docs-agent/fixture/models.yaml, which run.sh merges into
+# the server's config so these answers are the same on every machine. Every
+# value asserted here is in that file; grep the model id before changing one.
+#
+# What this file measures: config__get_config takes a jq query, and these
+# questions are about one nested field of a 24 model configuration. Reading the
+# whole document to answer them costs several thousand tokens and usually loses
+# the field in the noise, so a pass here means the agent queried for what it
+# actually needed.
+
+- id: running-config-model-ttl
+  question: On this server, what ttl is configured for the model eval-llama33-70b?
+  tags: [config, running-config, ttl]
+  expect_regex: ["3600"]
+  expect_tools: [config__get_config]
+  max_iterations: 6
+  reference: |
+    `ttl: 3600` — it unloads after an hour of inactivity.
+  rubric:
+    - Gives 3600
+    - Reads the value from the running configuration rather than the documentation
+
+- id: running-config-strip-params
+  question: Which request parameters does the model eval-devstral-24b strip out on this server?
+  tags: [config, running-config, filters]
+  expect_regex: ["temperature", "top[_-]?p", "top[_-]?k"]
+  expect_tools: [config__get_config]
+  max_iterations: 6
+  reference: |
+    Its `filters.stripParams` is `temperature, top_p, top_k`, so those three are
+    removed from requests before they reach the upstream server.
+  rubric:
+    - Names all three of temperature, top_p and top_k
+    - Attributes them to the model's filters.stripParams setting
+
+- id: running-config-capabilities-context
+  question: What context length does eval-llama4-scout declare in this server's config, and does it take image input?
+  tags: [config, running-config, capabilities]
+  expect_regex: ["262,?144"]
+  expect_any: ["image", "vision", "multimodal"]
+  expect_tools: [config__get_config]
+  max_iterations: 6
+  reference: |
+    `capabilities.context` is 262144 and `capabilities.in` is `[text, image]`,
+    so yes, it accepts images.
+  rubric:
+    - Gives 262144 as the declared context
+    - Says it accepts image input as well as text
+
+- id: running-config-nested-metadata
+  question: What does the metadata on eval-deepseek-r1-distill-32b record about reasoning in this server's config?
+  tags: [config, running-config, metadata]
+  expect_regex: ["high", "think"]
+  expect_tools: [config__get_config]
+  max_iterations: 6
+  reference: |
+    `metadata.reasoning` is `{enabled: true, effort: high, tag: think}`.
+  rubric:
+    - Reports the effort as high and the tag as think
+    - Says reasoning is enabled
+
+- id: running-config-group-members
+  question: Which models are in the eval-vision group on this server?
+  tags: [config, running-config, groups]
+  expect_regex:
+    ["eval-gemma3-27b-vision", "eval-llama4-scout", "eval-qwen25-vl-7b"]
+  forbid_regex: ["eval-nomic-embed-v15", "eval-bge-reranker-v2"]
+  expect_tools: [config__get_config]
+  max_iterations: 6
+  reference: |
+    eval-gemma3-27b-vision, eval-llama4-scout and eval-qwen25-vl-7b. The group
+    swaps and is exclusive, so loading one unloads the others.
+  rubric:
+    - Lists exactly the three vision models
+    - Does not list members of another group
+
+- id: running-config-timeout-field
+  question: What response header timeout is configured for eval-mistral-nemo-12b on this server?
+  tags: [config, running-config, timeouts]
+  expect_regex: ["300"]
+  forbid_regex: ["\\b15\\b"]
+  expect_tools: [config__get_config]
+  max_iterations: 6
+  reference: |
+    `timeouts.responseHeader: 300`.
+  rubric:
+    - Gives 300 seconds
+    - Answers with the responseHeader timeout, not the connect timeout
+
+- id: running-config-concurrency-across-models
+  question: Which of the eval- models on this server set a concurrencyLimit, and what is each limit?
+  tags: [config, running-config, hard]
+  expect_regex:
+    [
+      "eval-qwen3-coder-30b",
+      "eval-nemotron-49b",
+      "eval-nomic-embed-v15",
+      "eval-qwen3-embed-8b",
+    ]
+  expect_tools: [config__get_config]
+  max_iterations: 8
+  reference: |
+    Four of them: eval-qwen3-coder-30b (2), eval-nemotron-49b (1),
+    eval-nomic-embed-v15 (8) and eval-qwen3-embed-8b (4).
+  rubric:
+    - Names all four models
+    - Gives the right limit for each

--- a/evals/docs-agent/fixture/models.yaml
+++ b/evals/docs-agent/fixture/models.yaml
@@ -1,0 +1,266 @@
+# A long, deterministic configuration for the Docs Agent eval.
+#
+# run.sh merges this file on top of the user's evals/config.yaml with
+# -config-dir, so `config__get_config` answers over the same models on every
+# machine. Without it, cases about the running setup could only be graded
+# against whatever config the person running the eval happens to have, which is
+# why the README used to rule such cases out entirely.
+#
+# What it is for: the config tool takes a jq query, and the point of a query is
+# that a model can pull one nested field out of a configuration far too large to
+# read. That only gets measured against a configuration that is actually large.
+# Two dozen models with real nested blocks -- capabilities, filters, timeouts,
+# metadata, macros -- render to several thousand tokens of YAML.
+#
+# Rules for editing:
+#
+#   - Every id, alias and group name starts with "eval-". Models, groups and
+#     peers are identity-keyed: a name that collides with one in the user's own
+#     config is a hard merge error that stops the server from starting.
+#   - Define nothing but `models` and `groups`. A top-level scalar that differs
+#     from the user's config is also a merge error.
+#   - No global `macros`. Those merge by name and would silently rewrite a
+#     macro the user's own models depend on. Model-scoped macros are safe.
+#   - Nothing here is ever started, so the commands only have to parse. They
+#     still need ${PORT}, because the default proxy address uses it.
+#   - Changing a value here changes what the cases assert. Grep the case files
+#     for the id before editing one.
+
+models:
+  # -- coding ---------------------------------------------------------------
+  eval-qwen3-coder-30b:
+    macros:
+      eval-srv: /opt/llama.cpp/llama-server --port ${PORT} --host 127.0.0.1
+    cmd: |
+      ${eval-srv}
+      --model /models/qwen3-coder-30b-a3b-Q4_K_M.gguf
+      --ctx-size 65536 --n-gpu-layers 99
+    aliases: [eval-coder, eval-qwen3-coder]
+    ttl: 1800
+    concurrencyLimit: 2
+    metadata:
+      family: qwen3
+      quant: Q4_K_M
+      vram_gb: 22
+    capabilities:
+      in: [text]
+      out: [text]
+      tools: true
+      context: 65536
+
+  eval-qwen3-coder-480b:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/qwen3-coder-480b-a35b-UD-Q2_K_XL.gguf --ctx-size 32768
+    env:
+      - CUDA_VISIBLE_DEVICES=0,1,2,3
+      - GGML_CUDA_ENABLE_UNIFIED_MEMORY=1
+    unloadTimeout: 300
+    description: The big coder. Loads slowly; leave it running.
+    metadata:
+      family: qwen3
+      quant: UD-Q2_K_XL
+      vram_gb: 176
+
+  eval-devstral-24b:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/devstral-small-2507-Q5_K_M.gguf --ctx-size 49152
+    ttl: 600
+    filters:
+      stripParams: "temperature, top_p, top_k"
+    metadata:
+      family: mistral
+      quant: Q5_K_M
+
+  # -- vision ---------------------------------------------------------------
+  eval-gemma3-27b-vision:
+    cmd: >
+      /opt/llama.cpp/llama-server --port ${PORT}
+      --model /models/gemma-3-27b-it-Q4_K_M.gguf
+      --mmproj /models/gemma-3-27b-mmproj-F16.gguf
+    ttl: 900
+    capabilities:
+      in: [text, image]
+      out: [text]
+      tools: true
+      context: 131072
+    metadata:
+      family: gemma3
+      quant: Q4_K_M
+
+  eval-llama4-scout:
+    cmd: >
+      /opt/llama.cpp/llama-server --port ${PORT}
+      --model /models/llama-4-scout-17b-16e-UD-Q4_K_XL.gguf
+      --mmproj /models/llama-4-scout-mmproj-F16.gguf
+    ttl: 1200
+    capabilities:
+      in: [text, image]
+      out: [text]
+      tools: true
+      context: 262144
+    filters:
+      stripParams: "presence_penalty, frequency_penalty"
+    metadata:
+      family: llama4
+      quant: UD-Q4_K_XL
+
+  eval-qwen25-vl-7b:
+    cmd: >
+      /opt/llama.cpp/llama-server --port ${PORT}
+      --model /models/qwen2.5-vl-7b-instruct-Q8_0.gguf
+      --mmproj /models/qwen2.5-vl-7b-mmproj-F16.gguf
+    ttl: 300
+    capabilities:
+      in: [text, image]
+      out: [text]
+      context: 32768
+
+  # -- general ---------------------------------------------------------------
+  eval-llama33-70b:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/llama-3.3-70b-instruct-Q4_K_M.gguf --ctx-size 32768
+    ttl: 3600
+    timeouts:
+      connect: 45
+      responseHeader: 120
+    metadata:
+      family: llama3
+      quant: Q4_K_M
+      vram_gb: 42
+
+  eval-mistral-nemo-12b:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/mistral-nemo-12b-instruct-Q6_K.gguf --ctx-size 65536
+    ttl: 450
+    timeouts:
+      connect: 15
+      responseHeader: 300
+      idleConn: 90
+
+  eval-phi4-14b:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/phi-4-Q6_K.gguf --ctx-size 16384
+    checkEndpoint: /v1/models
+    ttl: 240
+
+  eval-glm4-32b:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/glm-4-32b-0414-Q4_K_M.gguf --ctx-size 32768
+    useModelName: glm-4-32b
+    ttl: 900
+
+  eval-deepseek-r1-distill-32b:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/deepseek-r1-distill-qwen-32b-Q4_K_M.gguf --ctx-size 65536
+    ttl: 1500
+    metadata:
+      family: deepseek
+      quant: Q4_K_M
+      reasoning:
+        enabled: true
+        effort: high
+        tag: think
+
+  eval-deepseek-v3-671b:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/deepseek-v3-0324-UD-IQ1_S.gguf --ctx-size 16384
+    cmdStop: pkill -f deepseek-v3-0324
+    unloadTimeout: 600
+    metadata:
+      family: deepseek
+      quant: UD-IQ1_S
+      vram_gb: 160
+
+  eval-nemotron-49b:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/llama-3.3-nemotron-super-49b-Q4_K_M.gguf --ctx-size 32768
+    ttl: 1200
+    concurrencyLimit: 1
+
+  eval-command-r-35b:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/c4ai-command-r-35b-08-2024-Q4_K_M.gguf --ctx-size 32768
+    ttl: 600
+    filters:
+      stripParams: "logit_bias"
+
+  eval-olmo2-13b:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/olmo-2-13b-instruct-Q6_K.gguf --ctx-size 8192
+    ttl: 300
+    description: Fully open weights and data, kept for comparison runs.
+
+  eval-tinyllama-smoke:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/tinyllama-1.1b-chat-Q4_K_M.gguf --ctx-size 2048
+    ttl: 60
+    unlisted: true
+
+  # -- embeddings and reranking ---------------------------------------------
+  eval-nomic-embed-v15:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/nomic-embed-text-v1.5-F16.gguf --embedding --pooling mean
+    ttl: 7200
+    concurrencyLimit: 8
+    capabilities:
+      in: [text]
+      out: [text]
+      context: 8192
+
+  eval-qwen3-embed-8b:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/qwen3-embedding-8b-Q8_0.gguf --embedding --pooling last
+    ttl: 7200
+    concurrencyLimit: 4
+
+  eval-bge-reranker-v2:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/bge-reranker-v2-m3-Q8_0.gguf --reranking
+    ttl: 7200
+    capabilities:
+      in: [text]
+      out: [text]
+      reranker: true
+      context: 8192
+
+  # -- audio ------------------------------------------------------------------
+  eval-whisper-large-v3:
+    cmd: /opt/whisper.cpp/whisper-server --port ${PORT} --model /models/ggml-large-v3-turbo.bin --inference-path /v1/audio/transcriptions
+    checkEndpoint: /
+    ttl: 1800
+    capabilities:
+      in: [audio]
+      out: [text]
+
+  eval-parakeet-tdt:
+    cmd: /opt/parakeet/serve.py --port ${PORT} --model /models/parakeet-tdt-0.6b-v2
+    checkEndpoint: /healthz
+    ttl: 1800
+    capabilities:
+      in: [audio]
+      out: [text]
+
+  # -- draft models, never served directly ------------------------------------
+  eval-qwen3-32b-draft:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/qwen3-0.6b-Q8_0.gguf --ctx-size 8192
+    unlisted: true
+    ttl: 120
+
+  eval-llama31-8b-draft:
+    cmd: /opt/llama.cpp/llama-server --port ${PORT} --model /models/llama-3.2-1b-instruct-Q8_0.gguf --ctx-size 8192
+    unlisted: true
+    ttl: 120
+
+  eval-sd35-medium:
+    cmd: /opt/stable-diffusion.cpp/sd-server --port ${PORT} --model /models/sd3.5-medium-Q8_0.gguf
+    checkEndpoint: /
+    ttl: 600
+    capabilities:
+      in: [text]
+      out: [image]
+
+groups:
+  # Vision models share one set of GPUs, so loading one unloads the others.
+  eval-vision:
+    swap: true
+    exclusive: true
+    members:
+      - eval-gemma3-27b-vision
+      - eval-llama4-scout
+      - eval-qwen25-vl-7b
+
+  # Retrieval models are small and stay up together alongside whatever else is
+  # loaded.
+  eval-retrieval:
+    swap: false
+    exclusive: false
+    persistent: true
+    members:
+      - eval-nomic-embed-v15
+      - eval-qwen3-embed-8b
+      - eval-bge-reranker-v2

--- a/evals/docs-agent/run.sh
+++ b/evals/docs-agent/run.sh
@@ -7,6 +7,11 @@
 # visible after a rebuild. Everything the agent model needs comes through the
 # same server, via peers, so there is only ever one base URL.
 #
+# The server is started with fixture/ merged in through -config-dir. That is
+# what makes the cases about the running configuration gradeable: without it
+# config__get_config would answer over whatever config this machine happens to
+# have. Attaching with --base-url means supplying it yourself; see below.
+#
 # Usage:
 #   ./run.sh                              build, start, eval, tear down
 #   ./run.sh --repeat 3 --label prompt-v2  what to run before keeping a change
@@ -25,6 +30,7 @@ CONCURRENCY=1
 PORT=18080
 BASE_URL=""
 CASES="evals/docs-agent/cases"
+FIXTURE_DIR="evals/docs-agent/fixture"
 EMBED_UI=0
 AGENT_ARGS=()
 
@@ -38,7 +44,7 @@ while [[ $# -gt 0 ]]; do
     --cases)    CASES="$2"; shift 2 ;;
     --holdout)  CASES="evals/docs-agent/cases-holdout"; shift ;;
     --embed-ui) EMBED_UI=1; shift ;;
-    -h|--help)  sed -n '2,16p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'; exit 0 ;;
+    -h|--help)  sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'; exit 0 ;;
     # Everything else is forwarded: --repeat, --label, --only, --system-prompt,
     # --temperature, --out, --report ...
     *)          AGENT_ARGS+=("$1"); shift ;;
@@ -64,8 +70,8 @@ if [[ -z "$BASE_URL" ]]; then
     go build -o build/llama-swap .
   fi
 
-  echo "==> starting llama-swap on 127.0.0.1:$PORT"
-  ./build/llama-swap -config "$CONFIG" -listen "127.0.0.1:$PORT" >"${TMPDIR:-/tmp}/docs-agent-swap.log" 2>&1 &
+  echo "==> starting llama-swap on 127.0.0.1:$PORT with $FIXTURE_DIR merged in"
+  ./build/llama-swap -config "$CONFIG" -config-dir "$FIXTURE_DIR" -listen "127.0.0.1:$PORT" >"${TMPDIR:-/tmp}/docs-agent-swap.log" 2>&1 &
   SERVER_PID=$!
   trap 'kill "$SERVER_PID" 2>/dev/null || true; wait "$SERVER_PID" 2>/dev/null || true' EXIT
 
@@ -87,6 +93,12 @@ if [[ -z "$BASE_URL" ]]; then
     echo "error: llama-swap did not become healthy within 30s" >&2
     exit 1
   fi
+else
+  # The running-config cases ask about models that only exist in the fixture.
+  # A server started without it answers them from the wrong config and fails
+  # them all, which looks like a regression in the agent.
+  echo "==> attaching to $BASE_URL; it must have been started with:"
+  echo "      -config-dir $FIXTURE_DIR"
 fi
 
 echo "==> $BASE_URL is up; running eval with $MODEL"

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.1
 	github.com/gin-gonic/gin v1.10.0
 	github.com/google/jsonschema-go v0.4.3
+	github.com/itchyny/gojq v0.12.19
 	github.com/klauspost/compress v1.19.1
 	github.com/pressly/goose/v3 v3.27.2
 	github.com/shirou/gopsutil/v4 v4.26.4
@@ -66,6 +67,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hdevalence/ed25519consensus v0.2.0 // indirect
+	github.com/itchyny/timefmt-go v0.1.8 // indirect
 	github.com/jsimonetti/rtnetlink v1.4.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,10 @@ github.com/illarion/gonotify/v3 v3.0.2 h1:O7S6vcopHexutmpObkeWsnzMJt/r1hONIEogeV
 github.com/illarion/gonotify/v3 v3.0.2/go.mod h1:HWGPdPe817GfvY3w7cx6zkbzNZfi3QjcBm/wgVvEL1U=
 github.com/insomniacslk/dhcp v0.0.0-20240129002554-15c9b8791914 h1:kD8PseueGeYiid/Mmcv17Q0Qqicc4F46jcX22L/e/Hs=
 github.com/insomniacslk/dhcp v0.0.0-20240129002554-15c9b8791914/go.mod h1:3A9PQ1cunSDF/1rbTq99Ts4pVnycWg+vlPkfeD2NLFI=
+github.com/itchyny/gojq v0.12.19 h1:ttXA0XCLEMoaLOz5lSeFOZ6u6Q3QxmG46vfgI4O0DEs=
+github.com/itchyny/gojq v0.12.19/go.mod h1:5galtVPDywX8SPSOrqjGxkBeDhSxEW1gSxoy7tn1iZY=
+github.com/itchyny/timefmt-go v0.1.8 h1:1YEo1JvfXeAHKdjelbYr/uCuhkybaHCeTkH8Bo791OI=
+github.com/itchyny/timefmt-go v0.1.8/go.mod h1:5E46Q+zj7vbTgWY8o5YkMeYb4I6GeWLFnetPy5oBrAI=
 github.com/jellydator/ttlcache/v3 v3.1.0 h1:0gPFG0IHHP6xyUyXq+JaD8fwkDCqgqwohXNJBcYE71g=
 github.com/jellydator/ttlcache/v3 v3.1.0/go.mod h1:hi7MGFdMAwZna5n2tuvh63DvFLzVKySzCVW6+0gA2n4=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/internal/config/evalfixture_test.go
+++ b/internal/config/evalfixture_test.go
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The Docs Agent eval merges this file into the server it starts, and
+// evals/docs-agent/cases/configuration/running-config.yaml asserts on the
+// values in it. A break here only shows up as a failing eval run against a
+// local model, which is slow, stochastic, and easy to blame on the model, so
+// the fixture is checked here instead.
+const evalFixturePath = "../../evals/docs-agent/fixture/models.yaml"
+
+func loadEvalFixture(t *testing.T) Config {
+	t.Helper()
+	data, err := os.ReadFile(evalFixturePath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", evalFixturePath, err)
+	}
+	cfg, err := LoadConfigFromReader(strings.NewReader(string(data)))
+	if err != nil {
+		t.Fatalf("loading %s: %v", evalFixturePath, err)
+	}
+	return cfg
+}
+
+// Every name in the fixture has to be prefixed, because models, groups and
+// peers are identity-keyed: a name that also appears in the config of whoever
+// runs the eval is a merge error that stops the server from starting.
+func TestEvalFixture_NamesAreNamespaced(t *testing.T) {
+	cfg := loadEvalFixture(t)
+
+	if len(cfg.Models) < 20 {
+		t.Errorf("fixture has %d models; the cases assume a config too long to read whole", len(cfg.Models))
+	}
+	for id := range cfg.Models {
+		if !strings.HasPrefix(id, "eval-") {
+			t.Errorf("model %q does not start with \"eval-\" and can collide with a real config", id)
+		}
+		for _, alias := range cfg.Models[id].Aliases {
+			if !strings.HasPrefix(alias, "eval-") {
+				t.Errorf("model %q has alias %q that does not start with \"eval-\"", id, alias)
+			}
+		}
+	}
+	for name := range cfg.Groups {
+		if name == "(default)" {
+			continue // synthesized for models that name no group
+		}
+		if !strings.HasPrefix(name, "eval-") {
+			t.Errorf("group %q does not start with \"eval-\" and can collide with a real config", name)
+		}
+	}
+	// A top-level scalar or a global macro merges by value or by name, so
+	// either one can conflict with, or silently rewrite, the user's config.
+	if len(cfg.Macros) != 0 {
+		t.Errorf("fixture defines global macros %v; use model-scoped macros instead", cfg.Macros)
+	}
+	if len(cfg.Peers) != 0 {
+		t.Error("fixture defines peers; nothing in the cases needs them")
+	}
+}
+
+// The values the eval cases assert on, read back through the tool the agent
+// actually calls. Changing the fixture without changing the cases fails here.
+func TestEvalFixture_CaseValuesResolve(t *testing.T) {
+	provider := NewConfigProvider(loadEvalFixture(t))
+
+	for _, tc := range []struct {
+		caseID string
+		query  string
+		want   []string
+	}{
+		{"running-config-model-ttl", `.models["eval-llama33-70b"].ttl`, []string{"3600"}},
+		{"running-config-strip-params", `.models["eval-devstral-24b"].filters.stripParams`,
+			[]string{"temperature", "top_p", "top_k"}},
+		{"running-config-capabilities-context", `.models["eval-llama4-scout"].capabilities`,
+			[]string{"262144", "image"}},
+		{"running-config-nested-metadata", `.models["eval-deepseek-r1-distill-32b"].metadata.reasoning`,
+			[]string{"high", "think"}},
+		{"running-config-group-members", `.groups["eval-vision"].members`,
+			[]string{"eval-gemma3-27b-vision", "eval-llama4-scout", "eval-qwen25-vl-7b"}},
+		{"running-config-timeout-field", `.models["eval-mistral-nemo-12b"].timeouts.responseHeader`,
+			[]string{"300"}},
+		{"running-config-concurrency-across-models",
+			`.models | to_entries | map(select(.value.concurrencyLimit != null) | .key)`,
+			[]string{"eval-qwen3-coder-30b", "eval-nemotron-49b", "eval-nomic-embed-v15", "eval-qwen3-embed-8b"}},
+		{"holdout-running-config-idle-unload", `.models["eval-qwen3-coder-30b"].ttl`, []string{"1800"}},
+		{"holdout-running-config-check-endpoint", `.models["eval-phi4-14b"].checkEndpoint`, []string{"/v1/models"}},
+		{"holdout-running-config-metadata-quant", `.models["eval-deepseek-v3-671b"].metadata.quant`,
+			[]string{"UD-IQ1_S"}},
+	} {
+		t.Run(tc.caseID, func(t *testing.T) {
+			args := map[string]json.RawMessage{"query": mustJSONString(t, tc.query)}
+			result, err := provider.Call(context.Background(), "get_config", args)
+			if err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("query %s failed:\n%s", tc.query, result.Content)
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(result.Content, want) {
+					t.Errorf("query %s no longer returns %q, which case %s asserts on:\n%s",
+						tc.query, want, tc.caseID, result.Content)
+				}
+			}
+		})
+	}
+}
+
+// The cases are worth running only against a config the agent cannot simply
+// read in full. This is the size that makes a jq query the cheaper move.
+func TestEvalFixture_IsLongEnoughToNeedAQuery(t *testing.T) {
+	provider := NewConfigProvider(loadEvalFixture(t))
+
+	result, err := provider.Call(context.Background(), "get_config", nil)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("the whole fixture no longer renders:\n%s", result.Content)
+	}
+	if len(result.Content) < 8*1024 {
+		t.Errorf("the whole fixture renders to %d bytes; too small for a query to be worth writing",
+			len(result.Content))
+	}
+	// Past the cap the tool refuses instead of answering, which turns every
+	// case into a test of error recovery rather than of field extraction.
+	if len(result.Content) > maxConfigResultBytes {
+		t.Errorf("the whole fixture renders to %d bytes, over the %d byte cap; get_config will refuse it",
+			len(result.Content), maxConfigResultBytes)
+	}
+}
+
+func mustJSONString(t *testing.T, value string) json.RawMessage {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("encoding %q: %v", value, err)
+	}
+	return json.RawMessage(encoded)
+}

--- a/internal/config/mcpprovider.go
+++ b/internal/config/mcpprovider.go
@@ -3,20 +3,35 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"math"
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/itchyny/gojq"
 	"github.com/mostlygeek/llama-swap/internal/mcptools"
 	"gopkg.in/yaml.v3"
 )
 
-// maxConfigResultBytes caps a get_config result. It is larger than the docs
-// cap: a config review is a heavier task and the whole point is to see the
-// setup, but it is still bounded so a full dump cannot swamp a small context.
+// maxConfigResultBytes bounds one get_config result. The caller chooses what
+// comes back by writing a jq query, so this cap is a backstop against a query
+// that asks for more than a context window can hold. When it trips the caller
+// is told to narrow the query rather than handed a document that stops
+// mid-value.
 const maxConfigResultBytes = 32 * 1024
+
+// configQueryTimeout bounds evaluation. jq is a real language and the queries
+// come from a model, so a non-terminating expression is a question of when,
+// not if.
+const configQueryTimeout = 5 * time.Second
+
+// errConfigResultTooLarge signals that rendering stopped because the result
+// passed maxConfigResultBytes.
+var errConfigResultTooLarge = errors.New("config query result is too large")
 
 // ConfigProvider serves the running llama-swap configuration so an agent can
 // give advice about the setup in front of it rather than in the abstract.
@@ -49,22 +64,27 @@ func (p *ConfigProvider) Tools(context.Context) ([]mcptools.Tool, error) {
 	return []mcptools.Tool{
 		{
 			Name:  "get_config",
-			Title: "Show the current llama-swap configuration",
-			Description: "Return the configuration llama-swap is running right now, as YAML, with " +
-				"API keys and other credentials redacted. Values are fully resolved: ${env.*} and " +
-				"macro references are already expanded, and values equal to their defaults are omitted. " +
-				"Pass \"path\" to narrow to a section, for example \"models\" or \"models.qwen3\" or " +
-				"\"peers\"; omit it for the whole document. Use this to review or troubleshoot the " +
-				"active setup before suggesting changes.",
+			Title: "Query the current llama-swap configuration",
+			Description: "Query the configuration llama-swap is running right now with a jq expression. " +
+				"The result is YAML, with API keys and other credentials redacted. Values are fully " +
+				"resolved: ${env.*} and macro references are already expanded, and values equal to " +
+				"their defaults are omitted. Pass \"query\" to select exactly the part you need, so " +
+				"nothing has to be truncated; omit it for the whole document. For example: " +
+				"\".models | keys\" lists the configured model ids, \".models.qwen3\" shows one model, " +
+				"\".models | to_entries | map({id: .key, ttl: .value.ttl})\" pulls one field from every " +
+				"model, and \".peers\" shows the peers. Quote any id that is not a plain word: " +
+				"\".models[\"qwen3-8b\"]\". Use this to review or troubleshoot the active setup before " +
+				"suggesting changes.",
 			Annotations: configAnnotations(),
 			Tags:        []string{"config", "configuration", "troubleshooting"},
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"path": map[string]any{
+					"query": map[string]any{
 						"type": "string",
-						"description": "Dotted key selecting a section of the config, for example " +
-							"'models', 'models.qwen3', 'peers', or 'macros'. Omit for the full config.",
+						"description": "jq expression selecting part of the config, for example " +
+							"'.models | keys', '.models.qwen3', '.models[\"qwen3-8b\"].ttl', or '.macros'. " +
+							"Defaults to '.', the whole config.",
 					},
 				},
 				"additionalProperties": false,
@@ -73,83 +93,233 @@ func (p *ConfigProvider) Tools(context.Context) ([]mcptools.Tool, error) {
 	}, nil
 }
 
-func (p *ConfigProvider) Call(_ context.Context, name string, args map[string]json.RawMessage) (mcptools.Result, error) {
+func (p *ConfigProvider) Call(ctx context.Context, name string, args map[string]json.RawMessage) (mcptools.Result, error) {
 	if name != "get_config" {
 		return mcptools.Result{}, fmt.Errorf("unknown tool %q", name)
 	}
 
-	path := mcptools.StringArg(args, "path")
-	// Render the full tree before selecting a path so default-only sections can
-	// still be addressed. For example, get_config({"path":"performance"})
-	// should return an empty mapping, rather than report that the section does
-	// not exist merely because every value in it is a default.
+	query := mcptools.StringArg(args, "query")
+	if query == "" {
+		// get_config took a dotted "path" before it took a jq query. Name the
+		// equivalent expression instead of silently returning the whole config,
+		// which is the answer a caller with the old argument least expects.
+		if path := mcptools.StringArg(args, "path"); path != "" {
+			return mcptools.Result{IsError: true, Content: fmt.Sprintf(
+				"Error: get_config takes a jq \"query\", not a \"path\". Call it again with query=%s",
+				jqPathQuery(path))}, nil
+		}
+		query = "."
+	}
+
+	code, err := compileConfigQuery(query)
+	if err != nil {
+		return mcptools.Result{IsError: true, Content: fmt.Sprintf(
+			"Error: %s is not a valid jq query: %v. An id that is not a plain word has to be "+
+				"quoted, as in \".models[\"qwen3-8b\"]\"; \".models.qwen3-8b\" is a subtraction to jq. "+
+				"Use \".\" for the whole config, or \".models | keys\" for the model ids.",
+			query, err)}, nil
+	}
+
+	document, err := p.queryDocument()
+	if err != nil {
+		return mcptools.Result{}, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, configQueryTimeout)
+	defer cancel()
+
+	out, err := runConfigQuery(ctx, code, document, maxConfigResultBytes)
+	switch {
+	case errors.Is(err, errConfigResultTooLarge):
+		return mcptools.Result{IsError: true, Content: fmt.Sprintf(
+			"Error: the result of %s is larger than %dKB. Ask for less rather than everything: "+
+				"\".models | keys\" lists the model ids, \".models.<id>\" reads one model, and "+
+				"\".models | to_entries | map({id: .key, ttl: .value.ttl})\" pulls one field from all "+
+				"of them. %s", query, maxConfigResultBytes/1024, p.topLevelKeyHint())}, nil
+	case errors.Is(err, context.DeadlineExceeded):
+		return mcptools.Result{IsError: true, Content: fmt.Sprintf(
+			"Error: the query %s did not finish within %s. Simplify it.", query, configQueryTimeout)}, nil
+	case err != nil:
+		return mcptools.Result{IsError: true, Content: fmt.Sprintf(
+			"Error: the query %s failed: %v", query, err)}, nil
+	}
+
+	if out.results == 0 {
+		return mcptools.Result{Content: fmt.Sprintf(
+			"The query %s matched nothing. %s", query, p.topLevelKeyHint())}, nil
+	}
+
+	var b strings.Builder
+	if query == "." {
+		b.WriteString("Current llama-swap configuration (credentials redacted, values resolved):\n\n")
+	} else {
+		fmt.Fprintf(&b, "Current llama-swap configuration, jq query %s (credentials redacted, values resolved):\n\n", query)
+	}
+	b.WriteString("```yaml\n")
+	b.WriteString(strings.TrimRight(out.body, "\n"))
+	b.WriteString("\n```\n")
+	if out.nullOnly {
+		// jq answers a key that is not there with null, which reads like a
+		// value. Say what it means, since an omitted default looks the same.
+		fmt.Fprintf(&b, "\nnull means nothing is set there: either the key does not exist, "+
+			"or its value is the default and defaults are omitted. %s\n", p.topLevelKeyHint())
+	}
+	return mcptools.Result{Content: b.String()}, nil
+}
+
+// configQueryOutput is what one evaluation produced: the results rendered as
+// YAML documents, how many there were, and whether every one of them was null.
+type configQueryOutput struct {
+	body     string
+	results  int
+	nullOnly bool
+}
+
+// runConfigQuery evaluates code over document and renders each result as a YAML
+// document. It gives up as soon as the rendered output passes limit, so an
+// expression like `range(1e9)` cannot build a huge string in memory.
+func runConfigQuery(ctx context.Context, code *gojq.Code, document any, limit int) (configQueryOutput, error) {
+	out := configQueryOutput{nullOnly: true}
+
+	var b strings.Builder
+	iter := code.RunWithContext(ctx, document)
+	for {
+		value, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err, isErr := value.(error); isErr {
+			return configQueryOutput{}, err
+		}
+
+		buf, err := yaml.Marshal(value)
+		if err != nil {
+			return configQueryOutput{}, fmt.Errorf("rendering result as YAML: %w", err)
+		}
+		if out.results > 0 {
+			// Several results are several YAML documents, which is what the
+			// document separator is for.
+			b.WriteString("---\n")
+		}
+		b.Write(buf)
+
+		out.results++
+		if value != nil {
+			out.nullOnly = false
+		}
+		if b.Len() > limit {
+			return configQueryOutput{}, errConfigResultTooLarge
+		}
+	}
+
+	out.body = b.String()
+	return out, nil
+}
+
+// compileConfigQuery parses and compiles one jq expression. gojq keeps the
+// process environment out of reach by default; the loader is passed explicitly
+// because `env` would otherwise hand back exactly the credentials that
+// redaction removes from the config.
+func compileConfigQuery(query string) (*gojq.Code, error) {
+	parsed, err := gojq.Parse(query)
+	if err != nil {
+		return nil, err
+	}
+	return gojq.Compile(parsed, gojq.WithEnvironLoader(func() []string { return nil }))
+}
+
+// queryDocument renders the effective configuration as the plain JSON-shaped
+// values gojq evaluates over.
+func (p *ConfigProvider) queryDocument() (any, error) {
 	yamlText, found, err := p.cfg.RedactedYAML("")
 	if err != nil {
-		return mcptools.Result{}, fmt.Errorf("rendering config: %w", err)
+		return nil, fmt.Errorf("rendering config: %w", err)
 	}
 	if !found { // RedactedYAML for the root always succeeds; retain this guard.
-		return mcptools.Result{}, fmt.Errorf("rendering config: root configuration was not found")
+		return nil, fmt.Errorf("rendering config: root configuration was not found")
 	}
 
 	var current map[string]any
 	if err := yaml.Unmarshal([]byte(yamlText), &current); err != nil {
-		return mcptools.Result{}, fmt.Errorf("parsing rendered config: %w", err)
-	}
-
-	if path != "" {
-		_, exists := navigateConfig(current, strings.Split(path, "."))
-		if !exists {
-			keys := p.cfg.ConfigTopLevelKeys()
-			sort.Strings(keys)
-			return mcptools.Result{
-				IsError: true,
-				Content: fmt.Sprintf("Error: no config section at path %q. Top-level keys: %s.",
-					path, strings.Join(keys, ", ")),
-			}, nil
-		}
+		return nil, fmt.Errorf("parsing rendered config: %w", err)
 	}
 
 	defaults, err := configProviderDefaults(p.cfg)
 	if err != nil {
-		return mcptools.Result{}, fmt.Errorf("building config defaults: %w", err)
+		return nil, fmt.Errorf("building config defaults: %w", err)
 	}
 	filtered, empty := pruneConfigDefaults(current, defaults, "")
 	if empty {
 		filtered = map[string]any{}
 	}
-	if path != "" {
-		filtered, _ = navigateConfig(filtered, strings.Split(path, "."))
-		if filtered == nil {
-			filtered = map[string]any{}
+
+	// A round trip through JSON is what makes the tree safe to hand to gojq: it
+	// flattens the YAML-only types (timestamps, for one) that gojq cannot walk.
+	encoded, err := json.Marshal(filtered)
+	if err != nil {
+		return nil, fmt.Errorf("encoding config for the query: %w", err)
+	}
+	var document any
+	if err := json.Unmarshal(encoded, &document); err != nil {
+		return nil, fmt.Errorf("decoding config for the query: %w", err)
+	}
+	return normalizeQueryNumbers(document), nil
+}
+
+// normalizeQueryNumbers turns whole float64 values back into ints. JSON decoding
+// makes every number a float64, and gojq passes that straight through, so
+// without this a port renders as 8.08e+03.
+func normalizeQueryNumbers(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, child := range typed {
+			typed[key] = normalizeQueryNumbers(child)
+		}
+		return typed
+	case []any:
+		for i, child := range typed {
+			typed[i] = normalizeQueryNumbers(child)
+		}
+		return typed
+	case float64:
+		if typed == math.Trunc(typed) && math.Abs(typed) < 1<<53 {
+			return int(typed)
+		}
+		return typed
+	default:
+		return value
+	}
+}
+
+// topLevelKeyHint names the sections a query can start from, so a caller that
+// asked for something that is not there can correct itself in one turn.
+func (p *ConfigProvider) topLevelKeyHint() string {
+	keys := p.cfg.ConfigTopLevelKeys()
+	if len(keys) == 0 {
+		return ""
+	}
+	sort.Strings(keys)
+	return "Top-level keys: " + strings.Join(keys, ", ") + "."
+}
+
+// bareJQKey matches the field names jq accepts after a dot without quoting.
+var bareJQKey = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// jqPathQuery renders a dotted config path as the jq expression selecting the
+// same subtree, quoting the segments jq would not take bare.
+func jqPathQuery(path string) string {
+	var b strings.Builder
+	for _, segment := range strings.Split(path, ".") {
+		if bareJQKey.MatchString(segment) {
+			b.WriteString("." + segment)
+		} else {
+			fmt.Fprintf(&b, "[%q]", segment)
 		}
 	}
-
-	buf, err := yaml.Marshal(filtered)
-	if err != nil {
-		return mcptools.Result{}, fmt.Errorf("marshaling filtered config: %w", err)
+	if b.Len() == 0 {
+		return "."
 	}
-	yamlText = string(buf)
-
-	var b strings.Builder
-	if path == "" {
-		b.WriteString("Current llama-swap configuration (credentials redacted, values resolved):\n\n")
-	} else {
-		fmt.Fprintf(&b, "Current llama-swap configuration at %q (credentials redacted, values resolved):\n\n", path)
-	}
-	b.WriteString("```yaml\n")
-	b.WriteString(strings.TrimRight(yamlText, "\n"))
-	b.WriteString("\n```\n")
-
-	// A large config can still exceed the cap even after pruning. Give the
-	// model the one move that fixes it rather than leaving it with a
-	// half-parsed document.
-	result := mcptools.CapResult(b.String(), maxConfigResultBytes)
-	if result.Truncated {
-		result.Content += "\nThe full config is larger than one response. Call get_config again " +
-			"with a \"path\" (for example \"models\", \"models.<id>\", \"peers\", \"groups\") " +
-			"to read a section in full."
-	}
-	return result, nil
+	return b.String()
 }
 
 // configProviderDefaults returns rendered defaults in the same YAML shape as

--- a/internal/config/mcpprovider.go
+++ b/internal/config/mcpprovider.go
@@ -8,8 +8,10 @@ import (
 	"math"
 	"reflect"
 	"regexp"
+	"runtime/metrics"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/itchyny/gojq"
@@ -29,9 +31,46 @@ const maxConfigResultBytes = 32 * 1024
 // not if.
 const configQueryTimeout = 5 * time.Second
 
+// maxConfigQueryNodes caps the values in one result -- every scalar, and every
+// array and object holding them -- counted before the result is rendered.
+//
+// Rendering is not free: yaml.Marshal walks the whole value and builds the
+// whole string before anything can be measured, so a result that will be
+// refused for its size has to be refused before that. The configuration
+// document is a few thousand values at most, and the rendered answer is capped
+// at 32KB, so nothing a caller has any business asking for comes near this.
+const maxConfigQueryNodes = 200_000
+
+// maxConfigQueryHeapGrowth is how far the live heap may grow during one query
+// before it is cancelled.
+//
+// This is the only limit that can stop a query like "[range(0; 5000000)]".
+// gojq builds that array in full before it hands the value back, so the caps
+// above never get to see it -- the process is killed by the allocator first,
+// and /api/mcp needs no credentials by default. gojq checks for cancellation
+// on every instruction it executes, so cancelling lands part-way through the
+// build rather than after it.
+//
+// The budget is enormous next to any legitimate result and small next to the
+// machine, which is the right trade: the cost of tripping it is one error
+// message the caller can act on.
+const maxConfigQueryHeapGrowth = 128 << 20
+
+// configQueryHeapPoll is how often that growth is sampled. A single append can
+// double a large slice in one allocation, so the peak overshoots the budget by
+// however much one such step adds; sampling often keeps that bounded.
+const configQueryHeapPoll = 10 * time.Millisecond
+
 // errConfigResultTooLarge signals that rendering stopped because the result
 // passed maxConfigResultBytes.
 var errConfigResultTooLarge = errors.New("config query result is too large")
+
+// errConfigValueTooLarge signals that a single result held more values than
+// maxConfigQueryNodes, so it was refused rather than rendered.
+var errConfigValueTooLarge = errors.New("config query result has too many values")
+
+// errConfigQueryOutOfMemory signals that the heap guard cancelled the query.
+var errConfigQueryOutOfMemory = errors.New("config query used too much memory")
 
 // ConfigProvider serves the running llama-swap configuration so an agent can
 // give advice about the setup in front of it rather than in the abstract.
@@ -40,12 +79,34 @@ var errConfigResultTooLarge = errors.New("config query result is too large")
 // reload constructs a fresh Server and therefore a fresh registry, so the
 // snapshot always matches what is actually running.
 type ConfigProvider struct {
-	cfg Config
+	cfg    Config
+	limits configQueryLimits
+}
+
+// configQueryLimits bounds one evaluation. They are a field rather than
+// constants read in place so a test can prove a limit works without spending
+// what the production budget is worth of memory or time to do it.
+type configQueryLimits struct {
+	timeout     time.Duration
+	resultBytes int
+	valueNodes  int
+	heapGrowth  uint64
+	heapPoll    time.Duration
+}
+
+func defaultConfigQueryLimits() configQueryLimits {
+	return configQueryLimits{
+		timeout:     configQueryTimeout,
+		resultBytes: maxConfigResultBytes,
+		valueNodes:  maxConfigQueryNodes,
+		heapGrowth:  maxConfigQueryHeapGrowth,
+		heapPoll:    configQueryHeapPoll,
+	}
 }
 
 // NewConfigProvider builds the provider around a configuration snapshot.
 func NewConfigProvider(cfg Config) *ConfigProvider {
-	return &ConfigProvider{cfg: cfg}
+	return &ConfigProvider{cfg: cfg, limits: defaultConfigQueryLimits()}
 }
 
 var _ mcptools.Provider = (*ConfigProvider)(nil)
@@ -125,20 +186,30 @@ func (p *ConfigProvider) Call(ctx context.Context, name string, args map[string]
 		return mcptools.Result{}, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, configQueryTimeout)
+	ctx, cancel := context.WithTimeout(ctx, p.limits.timeout)
 	defer cancel()
 
-	out, err := runConfigQuery(ctx, code, document, maxConfigResultBytes)
+	// The guard cancels ctx, so it has to be watching before the query starts
+	// running and stopped once it has finished.
+	guard := newHeapGuard(cancel, p.limits.heapGrowth, p.limits.heapPoll)
+	out, err := runConfigQuery(ctx, code, document, p.limits.resultBytes, p.limits.valueNodes)
+	guard.stop()
+
 	switch {
-	case errors.Is(err, errConfigResultTooLarge):
+	case guard.tripped():
+		return mcptools.Result{IsError: true, Content: fmt.Sprintf(
+			"Error: the query %s was building a value too large to hold in memory, so it was "+
+				"stopped. Ask for part of the config rather than generating data: \".models | keys\" "+
+				"lists the model ids, and \".models.<id>\" reads one model.", query)}, nil
+	case errors.Is(err, errConfigValueTooLarge), errors.Is(err, errConfigResultTooLarge):
 		return mcptools.Result{IsError: true, Content: fmt.Sprintf(
 			"Error: the result of %s is larger than %dKB. Ask for less rather than everything: "+
 				"\".models | keys\" lists the model ids, \".models.<id>\" reads one model, and "+
 				"\".models | to_entries | map({id: .key, ttl: .value.ttl})\" pulls one field from all "+
-				"of them. %s", query, maxConfigResultBytes/1024, p.topLevelKeyHint())}, nil
+				"of them. %s", query, p.limits.resultBytes/1024, p.topLevelKeyHint())}, nil
 	case errors.Is(err, context.DeadlineExceeded):
 		return mcptools.Result{IsError: true, Content: fmt.Sprintf(
-			"Error: the query %s did not finish within %s. Simplify it.", query, configQueryTimeout)}, nil
+			"Error: the query %s did not finish within %s. Simplify it.", query, p.limits.timeout)}, nil
 	case err != nil:
 		return mcptools.Result{IsError: true, Content: fmt.Sprintf(
 			"Error: the query %s failed: %v", query, err)}, nil
@@ -176,9 +247,14 @@ type configQueryOutput struct {
 }
 
 // runConfigQuery evaluates code over document and renders each result as a YAML
-// document. It gives up as soon as the rendered output passes limit, so an
-// expression like `range(1e9)` cannot build a huge string in memory.
-func runConfigQuery(ctx context.Context, code *gojq.Code, document any, limit int) (configQueryOutput, error) {
+// document.
+//
+// Two budgets bound the work. byteLimit stops the loop once the rendered output
+// is longer than any answer should be, and nodeLimit refuses a single result
+// before it is rendered, because yaml.Marshal builds the whole string before
+// there is anything to measure. Neither can bound what gojq does inside Next;
+// that is the heap guard's job.
+func runConfigQuery(ctx context.Context, code *gojq.Code, document any, byteLimit, nodeLimit int) (configQueryOutput, error) {
 	out := configQueryOutput{nullOnly: true}
 
 	var b strings.Builder
@@ -190,6 +266,9 @@ func runConfigQuery(ctx context.Context, code *gojq.Code, document any, limit in
 		}
 		if err, isErr := value.(error); isErr {
 			return configQueryOutput{}, err
+		}
+		if countValues(value, nodeLimit) > nodeLimit {
+			return configQueryOutput{}, errConfigValueTooLarge
 		}
 
 		buf, err := yaml.Marshal(value)
@@ -207,13 +286,41 @@ func runConfigQuery(ctx context.Context, code *gojq.Code, document any, limit in
 		if value != nil {
 			out.nullOnly = false
 		}
-		if b.Len() > limit {
+		if b.Len() > byteLimit {
 			return configQueryOutput{}, errConfigResultTooLarge
 		}
 	}
 
 	out.body = b.String()
 	return out, nil
+}
+
+// countValues counts the scalars and containers in value, giving up once the
+// count is past limit. Walking a value that is already too big to render is
+// only worth doing until that is established.
+func countValues(value any, limit int) int {
+	switch typed := value.(type) {
+	case map[string]any:
+		count := 1
+		for _, child := range typed {
+			count += countValues(child, limit-count)
+			if count > limit {
+				return count
+			}
+		}
+		return count
+	case []any:
+		count := 1
+		for _, child := range typed {
+			count += countValues(child, limit-count)
+			if count > limit {
+				return count
+			}
+		}
+		return count
+	default:
+		return 1
+	}
 }
 
 // compileConfigQuery parses and compiles one jq expression. gojq keeps the
@@ -461,4 +568,77 @@ func pruneConfigDefaults(value, defaults any, path string) (any, bool) {
 		}
 	}
 	return out, len(out) == 0
+}
+
+// heapGuard cancels a running query when the live heap grows past a budget.
+//
+// It exists for one shape of query: the kind that builds a single enormous
+// value. gojq returns nothing until that value is complete, so a caller writing
+// "[range(0; 5000000)]" reaches the allocator long before it reaches any check
+// on the result. Measuring the heap is the only signal available while the
+// query is still inside gojq.
+//
+// The measurement is the whole process, not the query, so it is a safety net
+// rather than an accountant: other work allocating heavily at the same moment
+// can trip it. That costs one recoverable error message, which is the cheaper
+// mistake.
+type heapGuard struct {
+	fired atomic.Bool
+	done  chan struct{}
+	over  chan struct{}
+}
+
+// newHeapGuard starts watching. It cancels the query's context when the live
+// heap has grown by more than growth bytes since now, sampling every poll.
+func newHeapGuard(cancel context.CancelFunc, growth uint64, poll time.Duration) *heapGuard {
+	guard := &heapGuard{done: make(chan struct{}), over: make(chan struct{})}
+	ceiling := liveHeapBytes() + growth
+
+	go func() {
+		defer close(guard.over)
+		ticker := time.NewTicker(poll)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-guard.done:
+				return
+			case <-ticker.C:
+				if liveHeapBytes() > ceiling {
+					guard.fired.Store(true)
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+
+	return guard
+}
+
+// stop ends the watch and waits for it, so a finished query leaves no
+// goroutine behind and tripped() is settled by the time it returns.
+func (g *heapGuard) stop() {
+	close(g.done)
+	<-g.over
+}
+
+// tripped reports whether the guard is what cancelled the query. Only call it
+// after stop.
+func (g *heapGuard) tripped() bool { return g.fired.Load() }
+
+// heapObjectsMetric is the live heap: objects allocated and not yet collected.
+// Reading it does not stop the world, unlike runtime.ReadMemStats, which
+// matters because this is sampled every few milliseconds while a query runs.
+const heapObjectsMetric = "/memory/classes/heap/objects:bytes"
+
+func liveHeapBytes() uint64 {
+	sample := []metrics.Sample{{Name: heapObjectsMetric}}
+	metrics.Read(sample)
+	if sample[0].Value.Kind() != metrics.KindUint64 {
+		// The metric was removed from the runtime. TestConfigProvider_HeapMetricIsSupported
+		// fails in that case; returning 0 here leaves the guard inert rather
+		// than cancelling every query.
+		return 0
+	}
+	return sample[0].Value.Uint64()
 }

--- a/internal/config/mcpprovider_test.go
+++ b/internal/config/mcpprovider_test.go
@@ -3,7 +3,9 @@ package config
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"runtime/metrics"
 	"strings"
 	"testing"
 	"time"
@@ -308,5 +310,117 @@ func TestConfigProvider_UnknownTool(t *testing.T) {
 	_, err := newTestConfigProvider(t).Call(context.Background(), "get_doc", nil)
 	if err == nil {
 		t.Fatal("want an error for an unknown tool")
+	}
+}
+
+// A query that builds one enormous value is the shape none of the result-size
+// caps can catch: gojq returns nothing until the value is complete, so
+// "[range(0; 1000000000)]" reaches the allocator long before it reaches any
+// check on the result. Before the heap guard this killed the process, and
+// /api/mcp needs no credentials by default.
+func TestConfigProvider_GetConfigQuerySurvivesAHugeConstructedValue(t *testing.T) {
+	provider := newTestConfigProvider(t)
+	// A budget small enough that the test costs megabytes rather than the
+	// production budget's worth of them.
+	provider.limits.heapGrowth = 16 << 20
+	provider.limits.heapPoll = 2 * time.Millisecond
+	// Long enough that the timeout cannot be what ends these queries -- under
+	// -race the same work takes an order of magnitude longer, and a timeout
+	// standing in for the guard would hide the guard failing. Still short
+	// enough to bound the damage if it does.
+	provider.limits.timeout = 30 * time.Second
+
+	for _, query := range []string{
+		`[range(0; 1000000000)]`,
+		`[range(0; 5000000)]`,
+		`[limit(5000000; repeat("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))]`,
+	} {
+		t.Run(query, func(t *testing.T) {
+			start := time.Now()
+			res := callConfig(t, provider, fmt.Sprintf(`{"query":%q}`, query))
+			if !res.IsError {
+				t.Fatalf("want IsError for a query that builds an unbounded value, got %d bytes", len(res.Content))
+			}
+			if !strings.Contains(res.Content, "too large to hold in memory") {
+				t.Errorf("the caller should be told what happened:\n%s", res.Content)
+			}
+			// The point of the guard is that it fires while the value is being
+			// built, rather than the query running to its deadline.
+			if elapsed := time.Since(start); elapsed >= provider.limits.timeout {
+				t.Errorf("took %s; the guard should stop this well before the %s timeout",
+					elapsed.Round(time.Millisecond), provider.limits.timeout)
+			}
+		})
+	}
+}
+
+// The guard must not fire on a query that asks for something real.
+func TestConfigProvider_GetConfigQueryGuardLeavesNormalQueriesAlone(t *testing.T) {
+	provider := newTestConfigProvider(t)
+	provider.limits.heapGrowth = 16 << 20
+	provider.limits.heapPoll = 2 * time.Millisecond
+
+	for _, query := range []string{".", ".models | keys", `.models["qwen3"].cmd`, ".peers"} {
+		res := callConfig(t, provider, fmt.Sprintf(`{"query":%q}`, query))
+		if res.IsError {
+			t.Errorf("query %s was refused:\n%s", query, res.Content)
+		}
+	}
+}
+
+// yaml.Marshal walks and copies the whole value before anything can measure
+// the result, so a value that will be refused has to be refused before it is
+// rendered. A generous byte limit with a tiny node limit proves which check
+// fired.
+func TestConfigProvider_RunConfigQueryRefusesABigValueBeforeRenderingIt(t *testing.T) {
+	code, err := compileConfigQuery("[range(0; 5000)]")
+	if err != nil {
+		t.Fatalf("compileConfigQuery: %v", err)
+	}
+
+	_, err = runConfigQuery(context.Background(), code, map[string]any{}, 1<<30, 100)
+	if !errors.Is(err, errConfigValueTooLarge) {
+		t.Fatalf("err = %v, want errConfigValueTooLarge", err)
+	}
+}
+
+func TestConfigProvider_CountValues(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value any
+		want  int
+	}{
+		{"scalar", 1, 1},
+		{"null", nil, 1},
+		{"empty array", []any{}, 1},
+		{"flat array", []any{1, 2, 3}, 4},
+		{"map", map[string]any{"a": 1, "b": 2}, 3},
+		{"nested", map[string]any{"a": []any{1, map[string]any{"b": 2}}}, 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := countValues(tc.value, 1000); got != tc.want {
+				t.Errorf("countValues = %d, want %d", got, tc.want)
+			}
+		})
+	}
+
+	// Counting stops once the answer is "more than the limit"; it does not
+	// walk the rest of a value it has already rejected.
+	big := make([]any, 10_000)
+	if got := countValues(big, 10); got <= 10 {
+		t.Errorf("countValues = %d, want a count over the limit", got)
+	}
+}
+
+// The guard reads the live heap through runtime/metrics. If that metric ever
+// goes away the guard silently stops guarding, so notice here instead.
+func TestConfigProvider_HeapMetricIsSupported(t *testing.T) {
+	sample := []metrics.Sample{{Name: heapObjectsMetric}}
+	metrics.Read(sample)
+	if sample[0].Value.Kind() != metrics.KindUint64 {
+		t.Fatalf("%s is no longer a uint64 metric; the heap guard is inert without it", heapObjectsMetric)
+	}
+	if liveHeapBytes() == 0 {
+		t.Error("liveHeapBytes() = 0, want the live heap size")
 	}
 }

--- a/internal/config/mcpprovider_test.go
+++ b/internal/config/mcpprovider_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mostlygeek/llama-swap/internal/mcptools"
 )
@@ -61,6 +62,13 @@ func TestConfigProvider_Tools(t *testing.T) {
 	if tools[0].InputSchema == nil {
 		t.Error("get_config has no inputSchema")
 	}
+	properties, _ := tools[0].InputSchema["properties"].(map[string]any)
+	if _, ok := properties["query"]; !ok {
+		t.Errorf("get_config should take a \"query\", schema properties are %v", properties)
+	}
+	if _, ok := properties["path"]; ok {
+		t.Error("get_config should no longer advertise a \"path\"")
+	}
 }
 
 func TestConfigProvider_GetConfigRedactsAndFences(t *testing.T) {
@@ -79,14 +87,54 @@ func TestConfigProvider_GetConfigRedactsAndFences(t *testing.T) {
 	}
 }
 
-func TestConfigProvider_GetConfigWithPath(t *testing.T) {
-	got := callConfig(t, newTestConfigProvider(t), `{"path":"models.qwen3"}`).Content
+func TestConfigProvider_GetConfigWithQuery(t *testing.T) {
+	got := callConfig(t, newTestConfigProvider(t), `{"query":".models.qwen3"}`).Content
 
-	if !strings.Contains(got, `at "models.qwen3"`) {
-		t.Errorf("result does not name the path:\n%s", got)
+	if !strings.Contains(got, `jq query .models.qwen3`) {
+		t.Errorf("result does not name the query:\n%s", got)
 	}
 	if !strings.Contains(got, "cmd:") || strings.Contains(got, "peers:") {
-		t.Errorf("path did not scope the output to the model:\n%s", got)
+		t.Errorf("query did not scope the output to the model:\n%s", got)
+	}
+}
+
+func TestConfigProvider_GetConfigQueryTransforms(t *testing.T) {
+	got := callConfig(t, newTestConfigProvider(t), `{"query":".models | keys"}`).Content
+	if !strings.Contains(got, "- qwen3") {
+		t.Errorf("`.models | keys` did not list the model ids:\n%s", got)
+	}
+
+	got = callConfig(t, newTestConfigProvider(t), `{"query":".peers | to_entries | map(.value.proxy)"}`).Content
+	if !strings.Contains(got, "http://edge:8080") {
+		t.Errorf("a pipeline over peers did not reach the proxy:\n%s", got)
+	}
+}
+
+// A jq query is only useful if the caller can select values, not just objects,
+// and a number has to come back as a number rather than in float notation.
+func TestConfigProvider_GetConfigQueryScalarResults(t *testing.T) {
+	cfg, err := LoadConfigFromReader(strings.NewReader("healthCheckTimeout: 300\nmodels:\n  qwen3:\n    cmd: \"server --port ${PORT}\"\n"))
+	if err != nil {
+		t.Fatalf("LoadConfigFromReader: %v", err)
+	}
+
+	got := callConfig(t, NewConfigProvider(cfg), `{"query":".healthCheckTimeout"}`).Content
+	if !strings.Contains(got, "300") || strings.Contains(got, "e+") {
+		t.Errorf("want a plain integer result:\n%s", got)
+	}
+}
+
+// Several results are several YAML documents, so a caller reading them back
+// gets a document separator rather than two values run together.
+func TestConfigProvider_GetConfigQueryMultipleResults(t *testing.T) {
+	got := callConfig(t, newTestConfigProvider(t), `{"query":".models | keys[]"}`).Content
+	if !strings.Contains(got, "qwen3") {
+		t.Errorf("want the model id in the results:\n%s", got)
+	}
+
+	got = callConfig(t, newTestConfigProvider(t), `{"query":"1, 2"}`).Content
+	if !strings.Contains(got, "1\n---\n2") {
+		t.Errorf("want two YAML documents:\n%s", got)
 	}
 }
 
@@ -116,17 +164,97 @@ func TestConfigProvider_GetConfigOmitsDefaults(t *testing.T) {
 	}
 }
 
-func TestConfigProvider_GetConfigUnknownPath(t *testing.T) {
-	res := callConfig(t, newTestConfigProvider(t), `{"path":"nope.nowhere"}`)
-	if !res.IsError {
-		t.Fatalf("want IsError for a bad path, got:\n%s", res.Content)
+// jq answers a missing key with null rather than an error, so the result has to
+// say what null means or the caller reads it as a configured value.
+func TestConfigProvider_GetConfigQueryMissingKey(t *testing.T) {
+	res := callConfig(t, newTestConfigProvider(t), `{"query":".nowhere"}`)
+	if res.IsError {
+		t.Errorf("a null result is an answer, not an error:\n%s", res.Content)
+	}
+	if !strings.Contains(res.Content, "null means nothing is set there") {
+		t.Errorf("result should explain null:\n%s", res.Content)
 	}
 	if !strings.Contains(res.Content, "Top-level keys:") {
-		t.Errorf("error should list valid top-level keys:\n%s", res.Content)
+		t.Errorf("result should list valid top-level keys:\n%s", res.Content)
 	}
 }
 
-func TestConfigProvider_GetConfigTruncationPointsAtPath(t *testing.T) {
+func TestConfigProvider_GetConfigQueryMatchesNothing(t *testing.T) {
+	res := callConfig(t, newTestConfigProvider(t), `{"query":".models | keys[] | select(. == \"nope\")"}`)
+	if res.IsError {
+		t.Errorf("an empty result set is an answer, not an error:\n%s", res.Content)
+	}
+	if !strings.Contains(res.Content, "matched nothing") {
+		t.Errorf("result should say the query matched nothing:\n%s", res.Content)
+	}
+}
+
+func TestConfigProvider_GetConfigInvalidQuery(t *testing.T) {
+	res := callConfig(t, newTestConfigProvider(t), `{"query":".models | ["}`)
+	if !res.IsError {
+		t.Fatalf("want IsError for a query that does not parse, got:\n%s", res.Content)
+	}
+	if !strings.Contains(res.Content, "not a valid jq query") {
+		t.Errorf("error should name the problem:\n%s", res.Content)
+	}
+}
+
+// Model ids usually contain a hyphen, which jq reads as subtraction, so the
+// error has to point at the bracket form rather than only saying "invalid".
+func TestConfigProvider_GetConfigInvalidQueryHintsAtQuotingIDs(t *testing.T) {
+	res := callConfig(t, newTestConfigProvider(t), `{"query":".models.qwen3-8b"}`)
+	if !res.IsError {
+		t.Fatalf("want IsError for an unquoted hyphenated id, got:\n%s", res.Content)
+	}
+	if !strings.Contains(res.Content, `.models["qwen3-8b"]`) {
+		t.Errorf("error should show the quoted form:\n%s", res.Content)
+	}
+}
+
+func TestConfigProvider_GetConfigQueryRuntimeError(t *testing.T) {
+	res := callConfig(t, newTestConfigProvider(t), `{"query":".models | length + \"x\""}`)
+	if !res.IsError {
+		t.Fatalf("want IsError for a query that fails at run time, got:\n%s", res.Content)
+	}
+	if !strings.Contains(res.Content, "failed") {
+		t.Errorf("error should say the query failed:\n%s", res.Content)
+	}
+}
+
+// The environment holds the credentials redaction exists to keep out of the
+// result, so jq's env access must stay closed.
+func TestConfigProvider_GetConfigQueryCannotReadEnvironment(t *testing.T) {
+	t.Setenv("LLAMA_SWAP_TEST_SECRET", "do-not-leak")
+
+	for _, query := range []string{"env", "$ENV"} {
+		res := callConfig(t, newTestConfigProvider(t), fmt.Sprintf(`{"query":%q}`, query))
+		if strings.Contains(res.Content, "do-not-leak") || strings.Contains(res.Content, "LLAMA_SWAP_TEST_SECRET") {
+			t.Errorf("query %q leaked the process environment:\n%s", query, res.Content)
+		}
+	}
+}
+
+// A query that never terminates has to end with the tool answering, not with
+// the request hanging. The deadline comes from the caller's context here so the
+// test does not sit out configQueryTimeout.
+func TestConfigProvider_GetConfigQueryTimesOut(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	args := map[string]json.RawMessage{"query": json.RawMessage(`"def f: f; f"`)}
+	res, err := newTestConfigProvider(t).Call(ctx, "get_config", args)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("want IsError for a non-terminating query, got:\n%s", res.Content)
+	}
+	if !strings.Contains(res.Content, "did not finish") {
+		t.Errorf("error should say the query ran out of time:\n%s", res.Content)
+	}
+}
+
+func TestConfigProvider_GetConfigOversizeResultAsksForANarrowerQuery(t *testing.T) {
 	var b strings.Builder
 	b.WriteString("models:\n")
 	for i := 0; i < 220; i++ {
@@ -136,13 +264,43 @@ func TestConfigProvider_GetConfigTruncationPointsAtPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadConfigFromReader: %v", err)
 	}
+	provider := NewConfigProvider(cfg)
 
-	got := callConfig(t, NewConfigProvider(cfg), "").Content
-	if !strings.Contains(got, "[truncated]") {
-		t.Fatalf("expected a large config to truncate, got %d bytes", len(got))
+	res := callConfig(t, provider, "")
+	if !res.IsError {
+		t.Fatalf("expected a large config to be refused, got %d bytes", len(res.Content))
 	}
-	if !strings.Contains(got, `with a "path"`) {
-		t.Errorf("truncated result should tell the caller to use a path:\n%s", got[len(got)-400:])
+	if res.Truncated || strings.Contains(res.Content, "[truncated]") {
+		t.Errorf("an oversize result should be refused, not truncated:\n%s", res.Content)
+	}
+	if !strings.Contains(res.Content, "larger than") || !strings.Contains(res.Content, ".models | keys") {
+		t.Errorf("the refusal should suggest a narrower query:\n%s", res.Content)
+	}
+
+	// The narrower query the refusal suggests has to actually fit.
+	narrowed := callConfig(t, provider, `{"query":".models[\"model-007\"]"}`)
+	if narrowed.IsError {
+		t.Fatalf("the suggested narrower query failed:\n%s", narrowed.Content)
+	}
+	if !strings.Contains(narrowed.Content, "model-007.gguf") {
+		t.Errorf("narrowed query did not return the model:\n%s", narrowed.Content)
+	}
+}
+
+// The tool took a dotted path before it took a jq query, so a caller still
+// passing one is told the expression that replaces it.
+func TestConfigProvider_GetConfigRejectsLegacyPath(t *testing.T) {
+	res := callConfig(t, newTestConfigProvider(t), `{"path":"models.qwen3"}`)
+	if !res.IsError {
+		t.Fatalf("want IsError for the old path argument, got:\n%s", res.Content)
+	}
+	if !strings.Contains(res.Content, "query=.models.qwen3") {
+		t.Errorf("error should name the equivalent query:\n%s", res.Content)
+	}
+
+	res = callConfig(t, newTestConfigProvider(t), `{"path":"models.qwen3-8b"}`)
+	if !strings.Contains(res.Content, `.models["qwen3-8b"]`) {
+		t.Errorf("an id jq cannot take bare should be quoted:\n%s", res.Content)
 	}
 }
 

--- a/internal/server/apimcp.go
+++ b/internal/server/apimcp.go
@@ -110,8 +110,10 @@ const mcpInstructions = "Tools are namespaced by provider. The docs__* tools ans
 	"llama-swap's own configuration: call docs__list_docs for an index, docs__search_docs to find " +
 	"something by keyword, docs__get_doc to read a document in full, and docs__get_config_schema to " +
 	"check what a configuration key accepts. Document ids starting with 'reference/config/' return " +
-	"sections of config.example.yaml verbatim. config__get_config returns the configuration this " +
-	"server is running right now, with credentials redacted, for advice about the active setup. " +
+	"sections of config.example.yaml verbatim. config__get_config answers a jq query against the " +
+	"configuration this server is running right now, with credentials redacted, for advice about " +
+	"the active setup: pass a \"query\" such as \".models | keys\" or \".models.qwen3\" to read " +
+	"exactly the part you need. " +
 	"The sys__* tools report facts about the machine llama-swap is running on."
 
 func (s *Server) mcpDiscover() discoverResult {

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -5,7 +5,7 @@
   import { wrap } from "svelte-spa-router/wrap";
   import AppSidebar from "./components/AppSidebar.svelte";
   import RouteLoadingImpl from "./components/RouteLoading.svelte";
-  import PlaygroundStub from "./routes/PlaygroundStub.svelte";
+  import AlwaysMountedStub from "./routes/AlwaysMountedStub.svelte";
   import * as Sidebar from "$lib/components/ui/sidebar/index.js";
   import * as Tooltip from "$lib/components/ui/tooltip/index.js";
   import { Separator } from "$lib/components/ui/separator/index.js";
@@ -32,7 +32,8 @@
   // placeholder instead of a blank/white flash.
   const routes = {
     "/": wrap({ asyncComponent: () => import("./routes/Activity.svelte"), loadingComponent: RouteLoading }),
-    "/playground": PlaygroundStub,
+    "/playground": AlwaysMountedStub,
+    "/help": AlwaysMountedStub,
     "/models": wrap({ asyncComponent: () => import("./routes/ModelsDash.svelte"), loadingComponent: RouteLoading }),
     "/models/:id": wrap({ asyncComponent: () => import("./routes/ModelDetail.svelte"), loadingComponent: RouteLoading }),
     "/logs": wrap({ asyncComponent: () => import("./routes/LogViewer.svelte"), loadingComponent: RouteLoading }),
@@ -47,6 +48,7 @@
   const routeTitles: Record<string, string> = {
     "/": "Activity",
     "/playground": "Playground",
+    "/help": "Help",
     "/models": "Models",
     "/activity": "Activity",
     "/logs": "Logs",
@@ -108,11 +110,13 @@
     document.title = `${icon} ${$appTitle}`;
   });
 
-  // Playground is always mounted (rather than routed) so it keeps its state
-  // when the user navigates away, but it's still lazy-loaded on app start so
-  // its dependencies (chat markdown/KaTeX/highlight.js rendering) don't block
-  // the initial page load.
+  // Playground and Help are always mounted (rather than routed) so they keep
+  // their state when the user navigates away -- a chat that is still streaming
+  // survives a look at the logs. Both are still lazy-loaded on app start so
+  // their dependencies (chat markdown/KaTeX/highlight.js rendering) don't
+  // block the initial page load.
   let PlaygroundComponent = $state<Component | null>(null);
+  let HelpComponent = $state<Component | null>(null);
 
   onMount(() => {
     const cleanupScreenWidth = initScreenWidth();
@@ -121,6 +125,9 @@
     checkPerformanceEnabled();
     import("./routes/Playground.svelte").then((m) => {
       PlaygroundComponent = m.default;
+    });
+    import("./routes/Help.svelte").then((m) => {
+      HelpComponent = m.default;
     });
 
     return () => {
@@ -175,7 +182,14 @@
             <RouteLoading />
           {/if}
         </div>
-        <div class="h-full" class:hidden={$currentRoute === "/playground"}>
+        <div class="h-full" class:hidden={$currentRoute !== "/help"}>
+          {#if HelpComponent}
+            <HelpComponent />
+          {:else}
+            <RouteLoading />
+          {/if}
+        </div>
+        <div class="h-full" class:hidden={$currentRoute === "/playground" || $currentRoute === "/help"}>
           <Router {routes} on:routeLoaded={handleRouteLoaded} />
         </div>
       </main>

--- a/ui/src/cli/docsAgent.ts
+++ b/ui/src/cli/docsAgent.ts
@@ -25,7 +25,7 @@ import { DOCS_AGENT_SYSTEM_PROMPT } from "../lib/prompts/docsAgent";
 import type { ChatMessage } from "../lib/types";
 
 /**
- * Headless driver for the Playground's Docs Agent.
+ * Headless driver for the Docs Agent behind the UI's Help page.
  *
  * The whole point is that this imports agentLoop.ts, chatApi.ts and
  * agentTools.ts unmodified, so what is measured here is exactly what the

--- a/ui/src/components/AppSidebar.svelte
+++ b/ui/src/components/AppSidebar.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { link } from "svelte-spa-router";
-  import { FerrisWheel, Boxes, Activity, Cat, ScrollText, Gauge, Cpu, Sun, Moon, Monitor, ChevronRight, Settings } from "@lucide/svelte";
+  import { FerrisWheel, Boxes, Activity, Cat, ScrollText, Gauge, Cpu, Sun, Moon, Monitor, ChevronRight, Settings, CircleQuestionMark } from "@lucide/svelte";
   import * as Sidebar from "$lib/components/ui/sidebar/index.js";
   import * as Collapsible from "$lib/components/ui/collapsible/index.js";
   import { Button } from "$lib/components/ui/button/index.js";
   import { toggleTheme, themeMode, appTitle } from "../stores/theme";
   import { currentRoute } from "../stores/route";
-  import { playgroundActivity } from "../stores/playgroundActivity";
+  import { playgroundActivity, docsAgentStreaming } from "../stores/playgroundActivity";
   import { performanceEnabled, models, tailcatStatus } from "../stores/api";
   import { showUnlistedModels } from "../stores/modelDisplay";
   import { modelsMenuOpen } from "../stores/sidebar";
@@ -224,6 +224,19 @@
   </Sidebar.Content>
 
   <Sidebar.Footer>
+    <Sidebar.Menu>
+      <Sidebar.MenuItem>
+        <Sidebar.MenuButton isActive={isActive("/help", $currentRoute)} tooltipContent="Help">
+          {#snippet child({ props })}
+            <a href="/help" use:link {...props}>
+              <CircleQuestionMark />
+              <span class={$docsAgentStreaming ? "activity-link" : ""}>Help</span>
+            </a>
+          {/snippet}
+        </Sidebar.MenuButton>
+      </Sidebar.MenuItem>
+    </Sidebar.Menu>
+
     <div
       class="flex items-center justify-between gap-2 px-1 group-data-[collapsible=icon]:flex-col-reverse"
     >

--- a/ui/src/components/playground/DocsInterface.svelte
+++ b/ui/src/components/playground/DocsInterface.svelte
@@ -468,14 +468,18 @@
               from what the model remembers.
             </p>
             <div class="mt-4 flex flex-col gap-2">
-              {#each suggestions as suggestion (suggestion)}
+              {#each suggestions as suggestion (suggestion.number)}
                 <button
                   type="button"
                   class="hover:bg-muted/70 disabled:hover:bg-transparent rounded-md border px-3 py-2 text-left text-sm transition-colors disabled:opacity-50"
                   disabled={!canSend}
-                  onclick={() => ask(suggestion)}
+                  onclick={() => ask(suggestion.question)}
                 >
-                  {suggestion}
+                  <!-- The number is the topic's place in the pool, not this
+                       button's place on screen, so it stays muted: it labels
+                       the question rather than competing with it. -->
+                  <span class="text-muted-foreground tabular-nums">#{suggestion.number}.</span>
+                  {suggestion.question}
                 </button>
               {/each}
             </div>

--- a/ui/src/components/playground/DocsInterface.svelte
+++ b/ui/src/components/playground/DocsInterface.svelte
@@ -6,6 +6,7 @@
   import { runAgent, sanitizeMessages, DEFAULT_MAX_ITERATIONS } from "../../lib/agentLoop";
   import { fetchToolDefinitions, callTool, friendlyToolName } from "../../lib/agentTools";
   import { DOCS_AGENT_SYSTEM_PROMPT } from "../../lib/prompts/docsAgent";
+  import { pickSuggestions } from "../../lib/prompts/docsSuggestions";
   import { docsAgentStreaming } from "../../stores/playgroundActivity";
   import { getTextContent, type ChatMessage } from "../../lib/types";
   import { isSubmitEnter } from "../../lib/ime";
@@ -32,13 +33,6 @@
   const TEMPERATURE = 0;
   const MAX_TOKENS = 4096;
 
-  const SUGGESTIONS = [
-    "How do I unload a model after 5 minutes of inactivity?",
-    "How do I run two models on one GPU at the same time?",
-    "What models are configured on this server?",
-    "My model won't load. How do I debug it?",
-  ];
-
   const selectedModelStore = persistentStore<string>("playground-docs-model", "");
 
   function loadMessages(): ChatMessage[] {
@@ -54,6 +48,9 @@
   }
 
   let messages = $state<ChatMessage[]>(loadMessages());
+  // Drawn once per empty chat rather than derived: a list that recomputed
+  // would reshuffle under the reader's cursor.
+  let suggestions = $state(pickSuggestions());
   let userInput = $state("");
   let isStreaming = $state(false);
   let isReasoning = $state(false);
@@ -243,6 +240,7 @@
       cancelStreaming();
     }
     messages = [];
+    suggestions = pickSuggestions();
     isReasoning = false;
     reasoningStartTime = 0;
     agentIteration = 0;
@@ -470,7 +468,7 @@
               from what the model remembers.
             </p>
             <div class="mt-4 flex flex-col gap-2">
-              {#each SUGGESTIONS as suggestion (suggestion)}
+              {#each suggestions as suggestion (suggestion)}
                 <button
                   type="button"
                   class="hover:bg-muted/70 disabled:hover:bg-transparent rounded-md border px-3 py-2 text-left text-sm transition-colors disabled:opacity-50"

--- a/ui/src/components/playground/DocsInterface.svelte
+++ b/ui/src/components/playground/DocsInterface.svelte
@@ -6,7 +6,7 @@
   import { runAgent, sanitizeMessages, DEFAULT_MAX_ITERATIONS } from "../../lib/agentLoop";
   import { fetchToolDefinitions, callTool, friendlyToolName } from "../../lib/agentTools";
   import { DOCS_AGENT_SYSTEM_PROMPT } from "../../lib/prompts/docsAgent";
-  import { playgroundStores } from "../../stores/playgroundActivity";
+  import { docsAgentStreaming } from "../../stores/playgroundActivity";
   import { getTextContent, type ChatMessage } from "../../lib/types";
   import { isSubmitEnter } from "../../lib/ime";
   import ChatMessageComponent from "./ChatMessage.svelte";
@@ -19,7 +19,10 @@
 
   /**
    * The Docs Agent: a fixed agentic client for llama-swap's own documentation
-   * tools.
+   * tools. This is the whole of the Help page; routes/Help.svelte only frames
+   * it. It sits among the playground components because it is built from them
+   * -- the same chat message, model selector and textarea -- not because Help
+   * is a playground tab. It stopped being one.
    *
    * Unlike the Chat tab this exposes no settings. The prompt, temperature and
    * tool set are the thing being shipped -- they are tuned together against
@@ -169,7 +172,7 @@
   });
 
   $effect(() => {
-    playgroundStores.docsStreaming.set(isStreaming);
+    docsAgentStreaming.set(isStreaming);
   });
 
   let wasStreaming = $state(false);

--- a/ui/src/lib/hooks/playground-models.svelte.ts
+++ b/ui/src/lib/hooks/playground-models.svelte.ts
@@ -1,0 +1,36 @@
+import { fromStore } from "svelte/store";
+import { fetchPlaygroundModels, models } from "../../stores/api";
+
+const MODEL_REFRESH_DEBOUNCE_MS = 200;
+
+/**
+ * Keeps the playground model list in step with the server's for as long as the
+ * calling component lives. Call it during setup.
+ *
+ * The Playground and Help both need that list, and this ran in the Playground
+ * for both of them while Help was one of its tabs. Now that Help is its own
+ * page it asks for the list itself, rather than working only because the
+ * Playground happens to be mounted too. Two callers still make one request:
+ * fetchPlaygroundModels shares an in-flight fetch and coalesces the refresh
+ * behind it.
+ */
+export function refreshPlaygroundModels(): void {
+  const serverModels = fromStore(models);
+  let initialized = false;
+
+  $effect(() => {
+    void serverModels.current;
+
+    // The first pass is the initial load; there is nothing to debounce yet.
+    if (!initialized) {
+      initialized = true;
+      void fetchPlaygroundModels();
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      void fetchPlaygroundModels();
+    }, MODEL_REFRESH_DEBOUNCE_MS);
+    return () => window.clearTimeout(timeout);
+  });
+}

--- a/ui/src/lib/prompts/docsAgent.ts
+++ b/ui/src/lib/prompts/docsAgent.ts
@@ -2,7 +2,7 @@
  * The Docs Agent's system prompt.
  *
  * This is the single tuning surface that needs no server restart: it is sent by
- * the client on every request. Both the Playground's Docs tab and the headless
+ * the client on every request. Both the UI's Help page and the headless
  * CLI in src/cli/ use this constant, so an edit here changes what real users get
  * and what the eval suite measures at the same time. That is deliberate -- a
  * prompt that only ever improved the benchmark would be worthless.
@@ -10,7 +10,7 @@
  * The tool inventory below deliberately restates internal/server/apimcp.go's
  * `mcpInstructions`. That string is only returned from MCP `server/discover`,
  * which agentTools.ts never calls, so it reaches external MCP clients but never
- * the Playground. Until the two are unified, keep them consistent by hand.
+ * the Help page. Until the two are unified, keep them consistent by hand.
  *
  * Measure before and after with:
  *   npm run agent -- eval --repeat 3

--- a/ui/src/lib/prompts/docsAgent.ts
+++ b/ui/src/lib/prompts/docsAgent.ts
@@ -26,7 +26,7 @@ Tools are namespaced by provider.
 - \`docs__list_docs\` - the index of every document, with ids, titles and summaries. Use it to browse when a search comes back empty.
 - \`docs__get_doc\` - read one document in full by id. Ids come from the other two tools.
 - \`docs__get_config_schema\` - look up one configuration key by dotted path (for example \`models.*.ttl\`) to get its type, default and allowed values.
-- \`config__get_config\` - the configuration this server is running right now, with credentials redacted. Use it only when the question is about this specific running setup.
+- \`config__get_config\` - the configuration this server is running right now, with credentials redacted. It answers a jq query, so ask for exactly the part you need: \`.models | keys\` for the configured model ids, \`.models.qwen3\` for one model, \`.models["qwen3-8b"].ttl\` when the id is not a plain word, \`.\` for everything. Use it only when the question is about this specific running setup.
 - \`sys__now\` - the current date and time on the server.
 
 Document ids beginning with \`reference/config/\` are sections of \`config.example.yaml\` reproduced verbatim.

--- a/ui/src/lib/prompts/docsSuggestions.test.ts
+++ b/ui/src/lib/prompts/docsSuggestions.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { DOCS_SUGGESTIONS, SUGGESTION_COUNT, pickSuggestions } from "./docsSuggestions";
+
+describe("pickSuggestions", () => {
+  it("draws the number the Help page shows", () => {
+    expect(pickSuggestions()).toHaveLength(SUGGESTION_COUNT);
+  });
+
+  it("never repeats a question in one draw", () => {
+    for (let attempt = 0; attempt < 50; attempt++) {
+      const drawn = pickSuggestions();
+      expect(new Set(drawn).size).toBe(drawn.length);
+    }
+  });
+
+  it("only draws questions from the pool", () => {
+    for (const suggestion of pickSuggestions(SUGGESTION_COUNT * 2)) {
+      expect(DOCS_SUGGESTIONS).toContain(suggestion);
+    }
+  });
+
+  it("returns the whole pool rather than padding when asked for more than it has", () => {
+    expect(pickSuggestions(DOCS_SUGGESTIONS.length + 10)).toHaveLength(DOCS_SUGGESTIONS.length);
+  });
+
+  // A question that can never be drawn is a question nobody wrote. This catches
+  // an off-by-one in the shuffle, which is the classic way to strand an entry.
+  it("can eventually draw every question in the pool", () => {
+    const seen = new Set<string>();
+    for (let attempt = 0; attempt < 2000 && seen.size < DOCS_SUGGESTIONS.length; attempt++) {
+      for (const suggestion of pickSuggestions()) seen.add(suggestion);
+    }
+    expect(seen.size).toBe(DOCS_SUGGESTIONS.length);
+  });
+
+  it("offers enough questions that a repeat visit is a different set", () => {
+    expect(DOCS_SUGGESTIONS.length).toBeGreaterThanOrEqual(SUGGESTION_COUNT * 4);
+  });
+
+  it("asks the question that sends the reader looking for what they are missing", () => {
+    expect(DOCS_SUGGESTIONS).toContain("What llama-swap features am I not using?");
+  });
+});

--- a/ui/src/lib/prompts/docsSuggestions.test.ts
+++ b/ui/src/lib/prompts/docsSuggestions.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { DOCS_SUGGESTIONS, SUGGESTION_COUNT, pickSuggestions } from "./docsSuggestions";
+import {
+  DOCS_SUGGESTIONS,
+  NUMBERED_SUGGESTIONS,
+  SUGGESTION_COUNT,
+  pickSuggestions,
+} from "./docsSuggestions";
 
 describe("pickSuggestions", () => {
   it("draws the number the Help page shows", () => {
@@ -9,13 +14,22 @@ describe("pickSuggestions", () => {
   it("never repeats a question in one draw", () => {
     for (let attempt = 0; attempt < 50; attempt++) {
       const drawn = pickSuggestions();
-      expect(new Set(drawn).size).toBe(drawn.length);
+      expect(new Set(drawn.map((s) => s.number)).size).toBe(drawn.length);
     }
   });
 
   it("only draws questions from the pool", () => {
     for (const suggestion of pickSuggestions(SUGGESTION_COUNT * 2)) {
-      expect(DOCS_SUGGESTIONS).toContain(suggestion);
+      expect(NUMBERED_SUGGESTIONS).toContainEqual(suggestion);
+    }
+  });
+
+  // Four numbers going up read as a list; the same four shuffled read as a
+  // mistake. The draw is random, the order is not.
+  it("shows the drawn questions in ascending order", () => {
+    for (let attempt = 0; attempt < 50; attempt++) {
+      const numbers = pickSuggestions().map((s) => s.number);
+      expect(numbers).toEqual([...numbers].sort((a, b) => a - b));
     }
   });
 
@@ -26,9 +40,9 @@ describe("pickSuggestions", () => {
   // A question that can never be drawn is a question nobody wrote. This catches
   // an off-by-one in the shuffle, which is the classic way to strand an entry.
   it("can eventually draw every question in the pool", () => {
-    const seen = new Set<string>();
+    const seen = new Set<number>();
     for (let attempt = 0; attempt < 2000 && seen.size < DOCS_SUGGESTIONS.length; attempt++) {
-      for (const suggestion of pickSuggestions()) seen.add(suggestion);
+      for (const suggestion of pickSuggestions()) seen.add(suggestion.number);
     }
     expect(seen.size).toBe(DOCS_SUGGESTIONS.length);
   });
@@ -39,5 +53,25 @@ describe("pickSuggestions", () => {
 
   it("asks the question that sends the reader looking for what they are missing", () => {
     expect(DOCS_SUGGESTIONS).toContain("What llama-swap features am I not using?");
+  });
+});
+
+describe("NUMBERED_SUGGESTIONS", () => {
+  // The number names a topic, so the same one has to mean the same question
+  // every time it is shown.
+  it("numbers every question by its place in the pool, from 1", () => {
+    expect(NUMBERED_SUGGESTIONS).toHaveLength(DOCS_SUGGESTIONS.length);
+    NUMBERED_SUGGESTIONS.forEach((suggestion, index) => {
+      expect(suggestion.number).toBe(index + 1);
+      expect(suggestion.question).toBe(DOCS_SUGGESTIONS[index]);
+    });
+  });
+
+  it("gives no two questions the same number", () => {
+    expect(new Set(NUMBERED_SUGGESTIONS.map((s) => s.number)).size).toBe(NUMBERED_SUGGESTIONS.length);
+  });
+
+  it("lists no question twice", () => {
+    expect(new Set(DOCS_SUGGESTIONS).size).toBe(DOCS_SUGGESTIONS.length);
   });
 });

--- a/ui/src/lib/prompts/docsSuggestions.ts
+++ b/ui/src/lib/prompts/docsSuggestions.ts
@@ -1,0 +1,93 @@
+/**
+ * The questions offered on the empty Help page.
+ *
+ * These are the first thing a new user reads, so they do double duty: they
+ * show that the agent answers questions about *this* server, and they name
+ * features most people never find. Someone who does not know llama-swap can
+ * run several models at once, or resolve one model ID to a different model per
+ * request, will never think to ask -- so the list asks for them.
+ *
+ * Two rules for editing:
+ *
+ *   1. Every question must be answerable from `docs/kb/` or the running
+ *      config. A suggestion the agent cannot answer teaches the reader that
+ *      Help does not work, which is worse than offering nothing. The comment
+ *      above each group names the article that answers it.
+ *   2. Keep them short enough to read at a glance -- roughly two lines in the
+ *      button at a narrow width.
+ */
+export const DOCS_SUGGESTIONS: string[] = [
+  // The running config, read through config__get_config.
+  "What llama-swap features am I not using?",
+  "What models are configured on this server?",
+  "Which of my models never unload, and how much are they holding?",
+
+  // guides/routing/groups-and-matrix, guides/routing/profiles-and-selectors
+  "How do I run several models at once instead of swapping between them?",
+  "Can I switch between whole sets of models at runtime?",
+  "Can one model name resolve to a different model per request?",
+
+  // guides/model-runtime/ttl-and-unloading, .../troubleshooting-model-wont-load
+  "How do I unload a model after 5 minutes of inactivity?",
+  "My model won't load. How do I debug it?",
+
+  // guides/connectivity/remote-peers, examples/peers-and-multi-host
+  "How do I serve models running on another machine through this one?",
+
+  // examples/speculative-decoding
+  "How do I use a small draft model to speed up a large one?",
+
+  // guides/operations/startup-preloading-and-hooks
+  "How do I load my most-used models at startup instead of on the first request?",
+
+  // guides/routing/capacity-and-queues
+  "How do I limit how many requests one model handles at a time?",
+
+  // guides/api-integration/filters-and-request-rewriting
+  "How do I stop clients from overriding a sampling parameter?",
+
+  // guides/configuration/macros
+  "How do I stop repeating the same long command in every model?",
+
+  // guides/api-integration/api-keys-and-auth
+  "How do I keep API keys out of my config file?",
+
+  // guides/model-runtime/capabilities-and-model-listings
+  "How do I tell clients which of my models handle images or tool calls?",
+
+  // guides/model-runtime/client-compatibility-and-loading-feedback
+  "My client errors out while a model is still loading. Can I fix that?",
+
+  // guides/operations/observability-storage-and-activity
+  "Can I see the full request and response body for a call?",
+
+  // guides/api-integration/mcp-endpoint
+  "How do I point an MCP client at this server?",
+
+  // guides/operations/tailcat
+  "How do I reach this server from another network without opening a port?",
+
+  // guides/operations/container-security
+  "How do I run llama-swap in a container without running as root?",
+];
+
+/** How many suggestions the Help page shows at once. */
+export const SUGGESTION_COUNT = 4;
+
+/**
+ * Draws suggestions at random, without repeats.
+ *
+ * The draw is what makes the list a tour: a reader who comes back, or clears
+ * the chat, is shown a different corner of llama-swap rather than the same
+ * four questions they already decided they did not need.
+ */
+export function pickSuggestions(count: number = SUGGESTION_COUNT, pool: string[] = DOCS_SUGGESTIONS): string[] {
+  const shuffled = [...pool];
+  // Fisher-Yates. Sorting by a random comparator is the tempting one-liner and
+  // it is not a uniform shuffle.
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled.slice(0, Math.max(0, count));
+}

--- a/ui/src/lib/prompts/docsSuggestions.ts
+++ b/ui/src/lib/prompts/docsSuggestions.ts
@@ -15,6 +15,9 @@
  *      above each group names the article that answers it.
  *   2. Keep them short enough to read at a glance -- roughly two lines in the
  *      button at a narrow width.
+ *   3. Add new questions at the end. Each one is shown with its position in
+ *      this list ("#12."), so inserting in the middle renumbers everything
+ *      after it and the number someone wrote down stops meaning what it did.
  */
 export const DOCS_SUGGESTIONS: string[] = [
   // The running config, read through config__get_config.
@@ -74,14 +77,36 @@ export const DOCS_SUGGESTIONS: string[] = [
 /** How many suggestions the Help page shows at once. */
 export const SUGGESTION_COUNT = 4;
 
+/** One question, with the number it is shown under. */
+export interface DocsSuggestion {
+  /** Its position in the pool, from 1. Shown to the reader as "#12.". */
+  number: number;
+  question: string;
+}
+
 /**
- * Draws suggestions at random, without repeats.
+ * The pool, numbered. The number is the question's place in the list, so it
+ * names a specific topic rather than a slot on screen: four are shown at a
+ * time, and "#12" is the same question every time it comes up.
+ */
+export const NUMBERED_SUGGESTIONS: DocsSuggestion[] = DOCS_SUGGESTIONS.map((question, index) => ({
+  number: index + 1,
+  question,
+}));
+
+/**
+ * Draws suggestions at random, without repeats, in ascending order.
  *
  * The draw is what makes the list a tour: a reader who comes back, or clears
  * the chat, is shown a different corner of llama-swap rather than the same
- * four questions they already decided they did not need.
+ * four questions they already decided they did not need. The order is not part
+ * of that -- four numbers going up read as a list, the same four shuffled read
+ * as a mistake -- so the randomness picks which questions, not where they sit.
  */
-export function pickSuggestions(count: number = SUGGESTION_COUNT, pool: string[] = DOCS_SUGGESTIONS): string[] {
+export function pickSuggestions(
+  count: number = SUGGESTION_COUNT,
+  pool: DocsSuggestion[] = NUMBERED_SUGGESTIONS,
+): DocsSuggestion[] {
   const shuffled = [...pool];
   // Fisher-Yates. Sorting by a random comparator is the tempting one-liner and
   // it is not a uniform shuffle.
@@ -89,5 +114,5 @@ export function pickSuggestions(count: number = SUGGESTION_COUNT, pool: string[]
     const j = Math.floor(Math.random() * (i + 1));
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
-  return shuffled.slice(0, Math.max(0, count));
+  return shuffled.slice(0, Math.max(0, count)).sort((a, b) => a.number - b.number);
 }

--- a/ui/src/routes/AlwaysMountedStub.svelte
+++ b/ui/src/routes/AlwaysMountedStub.svelte
@@ -1,0 +1,6 @@
+<!--
+  Stands in for a route whose real component is mounted permanently in
+  App.svelte, so that navigating to it does not tear its state down. Both
+  /playground and /help are that kind of route: they hold a conversation and
+  in-flight streams that a user expects to still be there when they come back.
+-->

--- a/ui/src/routes/Help.svelte
+++ b/ui/src/routes/Help.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import DocsInterface from "../components/playground/DocsInterface.svelte";
+  import * as Card from "$lib/components/ui/card/index.js";
+  import { refreshPlaygroundModels } from "$lib/hooks/playground-models.svelte";
+
+  /**
+   * Help: ask llama-swap's own documentation a question.
+   *
+   * It was a Playground tab until it became its own page. The Playground is
+   * for trying a model out; this is for finding out how something works, which
+   * is what someone reaching for "Help" is after -- and it is one click from
+   * the bottom of the sidebar rather than three tabs deep.
+   */
+  refreshPlaygroundModels();
+</script>
+
+<Card.Root class="flex h-full flex-col gap-0 overflow-hidden p-4">
+  <div class="relative flex-1 overflow-hidden">
+    <DocsInterface />
+  </div>
+</Card.Root>

--- a/ui/src/routes/Playground.svelte
+++ b/ui/src/routes/Playground.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import type { Component } from "svelte";
   import ChatInterface from "../components/playground/ChatInterface.svelte";
-  import DocsInterface from "../components/playground/DocsInterface.svelte";
   import ImageInterface from "../components/playground/ImageInterface.svelte";
   import AudioInterface from "../components/playground/AudioInterface.svelte";
   import SpeechInterface from "../components/playground/SpeechInterface.svelte";
@@ -9,14 +8,11 @@
   import ConcurrencyInterface from "../components/playground/ConcurrencyInterface.svelte";
   import * as Card from "$lib/components/ui/card/index.js";
   import { Tabs, TabsList, TabsTrigger } from "$lib/components/ui/tabs/index.js";
-  import { fetchPlaygroundModels, models } from "../stores/api";
+  import { refreshPlaygroundModels } from "$lib/hooks/playground-models.svelte";
   import { selectedPlaygroundTab, playgroundTabs, type PlaygroundTab } from "../stores/playground";
-
-  const MODEL_REFRESH_DEBOUNCE_MS = 200;
 
   const tabComponents: Record<PlaygroundTab, Component> = {
     chat: ChatInterface,
-    docs: DocsInterface,
     images: ImageInterface,
     speech: SpeechInterface,
     audio: AudioInterface,
@@ -24,20 +20,7 @@
     concurrency: ConcurrencyInterface,
   };
 
-  let initializedModels = false;
-  $effect(() => {
-    void $models;
-    if (!initializedModels) {
-      initializedModels = true;
-      void fetchPlaygroundModels();
-      return;
-    }
-
-    const timeout = window.setTimeout(() => {
-      void fetchPlaygroundModels();
-    }, MODEL_REFRESH_DEBOUNCE_MS);
-    return () => window.clearTimeout(timeout);
-  });
+  refreshPlaygroundModels();
 </script>
 
 <Card.Root class="flex h-full flex-col gap-0 overflow-hidden p-4">

--- a/ui/src/routes/PlaygroundStub.svelte
+++ b/ui/src/routes/PlaygroundStub.svelte
@@ -1,1 +1,0 @@
-<!-- empty: real Playground is always mounted in App.svelte -->

--- a/ui/src/stores/playground.test.ts
+++ b/ui/src/stores/playground.test.ts
@@ -1,0 +1,32 @@
+import { get } from "svelte/store";
+import { describe, expect, it } from "vitest";
+import {
+  playgroundTabs,
+  resetUnknownPlaygroundTab,
+  selectedPlaygroundTab,
+  type PlaygroundTab,
+} from "./playground";
+
+// "docs" was the Help tab. It is a page of its own now, so a browser that
+// still has it stored would open the Playground on a tab that no longer
+// exists: every panel hidden, and a header reading "Playground /".
+const removedTab = "docs" as unknown as PlaygroundTab;
+
+describe("selectedPlaygroundTab", () => {
+  it("falls back to the first tab when the stored one was removed", () => {
+    selectedPlaygroundTab.set(removedTab);
+    resetUnknownPlaygroundTab();
+    expect(get(selectedPlaygroundTab)).toBe(playgroundTabs[0].id);
+  });
+
+  it("leaves a tab that still exists alone", () => {
+    selectedPlaygroundTab.set("rerank");
+    resetUnknownPlaygroundTab();
+    expect(get(selectedPlaygroundTab)).toBe("rerank");
+  });
+
+  it("no longer offers Help as a tab", () => {
+    expect(playgroundTabs.map((tab) => tab.id)).not.toContain("docs");
+    expect(playgroundTabs.map((tab) => tab.label)).not.toContain("Help");
+  });
+});

--- a/ui/src/stores/playground.ts
+++ b/ui/src/stores/playground.ts
@@ -1,6 +1,7 @@
+import { get } from "svelte/store";
 import { persistentStore } from "./persistent";
 
-export type PlaygroundTab = "chat" | "docs" | "images" | "speech" | "audio" | "rerank" | "concurrency";
+export type PlaygroundTab = "chat" | "images" | "speech" | "audio" | "rerank" | "concurrency";
 
 export const playgroundTabs: { id: PlaygroundTab; label: string }[] = [
   { id: "chat", label: "Chat" },
@@ -9,7 +10,21 @@ export const playgroundTabs: { id: PlaygroundTab; label: string }[] = [
   { id: "audio", label: "Transcription" },
   { id: "rerank", label: "Rerank" },
   { id: "concurrency", label: "Load Test" },
-  { id: "docs", label: "Help" },
 ];
 
 export const selectedPlaygroundTab = persistentStore<PlaygroundTab>("playground-selected-tab", "chat");
+
+/**
+ * Drop a stored tab that no longer exists.
+ *
+ * "docs" was a tab here until Help became its own page. A browser that last
+ * left the Playground on it would select a tab with nothing behind it: every
+ * panel hidden, and a header reading "Playground /".
+ */
+export function resetUnknownPlaygroundTab(): void {
+  if (!playgroundTabs.some((tab) => tab.id === get(selectedPlaygroundTab))) {
+    selectedPlaygroundTab.set(playgroundTabs[0].id);
+  }
+}
+
+resetUnknownPlaygroundTab();

--- a/ui/src/stores/playgroundActivity.ts
+++ b/ui/src/stores/playgroundActivity.ts
@@ -1,21 +1,24 @@
 import { writable, derived } from "svelte/store";
 
 const chatStreaming = writable(false);
-const docsStreaming = writable(false);
 const imageGenerating = writable(false);
 const speechGenerating = writable(false);
 const audioTranscribing = writable(false);
 const rerankLoading = writable(false);
 
+/**
+ * The Docs Agent's flag. It is not part of playgroundActivity: Help is its own
+ * page, so its sidebar link is the one that should show the work.
+ */
+export const docsAgentStreaming = writable(false);
+
 export const playgroundActivity = derived(
-  [chatStreaming, docsStreaming, imageGenerating, speechGenerating, audioTranscribing, rerankLoading],
-  ([$chat, $docs, $image, $speech, $audio, $rerank]) =>
-    $chat || $docs || $image || $speech || $audio || $rerank
+  [chatStreaming, imageGenerating, speechGenerating, audioTranscribing, rerankLoading],
+  ([$chat, $image, $speech, $audio, $rerank]) => $chat || $image || $speech || $audio || $rerank
 );
 
 export const playgroundStores = {
   chatStreaming,
-  docsStreaming,
   imageGenerating,
   speechGenerating,
   audioTranscribing,


### PR DESCRIPTION
## Summary

Replace the `get_config` tool's simple dotted-path selection with full jq query support, enabling agents to extract specific nested values from large configurations without reading the entire document.

## Key Changes

- **Config query language**: `get_config` now takes a `query` parameter (jq expression) instead of `path` (dotted notation). Examples: `.models | keys`, `.models["qwen3-8b"].ttl`, `.models | to_entries | map({id: .key, ttl: .value.ttl})`

- **Query evaluation**: Added `compileConfigQuery()` and `runConfigQuery()` to parse and execute jq expressions with:
  - 5-second timeout to prevent non-terminating queries
  - Streaming result rendering to stop early if output exceeds 32KB
  - Environment access disabled (prevents credential leakage)
  - Support for multiple results as separate YAML documents

- **Error handling**: Improved error messages that:
  - Suggest bracket notation for hyphenated IDs (`.models["qwen3-8b"]` not `.models.qwen3-8b`)
  - Distinguish between parse errors, runtime errors, timeouts, and size limits
  - Explain null results (missing keys vs. default values)
  - List top-level keys when queries match nothing

- **Backward compatibility**: Detects old `path` argument and suggests equivalent jq query

- **Eval fixture**: Added `evals/docs-agent/fixture/models.yaml` with 24 models and realistic nested configuration (several thousand tokens) to make query optimization measurable in eval cases

- **Eval cases**: Added `running-config.yaml` test cases that verify the agent queries for specific fields rather than reading the whole config, plus holdout cases for validation

- **UI changes**: 
  - Moved Help (formerly Docs tab) to its own page at `/help`
  - Both Playground and Help now refresh the model list independently
  - Added `AlwaysMountedStub` to keep Help state persistent across navigation

- **Dependencies**: Added `github.com/itchyny/gojq` for jq expression evaluation

## Implementation Details

The query system uses gojq's context-aware evaluation to enforce timeouts and prevent environment access. Results are rendered incrementally as YAML documents, allowing early termination when size limits are reached. This prevents a query like `range(1e9)` from consuming unbounded memory.

The eval fixture is deterministic and namespaced (all IDs start with `eval-`) to avoid collisions with user configs when merged via `-config-dir`.

https://claude.ai/code/session_01XqHm42wxNkeM9bhHv2T7if