### PR TITLE
process: start TTL idle window when model becomes ready

### DIFF
--- a/internal/process/process_command.go
+++ b/internal/process/process_command.go
@@ -329,6 +329,10 @@ func (p *ProcessCommand) run() {
 					cmdCancel = res.cancel
 					fn := res.handlerFn
 					p.handler.Store(&fn)
+					// A newly ready process starts a fresh idle window. Without this,
+					// lastUse is zero on first start or stale after a restart, so TTL
+					// can unload it on the first one-second ticker tick.
+					p.lastUse.Store(time.Now().UnixNano())
 					setState(StateReady)
 					notifyWaiters(nil)
 					if req.block {

--- a/internal/process/process_command.go
+++ b/internal/process/process_command.go
@@ -129,7 +129,9 @@ type ProcessCommand struct {
 	// Written only by run(); read by ServeHTTP via atomic load.
 	handler atomic.Pointer[http.HandlerFunc]
 
-	lastUse  atomic.Int64 // unix nano timestamp of last ServeHTTP completion
+	// lastUse is the unix-nano timestamp of the most recent activity baseline.
+	// It is initialized when the process becomes Ready and updated after ServeHTTP completes.
+	lastUse  atomic.Int64
 	inflight atomic.Int64 // current in-flight ServeHTTP calls
 }
 

--- a/internal/process/ttl_ready_baseline_regression_test.go
+++ b/internal/process/ttl_ready_baseline_regression_test.go
@@ -1,0 +1,48 @@
+package process
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+)
+
+// TestProcessCommand_TTLStartsWhenProcessBecomesReady verifies that a freshly
+// started/preloaded process receives a full TTL window even if no inference
+// request has completed yet. lastUse starts at zero, so using it as the idle
+// baseline would make the first one-second TTL tick unload any positive-TTL
+// process immediately.
+func TestProcessCommand_TTLStartsWhenProcessBecomesReady(t *testing.T) {
+	skipIfNoSimpleResponder(t)
+
+	cmd, port := simpleResponderCmd(t, "-silent")
+	p := newProcessCommand(t, config.ModelConfig{
+		Cmd:                cmd,
+		Proxy:              fmt.Sprintf("http://127.0.0.1:%d", port),
+		CheckEndpoint:      "/health",
+		HealthCheckTimeout: 10,
+		UnloadAfter:        5,
+		UnloadTimeout:      1,
+	})
+
+	runErr := runAsync(t, p)
+	defer func() {
+		if p.State() == StateReady {
+			_ = p.Stop(testStopTimeout)
+		}
+		select {
+		case <-runErr:
+		case <-time.After(testReturnTimeout):
+		}
+	}()
+
+	// The TTL is five seconds. With no user request, the process must still be
+	// ready well before that deadline. The buggy implementation compares the
+	// current time to Unix epoch because lastUse is still zero and stops on the
+	// first ~1s ticker iteration.
+	time.Sleep(1500 * time.Millisecond)
+	if got := p.State(); got != StateReady {
+		t.Fatalf("process state after 1.5s with ttl=5s = %s, want ready", got)
+	}
+}


### PR DESCRIPTION
Initialize lastUse when a process reaches Ready so positive-TTL models get a full idle window even before the first request, and reset the baseline on restart.

Add regression coverage for a freshly ready model with no requests.