### PR TITLE
feat: optionally store request captures on disk

### DIFF
--- a/config-schema.json
+++ b/config-schema.json
@@ -228,6 +228,15 @@
                     "type": "string",
                     "minLength": 1,
                     "description": "SQLite database file path for persistent activity logs."
+                },
+                "captureDir": {
+                    "type": "string",
+                    "description": "Directory for on-disk request/response captures. Empty (default) stores nothing on disk; set it to opt in. Requires a persistent store.path."
+                },
+                "captureMaxMB": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Maximum MB of captures to keep under store.captureDir; 0 (default) means unlimited disk usage. Only used when store.captureDir is set."
                 }
             },
             "required": [

--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -48,8 +48,16 @@ logToStdout: "proxy"
 # - optional, default: in-memory sqlite database capped by metricsMaxInMemory
 # - path is a sqlite database file path
 # - file-backed sqlite keeps activity logs across restarts
+# - captureDir opts into on-disk storage of raw request/response captures;
+#   empty (default) keeps captures in memory only (see captureBuffer)
+# - captureMaxMB caps that directory in MB; 0 (default) means unlimited
+# - persisted captures require a persistent store.path (activity IDs must
+#   survive restarts); the option is ignored for an in-memory database
 # store:
 #   path: /path/to/file.sqlite
+#   captureDir: /path/to/captures
+#   captureMaxMB: 512
+
 
 # metricsMaxInMemory: maximum number of metrics to keep in memory
 # - optional, default: 1000

--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -53,6 +53,9 @@ logToStdout: "proxy"
 # - captureMaxMB caps that directory in MB; 0 (default) means unlimited
 # - persisted captures require a persistent store.path (activity IDs must
 #   survive restarts); the option is ignored for an in-memory database
+# - captures are namespaced by the store.path database: replacing or recreating
+#   it restarts IDs, so each database keeps its own folder (captureMaxMB spans
+#   them all and prunes the oldest generation first)
 # store:
 #   path: /path/to/file.sqlite
 #   captureDir: /path/to/captures

--- a/docs/kb/guides/operations/observability-storage-and-activity.md
+++ b/docs/kb/guides/operations/observability-storage-and-activity.md
@@ -4,7 +4,7 @@ summary: Use logs, metrics, captures and the Activity view to diagnose requests 
 category: guides
 tags: [operations, logs, metrics, activity, captures]
 config_keys: [logLevel, logToStdout, metricsMaxInMemory, captureBuffer, store.captureDir, store.captureMaxMB]
-updated: 2026-09-05
+updated: 2026-09-06
 ---
 
 # Observability, storage and Activity
@@ -46,6 +46,12 @@ is needed and captures survive restarts; the `captureMaxMB` budget is enforced b
 a periodic background pass rather than inline, so disk usage can briefly exceed
 the cap right after a burst before the oldest captures are pruned.
 
+Captures are namespaced by the activity database at `store.path`: if that
+database is replaced or recreated, IDs restart at 1, so each database gets its
+own folder in the capture directory and old captures are never misread as new
+ones. They are kept, not deleted — flipping back to the old database serves
+them again — and the `captureMaxMB` budget spans all generations, pruning the
+older ones first.
 
 Do not put secrets in captures or debug logs. Reduce retention after diagnosing
 an issue.

--- a/docs/kb/guides/operations/observability-storage-and-activity.md
+++ b/docs/kb/guides/operations/observability-storage-and-activity.md
@@ -40,6 +40,12 @@ oldest captures when exceeded; `0` (default) means unlimited disk usage. It also
 requires a persistent `store.path` because captures are keyed by activity IDs
 that reset on every in-memory boot.
 
+Each capture is stored as its own file, grouped into folders of 1000 IDs to keep
+directories small. Lookups read the exact file path directly, so no startup scan
+is needed and captures survive restarts; the `captureMaxMB` budget is enforced by
+a periodic background pass rather than inline, so disk usage can briefly exceed
+the cap right after a burst before the oldest captures are pruned.
+
 
 Do not put secrets in captures or debug logs. Reduce retention after diagnosing
 an issue.

--- a/docs/kb/guides/operations/observability-storage-and-activity.md
+++ b/docs/kb/guides/operations/observability-storage-and-activity.md
@@ -3,8 +3,8 @@ title: Observability, storage and Activity
 summary: Use logs, metrics, captures and the Activity view to diagnose requests and retain useful history.
 category: guides
 tags: [operations, logs, metrics, activity, captures]
-config_keys: [logLevel, logToStdout, metricsMaxInMemory, captureBuffer]
-updated: 2026-08-28
+config_keys: [logLevel, logToStdout, metricsMaxInMemory, captureBuffer, store.captureDir, store.captureMaxMB]
+updated: 2026-09-05
 ---
 
 # Observability, storage and Activity
@@ -20,6 +20,26 @@ logToStdout: true
 metricsMaxInMemory: 1000
 captureBuffer: 100
 ```
+
+By default request/response captures live only in memory (bounded by
+`captureBuffer`) and are lost on restart. To keep them across restarts, enable
+an on-disk capture tier under `store` alongside a persistent database path:
+
+```yaml
+store:
+  path: /var/lib/llama-swap/llama-swap.sqlite
+  captureDir: /var/lib/llama-swap/captures   # setting this opts in
+  captureMaxMB: 512                          # 0 (default) = unlimited disk usage
+```
+
+The on-disk tier is a second layer behind the in-memory one: recent captures are
+served from memory, older ones (or those too large for the memory buffer) are
+read back from disk. Set `captureDir` to opt in — an empty `captureDir` (default)
+stores nothing on disk. `captureMaxMB` caps the directory size and prunes the
+oldest captures when exceeded; `0` (default) means unlimited disk usage. It also
+requires a persistent `store.path` because captures are keyed by activity IDs
+that reset on every in-memory boot.
+
 
 Do not put secrets in captures or debug logs. Reduce retention after diagnosing
 an issue.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,6 +118,13 @@ type HookOnStartup struct {
 
 type Store struct {
 	Path string `yaml:"path"`
+
+	// CaptureDir opts into on-disk storage of raw request/response captures;
+	// empty (default) stores nothing on disk. CaptureMaxMB caps the directory
+	// size in MB; 0 (default) means unlimited. Both require a persistent
+	// store.path (activity IDs must survive restarts) and are otherwise ignored.
+	CaptureDir   string `yaml:"captureDir"`
+	CaptureMaxMB int    `yaml:"captureMaxMB"`
 }
 
 type UIConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -114,6 +114,69 @@ store:
 	})
 }
 
+func TestConfig_StoreCapturePersistence(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg, err := LoadConfigFromReader(strings.NewReader(`
+store:
+  path: ` + filepath.Join(dir, "db.sqlite") + `
+`))
+		require.NoError(t, err)
+		require.NotNil(t, cfg.Store)
+		assert.Equal(t, 0, cfg.Store.CaptureMaxMB)
+		assert.Equal(t, "", cfg.Store.CaptureDir)
+	})
+
+	t.Run("maxMB without dir stays disabled", func(t *testing.T) {
+		dir := t.TempDir()
+		cfg, err := LoadConfigFromReader(strings.NewReader(`
+store:
+  path: ` + filepath.Join(dir, "db.sqlite") + `
+  captureMaxMB: 256
+`))
+		require.NoError(t, err)
+		assert.Equal(t, 256, cfg.Store.CaptureMaxMB)
+		assert.Equal(t, "", cfg.Store.CaptureDir)
+	})
+
+	t.Run("explicit dir preserved", func(t *testing.T) {
+		dir := t.TempDir()
+		captureDir := filepath.Join(dir, "caps")
+		cfg, err := LoadConfigFromReader(strings.NewReader(`
+store:
+  path: ` + filepath.Join(dir, "db.sqlite") + `
+  captureMaxMB: 64
+  captureDir: ` + captureDir + `
+`))
+		require.NoError(t, err)
+		assert.Equal(t, captureDir, cfg.Store.CaptureDir)
+	})
+
+	t.Run("dir set with unlimited max", func(t *testing.T) {
+		dir := t.TempDir()
+		captureDir := filepath.Join(dir, "caps")
+		cfg, err := LoadConfigFromReader(strings.NewReader(`
+store:
+  path: ` + filepath.Join(dir, "db.sqlite") + `
+  captureDir: ` + captureDir + `
+`))
+		require.NoError(t, err)
+		assert.Equal(t, captureDir, cfg.Store.CaptureDir)
+		assert.Equal(t, 0, cfg.Store.CaptureMaxMB)
+	})
+
+	t.Run("negative max rejected", func(t *testing.T) {
+		dir := t.TempDir()
+		_, err := LoadConfigFromReader(strings.NewReader(`
+store:
+  path: ` + filepath.Join(dir, "db.sqlite") + `
+  captureMaxMB: -1
+`))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "store.captureMaxMB")
+	})
+}
+
 func TestConfig_FindConfig(t *testing.T) {
 
 	// TODO?

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -115,63 +115,33 @@ store:
 }
 
 func TestConfig_StoreCapturePersistence(t *testing.T) {
-	t.Run("disabled by default", func(t *testing.T) {
-		dir := t.TempDir()
-		cfg, err := LoadConfigFromReader(strings.NewReader(`
-store:
-  path: ` + filepath.Join(dir, "db.sqlite") + `
-`))
-		require.NoError(t, err)
-		require.NotNil(t, cfg.Store)
-		assert.Equal(t, 0, cfg.Store.CaptureMaxMB)
-		assert.Equal(t, "", cfg.Store.CaptureDir)
-	})
+	dir := t.TempDir()
+	db := filepath.Join(dir, "db.sqlite")
+	caps := filepath.Join(dir, "caps")
 
-	t.Run("maxMB without dir stays disabled", func(t *testing.T) {
-		dir := t.TempDir()
-		cfg, err := LoadConfigFromReader(strings.NewReader(`
-store:
-  path: ` + filepath.Join(dir, "db.sqlite") + `
-  captureMaxMB: 256
-`))
-		require.NoError(t, err)
-		assert.Equal(t, 256, cfg.Store.CaptureMaxMB)
-		assert.Equal(t, "", cfg.Store.CaptureDir)
-	})
-
-	t.Run("explicit dir preserved", func(t *testing.T) {
-		dir := t.TempDir()
-		captureDir := filepath.Join(dir, "caps")
-		cfg, err := LoadConfigFromReader(strings.NewReader(`
-store:
-  path: ` + filepath.Join(dir, "db.sqlite") + `
-  captureMaxMB: 64
-  captureDir: ` + captureDir + `
-`))
-		require.NoError(t, err)
-		assert.Equal(t, captureDir, cfg.Store.CaptureDir)
-	})
-
-	t.Run("dir set with unlimited max", func(t *testing.T) {
-		dir := t.TempDir()
-		captureDir := filepath.Join(dir, "caps")
-		cfg, err := LoadConfigFromReader(strings.NewReader(`
-store:
-  path: ` + filepath.Join(dir, "db.sqlite") + `
-  captureDir: ` + captureDir + `
-`))
-		require.NoError(t, err)
-		assert.Equal(t, captureDir, cfg.Store.CaptureDir)
-		assert.Equal(t, 0, cfg.Store.CaptureMaxMB)
-	})
+	cases := []struct {
+		name         string
+		yaml         string
+		captureDir   string
+		captureMaxMB int
+	}{
+		{"disabled by default", "store:\n  path: " + db, "", 0},
+		{"maxMB without dir stays disabled", "store:\n  path: " + db + "\n  captureMaxMB: 256", "", 256},
+		{"explicit dir preserved", "store:\n  path: " + db + "\n  captureMaxMB: 64\n  captureDir: " + caps, caps, 64},
+		{"dir set with unlimited max", "store:\n  path: " + db + "\n  captureDir: " + caps, caps, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := LoadConfigFromReader(strings.NewReader(tc.yaml))
+			require.NoError(t, err)
+			require.NotNil(t, cfg.Store)
+			assert.Equal(t, tc.captureDir, cfg.Store.CaptureDir)
+			assert.Equal(t, tc.captureMaxMB, cfg.Store.CaptureMaxMB)
+		})
+	}
 
 	t.Run("negative max rejected", func(t *testing.T) {
-		dir := t.TempDir()
-		_, err := LoadConfigFromReader(strings.NewReader(`
-store:
-  path: ` + filepath.Join(dir, "db.sqlite") + `
-  captureMaxMB: -1
-`))
+		_, err := LoadConfigFromReader(strings.NewReader("store:\n  path: " + db + "\n  captureMaxMB: -1"))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "store.captureMaxMB")
 	})

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -93,6 +93,12 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		if err := validateStorePath(config.Store.Path); err != nil {
 			return Config{}, err
 		}
+		if config.Store.CaptureMaxMB < 0 {
+			return Config{}, fmt.Errorf("store.captureMaxMB must be >= 0")
+		}
+		// On-disk captures are opt-in and enabled by store.captureDir alone: an
+		// empty dir stores nothing on disk. store.captureMaxMB only caps the
+		// directory size; 0 (default) means unlimited disk usage.
 	}
 
 	// Apply default for upstream.ignorePaths when not specified. The default

--- a/internal/server/captures.go
+++ b/internal/server/captures.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -92,6 +94,20 @@ func (t *tieredCapture) Has(id int) bool {
 		}
 	}
 	return false
+}
+
+// Close releases each tier that is an io.Closer (the disk tier's reconcile
+// goroutine; the in-memory tier is not a Closer and is skipped).
+func (t *tieredCapture) Close() error {
+	var errs []error
+	for _, tier := range t.tiers {
+		if closer, ok := tier.(io.Closer); ok {
+			if err := closer.Close(); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // captureFields is a bitmask controlling what a route stores in a ReqRespCapture.

--- a/internal/server/captures.go
+++ b/internal/server/captures.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/klauspost/compress/zstd"
+	"github.com/mostlygeek/llama-swap/internal/logmon"
 )
 
 // ReqRespCapture is a stored request/response pair for a single metered request.
@@ -34,7 +35,7 @@ type captureStore interface {
 // returns a single store when one tier is set, a tiered store when several are,
 // or nil when none is. Reads probe tiers in order (memory before disk); writes
 // go to every tier so a capture evicted from memory still survives on disk.
-func combineCapture(tiers ...captureStore) captureStore {
+func combineCapture(logger *logmon.Monitor, tiers ...captureStore) captureStore {
 	var active []captureStore
 	for _, tier := range tiers {
 		if tier != nil {
@@ -47,15 +48,19 @@ func combineCapture(tiers ...captureStore) captureStore {
 	case 1:
 		return active[0]
 	default:
-		return &tieredCapture{tiers: active}
+		return &tieredCapture{tiers: active, logger: logger}
 	}
 }
 
 // tieredCapture spans an ordered set of captureStore tiers.
 type tieredCapture struct {
-	tiers []captureStore
+	tiers  []captureStore
+	logger *logmon.Monitor
 }
 
+// Add writes every tier and reports partial failures: a capture the first
+// tiers accept but a later one rejects would silently vanish once the working
+// tiers evict it, so the failure is warned about instead of hidden.
 func (t *tieredCapture) Add(id int, data []byte) error {
 	var lastErr error
 	stored := false
@@ -66,10 +71,13 @@ func (t *tieredCapture) Add(id int, data []byte) error {
 			stored = true
 		}
 	}
-	if stored {
-		return nil
+	if !stored {
+		return lastErr
 	}
-	return lastErr
+	if lastErr != nil && t.logger != nil {
+		t.logger.Warnf("capture %d stored in only some tiers: %v (may be lost after eviction or restart)", id, lastErr)
+	}
+	return nil
 }
 
 func (t *tieredCapture) Get(id int) ([]byte, error) {

--- a/internal/server/captures.go
+++ b/internal/server/captures.go
@@ -20,6 +20,80 @@ type ReqRespCapture struct {
 	RespBody    []byte            `json:"resp_body"`
 }
 
+// captureStore persists compressed (zstd+CBOR) capture blobs keyed by activity
+// ID. The in-memory cache.Cache and the file-backed diskCapture both satisfy it.
+type captureStore interface {
+	Add(id int, data []byte) error
+	Get(id int) ([]byte, error)
+	Has(id int) bool
+}
+
+// combineCapture layers the given tiers, ignoring unconfigured (nil) ones. It
+// returns a single store when one tier is set, a tiered store when several are,
+// or nil when none is. Reads probe tiers in order (memory before disk); writes
+// go to every tier so a capture evicted from memory still survives on disk.
+func combineCapture(tiers ...captureStore) captureStore {
+	var active []captureStore
+	for _, tier := range tiers {
+		if tier != nil {
+			active = append(active, tier)
+		}
+	}
+	switch len(active) {
+	case 0:
+		return nil
+	case 1:
+		return active[0]
+	default:
+		return &tieredCapture{tiers: active}
+	}
+}
+
+// tieredCapture spans an ordered set of captureStore tiers.
+type tieredCapture struct {
+	tiers []captureStore
+}
+
+func (t *tieredCapture) Add(id int, data []byte) error {
+	var lastErr error
+	stored := false
+	for _, tier := range t.tiers {
+		if err := tier.Add(id, data); err != nil {
+			lastErr = err
+		} else {
+			stored = true
+		}
+	}
+	if stored {
+		return nil
+	}
+	return lastErr
+}
+
+func (t *tieredCapture) Get(id int) ([]byte, error) {
+	var lastErr error
+	for _, tier := range t.tiers {
+		data, err := tier.Get(id)
+		if err == nil {
+			return data, nil
+		}
+		lastErr = err
+	}
+	if lastErr == nil {
+		lastErr = errCaptureNotFound
+	}
+	return nil, lastErr
+}
+
+func (t *tieredCapture) Has(id int) bool {
+	for _, tier := range t.tiers {
+		if tier.Has(id) {
+			return true
+		}
+	}
+	return false
+}
+
 // captureFields is a bitmask controlling what a route stores in a ReqRespCapture.
 type captureFields uint
 

--- a/internal/server/captures_disk.go
+++ b/internal/server/captures_disk.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/mostlygeek/llama-swap/internal/logmon"
 )
@@ -23,33 +22,26 @@ var (
 
 const captureFileExt = ".cap"
 
-// captureShardSize groups capture files into decimal folders (id/captureShardSize)
-// so a single directory never accumulates an unbounded number of entries. This
-// keeps operations efficient on filesystems that degrade with very large
+// captureShardSize groups files into decimal folders (id/captureShardSize) so
+// no single directory grows unbounded on filesystems that degrade with large
 // directories.
 const captureShardSize = 1000
 
-// Reconcile loop timing. Package-level vars so tests can shorten the cadence.
-var (
-	reconcileInterval   = 30 * time.Second
-	reconcileFirstDelay = 2 * time.Second
-)
-
 // diskCapture is a durable captureStore backed by one file per capture under
-// dir/<id/1000>/<id>.cap. Reads and writes probe the exact path directly, so no
-// startup scan is needed regardless of how many captures exist: opening is O(1)
-// and a lookup is a single filesystem stat. When a byte budget is set, an
-// eviction pass runs in the background (never inline on Add, never at open) and
-// removes the lowest-id (oldest) captures until the store fits, recomputing the
-// total from disk each pass. maxSize == 0 means unlimited (no reconcile loop).
-// Activity IDs are monotonic AUTOINCREMENT values, so ascending id order equals
-// insertion order. IDs never reach the path from user input.
+// dir/<id/1000>/<id>.cap. Reads and writes probe the exact path, so opening is
+// O(1) and needs no startup scan regardless of capture count. Eviction of the
+// lowest-id (oldest) captures runs off the request path: Add signals a
+// background loop, which walks the disk only once the running byte total
+// crosses maxSize (0 = unlimited, no loop). Activity IDs are monotonic
+// AUTOINCREMENT values, so id order is insertion order; they never come from
+// user input.
 type diskCapture struct {
 	dir     string
 	maxSize int64 // 0 = unlimited
 	logger  *logmon.Monitor
 
-	dirty     atomic.Bool // set by Add, cleared by the reconcile loop
+	total     atomic.Int64 // bytes on disk, corrected by each reconcile walk
+	triggerCh chan struct{}
 	stopCh    chan struct{}
 	doneCh    chan struct{}
 	closeOnce sync.Once
@@ -73,6 +65,7 @@ func newDiskCaptureOpts(dir string, maxBytes int, logger *logmon.Monitor, startL
 	}
 	dc := &diskCapture{dir: dir, maxSize: int64(maxBytes), logger: logger}
 	if startLoop && dc.maxSize > 0 {
+		dc.triggerCh = make(chan struct{}, 1)
 		dc.stopCh = make(chan struct{})
 		dc.doneCh = make(chan struct{})
 		go dc.reconcileLoop()
@@ -88,9 +81,8 @@ func (dc *diskCapture) path(id int) string {
 	return filepath.Join(dc.shardDir(id), strconv.Itoa(id)+captureFileExt)
 }
 
-// Add writes a capture atomically (tmp + rename in the target shard dir) and
-// flags the store dirty for the background reconcile pass. A single blob larger
-// than the whole budget is rejected; it could never fit.
+// Add writes a capture atomically (tmp + rename) and signals the reconcile
+// loop. A blob larger than the whole budget is rejected; it could never fit.
 func (dc *diskCapture) Add(id int, data []byte) error {
 	size := int64(len(data))
 	if dc.maxSize > 0 && size > dc.maxSize {
@@ -109,12 +101,18 @@ func (dc *diskCapture) Add(id int, data []byte) error {
 		os.Remove(tmp)
 		return fmt.Errorf("store capture %d: %w", id, err)
 	}
-	dc.dirty.Store(true)
+
+	if dc.maxSize > 0 {
+		dc.total.Add(size)
+		select {
+		case dc.triggerCh <- struct{}{}:
+		default:
+		}
+	}
 	return nil
 }
 
-// Get reads the capture file for id directly from disk. A missing file reports
-// errCaptureNotFound; other I/O errors are surfaced unchanged.
+// Get reads the capture file for id. A missing file reports errCaptureNotFound.
 func (dc *diskCapture) Get(id int) ([]byte, error) {
 	data, err := os.ReadFile(dc.path(id))
 	if err != nil {
@@ -146,39 +144,37 @@ func (dc *diskCapture) Close() error {
 	return nil
 }
 
-// reconcileLoop enforces the byte budget off the request path: after a short
-// first delay (so a store with pre-existing files converges without a startup
-// scan) it runs on a fixed interval, but skips the disk walk when nothing was
-// written since the previous pass.
+// reconcileLoop enforces the byte budget off the request path. It reconciles
+// once at startup so over-budget files left by previous runs converge (open
+// itself never scans), then whenever Add signals and the running total says
+// the store may not fit.
 func (dc *diskCapture) reconcileLoop() {
 	defer close(dc.doneCh)
 
-	timer := time.NewTimer(reconcileFirstDelay)
-	defer timer.Stop()
-
-	first := true
+	dc.runReconcile()
 	for {
 		select {
 		case <-dc.stopCh:
 			return
-		case <-timer.C:
+		case <-dc.triggerCh:
+			if dc.total.Load() > dc.maxSize {
+				dc.runReconcile()
+			}
 		}
-		if !first && !dc.dirty.Swap(false) {
-			timer.Reset(reconcileInterval)
-			continue
-		}
-		first = false
-		if err := dc.reconcile(); err != nil {
-			dc.warnf("capture reconcile: %v", err)
-		}
-		timer.Reset(reconcileInterval)
 	}
 }
 
-// reconcile sums the sizes of all capture files from disk and, when the total is
-// over budget, deletes the lowest-id (oldest) files until it fits. The file list
-// is snapshotted first, so captures written concurrently during the pass (always
-// higher ids) are never removed here.
+func (dc *diskCapture) runReconcile() {
+	if err := dc.reconcile(); err != nil {
+		dc.warnf("capture reconcile: %v", err)
+	}
+}
+
+// reconcile sums all capture files from disk — the authoritative total, which
+// also corrects drift in the running counter — and deletes the lowest-id
+// (oldest) files until the store fits. The file list is snapshotted first so
+// captures written concurrently during the pass (always higher ids) are never
+// removed here.
 func (dc *diskCapture) reconcile() error {
 	if dc.maxSize <= 0 {
 		return nil
@@ -189,6 +185,12 @@ func (dc *diskCapture) reconcile() error {
 		path string
 		size int64
 	}
+	// Apply the walked sum as a delta onto the running counter instead of
+	// storing it, so Adds racing the walk are not clobbered. A racing write
+	// the walk missed can only skew total high (counted twice); the next
+	// walk corrects it.
+	before := dc.total.Load()
+
 	var entries []entry
 	var total int64
 
@@ -218,19 +220,20 @@ func (dc *diskCapture) reconcile() error {
 	if err != nil {
 		return err
 	}
+	dc.total.Add(total - before)
 	if total <= dc.maxSize {
 		return nil
 	}
 
 	slices.SortFunc(entries, func(a, b entry) int { return cmp.Compare(a.id, b.id) })
 	for _, e := range entries {
-		if total <= dc.maxSize {
+		if dc.total.Load() <= dc.maxSize {
 			break
 		}
 		if err := os.Remove(e.path); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
-		total -= e.size
+		dc.total.Add(-e.size)
 	}
 	return nil
 }

--- a/internal/server/captures_disk.go
+++ b/internal/server/captures_disk.go
@@ -29,6 +29,10 @@ const (
 	// consume disk the budget silently does not account for.
 	tmpPrefix    = ".tmp-"
 	tmpLegacyExt = ".cap.tmp"
+	// namespacePrefix names each database's capture folder (db-<instanceID>).
+	// The prefix keeps namespaces distinct from the numeric shard folders the
+	// pre-namespacing layout wrote at the store root.
+	namespacePrefix = "db-"
 )
 
 // captureShardSize groups files into decimal folders (id/captureShardSize) so
@@ -37,16 +41,19 @@ const (
 const captureShardSize = 1000
 
 // diskCapture is a durable captureStore backed by one file per capture under
-// dir/<id/1000>/<id>.cap. Reads and writes probe the exact path, so opening is
-// O(1) and needs no startup scan regardless of capture count. Eviction of the
-// lowest-id (oldest) captures runs off the request path: Add signals a
-// background loop, which walks the disk only once the running byte total
-// crosses maxSize (0 = unlimited, no loop). Activity IDs are monotonic
-// AUTOINCREMENT values, so id order is insertion order; they never come from
-// user input.
+// dir/db-<dbID>/<id/1000>/<id>.cap: each activity database gets its own folder,
+// because ids restart at 1 when the database is swapped or recreated, and a
+// folder per id keeps generations from colliding. Reads and writes probe the
+// exact path of the current database's namespace, so opening is O(1) and needs
+// no startup scan. Eviction runs off the request path: Add signals a background
+// loop, which walks the whole store — every generation, so captureMaxMB spans
+// them all — and deletes the newest-file folder's lowest-id captures first
+// (maxSize 0 = unlimited, no loop). Activity IDs are monotonic AUTOINCREMENT
+// values, so id order is insertion order; they never come from user input.
 type diskCapture struct {
-	dir     string
-	maxSize int64 // 0 = unlimited
+	dir     string // store root: one folder per database, plus pre-namespacing leftovers
+	ns      string // captures of the bound database live here (dir when unbound)
+	maxSize int64  // 0 = unlimited
 	logger  *logmon.Monitor
 
 	writeMu sync.Mutex // serializes file writes with reconcile walks
@@ -60,16 +67,18 @@ type diskCapture struct {
 	onWalkStart func() // test hook: invoked once when a reconcile walk begins
 }
 
-// newDiskCapture opens (creating if needed) a disk capture store and starts its
-// background reconcile loop when a budget is set. maxBytes < 0 is a
-// configuration error; maxBytes == 0 means unlimited disk usage.
-func newDiskCapture(dir string, maxBytes int, logger *logmon.Monitor) (*diskCapture, error) {
-	return newDiskCaptureOpts(dir, maxBytes, logger, true)
+// newDiskCapture opens (creating if needed) a disk capture store bound to the
+// activity database identified by dbID, and starts its background reconcile
+// loop when a budget is set. maxBytes < 0 is a configuration error;
+// maxBytes == 0 means unlimited disk usage. An empty dbID skips the identity
+// binding (tests); production callers pass store.InstanceID.
+func newDiskCapture(dir string, maxBytes int, dbID string, logger *logmon.Monitor) (*diskCapture, error) {
+	return newDiskCaptureOpts(dir, maxBytes, dbID, logger, true)
 }
 
 // newDiskCaptureOpts is newDiskCapture with control over starting the reconcile
 // loop, so tests can drive eviction deterministically via reconcile().
-func newDiskCaptureOpts(dir string, maxBytes int, logger *logmon.Monitor, startLoop bool) (*diskCapture, error) {
+func newDiskCaptureOpts(dir string, maxBytes int, dbID string, logger *logmon.Monitor, startLoop bool) (*diskCapture, error) {
 	if maxBytes < 0 {
 		return nil, fmt.Errorf("disk capture store: maxBytes must be >= 0, got %d", maxBytes)
 	}
@@ -79,7 +88,13 @@ func newDiskCaptureOpts(dir string, maxBytes int, logger *logmon.Monitor, startL
 	if info, err := os.Stat(dir); err == nil && info.Mode().Perm()&0o022 != 0 && logger != nil {
 		logger.Warnf("capture dir %s is group/world-writable (%o): local users can plant or read captures", dir, info.Mode().Perm())
 	}
-	dc := &diskCapture{dir: dir, maxSize: int64(maxBytes), logger: logger}
+	dc := &diskCapture{dir: dir, ns: dir, maxSize: int64(maxBytes), logger: logger}
+	if dbID != "" {
+		dc.ns = filepath.Join(dir, namespacePrefix+dbID)
+		if err := dc.adoptLegacy(); err != nil {
+			return nil, fmt.Errorf("disk capture store: %w", err)
+		}
+	}
 	if startLoop && dc.maxSize > 0 {
 		dc.triggerCh = make(chan struct{}, 1)
 		dc.stopCh = make(chan struct{})
@@ -89,8 +104,65 @@ func newDiskCaptureOpts(dir string, maxBytes int, logger *logmon.Monitor, startL
 	return dc, nil
 }
 
+// adoptLegacy prepares the current database's namespace and moves any
+// root-level shard folders into it. That pre-namespacing layout recorded no
+// database identity, so the only honest attribution is the database in use
+// now; later identity changes are encoded in the folder names themselves and
+// need no bookkeeping file.
+func (dc *diskCapture) adoptLegacy() error {
+	if err := os.MkdirAll(dc.ns, 0o700); err != nil {
+		return err
+	}
+	return dc.migrateRoot(dc.ns)
+}
+
+// migrateRoot relocates pre-namespacing shard folders from the store root
+// into target in one pass. It runs at construction only, before the reconcile
+// loop and request path exist.
+func (dc *diskCapture) migrateRoot(target string) error {
+	entries, err := os.ReadDir(dc.dir)
+	if err != nil {
+		return err
+	}
+	var moved int
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, cerr := strconv.Atoi(e.Name()); cerr != nil {
+			continue // not a pre-namespacing shard folder
+		}
+		if moved == 0 {
+			if err := os.MkdirAll(target, 0o700); err != nil {
+				return err
+			}
+		}
+		from := filepath.Join(dc.dir, e.Name())
+		if err := os.Rename(from, filepath.Join(target, e.Name())); err != nil {
+			return fmt.Errorf("move legacy capture dir %s: %w", from, err)
+		}
+		moved++
+	}
+	if moved > 0 && dc.logger != nil {
+		dc.logger.Debugf("moved %d legacy capture folders into %s", moved, target)
+	}
+	return nil
+}
+
 func (dc *diskCapture) shardDir(id int) string {
-	return filepath.Join(dc.dir, strconv.Itoa(id/captureShardSize))
+	return filepath.Join(dc.ns, strconv.Itoa(id/captureShardSize))
+}
+
+// captureNamespace returns p's first component under the store root: the
+// database folder in the namespaced layout, or a shard folder name for
+// pre-namespacing or unbound (dbID-less) layouts.
+func captureNamespace(root, p string) string {
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return ""
+	}
+	gen, _, _ := strings.Cut(rel, string(filepath.Separator))
+	return gen
 }
 
 func (dc *diskCapture) path(id int) string {
@@ -202,10 +274,12 @@ func (dc *diskCapture) runReconcile() {
 }
 
 // reconcile sums all capture files from disk — the authoritative total, which
-// also corrects drift in the running counter — and deletes the lowest-id
-// (oldest) files until the store fits. Add is serialized against the walk and
-// eviction via writeMu, so the sum used for eviction decisions is exact and a
-// write racing the pass can neither over- nor under-evict. The file list is
+// also corrects drift in the running counter — and deletes the oldest files
+// until the store fits: lowest id first within a database folder, folders
+// ranked oldest by their newest file, so a replaced database's captures go
+// before the current one's. Add is serialized against the walk and eviction
+// via writeMu, so the sum used for eviction decisions is exact and a write
+// racing the pass can neither over- nor under-evict. The file list is
 // snapshotted first so captures written by a later pass (always higher ids)
 // are never removed by this one.
 func (dc *diskCapture) reconcile() error {
@@ -214,6 +288,7 @@ func (dc *diskCapture) reconcile() error {
 	}
 
 	type entry struct {
+		gen  string // first path component under the store root: the database folder
 		id   int
 		path string
 		size int64
@@ -221,7 +296,8 @@ func (dc *diskCapture) reconcile() error {
 
 	var entries []entry
 	var total int64
-	complete := true // whether the walk saw the whole store
+	genNewest := map[string]int64{} // folder → newest mtime in it
+	complete := true                // whether the walk saw the whole store
 
 	dc.writeMu.Lock()
 	defer dc.writeMu.Unlock()
@@ -268,14 +344,23 @@ func (dc *diskCapture) reconcile() error {
 				return serr
 			}
 		}
-		entries = append(entries, entry{id: id, path: p, size: info.Size()})
+		gen := captureNamespace(dc.dir, p)
+		if mt := info.ModTime().UnixNano(); mt > genNewest[gen] {
+			genNewest[gen] = mt
+		}
+		entries = append(entries, entry{gen: gen, id: id, path: p, size: info.Size()})
 		total += info.Size()
 		return nil
 	})
 	if err != nil {
 		return err
 	}
-	slices.SortFunc(entries, func(a, b entry) int { return cmp.Compare(a.id, b.id) })
+	slices.SortFunc(entries, func(a, b entry) int {
+		if c := cmp.Compare(genNewest[a.gen], genNewest[b.gen]); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.id, b.id)
+	})
 	for _, e := range entries {
 		if total <= dc.maxSize {
 			break

--- a/internal/server/captures_disk.go
+++ b/internal/server/captures_disk.go
@@ -20,7 +20,16 @@ var (
 	errExceedsCaptureMax = errors.New("capture exceeds maximum store size")
 )
 
-const captureFileExt = ".cap"
+const (
+	captureFileExt = ".cap"
+	// tmpPrefix is the os.CreateTemp pattern Add uses; tmpLegacyExt was the
+	// predictable <id>.cap.tmp name from before the CreateTemp switch. The
+	// reconcile walk removes both: with writes serialized under writeMu, any
+	// temp file it sees must be a crash leftover, and lingering ones would
+	// consume disk the budget silently does not account for.
+	tmpPrefix    = ".tmp-"
+	tmpLegacyExt = ".cap.tmp"
+)
 
 // captureShardSize groups files into decimal folders (id/captureShardSize) so
 // no single directory grows unbounded on filesystems that degrade with large
@@ -106,7 +115,7 @@ func (dc *diskCapture) Add(id int, data []byte) error {
 	}
 	// A random temp name keeps the path unpredictable, so a planted symlink
 	// there cannot redirect the write (O_EXCL also never follows links).
-	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	tmp, err := os.CreateTemp(dir, tmpPrefix+"*")
 	if err != nil {
 		return fmt.Errorf("create temp capture %d: %w", id, err)
 	}
@@ -212,19 +221,38 @@ func (dc *diskCapture) reconcile() error {
 
 	var entries []entry
 	var total int64
+	complete := true // whether the walk saw the whole store
 
 	dc.writeMu.Lock()
 	defer dc.writeMu.Unlock()
-	defer func() { dc.total.Store(total) }()
+	defer func() {
+		// A walk that aborted partway holds a partial sum: installing it as
+		// the authoritative total would understate usage and mute the trigger
+		// predicate, so keep the running counter and retry on the next signal.
+		if complete {
+			dc.total.Store(total)
+		}
+	}()
 	if dc.onWalkStart != nil {
 		dc.onWalkStart()
 	}
 
 	err := filepath.WalkDir(dc.dir, func(p string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+		if err != nil {
+			complete = false
+			return err
+		}
+		if d.IsDir() {
 			return nil
 		}
 		base := filepath.Base(p)
+		if strings.HasPrefix(base, tmpPrefix) || strings.HasSuffix(base, tmpLegacyExt) {
+			if err := os.Remove(p); err != nil && !errors.Is(err, os.ErrNotExist) {
+				complete = false
+				return err
+			}
+			return nil
+		}
 		if !strings.HasSuffix(base, captureFileExt) {
 			return nil
 		}
@@ -236,7 +264,8 @@ func (dc *diskCapture) reconcile() error {
 		if serr != nil {
 			info, serr = os.Stat(p)
 			if serr != nil {
-				return nil
+				complete = false
+				return serr
 			}
 		}
 		entries = append(entries, entry{id: id, path: p, size: info.Size()})

--- a/internal/server/captures_disk.go
+++ b/internal/server/captures_disk.go
@@ -40,11 +40,15 @@ type diskCapture struct {
 	maxSize int64 // 0 = unlimited
 	logger  *logmon.Monitor
 
-	total     atomic.Int64 // bytes on disk, corrected by each reconcile walk
+	writeMu sync.Mutex // serializes file writes with reconcile walks
+
+	total     atomic.Int64 // bytes on disk; the authoritative reconcile value, kept in step by Add
 	triggerCh chan struct{}
 	stopCh    chan struct{}
 	doneCh    chan struct{}
 	closeOnce sync.Once
+
+	onWalkStart func() // test hook: invoked once when a reconcile walk begins
 }
 
 // newDiskCapture opens (creating if needed) a disk capture store and starts its
@@ -62,6 +66,9 @@ func newDiskCaptureOpts(dir string, maxBytes int, logger *logmon.Monitor, startL
 	}
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("disk capture store: %w", err)
+	}
+	if info, err := os.Stat(dir); err == nil && info.Mode().Perm()&0o022 != 0 && logger != nil {
+		logger.Warnf("capture dir %s is group/world-writable (%o): local users can plant or read captures", dir, info.Mode().Perm())
 	}
 	dc := &diskCapture{dir: dir, maxSize: int64(maxBytes), logger: logger}
 	if startLoop && dc.maxSize > 0 {
@@ -81,24 +88,39 @@ func (dc *diskCapture) path(id int) string {
 	return filepath.Join(dc.shardDir(id), strconv.Itoa(id)+captureFileExt)
 }
 
-// Add writes a capture atomically (tmp + rename) and signals the reconcile
-// loop. A blob larger than the whole budget is rejected; it could never fit.
+// Add writes a capture atomically (random-named tmp + rename) and signals the
+// reconcile loop, serialized against reconcile walks via writeMu. A blob
+// larger than the whole budget is rejected; it could never fit.
 func (dc *diskCapture) Add(id int, data []byte) error {
 	size := int64(len(data))
 	if dc.maxSize > 0 && size > dc.maxSize {
 		return errExceedsCaptureMax
 	}
 
-	if err := os.MkdirAll(dc.shardDir(id), 0o700); err != nil {
+	dc.writeMu.Lock()
+	defer dc.writeMu.Unlock()
+
+	dir := dc.shardDir(id)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("create capture shard for %d: %w", id, err)
 	}
-	p := dc.path(id)
-	tmp := p + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+	// A random temp name keeps the path unpredictable, so a planted symlink
+	// there cannot redirect the write (O_EXCL also never follows links).
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp capture %d: %w", id, err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmp.Name())
 		return fmt.Errorf("write capture %d: %w", id, err)
 	}
-	if err := os.Rename(tmp, p); err != nil {
-		os.Remove(tmp)
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmp.Name())
+		return fmt.Errorf("close capture %d: %w", id, err)
+	}
+	if err := os.Rename(tmp.Name(), dc.path(id)); err != nil {
+		os.Remove(tmp.Name())
 		return fmt.Errorf("store capture %d: %w", id, err)
 	}
 
@@ -172,9 +194,11 @@ func (dc *diskCapture) runReconcile() {
 
 // reconcile sums all capture files from disk — the authoritative total, which
 // also corrects drift in the running counter — and deletes the lowest-id
-// (oldest) files until the store fits. The file list is snapshotted first so
-// captures written concurrently during the pass (always higher ids) are never
-// removed here.
+// (oldest) files until the store fits. Add is serialized against the walk and
+// eviction via writeMu, so the sum used for eviction decisions is exact and a
+// write racing the pass can neither over- nor under-evict. The file list is
+// snapshotted first so captures written by a later pass (always higher ids)
+// are never removed by this one.
 func (dc *diskCapture) reconcile() error {
 	if dc.maxSize <= 0 {
 		return nil
@@ -185,14 +209,16 @@ func (dc *diskCapture) reconcile() error {
 		path string
 		size int64
 	}
-	// Apply the walked sum as a delta onto the running counter instead of
-	// storing it, so Adds racing the walk are not clobbered. A racing write
-	// the walk missed can only skew total high (counted twice); the next
-	// walk corrects it.
-	before := dc.total.Load()
 
 	var entries []entry
 	var total int64
+
+	dc.writeMu.Lock()
+	defer dc.writeMu.Unlock()
+	defer func() { dc.total.Store(total) }()
+	if dc.onWalkStart != nil {
+		dc.onWalkStart()
+	}
 
 	err := filepath.WalkDir(dc.dir, func(p string, d os.DirEntry, err error) error {
 		if err != nil || d.IsDir() {
@@ -220,20 +246,15 @@ func (dc *diskCapture) reconcile() error {
 	if err != nil {
 		return err
 	}
-	dc.total.Add(total - before)
-	if total <= dc.maxSize {
-		return nil
-	}
-
 	slices.SortFunc(entries, func(a, b entry) int { return cmp.Compare(a.id, b.id) })
 	for _, e := range entries {
-		if dc.total.Load() <= dc.maxSize {
+		if total <= dc.maxSize {
 			break
 		}
 		if err := os.Remove(e.path); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
-		dc.total.Add(-e.size)
+		total -= e.size
 	}
 	return nil
 }

--- a/internal/server/captures_disk.go
+++ b/internal/server/captures_disk.go
@@ -1,0 +1,171 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+var (
+	errCaptureNotFound   = errors.New("capture not found")
+	errExceedsCaptureMax = errors.New("capture exceeds maximum store size")
+)
+
+const captureFileExt = ".cap"
+
+// diskCapture is a durable captureStore backed by one file per capture under
+// dir, plus an in-memory index (id -> size) so Has is O(1) and the FIFO byte
+// budget is enforced across restarts. maxSize == 0 means unlimited (no size
+// cap, no eviction). Activity IDs are monotonic AUTOINCREMENT values, so
+// ascending id order equals insertion order and is a valid FIFO eviction order.
+// Filenames are "<id>.cap"; IDs never reach the path from user input.
+type diskCapture struct {
+	dir     string
+	maxSize int64 // 0 = unlimited
+
+	mu    sync.Mutex
+	items map[int]int64
+	order []int
+	total int64
+}
+
+// newDiskCapture opens (creating if needed) a disk capture store. maxBytes < 0
+// is a configuration error; maxBytes == 0 means unlimited disk usage.
+func newDiskCapture(dir string, maxBytes int) (*diskCapture, error) {
+	if maxBytes < 0 {
+		return nil, fmt.Errorf("disk capture store: maxBytes must be >= 0, got %d", maxBytes)
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("disk capture store: %w", err)
+	}
+	dc := &diskCapture{dir: dir, maxSize: int64(maxBytes), items: make(map[int]int64)}
+	if err := dc.loadIndex(); err != nil {
+		return nil, fmt.Errorf("disk capture store: load index: %w", err)
+	}
+	return dc, nil
+}
+
+// loadIndex rebuilds the in-memory index from files already on disk so the
+// byte budget stays correct across restarts.
+func (dc *diskCapture) loadIndex() error {
+	var ids []int
+	err := filepath.WalkDir(dc.dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		base := filepath.Base(path)
+		if !strings.HasSuffix(base, captureFileExt) {
+			return nil
+		}
+		id, err := strconv.Atoi(strings.TrimSuffix(base, captureFileExt))
+		if err != nil {
+			return nil
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil
+		}
+		dc.items[id] = info.Size()
+		ids = append(ids, id)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	slices.Sort(ids)
+	for _, id := range ids {
+		dc.order = append(dc.order, id)
+		dc.total += dc.items[id]
+	}
+	return nil
+}
+
+func (dc *diskCapture) path(id int) string {
+	return filepath.Join(dc.dir, strconv.Itoa(id)+captureFileExt)
+}
+
+func (dc *diskCapture) Add(id int, data []byte) error {
+	size := int64(len(data))
+	if dc.maxSize > 0 && size > dc.maxSize {
+		return errExceedsCaptureMax
+	}
+
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+
+	if old, exists := dc.items[id]; exists {
+		dc.total -= old
+		dc.removeOrder(id)
+		os.Remove(dc.path(id))
+	}
+
+	if dc.maxSize > 0 {
+		for dc.total+size > dc.maxSize && len(dc.order) > 0 {
+			dc.evictOldest()
+		}
+	}
+
+	tmp := dc.path(id) + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("write capture %d: %w", id, err)
+	}
+	if err := os.Rename(tmp, dc.path(id)); err != nil {
+		os.Remove(tmp)
+		return fmt.Errorf("store capture %d: %w", id, err)
+	}
+	dc.items[id] = size
+	dc.order = append(dc.order, id)
+	dc.total += size
+	return nil
+}
+
+func (dc *diskCapture) Get(id int) ([]byte, error) {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+
+	if _, exists := dc.items[id]; !exists {
+		return nil, errCaptureNotFound
+	}
+	data, err := os.ReadFile(dc.path(id))
+	if err != nil {
+		// The index claims the file but it is gone (external delete); drop the
+		// stale entry so Has and future budgets stay truthful.
+		dc.total -= dc.items[id]
+		delete(dc.items, id)
+		dc.removeOrder(id)
+		return nil, errCaptureNotFound
+	}
+	return data, nil
+}
+
+func (dc *diskCapture) Has(id int) bool {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+	_, exists := dc.items[id]
+	return exists
+}
+
+func (dc *diskCapture) Close() error { return nil }
+
+// evictOldest removes the lowest-id (oldest) capture. Caller holds dc.mu.
+func (dc *diskCapture) evictOldest() {
+	oldest := dc.order[0]
+	dc.order = dc.order[1:]
+	if size, exists := dc.items[oldest]; exists {
+		dc.total -= size
+		delete(dc.items, oldest)
+		os.Remove(dc.path(oldest))
+	}
+}
+
+func (dc *diskCapture) removeOrder(id int) {
+	i := slices.Index(dc.order, id)
+	if i >= 0 {
+		dc.order = slices.Delete(dc.order, i, i+1)
+	}
+}

--- a/internal/server/captures_disk.go
+++ b/internal/server/captures_disk.go
@@ -85,7 +85,7 @@ func newDiskCaptureOpts(dir string, maxBytes int, dbID string, logger *logmon.Mo
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("disk capture store: %w", err)
 	}
-	if info, err := os.Stat(dir); err == nil && info.Mode().Perm()&0o022 != 0 && logger != nil {
+	if info, err := os.Stat(dir); err == nil && sharedWritable(info) && logger != nil {
 		logger.Warnf("capture dir %s is group/world-writable (%o): local users can plant or read captures", dir, info.Mode().Perm())
 	}
 	dc := &diskCapture{dir: dir, ns: dir, maxSize: int64(maxBytes), logger: logger}

--- a/internal/server/captures_disk.go
+++ b/internal/server/captures_disk.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"os"
@@ -9,6 +10,10 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/mostlygeek/llama-swap/internal/logmon"
 )
 
 var (
@@ -18,154 +23,220 @@ var (
 
 const captureFileExt = ".cap"
 
+// captureShardSize groups capture files into decimal folders (id/captureShardSize)
+// so a single directory never accumulates an unbounded number of entries. This
+// keeps operations efficient on filesystems that degrade with very large
+// directories.
+const captureShardSize = 1000
+
+// Reconcile loop timing. Package-level vars so tests can shorten the cadence.
+var (
+	reconcileInterval   = 30 * time.Second
+	reconcileFirstDelay = 2 * time.Second
+)
+
 // diskCapture is a durable captureStore backed by one file per capture under
-// dir, plus an in-memory index (id -> size) so Has is O(1) and the FIFO byte
-// budget is enforced across restarts. maxSize == 0 means unlimited (no size
-// cap, no eviction). Activity IDs are monotonic AUTOINCREMENT values, so
-// ascending id order equals insertion order and is a valid FIFO eviction order.
-// Filenames are "<id>.cap"; IDs never reach the path from user input.
+// dir/<id/1000>/<id>.cap. Reads and writes probe the exact path directly, so no
+// startup scan is needed regardless of how many captures exist: opening is O(1)
+// and a lookup is a single filesystem stat. When a byte budget is set, an
+// eviction pass runs in the background (never inline on Add, never at open) and
+// removes the lowest-id (oldest) captures until the store fits, recomputing the
+// total from disk each pass. maxSize == 0 means unlimited (no reconcile loop).
+// Activity IDs are monotonic AUTOINCREMENT values, so ascending id order equals
+// insertion order. IDs never reach the path from user input.
 type diskCapture struct {
 	dir     string
 	maxSize int64 // 0 = unlimited
+	logger  *logmon.Monitor
 
-	mu    sync.Mutex
-	items map[int]int64
-	order []int
-	total int64
+	dirty     atomic.Bool // set by Add, cleared by the reconcile loop
+	stopCh    chan struct{}
+	doneCh    chan struct{}
+	closeOnce sync.Once
 }
 
-// newDiskCapture opens (creating if needed) a disk capture store. maxBytes < 0
-// is a configuration error; maxBytes == 0 means unlimited disk usage.
-func newDiskCapture(dir string, maxBytes int) (*diskCapture, error) {
+// newDiskCapture opens (creating if needed) a disk capture store and starts its
+// background reconcile loop when a budget is set. maxBytes < 0 is a
+// configuration error; maxBytes == 0 means unlimited disk usage.
+func newDiskCapture(dir string, maxBytes int, logger *logmon.Monitor) (*diskCapture, error) {
+	return newDiskCaptureOpts(dir, maxBytes, logger, true)
+}
+
+// newDiskCaptureOpts is newDiskCapture with control over starting the reconcile
+// loop, so tests can drive eviction deterministically via reconcile().
+func newDiskCaptureOpts(dir string, maxBytes int, logger *logmon.Monitor, startLoop bool) (*diskCapture, error) {
 	if maxBytes < 0 {
 		return nil, fmt.Errorf("disk capture store: maxBytes must be >= 0, got %d", maxBytes)
 	}
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("disk capture store: %w", err)
 	}
-	dc := &diskCapture{dir: dir, maxSize: int64(maxBytes), items: make(map[int]int64)}
-	if err := dc.loadIndex(); err != nil {
-		return nil, fmt.Errorf("disk capture store: load index: %w", err)
+	dc := &diskCapture{dir: dir, maxSize: int64(maxBytes), logger: logger}
+	if startLoop && dc.maxSize > 0 {
+		dc.stopCh = make(chan struct{})
+		dc.doneCh = make(chan struct{})
+		go dc.reconcileLoop()
 	}
 	return dc, nil
 }
 
-// loadIndex rebuilds the in-memory index from files already on disk so the
-// byte budget stays correct across restarts.
-func (dc *diskCapture) loadIndex() error {
-	var ids []int
-	err := filepath.WalkDir(dc.dir, func(path string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
-			return nil
-		}
-		base := filepath.Base(path)
-		if !strings.HasSuffix(base, captureFileExt) {
-			return nil
-		}
-		id, err := strconv.Atoi(strings.TrimSuffix(base, captureFileExt))
-		if err != nil {
-			return nil
-		}
-		info, err := os.Stat(path)
-		if err != nil {
-			return nil
-		}
-		dc.items[id] = info.Size()
-		ids = append(ids, id)
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-	slices.Sort(ids)
-	for _, id := range ids {
-		dc.order = append(dc.order, id)
-		dc.total += dc.items[id]
-	}
-	return nil
+func (dc *diskCapture) shardDir(id int) string {
+	return filepath.Join(dc.dir, strconv.Itoa(id/captureShardSize))
 }
 
 func (dc *diskCapture) path(id int) string {
-	return filepath.Join(dc.dir, strconv.Itoa(id)+captureFileExt)
+	return filepath.Join(dc.shardDir(id), strconv.Itoa(id)+captureFileExt)
 }
 
+// Add writes a capture atomically (tmp + rename in the target shard dir) and
+// flags the store dirty for the background reconcile pass. A single blob larger
+// than the whole budget is rejected; it could never fit.
 func (dc *diskCapture) Add(id int, data []byte) error {
 	size := int64(len(data))
 	if dc.maxSize > 0 && size > dc.maxSize {
 		return errExceedsCaptureMax
 	}
 
-	dc.mu.Lock()
-	defer dc.mu.Unlock()
-
-	if old, exists := dc.items[id]; exists {
-		dc.total -= old
-		dc.removeOrder(id)
-		os.Remove(dc.path(id))
+	if err := os.MkdirAll(dc.shardDir(id), 0o700); err != nil {
+		return fmt.Errorf("create capture shard for %d: %w", id, err)
 	}
-
-	if dc.maxSize > 0 {
-		for dc.total+size > dc.maxSize && len(dc.order) > 0 {
-			dc.evictOldest()
-		}
-	}
-
-	tmp := dc.path(id) + ".tmp"
+	p := dc.path(id)
+	tmp := p + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o600); err != nil {
 		return fmt.Errorf("write capture %d: %w", id, err)
 	}
-	if err := os.Rename(tmp, dc.path(id)); err != nil {
+	if err := os.Rename(tmp, p); err != nil {
 		os.Remove(tmp)
 		return fmt.Errorf("store capture %d: %w", id, err)
 	}
-	dc.items[id] = size
-	dc.order = append(dc.order, id)
-	dc.total += size
+	dc.dirty.Store(true)
 	return nil
 }
 
+// Get reads the capture file for id directly from disk. A missing file reports
+// errCaptureNotFound; other I/O errors are surfaced unchanged.
 func (dc *diskCapture) Get(id int) ([]byte, error) {
-	dc.mu.Lock()
-	defer dc.mu.Unlock()
-
-	if _, exists := dc.items[id]; !exists {
-		return nil, errCaptureNotFound
-	}
 	data, err := os.ReadFile(dc.path(id))
 	if err != nil {
-		// The index claims the file but it is gone (external delete); drop the
-		// stale entry so Has and future budgets stay truthful.
-		dc.total -= dc.items[id]
-		delete(dc.items, id)
-		dc.removeOrder(id)
-		return nil, errCaptureNotFound
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, errCaptureNotFound
+		}
+		return nil, err
 	}
 	return data, nil
 }
 
+// Has reports whether the capture file exists, by stat-ing its exact path.
 func (dc *diskCapture) Has(id int) bool {
-	dc.mu.Lock()
-	defer dc.mu.Unlock()
-	_, exists := dc.items[id]
-	return exists
+	_, err := os.Stat(dc.path(id))
+	return err == nil
 }
 
-func (dc *diskCapture) Close() error { return nil }
+// Close stops the background reconcile loop and waits for it to exit. It is
+// safe to call on a store with no loop and is idempotent.
+func (dc *diskCapture) Close() error {
+	dc.closeOnce.Do(func() {
+		if dc.stopCh != nil {
+			close(dc.stopCh)
+		}
+	})
+	if dc.doneCh != nil {
+		<-dc.doneCh
+	}
+	return nil
+}
 
-// evictOldest removes the lowest-id (oldest) capture. Caller holds dc.mu.
-func (dc *diskCapture) evictOldest() {
-	oldest := dc.order[0]
-	dc.order = dc.order[1:]
-	if size, exists := dc.items[oldest]; exists {
-		dc.total -= size
-		delete(dc.items, oldest)
-		os.Remove(dc.path(oldest))
+// reconcileLoop enforces the byte budget off the request path: after a short
+// first delay (so a store with pre-existing files converges without a startup
+// scan) it runs on a fixed interval, but skips the disk walk when nothing was
+// written since the previous pass.
+func (dc *diskCapture) reconcileLoop() {
+	defer close(dc.doneCh)
+
+	timer := time.NewTimer(reconcileFirstDelay)
+	defer timer.Stop()
+
+	first := true
+	for {
+		select {
+		case <-dc.stopCh:
+			return
+		case <-timer.C:
+		}
+		if !first && !dc.dirty.Swap(false) {
+			timer.Reset(reconcileInterval)
+			continue
+		}
+		first = false
+		if err := dc.reconcile(); err != nil {
+			dc.warnf("capture reconcile: %v", err)
+		}
+		timer.Reset(reconcileInterval)
 	}
 }
 
-func (dc *diskCapture) removeOrder(id int) {
-	i := slices.Index(dc.order, id)
-	if i >= 0 {
-		dc.order = slices.Delete(dc.order, i, i+1)
+// reconcile sums the sizes of all capture files from disk and, when the total is
+// over budget, deletes the lowest-id (oldest) files until it fits. The file list
+// is snapshotted first, so captures written concurrently during the pass (always
+// higher ids) are never removed here.
+func (dc *diskCapture) reconcile() error {
+	if dc.maxSize <= 0 {
+		return nil
+	}
+
+	type entry struct {
+		id   int
+		path string
+		size int64
+	}
+	var entries []entry
+	var total int64
+
+	err := filepath.WalkDir(dc.dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		base := filepath.Base(p)
+		if !strings.HasSuffix(base, captureFileExt) {
+			return nil
+		}
+		id, cerr := strconv.Atoi(strings.TrimSuffix(base, captureFileExt))
+		if cerr != nil {
+			return nil
+		}
+		info, serr := d.Info()
+		if serr != nil {
+			info, serr = os.Stat(p)
+			if serr != nil {
+				return nil
+			}
+		}
+		entries = append(entries, entry{id: id, path: p, size: info.Size()})
+		total += info.Size()
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if total <= dc.maxSize {
+		return nil
+	}
+
+	slices.SortFunc(entries, func(a, b entry) int { return cmp.Compare(a.id, b.id) })
+	for _, e := range entries {
+		if total <= dc.maxSize {
+			break
+		}
+		if err := os.Remove(e.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		total -= e.size
+	}
+	return nil
+}
+
+func (dc *diskCapture) warnf(format string, args ...any) {
+	if dc.logger != nil {
+		dc.logger.Warnf(format, args...)
 	}
 }

--- a/internal/server/captures_disk_test.go
+++ b/internal/server/captures_disk_test.go
@@ -1,0 +1,299 @@
+package server
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mostlygeek/llama-swap/internal/cache"
+	"github.com/mostlygeek/llama-swap/internal/logmon"
+	"github.com/mostlygeek/llama-swap/internal/store"
+)
+
+func newTestDiskCapture(t *testing.T, maxBytes int) *diskCapture {
+	t.Helper()
+	dir := t.TempDir()
+	dc, err := newDiskCapture(filepath.Join(dir, "captures"), maxBytes)
+	if err != nil {
+		t.Fatalf("newDiskCapture: %v", err)
+	}
+	t.Cleanup(func() { dc.Close() })
+	return dc
+}
+
+func TestCaptureDisk_Roundtrip(t *testing.T) {
+	dc := newTestDiskCapture(t, 1<<20)
+	if err := dc.Add(5, []byte("hello")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !dc.Has(5) {
+		t.Fatal("Has(5) = false, want true")
+	}
+	data, err := dc.Get(5)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(data) != "hello" {
+		t.Fatalf("Get = %q, want %q", data, "hello")
+	}
+}
+
+func TestCaptureDisk_GetMissing(t *testing.T) {
+	dc := newTestDiskCapture(t, 1<<20)
+	if dc.Has(42) {
+		t.Fatal("Has(42) on empty store = true")
+	}
+	_, err := dc.Get(42)
+	if !errors.Is(err, errCaptureNotFound) {
+		t.Fatalf("Get missing err = %v, want errCaptureNotFound", err)
+	}
+}
+
+func TestCaptureDisk_TooLargeRejected(t *testing.T) {
+	dc := newTestDiskCapture(t, 16)
+	if err := dc.Add(1, make([]byte, 17)); !errors.Is(err, errExceedsCaptureMax) {
+		t.Fatalf("Add oversized err = %v, want errExceedsCaptureMax", err)
+	}
+	if dc.Has(1) {
+		t.Fatal("oversized capture was stored")
+	}
+}
+
+// TestCaptureDisk_UnlimitedWhenMaxIsZero shows captureMaxMB == 0 means no disk
+// budget: nothing is rejected for size and nothing is evicted.
+func TestCaptureDisk_UnlimitedWhenMaxIsZero(t *testing.T) {
+	dc := newTestDiskCapture(t, 0)
+	for id := 1; id <= 50; id++ {
+		if err := dc.Add(id, make([]byte, 1000)); err != nil {
+			t.Fatalf("Add %d under unlimited budget: %v", id, err)
+		}
+	}
+	for id := 1; id <= 50; id++ {
+		if !dc.Has(id) {
+			t.Fatalf("id %d evicted despite unlimited budget", id)
+		}
+	}
+}
+
+func TestCaptureDisk_EvictsOldestFirst(t *testing.T) {
+	// budget fits two 10-byte captures; the third evicts id 1 (lowest id).
+	dc := newTestDiskCapture(t, 20)
+	for id := 1; id <= 3; id++ {
+		if err := dc.Add(id, make([]byte, 10)); err != nil {
+			t.Fatalf("Add %d: %v", id, err)
+		}
+	}
+	if dc.Has(1) {
+		t.Fatal("oldest (id 1) should be evicted")
+	}
+	if !dc.Has(2) || !dc.Has(3) {
+		t.Fatal("newest captures should be retained")
+	}
+}
+
+func TestCaptureDisk_OverwriteSameID(t *testing.T) {
+	dc := newTestDiskCapture(t, 1<<20)
+	if err := dc.Add(7, []byte("one")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := dc.Add(7, []byte("two-and-longer")); err != nil {
+		t.Fatalf("Add overwrite: %v", err)
+	}
+	data, err := dc.Get(7)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(data) != "two-and-longer" {
+		t.Fatalf("Get = %q, want overwritten value", data)
+	}
+}
+
+func TestCaptureDisk_SurvivesReopen(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "captures")
+	dc, err := newDiskCapture(dir, 1<<20)
+	if err != nil {
+		t.Fatalf("newDiskCapture: %v", err)
+	}
+	if err := dc.Add(11, []byte("persisted")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := dc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	dc2, err := newDiskCapture(dir, 1<<20)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer dc2.Close()
+	if !dc2.Has(11) {
+		t.Fatal("capture lost after reopen")
+	}
+	data, err := dc2.Get(11)
+	if err != nil || string(data) != "persisted" {
+		t.Fatalf("Get after reopen = %q, %v", data, err)
+	}
+}
+
+func TestCaptureDisk_RebuiltIndexHonorsBudget(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "captures")
+	dc, _ := newDiskCapture(dir, 20)
+	for id := 1; id <= 2; id++ {
+		if err := dc.Add(id, make([]byte, 10)); err != nil {
+			t.Fatalf("Add %d: %v", id, err)
+		}
+	}
+	dc.Close()
+
+	// Reopen with the same budget: total is rebuilt from disk, so adding a
+	// third capture must evict the oldest (id 1), not exceed the budget.
+	dc2, err := newDiskCapture(dir, 20)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer dc2.Close()
+	if err := dc2.Add(3, make([]byte, 10)); err != nil {
+		t.Fatalf("Add after reopen: %v", err)
+	}
+	if dc2.Has(1) {
+		t.Fatal("rebuilt index did not evict oldest id")
+	}
+	if !dc2.Has(3) {
+		t.Fatal("new capture missing")
+	}
+}
+
+func TestCaptureDisk_MissingFileTreatedAsNotFound(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "captures")
+	dc, _ := newDiskCapture(dir, 1<<20)
+	if err := dc.Add(9, []byte("x")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := os.Remove(dc.path(9)); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if _, err := dc.Get(9); !errors.Is(err, errCaptureNotFound) {
+		t.Fatalf("Get missing file err = %v, want errCaptureNotFound", err)
+	}
+}
+
+// TestCaptureDisk_TieredFallsBackToDisk proves a two-tier store writes to both
+// tiers, serves reads from memory when present, and falls back to disk once the
+// (small) memory tier has evicted the entry.
+func TestCaptureDisk_TieredFallsBackToDisk(t *testing.T) {
+	dc := newTestDiskCapture(t, 1<<20)
+	mem := cache.New(16)
+	layered := combineCapture(mem, dc)
+
+	if err := layered.Add(1, []byte("payload")); err != nil {
+		t.Fatalf("tiered Add: %v", err)
+	}
+	if !mem.Has(1) || !dc.Has(1) {
+		t.Fatal("tiered Add must write to both tiers")
+	}
+	mem.Clear()
+	if !layered.Has(1) {
+		t.Fatal("Has must report disk tier after memory eviction")
+	}
+	data, err := layered.Get(1)
+	if err != nil || string(data) != "payload" {
+		t.Fatalf("fallback Get = %q, %v", data, err)
+	}
+}
+
+// TestCaptureDisk_TieredMemTooLargeStoredOnDisk verifies an item too big for the
+// memory tier is still durably stored on disk and reports as present.
+func TestCaptureDisk_TieredMemTooLargeStoredOnDisk(t *testing.T) {
+	dc := newTestDiskCapture(t, 1<<20)
+	mem := cache.New(16)
+	layered := combineCapture(mem, dc)
+
+	big := make([]byte, 4096)
+	if err := layered.Add(2, big); err != nil {
+		t.Fatalf("tiered Add oversized-for-mem: %v", err)
+	}
+	if mem.Has(2) {
+		t.Fatal("oversized item unexpectedly in memory tier")
+	}
+	if !dc.Has(2) {
+		t.Fatal("oversized item must be retained on disk")
+	}
+}
+
+// newPersistMetricsMonitor builds a metricsMonitor backed by a persistent sqlite
+// store and a disk capture dir, exercising the real two-tier constructor.
+func newPersistMetricsMonitor(t *testing.T, dir string, memMB, diskMB int) *metricsMonitor {
+	t.Helper()
+	st, err := store.New(filepath.Join(dir, "activity.sqlite"))
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+	mm := newMetricsMonitorWithDisk(logmon.NewWriter(io.Discard), 0, memMB, diskMB, filepath.Join(dir, "captures"), st)
+	return mm
+}
+
+// TestCaptureDisk_MonitorPersistsAcrossRestart shows a capture written through
+// the metricsMonitor is retrievable by a fresh monitor over the same dir, i.e.
+// it survives a process restart (which the in-memory-only path cannot).
+func TestCaptureDisk_MonitorPersistsAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	mm := newPersistMetricsMonitor(t, dir, 0, 8)
+	if !mm.enableCaptures {
+		t.Fatal("captures should be enabled when a disk tier is configured")
+	}
+	if !mm.addCapture(ReqRespCapture{ID: 4, ReqBody: []byte("durable")}) {
+		t.Fatal("addCapture returned false")
+	}
+
+	reopened := newPersistMetricsMonitor(t, dir, 0, 8)
+	got := reopened.getCaptureByID(4)
+	if got == nil || string(got.ReqBody) != "durable" {
+		t.Fatalf("capture lost after restart: %+v", got)
+	}
+
+	entries := []ActivityLogEntry{{ID: 4}}
+	reopened.overlayCaptureState(entries)
+	if !entries[0].HasCapture {
+		t.Fatal("overlayCaptureState must report the persisted capture")
+	}
+}
+
+// TestCaptureDisk_MonitorDisabledWithoutPersistentStore verifies the gate: a
+// configured disk tier is refused when the activity DB is in-memory, since IDs
+// reset every boot and would orphan capture files.
+func TestCaptureDisk_MonitorDisabledWithoutPersistentStore(t *testing.T) {
+	st, err := store.New("")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer st.Close()
+	mm := newMetricsMonitorWithDisk(logmon.NewWriter(io.Discard), 0, 0, 8, filepath.Join(t.TempDir(), "caps"), st)
+	if mm.enableCaptures {
+		t.Fatal("disk captures must be disabled with an in-memory store")
+	}
+	if mm.captureCache != nil {
+		t.Fatal("no capture tier should be built")
+	}
+}
+
+// TestCaptureDisk_MonitorDisabledWithoutDir verifies the enable switch is the
+// directory, not the byte budget: an empty captureDir disables the disk tier
+// even when captureMaxMB is positive.
+func TestCaptureDisk_MonitorDisabledWithoutDir(t *testing.T) {
+	dir := t.TempDir()
+	st, err := store.New(filepath.Join(dir, "activity.sqlite"))
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer st.Close()
+	mm := newMetricsMonitorWithDisk(logmon.NewWriter(io.Discard), 0, 0, 512, "", st)
+	if mm.enableCaptures {
+		t.Fatal("disk captures must be disabled when captureDir is empty")
+	}
+	if mm.captureCache != nil {
+		t.Fatal("no capture tier should be built without a captureDir")
+	}
+}

--- a/internal/server/captures_disk_test.go
+++ b/internal/server/captures_disk_test.go
@@ -6,18 +6,21 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/mostlygeek/llama-swap/internal/cache"
 	"github.com/mostlygeek/llama-swap/internal/logmon"
 	"github.com/mostlygeek/llama-swap/internal/store"
 )
 
+// newTestDiskCapture opens a disk store with the background reconcile loop
+// disabled so tests drive eviction deterministically via reconcile().
 func newTestDiskCapture(t *testing.T, maxBytes int) *diskCapture {
 	t.Helper()
-	dir := t.TempDir()
-	dc, err := newDiskCapture(filepath.Join(dir, "captures"), maxBytes)
+	dir := filepath.Join(t.TempDir(), "captures")
+	dc, err := newDiskCaptureOpts(dir, maxBytes, nil, false)
 	if err != nil {
-		t.Fatalf("newDiskCapture: %v", err)
+		t.Fatalf("newDiskCaptureOpts: %v", err)
 	}
 	t.Cleanup(func() { dc.Close() })
 	return dc
@@ -62,13 +65,16 @@ func TestCaptureDisk_TooLargeRejected(t *testing.T) {
 }
 
 // TestCaptureDisk_UnlimitedWhenMaxIsZero shows captureMaxMB == 0 means no disk
-// budget: nothing is rejected for size and nothing is evicted.
+// budget: nothing is rejected for size and reconcile never evicts.
 func TestCaptureDisk_UnlimitedWhenMaxIsZero(t *testing.T) {
 	dc := newTestDiskCapture(t, 0)
 	for id := 1; id <= 50; id++ {
 		if err := dc.Add(id, make([]byte, 1000)); err != nil {
 			t.Fatalf("Add %d under unlimited budget: %v", id, err)
 		}
+	}
+	if err := dc.reconcile(); err != nil {
+		t.Fatalf("reconcile under unlimited budget: %v", err)
 	}
 	for id := 1; id <= 50; id++ {
 		if !dc.Has(id) {
@@ -77,13 +83,21 @@ func TestCaptureDisk_UnlimitedWhenMaxIsZero(t *testing.T) {
 	}
 }
 
-func TestCaptureDisk_EvictsOldestFirst(t *testing.T) {
-	// budget fits two 10-byte captures; the third evicts id 1 (lowest id).
+// TestCaptureDisk_ReconcileEvictsOldest proves eviction is reconcile-driven, not
+// inline: Add past the budget keeps everything until a reconcile pass runs, then
+// the lowest (oldest) ids go first until the total fits.
+func TestCaptureDisk_ReconcileEvictsOldest(t *testing.T) {
 	dc := newTestDiskCapture(t, 20)
 	for id := 1; id <= 3; id++ {
 		if err := dc.Add(id, make([]byte, 10)); err != nil {
 			t.Fatalf("Add %d: %v", id, err)
 		}
+	}
+	if !dc.Has(1) || !dc.Has(2) || !dc.Has(3) {
+		t.Fatal("Add must not evict inline; only reconcile enforces the budget")
+	}
+	if err := dc.reconcile(); err != nil {
+		t.Fatalf("reconcile: %v", err)
 	}
 	if dc.Has(1) {
 		t.Fatal("oldest (id 1) should be evicted")
@@ -110,73 +124,159 @@ func TestCaptureDisk_OverwriteSameID(t *testing.T) {
 	}
 }
 
-func TestCaptureDisk_SurvivesReopen(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "captures")
-	dc, err := newDiskCapture(dir, 1<<20)
-	if err != nil {
-		t.Fatalf("newDiskCapture: %v", err)
+// TestCaptureDisk_ShardsByThousandFiles checks the on-disk layout: ids are grouped
+// into decimal folders of 1000 (id/1000), no padding, and no flat files remain.
+func TestCaptureDisk_ShardsByThousandFiles(t *testing.T) {
+	dc := newTestDiskCapture(t, 1<<20)
+	for _, id := range []int{7, 999, 1000, 1050, 42_501} {
+		if err := dc.Add(id, []byte("x")); err != nil {
+			t.Fatalf("Add %d: %v", id, err)
+		}
 	}
-	if err := dc.Add(11, []byte("persisted")); err != nil {
+	cases := map[int]string{
+		7:      "0/7.cap",
+		999:    "0/999.cap",
+		1000:   "1/1000.cap",
+		1050:   "1/1050.cap",
+		42_501: "42/42501.cap",
+	}
+	for id, rel := range cases {
+		want := filepath.Join(dc.dir, filepath.FromSlash(rel))
+		if _, err := os.Stat(want); err != nil {
+			t.Fatalf("id %d not at %s: %v", id, rel, err)
+		}
+		// path() and direct layout must agree.
+		if got := dc.path(id); got != want {
+			t.Fatalf("path(%d) = %s, want %s", id, got, want)
+		}
+	}
+	// Nothing lives at the flat top level.
+	entries, err := os.ReadDir(dc.dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			t.Fatalf("unexpected top-level file %s (expected shard directories)", e.Name())
+		}
+	}
+}
+
+// TestCaptureDisk_LazyDiscoveryAcrossReopen proves no boot scan is required: a
+// fresh store with an empty in-memory state finds files purely by probing the
+// exact sharded path.
+func TestCaptureDisk_LazyDiscoveryAcrossReopen(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "captures")
+	dc, err := newDiskCaptureOpts(dir, 1<<20, nil, false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := dc.Add(1050, []byte("persisted")); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
 	if err := dc.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
 
-	dc2, err := newDiskCapture(dir, 1<<20)
+	dc2, err := newDiskCaptureOpts(dir, 1<<20, nil, false)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
 	defer dc2.Close()
-	if !dc2.Has(11) {
-		t.Fatal("capture lost after reopen")
+	if !dc2.Has(1050) {
+		t.Fatal("capture lost after reopen (lazy discovery failed)")
 	}
-	data, err := dc2.Get(11)
+	data, err := dc2.Get(1050)
 	if err != nil || string(data) != "persisted" {
 		t.Fatalf("Get after reopen = %q, %v", data, err)
 	}
 }
 
-func TestCaptureDisk_RebuiltIndexHonorsBudget(t *testing.T) {
+// TestCaptureDisk_NoEvictionAtOpen proves opening never scans or evicts: over-budget
+// files from a previous run all survive until reconcile runs. This is the startup
+// cost guarantee (O(1) open regardless of capture count).
+func TestCaptureDisk_NoEvictionAtOpen(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "captures")
-	dc, _ := newDiskCapture(dir, 20)
-	for id := 1; id <= 2; id++ {
-		if err := dc.Add(id, make([]byte, 10)); err != nil {
+	dc, err := newDiskCaptureOpts(dir, 30, nil, false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	for id := 1; id <= 5; id++ {
+		if err := dc.Add(id, make([]byte, 10)); err != nil { // 50 bytes over a 30 budget
 			t.Fatalf("Add %d: %v", id, err)
 		}
 	}
 	dc.Close()
 
-	// Reopen with the same budget: total is rebuilt from disk, so adding a
-	// third capture must evict the oldest (id 1), not exceed the budget.
-	dc2, err := newDiskCapture(dir, 20)
+	dc2, err := newDiskCaptureOpts(dir, 30, nil, false)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
 	defer dc2.Close()
-	if err := dc2.Add(3, make([]byte, 10)); err != nil {
-		t.Fatalf("Add after reopen: %v", err)
+	for id := 1; id <= 5; id++ {
+		if !dc2.Has(id) {
+			t.Fatalf("id %d evicted at open: reopening must not scan or evict", id)
+		}
 	}
-	if dc2.Has(1) {
-		t.Fatal("rebuilt index did not evict oldest id")
+	// One reconcile pass now enforces the budget by dropping the oldest ids.
+	if err := dc2.reconcile(); err != nil {
+		t.Fatalf("reconcile: %v", err)
 	}
-	if !dc2.Has(3) {
-		t.Fatal("new capture missing")
+	if dc2.Has(1) || dc2.Has(2) {
+		t.Fatal("reconcile must evict oldest ids to fit the budget")
+	}
+	for id := 3; id <= 5; id++ {
+		if !dc2.Has(id) {
+			t.Fatalf("id %d should be retained after reconcile", id)
+		}
 	}
 }
 
 func TestCaptureDisk_MissingFileTreatedAsNotFound(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "captures")
-	dc, _ := newDiskCapture(dir, 1<<20)
+	dc := newTestDiskCapture(t, 1<<20)
 	if err := dc.Add(9, []byte("x")); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
 	if err := os.Remove(dc.path(9)); err != nil {
 		t.Fatalf("Remove: %v", err)
 	}
+	if dc.Has(9) {
+		t.Fatal("Has must be false after the file is removed")
+	}
 	if _, err := dc.Get(9); !errors.Is(err, errCaptureNotFound) {
 		t.Fatalf("Get missing file err = %v, want errCaptureNotFound", err)
 	}
+}
+
+// TestCaptureDisk_ReconcileLoopEvictsInBackground exercises the goroutine that the
+// production constructor starts: after writes push the store over budget, the
+// background pass evicts the oldest ids without an explicit reconcile call.
+func TestCaptureDisk_ReconcileLoopEvictsInBackground(t *testing.T) {
+	prevInterval, prevFirst := reconcileInterval, reconcileFirstDelay
+	reconcileFirstDelay, reconcileInterval = 5*time.Millisecond, 5*time.Millisecond
+	t.Cleanup(func() { reconcileInterval, reconcileFirstDelay = prevInterval, prevFirst })
+
+	dir := filepath.Join(t.TempDir(), "captures")
+	dc, err := newDiskCapture(dir, 20, nil) // startLoop = true
+	if err != nil {
+		t.Fatalf("newDiskCapture: %v", err)
+	}
+	defer dc.Close()
+
+	for id := 1; id <= 3; id++ { // 30 bytes over a 20 budget
+		if err := dc.Add(id, make([]byte, 10)); err != nil {
+			t.Fatalf("Add %d: %v", id, err)
+		}
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if !dc.Has(1) {
+			return // background reconcile evicted the oldest: pass
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("background reconcile did not evict the oldest capture")
 }
 
 // TestCaptureDisk_TieredFallsBackToDisk proves a two-tier store writes to both
@@ -222,8 +322,30 @@ func TestCaptureDisk_TieredMemTooLargeStoredOnDisk(t *testing.T) {
 	}
 }
 
+// TestCaptureDisk_CloseStopsLoop proves Close terminates the background reconcile
+// goroutine (waited on, not just signaled), so reloads do not leak reconcilers.
+func TestCaptureDisk_CloseStopsLoop(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "captures")
+	dc, err := newDiskCapture(dir, 1<<20, nil) // loop started
+	if err != nil {
+		t.Fatalf("newDiskCapture: %v", err)
+	}
+	done := make(chan struct{})
+	go func() { dc.Close(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not stop the reconcile loop")
+	}
+	// Close must be idempotent.
+	if err := dc.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+
 // newPersistMetricsMonitor builds a metricsMonitor backed by a persistent sqlite
-// store and a disk capture dir, exercising the real two-tier constructor.
+// store and a disk capture dir, exercising the real two-tier constructor. It
+// registers mm.Close so the background reconcile goroutine is stopped at cleanup.
 func newPersistMetricsMonitor(t *testing.T, dir string, memMB, diskMB int) *metricsMonitor {
 	t.Helper()
 	st, err := store.New(filepath.Join(dir, "activity.sqlite"))
@@ -232,29 +354,31 @@ func newPersistMetricsMonitor(t *testing.T, dir string, memMB, diskMB int) *metr
 	}
 	t.Cleanup(func() { st.Close() })
 	mm := newMetricsMonitorWithDisk(logmon.NewWriter(io.Discard), 0, memMB, diskMB, filepath.Join(dir, "captures"), st)
+	t.Cleanup(func() { mm.Close() })
 	return mm
 }
 
 // TestCaptureDisk_MonitorPersistsAcrossRestart shows a capture written through
-// the metricsMonitor is retrievable by a fresh monitor over the same dir, i.e.
-// it survives a process restart (which the in-memory-only path cannot).
+// the metricsMonitor is retrievable by a fresh monitor over the same dir via the
+// lazy disk path, i.e. it survives a process restart (which the in-memory-only
+// path cannot) without any boot-time scan.
 func TestCaptureDisk_MonitorPersistsAcrossRestart(t *testing.T) {
 	dir := t.TempDir()
 	mm := newPersistMetricsMonitor(t, dir, 0, 8)
 	if !mm.enableCaptures {
 		t.Fatal("captures should be enabled when a disk tier is configured")
 	}
-	if !mm.addCapture(ReqRespCapture{ID: 4, ReqBody: []byte("durable")}) {
+	if !mm.addCapture(ReqRespCapture{ID: 1050, ReqBody: []byte("durable")}) {
 		t.Fatal("addCapture returned false")
 	}
 
 	reopened := newPersistMetricsMonitor(t, dir, 0, 8)
-	got := reopened.getCaptureByID(4)
+	got := reopened.getCaptureByID(1050)
 	if got == nil || string(got.ReqBody) != "durable" {
 		t.Fatalf("capture lost after restart: %+v", got)
 	}
 
-	entries := []ActivityLogEntry{{ID: 4}}
+	entries := []ActivityLogEntry{{ID: 1050}}
 	reopened.overlayCaptureState(entries)
 	if !entries[0].HasCapture {
 		t.Fatal("overlayCaptureState must report the persisted capture")

--- a/internal/server/captures_disk_test.go
+++ b/internal/server/captures_disk_test.go
@@ -428,6 +428,85 @@ func TestCaptureDisk_TmpWriteDoesNotFollowSymlink(t *testing.T) {
 	}
 }
 
+// TestCaptureDisk_ReconcileRemovesCrashTmpFiles proves temp files left by a
+// crashed Add (both the current os.CreateTemp pattern and the legacy
+// <id>.cap.tmp name) are dropped by the next walk: they must not linger and
+// must not count against the budget.
+func TestCaptureDisk_ReconcileRemovesCrashTmpFiles(t *testing.T) {
+	dc := newTestDiskCapture(t, 100)
+	if err := dc.Add(1, make([]byte, 10)); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	shard := dc.shardDir(2)
+	if err := os.MkdirAll(shard, 0o700); err != nil {
+		t.Fatalf("shard dir: %v", err)
+	}
+	leftovers := []string{
+		filepath.Join(shard, ".tmp-crashed"),
+		filepath.Join(shard, "2.cap.tmp"),
+	}
+	for _, p := range leftovers {
+		if err := os.WriteFile(p, make([]byte, 90), 0o600); err != nil {
+			t.Fatalf("plant leftover %s: %v", p, err)
+		}
+	}
+
+	if err := dc.reconcile(); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	for _, p := range leftovers {
+		if _, err := os.Stat(p); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("crash leftover %s survived reconcile: %v", p, err)
+		}
+	}
+	if !dc.Has(1) {
+		t.Fatal("capture evicted despite fitting the budget once leftovers are gone")
+	}
+	if got := dc.total.Load(); got != 10 {
+		t.Fatalf("total = %d, want 10: leftover bytes must not be counted", got)
+	}
+}
+
+// TestCaptureDisk_ReconcileKeepsTotalOnWalkError guards the authoritative
+// total: a walk that aborts on an unreadable shard saw only part of the store,
+// so its partial sum must not replace the running counter, and eviction must
+// not run from it.
+func TestCaptureDisk_ReconcileKeepsTotalOnWalkError(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "captures")
+	dc, err := newDiskCaptureOpts(dir, 100, nil, false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer dc.Close()
+	if err := dc.Add(1, make([]byte, 10)); err != nil {
+		t.Fatalf("Add 1: %v", err)
+	}
+	if err := dc.Add(1000, make([]byte, 10)); err != nil {
+		t.Fatalf("Add 1000: %v", err)
+	}
+
+	shard := dc.shardDir(1000)
+	if err := os.Chmod(shard, 0); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { os.Chmod(shard, 0o700) })
+	if _, err := os.ReadDir(shard); err == nil {
+		t.Skip("filesystem ignores directory permissions (running as root?)")
+	}
+
+	dc.total.Store(999) // the pre-walk running counter
+	err = dc.reconcile()
+	if err == nil {
+		t.Fatal("reconcile must report an unreadable shard")
+	}
+	if got := dc.total.Load(); got != 999 {
+		t.Fatalf("total = %d, want 999: a partial walk must not overwrite the authoritative total", got)
+	}
+	if !dc.Has(1) {
+		t.Fatal("id 1 evicted: a failed walk must not evict from its partial sum")
+	}
+}
+
 // TestCaptureDisk_WarnsOnSharedWritableDir verifies opening an existing capture
 // dir that group/others can write to is reported: local users could then plant
 // the files the store reads back.

--- a/internal/server/captures_disk_test.go
+++ b/internal/server/captures_disk_test.go
@@ -518,6 +518,14 @@ func TestCaptureDisk_WarnsOnSharedWritableDir(t *testing.T) {
 	if _, err := newDiskCaptureOpts(shared, 1<<20, "db", logger, false); err != nil {
 		t.Fatalf("open: %v", err)
 	}
+	if err := os.Chmod(shared, 0o700); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if info, err := os.Stat(shared); err != nil {
+		t.Fatalf("stat: %v", err)
+	} else if info.Mode().Perm()&0o077 != 0 {
+		t.Skip("filesystem ignores directory permissions (Windows?)")
+	}
 	if err := os.Chmod(shared, 0o777); err != nil {
 		t.Fatalf("chmod: %v", err)
 	}

--- a/internal/server/captures_disk_test.go
+++ b/internal/server/captures_disk_test.go
@@ -19,7 +19,7 @@ import (
 func newTestDiskCapture(t *testing.T, maxBytes int) *diskCapture {
 	t.Helper()
 	dir := filepath.Join(t.TempDir(), "captures")
-	dc, err := newDiskCaptureOpts(dir, maxBytes, nil, false)
+	dc, err := newDiskCaptureOpts(dir, maxBytes, "db", nil, false)
 	if err != nil {
 		t.Fatalf("newDiskCaptureOpts: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestCaptureDisk_ShardsByThousandFiles(t *testing.T) {
 		if err := dc.Add(id, []byte("x")); err != nil {
 			t.Fatalf("Add %d: %v", id, err)
 		}
-		want := filepath.Join(dc.dir, filepath.FromSlash(rel))
+		want := filepath.Join(dc.ns, filepath.FromSlash(rel))
 		if _, err := os.Stat(want); err != nil {
 			t.Fatalf("id %d not at %s: %v", id, rel, err)
 		}
@@ -160,7 +160,7 @@ func TestCaptureDisk_ShardsByThousandFiles(t *testing.T) {
 // found purely by probing the exact sharded path (lazy discovery).
 func TestCaptureDisk_NoEvictionOrScanAtOpen(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "captures")
-	dc, err := newDiskCaptureOpts(dir, 30, nil, false)
+	dc, err := newDiskCaptureOpts(dir, 30, "db", nil, false)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -174,7 +174,7 @@ func TestCaptureDisk_NoEvictionOrScanAtOpen(t *testing.T) {
 	}
 	dc.Close()
 
-	dc2, err := newDiskCaptureOpts(dir, 30, nil, false)
+	dc2, err := newDiskCaptureOpts(dir, 30, "db", nil, false)
 	if err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestCaptureDisk_NoEvictionOrScanAtOpen(t *testing.T) {
 // the oldest ids without an explicit reconcile call.
 func TestCaptureDisk_ReconcileLoopEvictsInBackground(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "captures")
-	dc, err := newDiskCapture(dir, 20, nil) // startLoop = true
+	dc, err := newDiskCapture(dir, 20, "db", nil) // startLoop = true
 	if err != nil {
 		t.Fatalf("newDiskCapture: %v", err)
 	}
@@ -267,7 +267,7 @@ func TestCaptureDisk_TieredStore(t *testing.T) {
 // reloads do not leak reconcilers.
 func TestCaptureDisk_CloseStopsLoop(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "captures")
-	dc, err := newDiskCapture(dir, 1<<20, nil) // loop started
+	dc, err := newDiskCapture(dir, 1<<20, "db", nil) // loop started
 	if err != nil {
 		t.Fatalf("newDiskCapture: %v", err)
 	}
@@ -473,7 +473,7 @@ func TestCaptureDisk_ReconcileRemovesCrashTmpFiles(t *testing.T) {
 // not run from it.
 func TestCaptureDisk_ReconcileKeepsTotalOnWalkError(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "captures")
-	dc, err := newDiskCaptureOpts(dir, 100, nil, false)
+	dc, err := newDiskCaptureOpts(dir, 100, "db", nil, false)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
@@ -515,13 +515,13 @@ func TestCaptureDisk_WarnsOnSharedWritableDir(t *testing.T) {
 	logger := logmon.NewWriter(&buf)
 
 	shared := filepath.Join(t.TempDir(), "shared")
-	if _, err := newDiskCaptureOpts(shared, 1<<20, logger, false); err != nil {
+	if _, err := newDiskCaptureOpts(shared, 1<<20, "db", logger, false); err != nil {
 		t.Fatalf("open: %v", err)
 	}
 	if err := os.Chmod(shared, 0o777); err != nil {
 		t.Fatalf("chmod: %v", err)
 	}
-	if _, err := newDiskCaptureOpts(shared, 1<<20, logger, false); err != nil {
+	if _, err := newDiskCaptureOpts(shared, 1<<20, "db", logger, false); err != nil {
 		t.Fatalf("reopen: %v", err)
 	}
 	if !bytes.Contains(buf.Bytes(), []byte("writable")) {
@@ -530,10 +530,117 @@ func TestCaptureDisk_WarnsOnSharedWritableDir(t *testing.T) {
 
 	buf.Reset()
 	private := filepath.Join(t.TempDir(), "private")
-	if _, err := newDiskCaptureOpts(private, 1<<20, logger, false); err != nil {
+	if _, err := newDiskCaptureOpts(private, 1<<20, "db", logger, false); err != nil {
 		t.Fatalf("open private: %v", err)
 	}
 	if buf.Len() != 0 {
 		t.Fatalf("private capture dir must not warn, log = %q", buf.Bytes())
+	}
+}
+
+// TestCaptureDisk_CapturesSurviveIdentityChange covers the store identity
+// binding: same-id reopens keep captures; an identity change — the activity
+// database was swapped or recreated, so ids restart at 1 — keeps the old
+// captures side by side (unreachable, still under budget) instead of deleting
+// them; root-level files from before namespacing are adopted into the
+// current database's namespace.
+func TestCaptureDisk_CapturesSurviveIdentityChange(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "captures")
+
+	dc, err := newDiskCaptureOpts(dir, 0, "one", nil, false)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := dc.Add(1, []byte("old database")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	dc.Close()
+
+	same, err := newDiskCaptureOpts(dir, 0, "one", nil, false)
+	if err != nil {
+		t.Fatalf("reopen same identity: %v", err)
+	}
+	if data, err := same.Get(1); err != nil || string(data) != "old database" {
+		t.Fatalf("Get = %q, %v, want %q", data, err, "old database")
+	}
+	same.Close()
+
+	swapped, err := newDiskCaptureOpts(dir, 1<<20, "two", nil, false)
+	if err != nil {
+		t.Fatalf("reopen swapped identity: %v", err)
+	}
+	if err := swapped.Add(1, []byte("new database")); err != nil {
+		t.Fatalf("Add after swap: %v", err)
+	}
+	if data, err := swapped.Get(1); err != nil || string(data) != "new database" {
+		t.Fatalf("Get after swap = %q, %v: id 1 must not expose old data", data, err)
+	}
+	oldFile := filepath.Join(dir, namespacePrefix+"one", "0", "1.cap")
+	if data, err := os.ReadFile(oldFile); err != nil || string(data) != "old database" {
+		t.Fatalf("old capture = %q, %v, want it kept at %s", data, err, oldFile)
+	}
+	swapped.Close()
+
+	// Flipping back to the old database finds its captures intact.
+	back, err := newDiskCaptureOpts(dir, 1<<20, "one", nil, false)
+	if err != nil {
+		t.Fatalf("reopen old identity: %v", err)
+	}
+	defer back.Close()
+	if data, err := back.Get(1); err != nil || string(data) != "old database" {
+		t.Fatalf("Get after flip back = %q, %v, want %q", data, err, "old database")
+	}
+
+	// The byte budget spans generations: an over-budget store evicts the
+	// older database's files before the current one's.
+	cross := filepath.Join(t.TempDir(), "cross")
+	a, err := newDiskCaptureOpts(cross, 1000, "ga", nil, false)
+	if err != nil {
+		t.Fatalf("open gen-a: %v", err)
+	}
+	if err := a.Add(1, make([]byte, 100)); err != nil {
+		t.Fatalf("gen-a Add: %v", err)
+	}
+	a.Close()
+	b, err := newDiskCaptureOpts(cross, 1000, "gb", nil, false)
+	if err != nil {
+		t.Fatalf("open gen-b: %v", err)
+	}
+	defer b.Close()
+	if err := b.Add(1, make([]byte, 500)); err != nil {
+		t.Fatalf("gen-b Add 1: %v", err)
+	}
+	if err := b.Add(2, make([]byte, 500)); err != nil {
+		t.Fatalf("gen-b Add 2: %v", err)
+	}
+	if err := b.reconcile(); err != nil {
+		t.Fatalf("cross-generation reconcile: %v", err)
+	}
+	if !b.Has(1) || !b.Has(2) {
+		t.Fatal("current database evicted while an older generation still had room to give")
+	}
+	if _, err := os.Stat(filepath.Join(cross, namespacePrefix+"ga", "0", "1.cap")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("oldest generation must be evicted first: %v", err)
+	}
+
+	// Root-level files from before namespacing are adopted into the current
+	// database's namespace at first open.
+	legacyDir := filepath.Join(t.TempDir(), "legacy")
+	if err := os.MkdirAll(filepath.Join(legacyDir, "0"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacyDir, "0", "7.cap"), []byte("adopted"), 0o600); err != nil {
+		t.Fatalf("write legacy capture: %v", err)
+	}
+	adopted, err := newDiskCaptureOpts(legacyDir, 0, "nine", nil, false)
+	if err != nil {
+		t.Fatalf("adopt open: %v", err)
+	}
+	defer adopted.Close()
+	if !adopted.Has(7) {
+		t.Fatal("existing captures must be adopted into the namespace")
+	}
+	if _, err := os.Stat(filepath.Join(legacyDir, namespacePrefix+"nine", "0", "7.cap")); err != nil {
+		t.Fatalf("adopted capture not relocated into its namespace: %v", err)
 	}
 }

--- a/internal/server/captures_disk_test.go
+++ b/internal/server/captures_disk_test.go
@@ -26,69 +26,68 @@ func newTestDiskCapture(t *testing.T, maxBytes int) *diskCapture {
 	return dc
 }
 
-func TestCaptureDisk_Roundtrip(t *testing.T) {
+// TestCaptureDisk_RoundtripAndMissing covers store/lookup of a capture and the
+// not-found contract: never-stored and externally-deleted ids both report
+// errCaptureNotFound.
+func TestCaptureDisk_RoundtripAndMissing(t *testing.T) {
 	dc := newTestDiskCapture(t, 1<<20)
+
+	if dc.Has(42) {
+		t.Fatal("Has(42) on empty store = true")
+	}
+	if _, err := dc.Get(42); !errors.Is(err, errCaptureNotFound) {
+		t.Fatalf("Get missing err = %v, want errCaptureNotFound", err)
+	}
+
 	if err := dc.Add(5, []byte("hello")); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
 	if !dc.Has(5) {
 		t.Fatal("Has(5) = false, want true")
 	}
-	data, err := dc.Get(5)
-	if err != nil {
-		t.Fatalf("Get: %v", err)
+	if data, err := dc.Get(5); err != nil || string(data) != "hello" {
+		t.Fatalf("Get = %q, %v, want %q", data, err, "hello")
 	}
-	if string(data) != "hello" {
-		t.Fatalf("Get = %q, want %q", data, "hello")
+
+	if err := os.Remove(dc.path(5)); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if dc.Has(5) {
+		t.Fatal("Has must be false after the file is removed")
+	}
+	if _, err := dc.Get(5); !errors.Is(err, errCaptureNotFound) {
+		t.Fatalf("Get removed err = %v, want errCaptureNotFound", err)
 	}
 }
 
-func TestCaptureDisk_GetMissing(t *testing.T) {
-	dc := newTestDiskCapture(t, 1<<20)
-	if dc.Has(42) {
-		t.Fatal("Has(42) on empty store = true")
+// TestCaptureDisk_BudgetEnforcement covers the budget rules: max == 0 stores
+// everything and never evicts; a blob over the whole budget is rejected
+// upfront; eviction is reconcile-driven (Add never evicts inline) and the
+// oldest ids go first until the total fits.
+func TestCaptureDisk_BudgetEnforcement(t *testing.T) {
+	unlimited := newTestDiskCapture(t, 0)
+	for id := 1; id <= 50; id++ {
+		if err := unlimited.Add(id, make([]byte, 1000)); err != nil {
+			t.Fatalf("Add %d under unlimited budget: %v", id, err)
+		}
 	}
-	_, err := dc.Get(42)
-	if !errors.Is(err, errCaptureNotFound) {
-		t.Fatalf("Get missing err = %v, want errCaptureNotFound", err)
+	if err := unlimited.reconcile(); err != nil {
+		t.Fatalf("reconcile under unlimited budget: %v", err)
 	}
-}
+	for id := 1; id <= 50; id++ {
+		if !unlimited.Has(id) {
+			t.Fatalf("id %d evicted despite unlimited budget", id)
+		}
+	}
 
-func TestCaptureDisk_TooLargeRejected(t *testing.T) {
-	dc := newTestDiskCapture(t, 16)
-	if err := dc.Add(1, make([]byte, 17)); !errors.Is(err, errExceedsCaptureMax) {
+	dc := newTestDiskCapture(t, 20)
+	if err := dc.Add(1, make([]byte, 21)); !errors.Is(err, errExceedsCaptureMax) {
 		t.Fatalf("Add oversized err = %v, want errExceedsCaptureMax", err)
 	}
 	if dc.Has(1) {
 		t.Fatal("oversized capture was stored")
 	}
-}
-
-// TestCaptureDisk_UnlimitedWhenMaxIsZero shows captureMaxMB == 0 means no disk
-// budget: nothing is rejected for size and reconcile never evicts.
-func TestCaptureDisk_UnlimitedWhenMaxIsZero(t *testing.T) {
-	dc := newTestDiskCapture(t, 0)
-	for id := 1; id <= 50; id++ {
-		if err := dc.Add(id, make([]byte, 1000)); err != nil {
-			t.Fatalf("Add %d under unlimited budget: %v", id, err)
-		}
-	}
-	if err := dc.reconcile(); err != nil {
-		t.Fatalf("reconcile under unlimited budget: %v", err)
-	}
-	for id := 1; id <= 50; id++ {
-		if !dc.Has(id) {
-			t.Fatalf("id %d evicted despite unlimited budget", id)
-		}
-	}
-}
-
-// TestCaptureDisk_ReconcileEvictsOldest proves eviction is reconcile-driven, not
-// inline: Add past the budget keeps everything until a reconcile pass runs, then
-// the lowest (oldest) ids go first until the total fits.
-func TestCaptureDisk_ReconcileEvictsOldest(t *testing.T) {
-	dc := newTestDiskCapture(t, 20)
-	for id := 1; id <= 3; id++ {
+	for id := 1; id <= 3; id++ { // 30 bytes over a 20 budget
 		if err := dc.Add(id, make([]byte, 10)); err != nil {
 			t.Fatalf("Add %d: %v", id, err)
 		}
@@ -115,24 +114,16 @@ func TestCaptureDisk_OverwriteSameID(t *testing.T) {
 	if err := dc.Add(7, []byte("two-and-longer")); err != nil {
 		t.Fatalf("Add overwrite: %v", err)
 	}
-	data, err := dc.Get(7)
-	if err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-	if string(data) != "two-and-longer" {
-		t.Fatalf("Get = %q, want overwritten value", data)
+	if data, err := dc.Get(7); err != nil || string(data) != "two-and-longer" {
+		t.Fatalf("Get = %q, %v, want overwritten value", data, err)
 	}
 }
 
-// TestCaptureDisk_ShardsByThousandFiles checks the on-disk layout: ids are grouped
-// into decimal folders of 1000 (id/1000), no padding, and no flat files remain.
+// TestCaptureDisk_ShardsByThousandFiles checks the on-disk layout: ids are
+// grouped into decimal folders of 1000 (id/1000) and nothing lands at the top
+// level.
 func TestCaptureDisk_ShardsByThousandFiles(t *testing.T) {
 	dc := newTestDiskCapture(t, 1<<20)
-	for _, id := range []int{7, 999, 1000, 1050, 42_501} {
-		if err := dc.Add(id, []byte("x")); err != nil {
-			t.Fatalf("Add %d: %v", id, err)
-		}
-	}
 	cases := map[int]string{
 		7:      "0/7.cap",
 		999:    "0/999.cap",
@@ -141,16 +132,17 @@ func TestCaptureDisk_ShardsByThousandFiles(t *testing.T) {
 		42_501: "42/42501.cap",
 	}
 	for id, rel := range cases {
+		if err := dc.Add(id, []byte("x")); err != nil {
+			t.Fatalf("Add %d: %v", id, err)
+		}
 		want := filepath.Join(dc.dir, filepath.FromSlash(rel))
 		if _, err := os.Stat(want); err != nil {
 			t.Fatalf("id %d not at %s: %v", id, rel, err)
 		}
-		// path() and direct layout must agree.
 		if got := dc.path(id); got != want {
 			t.Fatalf("path(%d) = %s, want %s", id, got, want)
 		}
 	}
-	// Nothing lives at the flat top level.
 	entries, err := os.ReadDir(dc.dir)
 	if err != nil {
 		t.Fatalf("ReadDir: %v", err)
@@ -162,47 +154,20 @@ func TestCaptureDisk_ShardsByThousandFiles(t *testing.T) {
 	}
 }
 
-// TestCaptureDisk_LazyDiscoveryAcrossReopen proves no boot scan is required: a
-// fresh store with an empty in-memory state finds files purely by probing the
-// exact sharded path.
-func TestCaptureDisk_LazyDiscoveryAcrossReopen(t *testing.T) {
+// TestCaptureDisk_NoEvictionOrScanAtOpen proves reopening is O(1): over-budget
+// files from a previous run all survive until reconcile runs, and every one is
+// found purely by probing the exact sharded path (lazy discovery).
+func TestCaptureDisk_NoEvictionOrScanAtOpen(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "captures")
-	dc, err := newDiskCaptureOpts(dir, 1<<20, nil, false)
+	dc, err := newDiskCaptureOpts(dir, 30, nil, false)
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
 	if err := dc.Add(1050, []byte("persisted")); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
-	if err := dc.Close(); err != nil {
-		t.Fatalf("Close: %v", err)
-	}
-
-	dc2, err := newDiskCaptureOpts(dir, 1<<20, nil, false)
-	if err != nil {
-		t.Fatalf("reopen: %v", err)
-	}
-	defer dc2.Close()
-	if !dc2.Has(1050) {
-		t.Fatal("capture lost after reopen (lazy discovery failed)")
-	}
-	data, err := dc2.Get(1050)
-	if err != nil || string(data) != "persisted" {
-		t.Fatalf("Get after reopen = %q, %v", data, err)
-	}
-}
-
-// TestCaptureDisk_NoEvictionAtOpen proves opening never scans or evicts: over-budget
-// files from a previous run all survive until reconcile runs. This is the startup
-// cost guarantee (O(1) open regardless of capture count).
-func TestCaptureDisk_NoEvictionAtOpen(t *testing.T) {
-	dir := filepath.Join(t.TempDir(), "captures")
-	dc, err := newDiskCaptureOpts(dir, 30, nil, false)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
 	for id := 1; id <= 5; id++ {
-		if err := dc.Add(id, make([]byte, 10)); err != nil { // 50 bytes over a 30 budget
+		if err := dc.Add(id, make([]byte, 10)); err != nil { // 59 bytes over a 30 budget
 			t.Fatalf("Add %d: %v", id, err)
 		}
 	}
@@ -213,49 +178,36 @@ func TestCaptureDisk_NoEvictionAtOpen(t *testing.T) {
 		t.Fatalf("reopen: %v", err)
 	}
 	defer dc2.Close()
+	if data, err := dc2.Get(1050); err != nil || string(data) != "persisted" {
+		t.Fatalf("lazy discovery after reopen: %q, %v", data, err)
+	}
 	for id := 1; id <= 5; id++ {
 		if !dc2.Has(id) {
 			t.Fatalf("id %d evicted at open: reopening must not scan or evict", id)
 		}
 	}
-	// One reconcile pass now enforces the budget by dropping the oldest ids.
+
+	// One reconcile pass drops the oldest ids until the budget fits: ids 1-3
+	// go, leaving ids 4-5 plus "persisted" (9 bytes) at 29 <= 30.
 	if err := dc2.reconcile(); err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
-	if dc2.Has(1) || dc2.Has(2) {
-		t.Fatal("reconcile must evict oldest ids to fit the budget")
+	for _, id := range []int{1, 2, 3} {
+		if dc2.Has(id) {
+			t.Fatalf("id %d should have been evicted", id)
+		}
 	}
-	for id := 3; id <= 5; id++ {
+	for _, id := range []int{4, 5, 1050} {
 		if !dc2.Has(id) {
 			t.Fatalf("id %d should be retained after reconcile", id)
 		}
 	}
 }
 
-func TestCaptureDisk_MissingFileTreatedAsNotFound(t *testing.T) {
-	dc := newTestDiskCapture(t, 1<<20)
-	if err := dc.Add(9, []byte("x")); err != nil {
-		t.Fatalf("Add: %v", err)
-	}
-	if err := os.Remove(dc.path(9)); err != nil {
-		t.Fatalf("Remove: %v", err)
-	}
-	if dc.Has(9) {
-		t.Fatal("Has must be false after the file is removed")
-	}
-	if _, err := dc.Get(9); !errors.Is(err, errCaptureNotFound) {
-		t.Fatalf("Get missing file err = %v, want errCaptureNotFound", err)
-	}
-}
-
-// TestCaptureDisk_ReconcileLoopEvictsInBackground exercises the goroutine that the
-// production constructor starts: after writes push the store over budget, the
-// background pass evicts the oldest ids without an explicit reconcile call.
+// TestCaptureDisk_ReconcileLoopEvictsInBackground exercises the goroutine the
+// production constructor starts: writes signal a background pass that evicts
+// the oldest ids without an explicit reconcile call.
 func TestCaptureDisk_ReconcileLoopEvictsInBackground(t *testing.T) {
-	prevInterval, prevFirst := reconcileInterval, reconcileFirstDelay
-	reconcileFirstDelay, reconcileInterval = 5*time.Millisecond, 5*time.Millisecond
-	t.Cleanup(func() { reconcileInterval, reconcileFirstDelay = prevInterval, prevFirst })
-
 	dir := filepath.Join(t.TempDir(), "captures")
 	dc, err := newDiskCapture(dir, 20, nil) // startLoop = true
 	if err != nil {
@@ -279,10 +231,10 @@ func TestCaptureDisk_ReconcileLoopEvictsInBackground(t *testing.T) {
 	t.Fatal("background reconcile did not evict the oldest capture")
 }
 
-// TestCaptureDisk_TieredFallsBackToDisk proves a two-tier store writes to both
-// tiers, serves reads from memory when present, and falls back to disk once the
-// (small) memory tier has evicted the entry.
-func TestCaptureDisk_TieredFallsBackToDisk(t *testing.T) {
+// TestCaptureDisk_TieredStore covers the two-tier behavior: Add writes both
+// tiers, an item too large for memory lands on disk only, and reads fall back
+// to disk once memory has evicted the entry.
+func TestCaptureDisk_TieredStore(t *testing.T) {
 	dc := newTestDiskCapture(t, 1<<20)
 	mem := cache.New(16)
 	layered := combineCapture(mem, dc)
@@ -290,40 +242,28 @@ func TestCaptureDisk_TieredFallsBackToDisk(t *testing.T) {
 	if err := layered.Add(1, []byte("payload")); err != nil {
 		t.Fatalf("tiered Add: %v", err)
 	}
+	if err := layered.Add(2, make([]byte, 4096)); err != nil {
+		t.Fatalf("tiered Add oversized-for-mem: %v", err)
+	}
 	if !mem.Has(1) || !dc.Has(1) {
 		t.Fatal("tiered Add must write to both tiers")
 	}
+	if mem.Has(2) || !dc.Has(2) {
+		t.Fatal("item too large for memory must be retained on disk only")
+	}
+
 	mem.Clear()
 	if !layered.Has(1) {
 		t.Fatal("Has must report disk tier after memory eviction")
 	}
-	data, err := layered.Get(1)
-	if err != nil || string(data) != "payload" {
+	if data, err := layered.Get(1); err != nil || string(data) != "payload" {
 		t.Fatalf("fallback Get = %q, %v", data, err)
 	}
 }
 
-// TestCaptureDisk_TieredMemTooLargeStoredOnDisk verifies an item too big for the
-// memory tier is still durably stored on disk and reports as present.
-func TestCaptureDisk_TieredMemTooLargeStoredOnDisk(t *testing.T) {
-	dc := newTestDiskCapture(t, 1<<20)
-	mem := cache.New(16)
-	layered := combineCapture(mem, dc)
-
-	big := make([]byte, 4096)
-	if err := layered.Add(2, big); err != nil {
-		t.Fatalf("tiered Add oversized-for-mem: %v", err)
-	}
-	if mem.Has(2) {
-		t.Fatal("oversized item unexpectedly in memory tier")
-	}
-	if !dc.Has(2) {
-		t.Fatal("oversized item must be retained on disk")
-	}
-}
-
-// TestCaptureDisk_CloseStopsLoop proves Close terminates the background reconcile
-// goroutine (waited on, not just signaled), so reloads do not leak reconcilers.
+// TestCaptureDisk_CloseStopsLoop proves Close terminates the background
+// reconcile goroutine (waited on, not just signaled) and is idempotent, so
+// reloads do not leak reconcilers.
 func TestCaptureDisk_CloseStopsLoop(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "captures")
 	dc, err := newDiskCapture(dir, 1<<20, nil) // loop started
@@ -337,7 +277,6 @@ func TestCaptureDisk_CloseStopsLoop(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("Close did not stop the reconcile loop")
 	}
-	// Close must be idempotent.
 	if err := dc.Close(); err != nil {
 		t.Fatalf("second Close: %v", err)
 	}
@@ -359,9 +298,9 @@ func newPersistMetricsMonitor(t *testing.T, dir string, memMB, diskMB int) *metr
 }
 
 // TestCaptureDisk_MonitorPersistsAcrossRestart shows a capture written through
-// the metricsMonitor is retrievable by a fresh monitor over the same dir via the
-// lazy disk path, i.e. it survives a process restart (which the in-memory-only
-// path cannot) without any boot-time scan.
+// the metricsMonitor is retrievable by a fresh monitor over the same dir via
+// the lazy disk path, i.e. it survives a process restart (which the
+// in-memory-only path cannot) without any boot-time scan.
 func TestCaptureDisk_MonitorPersistsAcrossRestart(t *testing.T) {
 	dir := t.TempDir()
 	mm := newPersistMetricsMonitor(t, dir, 0, 8)
@@ -385,39 +324,37 @@ func TestCaptureDisk_MonitorPersistsAcrossRestart(t *testing.T) {
 	}
 }
 
-// TestCaptureDisk_MonitorDisabledWithoutPersistentStore verifies the gate: a
-// configured disk tier is refused when the activity DB is in-memory, since IDs
-// reset every boot and would orphan capture files.
-func TestCaptureDisk_MonitorDisabledWithoutPersistentStore(t *testing.T) {
-	st, err := store.New("")
+// TestCaptureDisk_MonitorDiskTierGating verifies the disk tier is built only
+// with both a captureDir and a persistent activity store: IDs must survive
+// restarts (an in-memory DB resets every boot and would orphan capture files),
+// and captureDir — not the byte budget — is the enable switch.
+func TestCaptureDisk_MonitorDiskTierGating(t *testing.T) {
+	memStore, err := store.New("")
 	if err != nil {
 		t.Fatalf("store.New: %v", err)
 	}
-	defer st.Close()
-	mm := newMetricsMonitorWithDisk(logmon.NewWriter(io.Discard), 0, 0, 8, filepath.Join(t.TempDir(), "caps"), st)
-	if mm.enableCaptures {
-		t.Fatal("disk captures must be disabled with an in-memory store")
-	}
-	if mm.captureCache != nil {
-		t.Fatal("no capture tier should be built")
-	}
-}
-
-// TestCaptureDisk_MonitorDisabledWithoutDir verifies the enable switch is the
-// directory, not the byte budget: an empty captureDir disables the disk tier
-// even when captureMaxMB is positive.
-func TestCaptureDisk_MonitorDisabledWithoutDir(t *testing.T) {
+	defer memStore.Close()
 	dir := t.TempDir()
-	st, err := store.New(filepath.Join(dir, "activity.sqlite"))
+	persistStore, err := store.New(filepath.Join(dir, "activity.sqlite"))
 	if err != nil {
 		t.Fatalf("store.New: %v", err)
 	}
-	defer st.Close()
-	mm := newMetricsMonitorWithDisk(logmon.NewWriter(io.Discard), 0, 0, 512, "", st)
-	if mm.enableCaptures {
-		t.Fatal("disk captures must be disabled when captureDir is empty")
+	defer persistStore.Close()
+
+	cases := map[string]struct {
+		st      *store.Store
+		diskDir string
+	}{
+		"in-memory store":  {st: memStore, diskDir: filepath.Join(t.TempDir(), "caps")},
+		"empty captureDir": {st: persistStore, diskDir: ""},
 	}
-	if mm.captureCache != nil {
-		t.Fatal("no capture tier should be built without a captureDir")
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			mm := newMetricsMonitorWithDisk(logmon.NewWriter(io.Discard), 0, 0, 512, tc.diskDir, tc.st)
+			defer mm.Close()
+			if mm.enableCaptures || mm.captureCache != nil {
+				t.Fatalf("disk tier must be disabled with an %s", name)
+			}
+		})
 	}
 }

--- a/internal/server/captures_disk_test.go
+++ b/internal/server/captures_disk_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"os"
@@ -237,7 +238,7 @@ func TestCaptureDisk_ReconcileLoopEvictsInBackground(t *testing.T) {
 func TestCaptureDisk_TieredStore(t *testing.T) {
 	dc := newTestDiskCapture(t, 1<<20)
 	mem := cache.New(16)
-	layered := combineCapture(mem, dc)
+	layered := combineCapture(logmon.NewWriter(io.Discard), mem, dc)
 
 	if err := layered.Add(1, []byte("payload")); err != nil {
 		t.Fatalf("tiered Add: %v", err)
@@ -356,5 +357,104 @@ func TestCaptureDisk_MonitorDiskTierGating(t *testing.T) {
 				t.Fatalf("disk tier must be disabled with an %s", name)
 			}
 		})
+	}
+}
+
+// TestCaptureDisk_ReconcileNotOverEvictedByRacingAdd guards the eviction
+// budget against writes racing the reconcile walk: a capture added mid-walk
+// (counted both by Add and missed by the walk) must not inflate the total the
+// eviction loop uses, or older captures that still fit get deleted.
+func TestCaptureDisk_ReconcileNotOverEvictedByRacingAdd(t *testing.T) {
+	dc := newTestDiskCapture(t, 100)
+	for id := 1; id <= 4; id++ { // 104 bytes over a 100 budget: exactly id 1 must go
+		if err := dc.Add(id, make([]byte, 26)); err != nil {
+			t.Fatalf("Add %d: %v", id, err)
+		}
+	}
+
+	walkStarted := make(chan struct{})
+	release := make(chan struct{})
+	dc.onWalkStart = func() { close(walkStarted); <-release }
+
+	reconcileDone := make(chan error, 1)
+	go func() { reconcileDone <- dc.reconcile() }()
+
+	<-walkStarted
+	addDone := make(chan error, 1)
+	go func() { addDone <- dc.Add(5, make([]byte, 40)) }()
+	time.Sleep(50 * time.Millisecond) // let the racing Add reach the store
+	close(release)
+
+	if err := <-reconcileDone; err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if err := <-addDone; err != nil {
+		t.Fatalf("racing Add: %v", err)
+	}
+
+	if dc.Has(1) {
+		t.Fatal("oldest capture (id 1) should be evicted")
+	}
+	for _, id := range []int{2, 3, 4, 5} {
+		if !dc.Has(id) {
+			t.Fatalf("id %d evicted: a racing Add must not over-evict captures that still fit", id)
+		}
+	}
+}
+
+// TestCaptureDisk_TmpWriteDoesNotFollowSymlink proves a planted symlink at the
+// predictable temp path cannot make the store write through to another file.
+func TestCaptureDisk_TmpWriteDoesNotFollowSymlink(t *testing.T) {
+	dc := newTestDiskCapture(t, 1<<20)
+	victim := filepath.Join(t.TempDir(), "victim")
+	if err := os.WriteFile(victim, []byte("secret"), 0o600); err != nil {
+		t.Fatalf("seed victim: %v", err)
+	}
+	if err := os.MkdirAll(dc.shardDir(9), 0o700); err != nil {
+		t.Fatalf("shard dir: %v", err)
+	}
+	if err := os.Symlink(victim, dc.path(9)+".tmp"); err != nil {
+		t.Fatalf("plant symlink: %v", err)
+	}
+
+	if err := dc.Add(9, []byte("capture")); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if data, err := os.ReadFile(victim); err != nil || string(data) != "secret" {
+		t.Fatalf("temp write followed a symlink: victim = %q, %v", data, err)
+	}
+	if data, err := dc.Get(9); err != nil || string(data) != "capture" {
+		t.Fatalf("Get = %q, %v, want %q", data, err, "capture")
+	}
+}
+
+// TestCaptureDisk_WarnsOnSharedWritableDir verifies opening an existing capture
+// dir that group/others can write to is reported: local users could then plant
+// the files the store reads back.
+func TestCaptureDisk_WarnsOnSharedWritableDir(t *testing.T) {
+	var buf bytes.Buffer
+	logger := logmon.NewWriter(&buf)
+
+	shared := filepath.Join(t.TempDir(), "shared")
+	if _, err := newDiskCaptureOpts(shared, 1<<20, logger, false); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := os.Chmod(shared, 0o777); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if _, err := newDiskCaptureOpts(shared, 1<<20, logger, false); err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("writable")) {
+		t.Fatalf("no warning for shared-writable capture dir, log = %q", buf.Bytes())
+	}
+
+	buf.Reset()
+	private := filepath.Join(t.TempDir(), "private")
+	if _, err := newDiskCaptureOpts(private, 1<<20, logger, false); err != nil {
+		t.Fatalf("open private: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("private capture dir must not warn, log = %q", buf.Bytes())
 	}
 }

--- a/internal/server/captures_perm_posix.go
+++ b/internal/server/captures_perm_posix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package server
+
+import "io/fs"
+
+// sharedWritable reports POSIX group/other write access on an already
+// stat'ed capture directory.
+func sharedWritable(fi fs.FileInfo) bool {
+	return fi.Mode().Perm()&0o022 != 0
+}

--- a/internal/server/captures_perm_windows.go
+++ b/internal/server/captures_perm_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package server
+
+import "io/fs"
+
+// sharedWritable always reports false: Go synthesizes 0777 for every Windows
+// directory because NTFS ACLs have no POSIX mode bits, so the check would warn
+// on all dirs. Detecting world-writable ACLs would need an ACL API beyond the
+// best-effort advisory this warning provides.
+func sharedWritable(fi fs.FileInfo) bool {
+	return false
+}

--- a/internal/server/captures_test.go
+++ b/internal/server/captures_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/mostlygeek/llama-swap/internal/cache"
 	"github.com/mostlygeek/llama-swap/internal/logmon"
 )
 
@@ -66,6 +67,43 @@ func TestServer_CaptureDisabled(t *testing.T) {
 	}
 	if mm.getCaptureByID(1) != nil {
 		t.Fatal("getCaptureByID should return nil when disabled")
+	}
+}
+
+// failingStore is a captureStore whose every method fails with err.
+type failingStore struct{ err error }
+
+func (f failingStore) Add(int, []byte) error   { return f.err }
+func (f failingStore) Get(int) ([]byte, error) { return nil, f.err }
+func (f failingStore) Has(int) bool            { return false }
+
+// TestServer_CaptureTierPartialFailureIsReported verifies a capture the memory
+// tier accepts but the disk tier rejects still reports success (it is stored,
+// for now) yet warns: operators must know the copy will vanish after eviction
+// or restart. When no tier stores the capture the error must be returned.
+func TestServer_CaptureTierPartialFailureIsReported(t *testing.T) {
+	var buf bytes.Buffer
+	logger := logmon.NewWriter(&buf)
+	layered := combineCapture(logger, cache.New(1<<20), failingStore{err: errExceedsCaptureMax})
+
+	if err := layered.Add(1, []byte("payload")); err != nil {
+		t.Fatalf("Add must succeed when one tier stored the capture: %v", err)
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("capture 1")) || !bytes.Contains(buf.Bytes(), []byte("exceeds")) {
+		t.Fatalf("partial tier failure not reported, log = %q", buf.Bytes())
+	}
+
+	buf.Reset()
+	if err := combineCapture(logger, cache.New(1<<20), cache.New(1<<20)).Add(2, []byte("ok")); err != nil {
+		t.Fatalf("all tiers succeeding must not error: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("no warnings expected when every tier stored, log = %q", buf.Bytes())
+	}
+
+	buf.Reset()
+	if err := combineCapture(logger, failingStore{err: errExceedsCaptureMax}).Add(3, []byte("x")); err == nil {
+		t.Fatal("Add must fail when no tier stores the capture")
 	}
 }
 

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -73,7 +73,7 @@ func newMetricsMonitorWithDisk(logger *logmon.Monitor, maxMetrics, captureBuffer
 	if diskDir != "" {
 		if st.IsInMemory() {
 			mm.warnf("capture persistence requires a persistent store.path; ignoring the disk capture tier")
-		} else if dc, err := newDiskCapture(diskDir, diskMaxMB*1024*1024); err != nil {
+		} else if dc, err := newDiskCapture(diskDir, diskMaxMB*1024*1024, mm.logger); err != nil {
 			mm.warnf("failed to open disk capture store at %s: %v", diskDir, err)
 		} else {
 			disk = dc
@@ -136,6 +136,11 @@ func (mp *metricsMonitor) debugf(format string, args ...any) {
 }
 
 func (mp *metricsMonitor) Close() error {
+	// The capture store owns resources (the disk tier's reconcile goroutine)
+	// that must be released; the in-memory tier holds none and is not a Closer.
+	if closer, ok := mp.captureCache.(io.Closer); ok {
+		return closer.Close()
+	}
 	return nil
 }
 

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -80,7 +80,7 @@ func newMetricsMonitorWithDisk(logger *logmon.Monitor, maxMetrics, captureBuffer
 		}
 	}
 
-	mm.captureCache = combineCapture(mem, disk)
+	mm.captureCache = combineCapture(mm.logger, mem, disk)
 	mm.enableCaptures = mm.captureCache != nil
 	return mm
 }

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -36,28 +36,52 @@ func (e ActivityLogEvent) Type() uint32 {
 
 // metricsMonitor parses upstream responses for token statistics, stores
 // activity in a store, and (when captures are enabled) stores
-// zstd+CBOR-compressed request/response captures in a sized in-memory cache.
+// zstd+CBOR-compressed request/response captures in a captureStore. The store
+// may be an in-memory cache, a disk tier, or a two-tier combination of both.
 type metricsMonitor struct {
 	store          *store.Store
 	maxMetrics     int
 	logger         *logmon.Monitor
 	enableCaptures bool
-	captureCache   *cache.Cache // zstd-compressed CBOR of ReqRespCapture
+	captureCache   captureStore // zstd-compressed CBOR of ReqRespCapture
 }
 
 func newMetricsMonitor(logger *logmon.Monitor, maxMetrics int, captureBufferMB int, st *store.Store) *metricsMonitor {
+	return newMetricsMonitorWithDisk(logger, maxMetrics, captureBufferMB, 0, "", st)
+}
+
+// newMetricsMonitorWithDisk builds a monitor whose captures span an in-memory
+// tier (captureBufferMB) and/or a disk tier written under diskDir. The disk tier
+// is enabled by a non-empty diskDir (the byte budget, diskMaxMB, only caps it;
+// 0 means unlimited). It is refused when st is in-memory: activity IDs reset
+// every boot, so persisted captures keyed by those IDs would orphan on restart.
+func newMetricsMonitorWithDisk(logger *logmon.Monitor, maxMetrics, captureBufferMB, diskMaxMB int, diskDir string, st *store.Store) *metricsMonitor {
 	if maxMetrics <= 0 {
 		maxMetrics = 1000
 	}
 	mm := &metricsMonitor{
-		logger:         logger,
-		store:          st,
-		maxMetrics:     maxMetrics,
-		enableCaptures: captureBufferMB > 0,
+		logger:     logger,
+		store:      st,
+		maxMetrics: maxMetrics,
 	}
+
+	var mem captureStore
 	if captureBufferMB > 0 {
-		mm.captureCache = cache.New(captureBufferMB * 1024 * 1024)
+		mem = cache.New(captureBufferMB * 1024 * 1024)
 	}
+	var disk captureStore
+	if diskDir != "" {
+		if st.IsInMemory() {
+			mm.warnf("capture persistence requires a persistent store.path; ignoring the disk capture tier")
+		} else if dc, err := newDiskCapture(diskDir, diskMaxMB*1024*1024); err != nil {
+			mm.warnf("failed to open disk capture store at %s: %v", diskDir, err)
+		} else {
+			disk = dc
+		}
+	}
+
+	mm.captureCache = combineCapture(mem, disk)
+	mm.enableCaptures = mm.captureCache != nil
 	return mm
 }
 

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -73,7 +73,7 @@ func newMetricsMonitorWithDisk(logger *logmon.Monitor, maxMetrics, captureBuffer
 	if diskDir != "" {
 		if st.IsInMemory() {
 			mm.warnf("capture persistence requires a persistent store.path; ignoring the disk capture tier")
-		} else if dc, err := newDiskCapture(diskDir, diskMaxMB*1024*1024, mm.logger); err != nil {
+		} else if dc, err := newDiskCapture(diskDir, diskMaxMB*1024*1024, st.InstanceID(), mm.logger); err != nil {
 			mm.warnf("failed to open disk capture store at %s: %v", diskDir, err)
 		} else {
 			disk = dc

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -513,6 +513,10 @@ func (s *Server) Shutdown(timeout time.Duration) error {
 		errs = append(errs, err)
 	}
 
+	if err := s.metrics.Close(); err != nil {
+		errs = append(errs, err)
+	}
+
 	for _, rt := range []router.Router{s.local, s.peer} {
 		if rt == nil {
 			continue

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -220,6 +220,10 @@ func New(cfg config.Config, muxlog *logmon.Monitor, proxylog *logmon.Monitor, up
 	}
 
 	shutdownCtx, shutdownFn := context.WithCancel(context.Background())
+	diskCaptureMB, diskCaptureDir := 0, ""
+	if cfg.Store != nil {
+		diskCaptureMB, diskCaptureDir = cfg.Store.CaptureMaxMB, cfg.Store.CaptureDir
+	}
 	s := &Server{
 		cfg:           cfg,
 		muxlog:        muxlog,
@@ -227,7 +231,7 @@ func New(cfg config.Config, muxlog *logmon.Monitor, proxylog *logmon.Monitor, up
 		upstreamlog:   upstreamlog,
 		perf:          perfMon,
 		inflight:      newInflightTracker(),
-		metrics:       newMetricsMonitor(proxylog, cfg.MetricsMaxInMemory, cfg.CaptureBuffer, st),
+		metrics:       newMetricsMonitorWithDisk(proxylog, cfg.MetricsMaxInMemory, cfg.CaptureBuffer, diskCaptureMB, diskCaptureDir, st),
 		store:         st,
 		build:         build,
 		hardware:      hardware,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,8 +2,10 @@ package store
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
 	"embed"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -124,13 +126,49 @@ type HistogramData struct {
 }
 
 type Store struct {
-	db       *sql.DB
-	inMemory bool
+	db         *sql.DB
+	inMemory   bool
+	instanceID string
 }
 
 // IsInMemory returns true if the store is using an in-memory database.
 func (s *Store) IsInMemory() bool {
 	return s.inMemory
+}
+
+// InstanceID returns a stable identifier for this database instance, seeded at
+// open and persisted in the SQLite header via PRAGMA user_version (a 4-byte
+// application-defined field), so it needs no table or migration. Deleting or
+// recreating the database file yields a new ID, letting dependents (disk
+// capture storage) detect that AUTOINCREMENT ids restart at 1; reopens — and
+// copies restored from backups — keep theirs.
+func (s *Store) InstanceID() string {
+	return s.instanceID
+}
+
+// seedInstanceID reads PRAGMA user_version and, when unset, persists a random
+// nonzero value. Pragmas reject bind parameters, so the generated number is
+// formatted directly into the statement.
+func seedInstanceID(ctx context.Context, db *sql.DB) (string, error) {
+	var ver int64
+	if err := db.QueryRowContext(ctx, `PRAGMA user_version`).Scan(&ver); err != nil {
+		return "", fmt.Errorf("read store instance id: %w", err)
+	}
+	if ver == 0 {
+		var b [4]byte
+		// 31 random bits, not 32: the driver silently ignores PRAGMA writes
+		// of values above 2^31-1, and 0 means "unset".
+		for ver == 0 {
+			if _, err := rand.Read(b[:]); err != nil {
+				return "", fmt.Errorf("generate store instance id: %w", err)
+			}
+			ver = int64(binary.BigEndian.Uint32(b[:]) & 0x7fffffff)
+		}
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("PRAGMA user_version = %d", ver)); err != nil {
+			return "", fmt.Errorf("persist store instance id: %w", err)
+		}
+	}
+	return fmt.Sprintf("%08x", uint32(ver)), nil
 }
 
 // New opens a SQLite store at path. An empty path creates an in-memory store.
@@ -167,7 +205,12 @@ func New(path string) (*Store, error) {
 		db.Close()
 		return nil, err
 	}
-	return &Store{db: db, inMemory: !diskFile}, nil
+	instanceID, err := seedInstanceID(ctx, db)
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+	return &Store{db: db, inMemory: !diskFile, instanceID: instanceID}, nil
 }
 
 func runMigrations(ctx context.Context, db *sql.DB) error {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -414,3 +414,41 @@ func TestStore_NewFileUsesWAL(t *testing.T) {
 		t.Fatalf("journal_mode = %q, want wal", mode)
 	}
 }
+
+// TestStore_InstanceID proves the ID is seeded at open (via PRAGMA
+// user_version), stable across reopens of the same file, and distinct for a
+// recreated or different database — the signal capture storage uses to detect
+// restarting ids.
+func TestStore_InstanceID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "activity.sqlite")
+	s1, err := New(path)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	id1 := s1.InstanceID()
+	if id1 == "" {
+		t.Fatal("InstanceID is empty")
+	}
+	if again := s1.InstanceID(); again != id1 {
+		t.Fatalf("second InstanceID = %q, want %q", again, id1)
+	}
+	s1.Close()
+
+	s2, err := New(path)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer s2.Close()
+	if id2 := s2.InstanceID(); id2 != id1 {
+		t.Fatalf("reopened InstanceID = %q, want %q", id2, id1)
+	}
+
+	s3, err := New(filepath.Join(t.TempDir(), "other.sqlite"))
+	if err != nil {
+		t.Fatalf("New other: %v", err)
+	}
+	defer s3.Close()
+	if id3 := s3.InstanceID(); id3 == id1 {
+		t.Fatal("distinct databases share an InstanceID")
+	}
+}


### PR DESCRIPTION
Optionally store and load request captures from files on disk.

Functionality is gated by the `store.captureDir` setting - if it's empty, no files are stored on disk.
This PR also introduces a `store.captureMaxMB` setting which limits how much disk storage the capture files can use.

Happy to make any further changes based on feedback.