### PR TITLE
tailcat: update to v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mostlygeek/llama-swap
 
-go 1.27.0
+go 1.27.1
 
 require (
 	github.com/billziss-gh/golib v0.2.0
@@ -15,14 +15,14 @@ require (
 	github.com/pressly/goose/v3 v3.27.2
 	github.com/shirou/gopsutil/v4 v4.26.4
 	github.com/stretchr/testify v1.11.1
-	github.com/tailscale/tailcat v0.4.0
+	github.com/tailscale/tailcat v0.6.0
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/yusufpapurcu/wmi v1.2.4
 	golang.org/x/sys v0.47.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.53.0
-	tailscale.com v1.103.0-pre.0.20260830144538-72780705eda8
+	tailscale.com v1.103.0-pre.0.20260904030409-31d8badb3bfb
 )
 
 require (
@@ -103,7 +103,7 @@ require (
 	github.com/tailscale/hujson v0.0.0-20260302212456-ecc657c15afd // indirect
 	github.com/tailscale/peercred v0.0.0-20250107143737-35a0c7bd7edc // indirect
 	github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 // indirect
-	github.com/tailscale/wireguard-go v0.0.0-20260821191448-23d18d66172c // indirect
+	github.com/tailscale/wireguard-go v0.0.0-20260904023712-e855235c55a2 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -296,12 +296,16 @@ github.com/tailscale/peercred v0.0.0-20250107143737-35a0c7bd7edc h1:24heQPtnFR+y
 github.com/tailscale/peercred v0.0.0-20250107143737-35a0c7bd7edc/go.mod h1:f93CXfllFsO9ZQVq+Zocb1Gp4G5Fz0b0rXHLOzt/Djc=
 github.com/tailscale/tailcat v0.4.0 h1:WA8QIBcnn+x7BBmay3mPY+EeOp14RTQr4Qv1Df1GOxU=
 github.com/tailscale/tailcat v0.4.0/go.mod h1:ehG1UYhg+wPqPe8rlpmSyt9O+IMkBoxwA819l6qnM8Y=
+github.com/tailscale/tailcat v0.6.0 h1:q81gzzZpmitF9D87GHDqb36nLXSmwYO5gm/97+b2xMM=
+github.com/tailscale/tailcat v0.6.0/go.mod h1:QDtlF/V4jhC/EcZIB7nc8NaHelAN2BnllV9d/pQHyM8=
 github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 h1:UBPHPtv8+nEAy2PD8RyAhOYvau1ek0HDJqLS/Pysi14=
 github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976/go.mod h1:agQPE6y6ldqCOui2gkIh7ZMztTkIQKH049tv8siLuNQ=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 h1:l10Gi6w9jxvinoiq15g8OToDdASBni4CyJOdHY1Hr8M=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
 github.com/tailscale/wireguard-go v0.0.0-20260821191448-23d18d66172c h1:rjqTtbumXpM5B1UR7u+dsOaI9wRetOfIDan5kJJrgn8=
 github.com/tailscale/wireguard-go v0.0.0-20260821191448-23d18d66172c/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
+github.com/tailscale/wireguard-go v0.0.0-20260904023712-e855235c55a2 h1:nRCnARSGqRvSAK9S+vbH87dMykfv2vWwx6kb8rw9Ayk=
+github.com/tailscale/wireguard-go v0.0.0-20260904023712-e855235c55a2/go.mod h1:rUelGmuK4UnSJYM5gl5Mknp6YbwwcL8+VAPMhNYe+jg=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e h1:zOGKqN5D5hHhiYUp091JqK7DPCqSARyUfduhGUY8Bek=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e/go.mod h1:orPd6JZXXRyuDusYilywte7k094d7dycXXU5YnWsrwg=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
@@ -453,3 +457,5 @@ software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
 tailscale.com v1.103.0-pre.0.20260830144538-72780705eda8 h1:Ow72mYrStZyFA3kwBBACYJZ5EkicN7fc3IEQh/U7HBA=
 tailscale.com v1.103.0-pre.0.20260830144538-72780705eda8/go.mod h1:0FUeNgU+WylKFtsg4LOZQxceO16WyN9YjvrxmUiilbs=
+tailscale.com v1.103.0-pre.0.20260904030409-31d8badb3bfb h1:leFXEBE/Kgu/+RA+Zlfk2rgCQKc+YOL2JTBwjdTQHx4=
+tailscale.com v1.103.0-pre.0.20260904030409-31d8badb3bfb/go.mod h1:kDCPNk+EmNrMykwEddg757aH43nuhiPv/w58IfUeSQM=

--- a/internal/config/tailcat_test.go
+++ b/internal/config/tailcat_test.go
@@ -15,7 +15,7 @@ import (
 func testTailcatBlob() string {
 	private := tailcat.NewPrivateKey()
 	private.Public.RegionID = 1
-	return string(private.Public.ConnBlob())
+	return string(private.Public.Addr())
 }
 
 func writeTailcatKey(t *testing.T) string {

--- a/internal/router/peer_test.go
+++ b/internal/router/peer_test.go
@@ -747,7 +747,7 @@ func TestNewPeer_CustomTimeouts(t *testing.T) {
 func TestNewPeer_TailcatTransportDisablesEnvironmentProxyAndCleansUp(t *testing.T) {
 	private := tailcat.NewPrivateKey()
 	private.Public.RegionID = 1
-	blob := private.Public.ConnBlob()
+	blob := private.Public.Addr()
 	cfg, err := config.LoadConfigFromReader(strings.NewReader(`
 models: {}
 peers:

--- a/internal/tailcat/transport.go
+++ b/internal/tailcat/transport.go
@@ -69,7 +69,7 @@ func LoadPrivateKey(path string, requireRegion bool) (*PrivateKey, error) {
 	if requireRegion && pk.Public.RegionID == 0 && len(pk.Public.Region) == 0 {
 		return nil, fmt.Errorf("parse %q as Tailcat server key: relay region is missing", path)
 	}
-	if _, err := tailcatlib.ParseConnBlob(pk.Public.ConnBlob()); err != nil {
+	if _, err := tailcatlib.ParseAddr(pk.Public.Addr()); err != nil {
 		return nil, fmt.Errorf("parse %q as Tailcat PrivateKey JSON: invalid public connection data: %w", path, err)
 	}
 	return &PrivateKey{value: pk}, nil
@@ -86,7 +86,7 @@ func (p *PrivateKey) ConnectionBlob() string {
 	if p == nil {
 		return ""
 	}
-	return string(p.value.Public.ConnBlob())
+	return string(p.value.Public.Addr())
 }
 
 func ValidateNodePublic(raw string) (string, error) {
@@ -101,12 +101,12 @@ func ValidateNodePublic(raw string) (string, error) {
 }
 
 func ValidateConnectionBlob(blob string) error {
-	_, err := tailcatlib.ParseConnBlob(tailcatlib.ConnBlob(blob))
+	_, err := tailcatlib.ParseAddr(tailcatlib.Addr(blob))
 	return err
 }
 
 func ConnectionDestination(blob string) (string, error) {
-	ci, err := tailcatlib.ParseConnBlob(tailcatlib.ConnBlob(blob))
+	ci, err := tailcatlib.ParseAddr(tailcatlib.Addr(blob))
 	if err != nil {
 		return "", err
 	}
@@ -197,9 +197,11 @@ type Server struct {
 }
 
 type ephemeralServerIdentity struct {
-	private key.NodePrivate
-	region  *tailcfg.DERPRegion
-	blob    string
+	private             key.NodePrivate
+	presharedKey        tailcatlib.PresharedKey
+	disablePresharedKey bool
+	region              *tailcfg.DERPRegion
+	blob                string
 }
 
 var processServerIdentity struct {
@@ -214,13 +216,13 @@ func Start(ctx context.Context, opts ServerOptions) (*Server, error) {
 		return nil, errors.New("tailcat handler is required")
 	}
 
-	private, region, blob, err := resolveServerIdentity(ctx, opts.PrivateKey)
+	identity, err := resolveServerIdentity(ctx, opts.PrivateKey)
 	if err != nil {
 		return nil, err
 	}
 
 	ln := newChannelListener()
-	runtime := &Server{ln: ln, blob: blob}
+	runtime := &Server{ln: ln, blob: identity.blob}
 	allowed := make([]key.NodePublic, 0, len(opts.AllowedClients))
 	for _, raw := range opts.AllowedClients {
 		var public key.NodePublic
@@ -231,11 +233,13 @@ func Start(ctx context.Context, opts ServerOptions) (*Server, error) {
 		allowed = append(allowed, public)
 	}
 	tc := &tailcatlib.Server{
-		Key:            private,
-		Region:         region,
-		AllowedClients: allowed,
-		ServedTCPPorts: []filter.PortRange{{First: HTTPPort, Last: HTTPPort}},
-		Logf:           logFunc(opts.Logger, "tailcat server: "),
+		Key:                 identity.private,
+		PresharedKey:        identity.presharedKey,
+		DisablePresharedKey: identity.disablePresharedKey,
+		Region:              identity.region,
+		AllowedClients:      allowed,
+		ServedTCPPorts:      []filter.PortRange{{First: HTTPPort, Last: HTTPPort}},
+		Logf:                logFunc(opts.Logger, "tailcat server: "),
 	}
 	tc.OnTCP = func(port uint16) func(net.Conn) {
 		if port != HTTPPort {
@@ -269,12 +273,13 @@ func Start(ctx context.Context, opts ServerOptions) (*Server, error) {
 	if opts.PrivateKey == nil {
 		processServerIdentity.Lock()
 		if processServerIdentity.value == nil {
-			resolved, parseErr := tailcatlib.ParseConnBlob(tc.ConnBlob())
+			resolved, parseErr := tailcatlib.ParseAddr(tc.TailcatAddr())
 			if parseErr == nil && len(resolved.Region) > 0 {
 				processServerIdentity.value = &ephemeralServerIdentity{
-					private: private,
-					region:  resolved.Region[0],
-					blob:    string(tc.ConnBlob()),
+					private:      identity.private,
+					presharedKey: identity.presharedKey,
+					region:       resolved.Region[0],
+					blob:         string(tc.TailcatAddr()),
 				}
 				runtime.blob = processServerIdentity.value.blob
 			}
@@ -282,7 +287,7 @@ func Start(ctx context.Context, opts ServerOptions) (*Server, error) {
 		processServerIdentity.Unlock()
 	}
 	if runtime.blob == "" {
-		runtime.blob = string(tc.ConnBlob())
+		runtime.blob = string(tc.TailcatAddr())
 	}
 	runtime.http = newHTTPServer(opts)
 	go func() {
@@ -306,40 +311,52 @@ func newHTTPServer(opts ServerOptions) *http.Server {
 	}
 }
 
-func resolveServerIdentity(ctx context.Context, saved *PrivateKey) (key.NodePrivate, *tailcfg.DERPRegion, string, error) {
+func resolveServerIdentity(ctx context.Context, saved *PrivateKey) (ephemeralServerIdentity, error) {
 	if saved != nil {
 		ci := saved.value.Public
 		if err := ci.Expand(ctx, tailcatlib.ExpandForServer); err != nil {
-			return key.NodePrivate{}, nil, "", fmt.Errorf("resolve Tailcat server relay: %w", err)
+			return ephemeralServerIdentity{}, fmt.Errorf("resolve Tailcat server relay: %w", err)
 		}
 		if len(ci.Region) == 0 {
-			return key.NodePrivate{}, nil, "", errors.New("resolve Tailcat server relay: no region selected")
+			return ephemeralServerIdentity{}, errors.New("resolve Tailcat server relay: no region selected")
 		}
 		blob := ""
 		if saved.value.Public.RegionID != -1 {
-			blob = string(saved.value.Public.ConnBlob())
+			blob = string(saved.value.Public.Addr())
 		}
-		return saved.value.Private, ci.Region[0], blob, nil
+		return ephemeralServerIdentity{
+			private:             saved.value.Private,
+			presharedKey:        saved.value.Public.PresharedKey,
+			disablePresharedKey: saved.value.Public.PresharedKey.IsZero(),
+			region:              ci.Region[0],
+			blob:                blob,
+		}, nil
 	}
 
 	processServerIdentity.Lock()
 	defer processServerIdentity.Unlock()
 	if cached := processServerIdentity.value; cached != nil {
-		return cached.private, cached.region, cached.blob, nil
+		return *cached, nil
 	}
 	private := key.NewNode()
+	presharedKey := tailcatlib.NewPresharedKey()
 	ci := tailcatlib.ConnInfo{
 		ServerPublic:      tailcatlib.NodePublic{NodePublic: private.Public()},
 		ServerDiscoPublic: tailcatlib.DiscoPublicForNode(private),
+		PresharedKey:      presharedKey,
 		RegionID:          -1,
 	}
 	if err := ci.Expand(ctx, tailcatlib.ExpandForServer); err != nil {
-		return key.NodePrivate{}, nil, "", fmt.Errorf("select Tailcat server relay: %w", err)
+		return ephemeralServerIdentity{}, fmt.Errorf("select Tailcat server relay: %w", err)
 	}
 	if len(ci.Region) == 0 {
-		return key.NodePrivate{}, nil, "", errors.New("select Tailcat server relay: no region selected")
+		return ephemeralServerIdentity{}, errors.New("select Tailcat server relay: no region selected")
 	}
-	return private, ci.Region[0], "", nil
+	return ephemeralServerIdentity{
+		private:      private,
+		presharedKey: presharedKey,
+		region:       ci.Region[0],
+	}, nil
 }
 
 func resolveRemoteNodeKey(server *tailcatlib.Server, addr net.Addr) (key.NodePublic, bool) {
@@ -473,7 +490,7 @@ func NewClient(peerID, blob string, saved *PrivateKey, logger Logger) *Client {
 		processPeerKeys.Unlock()
 	}
 	return &Client{client: &tailcatlib.Client{
-		Server: tailcatlib.ConnBlob(blob),
+		Server: tailcatlib.Addr(blob),
 		Key:    private,
 		Logf:   logFunc(logger, "tailcat client "+peerID+": "),
 	}}

--- a/internal/tailcat/transport_test.go
+++ b/internal/tailcat/transport_test.go
@@ -157,14 +157,34 @@ func TestTailcatTransport_LocalDERPHTTP(t *testing.T) {
 	}
 	transport := &http.Transport{DialContext: client.DialContext}
 	httpClient := &http.Client{Transport: transport}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://server.tailcat/health", nil)
-	if err != nil {
-		t.Fatal(err)
+	var resp *http.Response
+	var responseCancel context.CancelFunc
+	for {
+		// A successful Ping means the peers authenticated, but the first TCP
+		// flow can still race the local DERP connection coming fully online.
+		// Keep each attempt short so slow CI runners can retry within the
+		// test's overall deadline.
+		requestCtx, requestCancel := context.WithTimeout(ctx, 2*time.Second)
+		req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, "http://server.tailcat/health", nil)
+		if err == nil {
+			resp, err = httpClient.Do(req)
+		}
+		if err == nil {
+			responseCancel = requestCancel
+			break
+		}
+		requestCancel()
+		httpClient.CloseIdleConnections()
+		if ctx.Err() != nil {
+			t.Fatalf("HTTP request over Tailcat: %v", err)
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("HTTP request over Tailcat: %v", err)
+		case <-time.After(100 * time.Millisecond):
+		}
 	}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		t.Fatalf("HTTP request over Tailcat: %v", err)
-	}
+	defer responseCancel()
 	body, err := io.ReadAll(resp.Body)
 	resp.Body.Close()
 	if err != nil {

--- a/internal/tailcat/transport_test.go
+++ b/internal/tailcat/transport_test.go
@@ -97,6 +97,7 @@ func TestTailcatTransport_LocalDERPHTTP(t *testing.T) {
 		Public: tailcatlib.ConnInfo{
 			ServerPublic:      tailcatlib.NodePublic{NodePublic: serverPrivate.Public()},
 			ServerDiscoPublic: tailcatlib.DiscoPublicForNode(serverPrivate),
+			PresharedKey:      tailcatlib.NewPresharedKey(),
 			Region:            []*tailcfg.DERPRegion{region},
 		},
 	}}
@@ -116,6 +117,9 @@ func TestTailcatTransport_LocalDERPHTTP(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("Start: %v", err)
+	}
+	if !server.tailcat.PresharedKey.Equal(serverKey.value.Public.PresharedKey) {
+		t.Fatal("server did not retain the persistent key's pre-shared key")
 	}
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
Update tailcat to v0.6.0 so tailcat addresses include a wireguard preshared key. 

- Requires tailcat clients be v0.6.0+. 
- ref: https://github.com/tailscale/tailcat/pull/85