### PR TITLE
ui/playground: show live generation stats in Chat

### DIFF
--- a/ui/src/components/playground/ChatInterface.svelte
+++ b/ui/src/components/playground/ChatInterface.svelte
@@ -18,6 +18,7 @@
   import { Textarea } from "$lib/components/ui/textarea/index.js";
   import { Label } from "$lib/components/ui/label/index.js";
   import * as Select from "$lib/components/ui/select/index.js";
+  import * as Switch from "$lib/components/ui/switch/index.js";
   import * as Dialog from "$lib/components/ui/dialog/index.js";
   import { X } from "@lucide/svelte";
 
@@ -26,6 +27,7 @@
   const temperatureStore = persistentStore<number>("playground-temperature", 0.7);
   const endpointStore = persistentStore<Endpoint>("playground-endpoint", "v1/chat/completions");
   const maxTokensStore = persistentStore<number>("playground-max-tokens", 4096);
+  const showStatsStore = persistentStore<boolean>("playground-show-stats", true);
 
   // This tab was briefly the docs agent; that is the Docs tab now. Anyone who
   // used it in between has the agent's prompt persisted here, which is not a
@@ -224,9 +226,11 @@
   /**
    * The stats a message is shown with. An assistant turn carries its own; a
    * user message borrows the turn it prompted, so its prompt-processing line
-   * sits right under it.
+   * sits right under it. Nothing when stats are switched off in settings;
+   * they are still tracked, so switching them back on shows past turns too.
    */
   function statsFor(idx: number) {
+    if (!$showStatsStore) return undefined;
     const msg = messages[idx];
     if (msg.role === "assistant") return msg.stats;
     const next = messages[idx + 1];
@@ -235,7 +239,7 @@
 
   /** True for the streaming assistant turn and the user message that prompted it. */
   function statsLiveFor(idx: number) {
-    return isStreaming && idx >= messages.length - 2;
+    return $showStatsStore && isStreaming && idx >= messages.length - 2;
   }
 
   async function regenerateFromIndex(idx: number) {
@@ -437,6 +441,15 @@
           <Label class="mb-1" for="max-tokens">Max Tokens</Label>
           <Input id="max-tokens" type="number" min="1" bind:value={$maxTokensStore} disabled={isStreaming} />
           <p class="text-muted-foreground mt-1 text-xs">Required for /v1/messages.</p>
+        </div>
+        <div class="flex items-start justify-between gap-4">
+          <div>
+            <Label for="show-stats">Show generation stats</Label>
+            <p class="text-muted-foreground mt-1 text-xs">
+              Tokens, time and speed for each turn, with a detailed breakdown under every reply.
+            </p>
+          </div>
+          <Switch.Root id="show-stats" checked={$showStatsStore} onCheckedChange={(v) => showStatsStore.set(v)} />
         </div>
       </div>
 

--- a/ui/src/components/playground/ChatInterface.svelte
+++ b/ui/src/components/playground/ChatInterface.svelte
@@ -67,7 +67,17 @@
   let imageError = $state<string | null>(null);
 
   let userScrolledUp = $state(false);
-  let selectedContextLength = $derived($playgroundModels.find((m) => m.id === $selectedModelStore)?.context_length);
+
+  /**
+   * Context window of the model the next request goes to. Looked up when the
+   * turn starts and stored with its stats, so a later switch of the dropdown
+   * does not rewrite older turns. The selector also offers aliases, which are
+   * not model entries themselves, so those resolve through their model.
+   */
+  function selectedContextLength(): number | undefined {
+    const id = $selectedModelStore;
+    return $playgroundModels.find((m) => m.id === id || m.aliases?.includes(id))?.context_length;
+  }
 
   $effect(() => {
     playgroundStores.chatStreaming.set(isStreaming);
@@ -242,7 +252,7 @@
 
     // Stats are refreshed on every chunk and, so the clocks keep moving while
     // the backend is quiet (prompt processing, a slow token), on a timer too.
-    const tracker = startTracking(performance.now());
+    const tracker = startTracking(performance.now(), selectedContextLength());
     const ticker = window.setInterval(() => {
       patchLast({ stats: currentStats(tracker, performance.now(), true) });
     }, 200);
@@ -459,7 +469,6 @@
             isReasoning={isReasoning && idx === messages.length - 1 && message.role === "assistant"}
             stats={statsFor(idx)}
             statsLive={statsLiveFor(idx)}
-            contextLength={selectedContextLength}
             onEdit={message.role === "user" ? (newContent) => editMessage(idx, newContent) : undefined}
             onRegenerate={message.role === "assistant" && idx > 0 && messages[idx - 1].role === "user"
               ? () => regenerateFromIndex(idx - 1)

--- a/ui/src/components/playground/ChatInterface.svelte
+++ b/ui/src/components/playground/ChatInterface.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
   import { get } from "svelte/store";
-  import { hasListedModels } from "../../stores/api";
+  import { hasListedModels, playgroundModels } from "../../stores/api";
   import { persistentStore } from "../../stores/persistent";
   import { streamChatCompletion, type Endpoint } from "../../lib/chatApi";
+  import { currentStats, markCancelled, startTracking, trackChunk } from "../../lib/generationStats";
   import { DOCS_AGENT_SYSTEM_PROMPT } from "../../lib/prompts/docsAgent";
   import { playgroundStores } from "../../stores/playgroundActivity";
   import type { ChatMessage, ContentPart } from "../../lib/types";
@@ -66,6 +67,7 @@
   let imageError = $state<string | null>(null);
 
   let userScrolledUp = $state(false);
+  let selectedContextLength = $derived($playgroundModels.find((m) => m.id === $selectedModelStore)?.context_length);
 
   $effect(() => {
     playgroundStores.chatStreaming.set(isStreaming);
@@ -209,6 +211,23 @@
     return out;
   }
 
+  /**
+   * The stats a message is shown with. An assistant turn carries its own; a
+   * user message borrows the turn it prompted, so its prompt-processing line
+   * sits right under it.
+   */
+  function statsFor(idx: number) {
+    const msg = messages[idx];
+    if (msg.role === "assistant") return msg.stats;
+    const next = messages[idx + 1];
+    return next?.role === "assistant" ? next.stats : undefined;
+  }
+
+  /** True for the streaming assistant turn and the user message that prompted it. */
+  function statsLiveFor(idx: number) {
+    return isStreaming && idx >= messages.length - 2;
+  }
+
   async function regenerateFromIndex(idx: number) {
     // Remove all messages after the edited user message
     messages = messages.slice(0, idx + 1);
@@ -221,6 +240,13 @@
     reasoningStartTime = 0;
     abortController = new AbortController();
 
+    // Stats are refreshed on every chunk and, so the clocks keep moving while
+    // the backend is quiet (prompt processing, a slow token), on a timer too.
+    const tracker = startTracking(performance.now());
+    const ticker = window.setInterval(() => {
+      patchLast({ stats: currentStats(tracker, performance.now(), true) });
+    }, 200);
+
     try {
       const stream = streamChatCompletion(
         $selectedModelStore,
@@ -230,13 +256,19 @@
       );
 
       for await (const chunk of stream) {
+        const now = performance.now();
+        trackChunk(tracker, chunk, now);
         if (chunk.done) break;
         if (chunk.reasoning_content) appendDelta("reasoning", chunk.reasoning_content);
         if (chunk.content) appendDelta("content", chunk.content);
+        patchLast({ stats: currentStats(tracker, now, true) });
       }
     } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") markCancelled(tracker);
       handleTurnError(error);
     } finally {
+      window.clearInterval(ticker);
+      patchLast({ stats: currentStats(tracker, performance.now(), false) });
       isStreaming = false;
       isReasoning = false;
       abortController = null;
@@ -425,6 +457,9 @@
             reasoningTimeMs={message.reasoningTimeMs}
             isStreaming={isStreaming && idx === messages.length - 1 && message.role === "assistant"}
             isReasoning={isReasoning && idx === messages.length - 1 && message.role === "assistant"}
+            stats={statsFor(idx)}
+            statsLive={statsLiveFor(idx)}
+            contextLength={selectedContextLength}
             onEdit={message.role === "user" ? (newContent) => editMessage(idx, newContent) : undefined}
             onRegenerate={message.role === "assistant" && idx > 0 && messages[idx - 1].role === "user"
               ? () => regenerateFromIndex(idx - 1)

--- a/ui/src/components/playground/ChatMessage.svelte
+++ b/ui/src/components/playground/ChatMessage.svelte
@@ -5,12 +5,14 @@
   import { Button } from "$lib/components/ui/button/index.js";
   import { Textarea } from "$lib/components/ui/textarea/index.js";
   import { getTextContent, getImageUrls } from "../../lib/types";
-  import type { ContentPart } from "../../lib/types";
+  import type { ContentPart, GenerationStats } from "../../lib/types";
   import { formatDuration } from "../../lib/format";
   import { copyText } from "../../lib/clipboard";
   import { isSubmitEnter } from "../../lib/ime";
   import ToolCallCard from "./ToolCallCard.svelte";
   import AgentWork from "./AgentWork.svelte";
+  import MessageStats from "./MessageStats.svelte";
+  import StatsBreakdown from "./StatsBreakdown.svelte";
   import type { WorkItem } from "./AgentWork.svelte";
 
   interface Props {
@@ -22,6 +24,17 @@
     isReasoning?: boolean;
     toolResults?: ToolWorkResult[];
     workItems?: WorkItem[];
+    /**
+     * Stats of the request this message belongs to: for an assistant message
+     * its own turn, for a user message the turn it prompted. Prompt processing
+     * is shown under the user message, thinking in the Reasoning header, and
+     * the answer under the reply.
+     */
+    stats?: GenerationStats;
+    /** That request is still in flight, so the stats are updating. */
+    statsLive?: boolean;
+    /** The model's context window, for the stats breakdown. */
+    contextLength?: number;
     onEdit?: (newContent: string) => void;
     onRegenerate?: () => void;
   }
@@ -45,6 +58,9 @@
     isReasoning = false,
     toolResults = [],
     workItems = [],
+    stats,
+    statsLive = false,
+    contextLength,
     onEdit,
     onRegenerate,
   }: Props = $props();
@@ -57,6 +73,21 @@
     role === "assistant" && !hasMessageText && !hasImages && Boolean(reasoning_content || workItems.length)
   );
   let canEdit = $derived(onEdit !== undefined && !hasImages);
+  let showActions = $derived(!isStreaming && hasMessageText);
+  // The footer shows the whole turn in one line; a chevron expands it into
+  // the detailed table. While the model is still thinking the footer would
+  // only repeat the live Reasoning header, so it waits for the answer; once
+  // the turn is over it shows even for a thinking-only turn, since that is
+  // where the stop reason and the details live.
+  let showGenerationStats = $derived(
+    stats?.generation?.tokens !== undefined && !(isStreaming && stats?.reasoning && !stats?.answer)
+  );
+  // Per message and deliberately not persisted: every new reply starts
+  // collapsed. The chat keys its list by position, so regenerating a reply
+  // reuses this component and keeps the choice made for it.
+  let statsExpanded = $state(false);
+  // The user message's prompt line pulses until the first generated token.
+  let waitingForFirstToken = $derived(statsLive && stats?.generation?.tokens === undefined);
 
   let streamingCache = createStreamingCache();
   let renderedParts = $derived.by(() => {
@@ -159,7 +190,7 @@
   }
 </script>
 
-<div class="flex {role === 'user' ? 'justify-end' : 'justify-start'}" class:mb-4={!isReasoningOnly}>
+<div class="flex flex-col {role === 'user' ? 'items-end' : 'items-start'}" class:mb-4={!isReasoningOnly}>
   <div
     class="group relative {role === 'user'
       ? 'bg-primary text-primary-foreground max-w-[85%] rounded-lg px-4 py-2'
@@ -183,9 +214,13 @@
             {/if}
             <Brain class="size-4" />
             <span class="font-medium">Reasoning</span>
-            <span class="text-muted-foreground ml-2">
-              ({reasoning_content.length} chars{#if !isReasoning && reasoningTimeMs > 0}, {formatDuration(reasoningTimeMs, { precision: 1, subSecondMs: true })}{/if})
-            </span>
+            {#if stats?.reasoning}
+              <MessageStats phase={stats.reasoning} kind="thinking" class="ml-2 font-normal" />
+            {:else}
+              <span class="text-muted-foreground ml-2">
+                ({reasoning_content.length} chars{#if !isReasoning && reasoningTimeMs > 0}, {formatDuration(reasoningTimeMs, { precision: 1, subSecondMs: true })}{/if})
+              </span>
+            {/if}
             {#if isReasoning}
               <span class="text-muted-foreground ml-auto flex items-center gap-1">
                 <span class="bg-primary h-1.5 w-1.5 animate-pulse rounded-full"></span>
@@ -244,35 +279,58 @@
           {/if}
         </div>
       {/if}
-      {#if !isStreaming && hasMessageText}
-        <div class="mt-2 flex gap-1 border-t pt-1">
-          {#if onRegenerate}
-            <Button variant="ghost" size="icon-xs" class="text-muted-foreground" onclick={onRegenerate} title="Regenerate response">
-              <RefreshCw />
-            </Button>
-          {/if}
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            class="text-muted-foreground"
-            onclick={copyToClipboard}
-            title={copied ? "Copied!" : "Copy to clipboard"}
-          >
-            {#if copied}
-              <Check class="text-success" />
-            {:else}
-              <Copy />
+      {#if showActions || showGenerationStats}
+        <div class="mt-2 border-t pt-1">
+          <div class="flex items-center gap-1">
+            {#if showActions && onRegenerate}
+              <Button variant="ghost" size="icon-xs" class="text-muted-foreground" onclick={onRegenerate} title="Regenerate response">
+                <RefreshCw />
+              </Button>
             {/if}
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            class={showRaw ? "text-primary" : "text-muted-foreground"}
-            onclick={() => showRaw = !showRaw}
-            title={showRaw ? "Show rendered" : "Show raw"}
-          >
-            <Code />
-          </Button>
+            {#if showActions}
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                class="text-muted-foreground"
+                onclick={copyToClipboard}
+                title={copied ? "Copied!" : "Copy to clipboard"}
+              >
+                {#if copied}
+                  <Check class="text-success" />
+                {:else}
+                  <Copy />
+                {/if}
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                class={showRaw ? "text-primary" : "text-muted-foreground"}
+                onclick={() => showRaw = !showRaw}
+                title={showRaw ? "Show rendered" : "Show raw"}
+              >
+                <Code />
+              </Button>
+            {/if}
+            {#if showGenerationStats && stats}
+              <span class="ml-auto inline-flex items-center gap-1 pr-1">
+                <button
+                  class="text-muted-foreground hover:text-foreground flex items-center"
+                  onclick={() => statsExpanded = !statsExpanded}
+                  title={statsExpanded ? "Hide detailed stats" : "Show detailed stats"}
+                >
+                  {#if statsExpanded}
+                    <ChevronDown class="size-3.5" />
+                  {:else}
+                    <ChevronRight class="size-3.5" />
+                  {/if}
+                </button>
+                <MessageStats phase={stats.generation} kind="generation" />
+              </span>
+            {/if}
+          </div>
+          {#if showGenerationStats && stats && statsExpanded}
+            <StatsBreakdown {stats} {contextLength} />
+          {/if}
         </div>
       {/if}
     {:else}
@@ -318,6 +376,15 @@
       {/if}
     {/if}
   </div>
+  {#if role === "user"}
+    <MessageStats
+      phase={stats?.prompt}
+      kind="prompt"
+      waiting={waitingForFirstToken}
+      cached={stats?.cachedTokens}
+      class="mt-1 pr-1"
+    />
+  {/if}
 </div>
 
 <!-- Full-size image modal -->

--- a/ui/src/components/playground/ChatMessage.svelte
+++ b/ui/src/components/playground/ChatMessage.svelte
@@ -33,8 +33,6 @@
     stats?: GenerationStats;
     /** That request is still in flight, so the stats are updating. */
     statsLive?: boolean;
-    /** The model's context window, for the stats breakdown. */
-    contextLength?: number;
     onEdit?: (newContent: string) => void;
     onRegenerate?: () => void;
   }
@@ -60,7 +58,6 @@
     workItems = [],
     stats,
     statsLive = false,
-    contextLength,
     onEdit,
     onRegenerate,
   }: Props = $props();
@@ -329,7 +326,7 @@
             {/if}
           </div>
           {#if showGenerationStats && stats && statsExpanded}
-            <StatsBreakdown {stats} {contextLength} />
+            <StatsBreakdown {stats} />
           {/if}
         </div>
       {/if}

--- a/ui/src/components/playground/ChatMessage.svelte
+++ b/ui/src/components/playground/ChatMessage.svelte
@@ -27,8 +27,8 @@
     /**
      * Stats of the request this message belongs to: for an assistant message
      * its own turn, for a user message the turn it prompted. Prompt processing
-     * is shown under the user message, thinking in the Reasoning header, and
-     * the answer under the reply.
+     * is shown under the user message, reasoning in the Reasoning header, and
+     * the response under the reply.
      */
     stats?: GenerationStats;
     /** That request is still in flight, so the stats are updating. */
@@ -212,7 +212,7 @@
             <Brain class="size-4" />
             <span class="font-medium">Reasoning</span>
             {#if stats?.reasoning}
-              <MessageStats phase={stats.reasoning} kind="thinking" class="ml-2 font-normal" />
+              <MessageStats phase={stats.reasoning} kind="reasoning" class="ml-2 font-normal" />
             {:else}
               <span class="text-muted-foreground ml-2">
                 ({reasoning_content.length} chars{#if !isReasoning && reasoningTimeMs > 0}, {formatDuration(reasoningTimeMs, { precision: 1, subSecondMs: true })}{/if})

--- a/ui/src/components/playground/MessageStats.svelte
+++ b/ui/src/components/playground/MessageStats.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import { Clock, Coins, Database, Gauge } from "@lucide/svelte";
+  import type { PhaseStats } from "../../lib/types";
+  import { formatDuration, formatSpeed } from "../../lib/format";
+  import { DETAIL_TOOLTIP, PHASE_LABEL, PHASE_TOOLTIP, phaseValueTooltip, type PhaseKind } from "../../lib/statsTooltips";
+
+  /**
+   * One line of token / time / speed for a single phase of a turn: prompt
+   * processing under the user message, thinking in the Reasoning header, and
+   * the generation under the reply, mirroring llama.cpp's web UI. Every value
+   * carries its own tooltip saying what it measures.
+   */
+  interface Props {
+    phase?: PhaseStats;
+    kind: PhaseKind;
+    /** Print the phase name in front of the numbers, for rows that hold several phases. */
+    showLabel?: boolean;
+    /** Show a pulsing "processing prompt…" in front of the numbers. */
+    waiting?: boolean;
+    /** Prompt tokens served from cache, shown after the count when known. */
+    cached?: number;
+    class?: string;
+  }
+
+  let { phase, kind, showLabel = false, waiting = false, cached, class: className = "" }: Props = $props();
+
+  let tokens = $derived(phase?.tokens);
+  let ms = $derived(phase?.ms);
+  let speed = $derived(phase?.perSecond);
+  let approxTokens = $derived(Boolean(phase?.approxTokens));
+  let approxSpeed = $derived(approxTokens || Boolean(phase?.approxTimings));
+  let visible = $derived(tokens !== undefined || ms !== undefined);
+  let tip = $derived((metric: "tokens" | "time" | "speed") => (phase ? phaseValueTooltip(kind, metric, phase) : ""));
+</script>
+
+{#if visible}
+  <span class="text-muted-foreground inline-flex flex-wrap items-center gap-x-3 gap-y-1 text-xs tabular-nums {className}" data-stats={kind}>
+    {#if waiting}
+      <span class="flex items-center gap-1" title={DETAIL_TOOLTIP.waiting}>
+        <span class="bg-primary h-1.5 w-1.5 animate-pulse rounded-full"></span>
+        processing prompt…
+      </span>
+    {/if}
+    {#if showLabel}
+      <span class="font-medium" title={PHASE_TOOLTIP[kind]}>{PHASE_LABEL[kind]}</span>
+    {/if}
+    {#if tokens !== undefined}
+      <span class="flex items-center gap-1" title={tip("tokens")}>
+        <Coins class="size-3" />
+        {approxTokens ? "~" : ""}{tokens.toLocaleString()} tokens
+      </span>
+    {/if}
+    {#if cached}
+      <span class="flex items-center gap-1" title={DETAIL_TOOLTIP.cached}>
+        <Database class="size-3" />
+        {cached.toLocaleString()} cached
+      </span>
+    {/if}
+    {#if ms !== undefined}
+      <span class="flex items-center gap-1" title={tip("time")}>
+        <Clock class="size-3" />
+        {formatDuration(ms, { precision: 1, subSecondMs: true })}
+      </span>
+    {/if}
+    {#if speed !== undefined}
+      <span class="flex items-center gap-1" title={tip("speed")}>
+        <Gauge class="size-3" />
+        {approxSpeed ? "~" : ""}{formatSpeed(speed)}
+      </span>
+    {/if}
+  </span>
+{/if}

--- a/ui/src/components/playground/MessageStats.svelte
+++ b/ui/src/components/playground/MessageStats.svelte
@@ -6,7 +6,7 @@
 
   /**
    * One line of token / time / speed for a single phase of a turn: prompt
-   * processing under the user message, thinking in the Reasoning header, and
+   * processing under the user message, reasoning in the Reasoning header, and
    * the generation under the reply, mirroring llama.cpp's web UI. Every value
    * carries its own tooltip saying what it measures.
    */

--- a/ui/src/components/playground/StatsBreakdown.svelte
+++ b/ui/src/components/playground/StatsBreakdown.svelte
@@ -12,11 +12,10 @@
    */
   interface Props {
     stats: GenerationStats;
-    /** The model's context window, to show how much of it the turn used. */
-    contextLength?: number;
   }
 
-  let { stats, contextLength }: Props = $props();
+  let { stats }: Props = $props();
+  let contextLength = $derived(stats.contextLength);
 
   interface Row {
     kind: PhaseKind;

--- a/ui/src/components/playground/StatsBreakdown.svelte
+++ b/ui/src/components/playground/StatsBreakdown.svelte
@@ -8,7 +8,7 @@
    * throughput and time per token, then the details a benchmark cares about
    * (cache hits, draft acceptance, time to first token, context use, stop
    * reason). Backend-reported values are exact; browser measurements and the
-   * thinking/answer split carry a ~.
+   * reasoning/response split carry a ~.
    */
   interface Props {
     stats: GenerationStats;
@@ -33,8 +33,8 @@
       processed: stats.prompt.tokens !== undefined && cached > 0 ? stats.prompt.tokens - cached : undefined,
     });
     if (stats.reasoning && stats.answer) {
-      out.push({ kind: "thinking", phase: stats.reasoning });
-      out.push({ kind: "answer", phase: stats.answer });
+      out.push({ kind: "reasoning", phase: stats.reasoning });
+      out.push({ kind: "response", phase: stats.answer });
     }
     out.push({ kind: "generation", phase: stats.generation });
     return out;

--- a/ui/src/components/playground/StatsBreakdown.svelte
+++ b/ui/src/components/playground/StatsBreakdown.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+  import type { GenerationStats, PhaseStats } from "../../lib/types";
+  import { formatDuration, formatSpeed } from "../../lib/format";
+  import { DETAIL_TOOLTIP, PHASE_LABEL, PHASE_TOOLTIP, phaseValueTooltip, type PhaseKind } from "../../lib/statsTooltips";
+
+  /**
+   * The expert view of a turn's stats: one row per phase with tokens, time,
+   * throughput and time per token, then the details a benchmark cares about
+   * (cache hits, draft acceptance, time to first token, context use, stop
+   * reason). Backend-reported values are exact; browser measurements and the
+   * thinking/answer split carry a ~.
+   */
+  interface Props {
+    stats: GenerationStats;
+    /** The model's context window, to show how much of it the turn used. */
+    contextLength?: number;
+  }
+
+  let { stats, contextLength }: Props = $props();
+
+  interface Row {
+    kind: PhaseKind;
+    phase: PhaseStats;
+    /** Tokens the throughput was measured over, when not all of them. */
+    processed?: number;
+  }
+
+  let rows = $derived.by((): Row[] => {
+    const out: Row[] = [];
+    const cached = stats.cachedTokens ?? 0;
+    out.push({
+      kind: "prompt",
+      phase: stats.prompt,
+      processed: stats.prompt.tokens !== undefined && cached > 0 ? stats.prompt.tokens - cached : undefined,
+    });
+    if (stats.reasoning && stats.answer) {
+      out.push({ kind: "thinking", phase: stats.reasoning });
+      out.push({ kind: "answer", phase: stats.answer });
+    }
+    out.push({ kind: "generation", phase: stats.generation });
+    return out;
+  });
+
+  let contextUsed = $derived(
+    stats.prompt.tokens !== undefined && stats.generation.tokens !== undefined
+      ? stats.prompt.tokens + stats.generation.tokens
+      : undefined
+  );
+  let hasDraft = $derived((stats.draftTokens ?? 0) > 0);
+  let draftText = $derived.by(() => {
+    if (!hasDraft) return "";
+    let text = `${stats.draftTokens!.toLocaleString()} proposed`;
+    if (stats.draftAccepted !== undefined) {
+      const rate = ((stats.draftAccepted / stats.draftTokens!) * 100).toFixed(0);
+      text += `, ${stats.draftAccepted.toLocaleString()} accepted (${rate}%)`;
+    }
+    return text;
+  });
+  let approxAnywhere = $derived(
+    [stats.prompt, stats.generation, stats.reasoning, stats.answer].some((p) => p && (p.approxTokens || p.approxTimings))
+  );
+
+  const tokens = (n: number | undefined, approx: boolean) =>
+    n === undefined ? "–" : `${approx ? "~" : ""}${n.toLocaleString()}`;
+  const time = (ms: number | undefined) => (ms === undefined ? "–" : formatDuration(ms, { precision: 1, subSecondMs: true }));
+  // The ~ belongs to a value; a phase the backend said nothing about is just
+  // a dash.
+  const speed = (row: Row) => {
+    if (row.phase.perSecond === undefined) return "–";
+    const approx = row.phase.approxTokens || row.phase.approxTimings;
+    return `${approx ? "~" : ""}${formatSpeed(row.phase.perSecond)}`;
+  };
+  const perToken = (row: Row) => {
+    const n = row.processed ?? row.phase.tokens;
+    if (n === undefined || n <= 0 || row.phase.ms === undefined) return "–";
+    return `${(row.phase.ms / n).toFixed(1)} ms`;
+  };
+  const pct = (part: number, whole: number) => (whole > 0 ? `${((part / whole) * 100).toFixed(1)}%` : "");
+
+  let stopReason = $derived.by(() => {
+    switch (stats.finishReason) {
+      case undefined:
+        return undefined;
+      case "stop":
+        return "end of turn";
+      case "length":
+        return "max_tokens reached";
+      case "tool_calls":
+        return "tool call";
+      case "cancelled":
+        return "cancelled by you";
+      default:
+        return stats.finishReason;
+    }
+  });
+</script>
+
+<div class="text-muted-foreground mt-1 text-xs tabular-nums">
+  <table class="ml-auto border-separate border-spacing-x-3 border-spacing-y-0">
+    <thead>
+      <tr class="text-right">
+        <th class="text-left font-normal"></th>
+        <th class="font-medium" title={DETAIL_TOOLTIP.columnTokens}>tokens</th>
+        <th class="font-medium" title={DETAIL_TOOLTIP.columnTime}>time</th>
+        <th class="font-medium" title={DETAIL_TOOLTIP.columnSpeed}>speed</th>
+        <th class="font-medium" title={DETAIL_TOOLTIP.columnPerToken}>per token</th>
+      </tr>
+    </thead>
+    <tbody>
+      {#each rows as row (row.kind)}
+        <tr class="text-right">
+          <td class="text-left font-medium" title={PHASE_TOOLTIP[row.kind]}>{PHASE_LABEL[row.kind]}</td>
+          <td title={phaseValueTooltip(row.kind, "tokens", row.phase)}>
+            {tokens(row.phase.tokens, row.phase.approxTokens)}
+            {#if row.processed !== undefined}
+              <span class="opacity-70" title="Prompt tokens that were not in the cache and had to be processed.">({row.processed.toLocaleString()} new)</span>
+            {/if}
+          </td>
+          <td title={phaseValueTooltip(row.kind, "time", row.phase)}>{time(row.phase.ms)}</td>
+          <td title={phaseValueTooltip(row.kind, "speed", row.phase)}>{speed(row)}</td>
+          <td title={phaseValueTooltip(row.kind, "perToken", row.phase)}>{perToken(row)}</td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+  <dl class="mt-1 flex flex-wrap justify-end gap-x-4 gap-y-0.5 pr-1">
+    {#if stats.cachedTokens && stats.prompt.tokens}
+      <div title={DETAIL_TOOLTIP.cached}><dt class="inline font-medium">Cache</dt> <dd class="inline">{stats.cachedTokens.toLocaleString()} tokens reused ({pct(stats.cachedTokens, stats.prompt.tokens)})</dd></div>
+    {/if}
+    {#if hasDraft}
+      <div title={DETAIL_TOOLTIP.draft}>
+        <dt class="inline font-medium">Draft</dt>
+        <dd class="inline">{draftText}</dd>
+      </div>
+    {/if}
+    {#if stats.firstTokenMs !== undefined}
+      <div title={DETAIL_TOOLTIP.firstToken}><dt class="inline font-medium">First token</dt> <dd class="inline">{time(stats.firstTokenMs)}</dd></div>
+    {/if}
+    {#if stats.wallMs !== undefined}
+      <div title={DETAIL_TOOLTIP.wall}><dt class="inline font-medium">Wall</dt> <dd class="inline">{time(stats.wallMs)}</dd></div>
+    {/if}
+    {#if contextUsed !== undefined}
+      <div title={DETAIL_TOOLTIP.context}>
+        <dt class="inline font-medium">Context</dt>
+        <dd class="inline">
+          {#if contextLength}
+            {contextUsed.toLocaleString()} / {contextLength.toLocaleString()} ({pct(contextUsed, contextLength)})
+          {:else}
+            {contextUsed.toLocaleString()}
+          {/if}
+        </dd>
+      </div>
+    {/if}
+    {#if stopReason}
+      <div title={DETAIL_TOOLTIP.stop}><dt class="inline font-medium">Stop</dt> <dd class="inline">{stopReason}</dd></div>
+    {/if}
+  </dl>
+  {#if approxAnywhere}
+    <p class="mt-0.5 pr-1 text-right opacity-70" title="Hover any value marked ~ to see how it was estimated.">~ estimated in the browser from the stream</p>
+  {/if}
+</div>

--- a/ui/src/lib/chatApi.test.ts
+++ b/ui/src/lib/chatApi.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { buildRequest, parseChatCompletionsLine, type ChatOptions, type ToolDefinition } from "./chatApi";
+import {
+  buildRequest,
+  normalizeAnthropicStopReason,
+  normalizeResponsesStop,
+  parseChatCompletionsLine,
+  type ChatOptions,
+  type ToolDefinition,
+} from "./chatApi";
 import type { ChatMessage, ToolCall } from "./types";
 
 const sse = (payload: unknown) => `data: ${JSON.stringify(payload)}`;
@@ -254,5 +261,27 @@ describe("buildRequest for the text-only endpoints", () => {
   it("still extracts the system prompt", () => {
     const body = buildRequest("v1/messages", "m", history, {}).body as any;
     expect(body.system).toBe("be helpful");
+  });
+});
+
+describe("stop reason normalization", () => {
+  it("maps Anthropic stop reasons onto the OpenAI vocabulary", () => {
+    expect(normalizeAnthropicStopReason("end_turn")).toBe("stop");
+    expect(normalizeAnthropicStopReason("stop_sequence")).toBe("stop");
+    expect(normalizeAnthropicStopReason("max_tokens")).toBe("length");
+    expect(normalizeAnthropicStopReason("tool_use")).toBe("tool_calls");
+    expect(normalizeAnthropicStopReason("refusal")).toBe("refusal"); // unknown ones pass through
+    expect(normalizeAnthropicStopReason(null)).toBeUndefined();
+    expect(normalizeAnthropicStopReason("")).toBeUndefined();
+  });
+
+  it("maps Responses terminal events onto the OpenAI vocabulary", () => {
+    expect(normalizeResponsesStop("response.completed", { status: "completed" })).toBe("stop");
+    expect(normalizeResponsesStop("response.incomplete", { incomplete_details: { reason: "max_output_tokens" } })).toBe("length");
+    expect(normalizeResponsesStop("response.incomplete", { incomplete_details: { reason: "content_filter" } })).toBe("content_filter");
+    expect(normalizeResponsesStop("response.incomplete", {})).toBe("incomplete");
+    expect(normalizeResponsesStop("response.completed", { status: "incomplete", incomplete_details: { reason: "max_output_tokens" } })).toBe("length");
+    expect(normalizeResponsesStop("response.failed", {})).toBe("error");
+    expect(normalizeResponsesStop("response.output_text.delta", {})).toBeUndefined();
   });
 });

--- a/ui/src/lib/chatApi.test.ts
+++ b/ui/src/lib/chatApi.test.ts
@@ -49,6 +49,61 @@ describe("parseChatCompletionsLine", () => {
     expect(parseChatCompletionsLine("data: [DONE]")).toEqual({ content: "", done: true });
   });
 
+  // The include_usage chunk has an empty choices array and nothing else.
+  it("reads a usage-only chunk", () => {
+    const line = sse({ choices: [], usage: { prompt_tokens: 12, completion_tokens: 3, total_tokens: 15 } });
+    const chunk = parseChatCompletionsLine(line);
+    expect(chunk?.usage).toEqual({ prompt_tokens: 12, completion_tokens: 3 });
+    expect(chunk?.content).toBe("");
+    expect(chunk?.done).toBe(false);
+  });
+
+  // usage.prompt_tokens is always the whole prompt, so it wins over
+  // timings.prompt_n, which counts only the tokens actually processed.
+  it("merges usage counts with llama.cpp timings", () => {
+    const line = sse({
+      choices: [{ delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 12, completion_tokens: 3 },
+      timings: { prompt_n: 10, prompt_ms: 120.5, predicted_n: 4, predicted_ms: 800, predicted_per_second: 5 },
+    });
+    expect(parseChatCompletionsLine(line)?.usage).toEqual({
+      prompt_tokens: 12,
+      completion_tokens: 3,
+      prompt_ms: 120.5,
+      completion_ms: 800,
+    });
+  });
+
+  it("reads cache and draft counts from llama.cpp timings", () => {
+    const line = sse({
+      choices: [],
+      timings: { prompt_n: 4, cache_n: 13, prompt_ms: 50, predicted_n: 500, predicted_ms: 14500, draft_n: 120, draft_n_accepted: 96 },
+    });
+    expect(parseChatCompletionsLine(line)?.usage).toEqual({
+      prompt_tokens: 17, // processed + cached
+      cached_tokens: 13,
+      completion_tokens: 500,
+      prompt_ms: 50,
+      completion_ms: 14500,
+      draft_tokens: 120,
+      draft_accepted: 96,
+    });
+  });
+
+  it("reads cached tokens from OpenAI-style usage details", () => {
+    const line = sse({
+      choices: [],
+      usage: { prompt_tokens: 20, completion_tokens: 1, prompt_tokens_details: { cached_tokens: 15 } },
+    });
+    expect(parseChatCompletionsLine(line)?.usage).toEqual({ prompt_tokens: 20, completion_tokens: 1, cached_tokens: 15 });
+  });
+
+  it("ignores malformed usage", () => {
+    const withText = sse({ choices: [{ delta: { content: "x" } }], usage: "nope" });
+    expect(parseChatCompletionsLine(withText)?.usage).toBeUndefined();
+    expect(parseChatCompletionsLine(sse({ choices: [], usage: { prompt_tokens: "12" } }))).toBeNull();
+  });
+
   it("returns null for lines with nothing to report", () => {
     for (const line of ["", "   ", ": keepalive", "event: message", "data: {not json", delta({})]) {
       expect(parseChatCompletionsLine(line)).toBeNull();
@@ -62,6 +117,20 @@ describe("buildRequest for v1/chat/completions", () => {
 
   it("targets the right url", () => {
     expect(buildRequest("v1/chat/completions", "m", [], {}).url).toBe("/v1/chat/completions");
+  });
+
+  it("asks for usage in the stream", () => {
+    expect(build([]).stream_options).toEqual({ include_usage: true });
+  });
+
+  // Without per-chunk timings the exact numbers only arrive in the final
+  // chunk, which a cancelled stream never delivers.
+  it("asks llama.cpp for timings on every chunk by default", () => {
+    expect(build([]).timings_per_token).toBe(true);
+  });
+
+  it("omits the timings extension when it is turned off", () => {
+    expect(build([], { timingsPerToken: false })).not.toHaveProperty("timings_per_token");
   });
 
   it("preserves tool_calls on an assistant turn", () => {
@@ -100,13 +169,23 @@ describe("buildRequest for v1/chat/completions", () => {
         toolOk: true,
         toolDurationMs: 12,
       },
-      { role: "assistant", content: "hi", reasoning_content: "think", reasoningTimeMs: 5 },
+      {
+        role: "assistant",
+        content: "hi",
+        reasoning_content: "think",
+        reasoningTimeMs: 5,
+        stats: {
+          prompt: { approxTokens: false, approxTimings: true },
+          generation: { tokens: 1, approxTokens: true, approxTimings: true },
+        },
+      },
     ]);
 
     expect(body.messages[0]).not.toHaveProperty("toolOk");
     expect(body.messages[0]).not.toHaveProperty("toolDurationMs");
     expect(body.messages[1]).not.toHaveProperty("reasoning_content");
     expect(body.messages[1]).not.toHaveProperty("reasoningTimeMs");
+    expect(body.messages[1]).not.toHaveProperty("stats");
   });
 
   it("does not put tool_calls on a non-assistant message", () => {

--- a/ui/src/lib/chatApi.ts
+++ b/ui/src/lib/chatApi.ts
@@ -279,6 +279,41 @@ function parseTimingsObject(timings: unknown): StreamUsage | undefined {
   return Object.keys(out).length ? out : undefined;
 }
 
+/**
+ * Maps an Anthropic `stop_reason` onto the OpenAI finish_reason vocabulary
+ * the stats use, so every endpoint reports why a turn ended the same way.
+ */
+export function normalizeAnthropicStopReason(reason: unknown): string | undefined {
+  if (typeof reason !== "string" || !reason) return undefined;
+  switch (reason) {
+    case "end_turn":
+    case "stop_sequence":
+      return "stop";
+    case "max_tokens":
+      return "length";
+    case "tool_use":
+      return "tool_calls";
+    default:
+      return reason;
+  }
+}
+
+/**
+ * Maps a Responses API terminal event (`response.completed`, `.incomplete`,
+ * `.failed`) and the response object it carries onto a finish_reason.
+ */
+export function normalizeResponsesStop(event: string, response: unknown): string | undefined {
+  const r = (response && typeof response === "object" ? response : {}) as Record<string, unknown>;
+  const details = r.incomplete_details as Record<string, unknown> | undefined;
+  if (event === "response.incomplete" || r.status === "incomplete") {
+    if (details?.reason === "max_output_tokens") return "length";
+    return typeof details?.reason === "string" ? details.reason : "incomplete";
+  }
+  if (event === "response.failed" || r.status === "failed") return "error";
+  if (event === "response.completed") return "stop";
+  return undefined;
+}
+
 // Exported for tests.
 export function parseChatCompletionsLine(line: string): StreamChunk | null {
   const trimmed = line.trim();
@@ -386,10 +421,13 @@ async function* parseMessagesStream(
       if (!parsed.data) continue;
       try {
         const json = JSON.parse(parsed.data);
-        // Input tokens arrive on message_start, output tokens on message_delta.
+        // Input tokens arrive on message_start; output tokens and the stop
+        // reason on message_delta.
         if (parsed.event === "message_start" || parsed.event === "message_delta") {
           const usage = parseUsageObject(parsed.event === "message_start" ? json.message?.usage : json.usage);
-          if (usage) yield { content: "", usage, done: false };
+          const finish_reason =
+            parsed.event === "message_delta" ? normalizeAnthropicStopReason(json.delta?.stop_reason) : undefined;
+          if (usage || finish_reason) yield { content: "", usage, finish_reason, done: false };
           continue;
         }
         if (parsed.event !== "content_block_delta") continue;
@@ -427,9 +465,14 @@ async function* parseResponsesStream(
       if (!parsed.data) continue;
       try {
         const json = JSON.parse(parsed.data);
-        if (parsed.event === "response.completed") {
+        if (
+          parsed.event === "response.completed" ||
+          parsed.event === "response.incomplete" ||
+          parsed.event === "response.failed"
+        ) {
           const usage = parseUsageObject(json.response?.usage);
-          if (usage) yield { content: "", usage, done: false };
+          const finish_reason = normalizeResponsesStop(parsed.event, json.response);
+          if (usage || finish_reason) yield { content: "", usage, finish_reason, done: false };
           yield { content: "", done: true };
           return;
         }
@@ -463,10 +506,12 @@ function parseStream(
 /**
  * Whether to keep asking for per-chunk timings. The parameter is a llama.cpp
  * extension, so a backend that validates its request body strictly answers
- * 400. The first such rejection turns it off for the rest of the session and
- * the request is retried without it.
+ * 400 and names the field. The first such rejection turns it off for the
+ * rest of the session and the request is retried without it. A 400 that does
+ * not mention the field is an ordinary error and is reported as one.
  */
 let perTokenTimingsWanted = true;
+const PER_TOKEN_TIMINGS_FIELD = "timings_per_token";
 
 export async function* streamChatCompletion(
   model: string,
@@ -491,16 +536,17 @@ export async function* streamChatCompletion(
   const askedForTimings = perTokenTimingsWanted && endpoint === "v1/chat/completions";
   let response = await send(askedForTimings);
 
-  // A 400 on the one request that carried the extension is taken to be about
-  // the extension: drop it and try once more, plainly.
-  if (!response.ok && response.status === 400 && askedForTimings) {
-    perTokenTimingsWanted = false;
-    response = await send(false);
-  }
-
   if (!response.ok) {
     const errorText = await response.text();
-    throw new Error(`Chat API error: ${response.status} - ${errorText}`);
+    const rejectedExtension = response.status === 400 && askedForTimings && errorText.includes(PER_TOKEN_TIMINGS_FIELD);
+    if (!rejectedExtension) {
+      throw new Error(`Chat API error: ${response.status} - ${errorText}`);
+    }
+    perTokenTimingsWanted = false;
+    response = await send(false);
+    if (!response.ok) {
+      throw new Error(`Chat API error: ${response.status} - ${await response.text()}`);
+    }
   }
 
   const reader = response.body?.getReader();

--- a/ui/src/lib/chatApi.ts
+++ b/ui/src/lib/chatApi.ts
@@ -27,11 +27,33 @@ export interface ToolCallDelta {
   function?: { name?: string; arguments?: string };
 }
 
+/**
+ * Token counts and timings reported by the backend, normalised across the
+ * endpoints. Every field is optional: OpenAI-style `usage` gives only the
+ * counts, llama.cpp's `timings` adds the time spent on each phase and the
+ * speculative-decoding draft counts.
+ */
+export interface StreamUsage {
+  /** The whole prompt, cached part included. */
+  prompt_tokens?: number;
+  /** Prompt tokens reused from the KV cache rather than processed. */
+  cached_tokens?: number;
+  completion_tokens?: number;
+  /** Time spent processing the non-cached part of the prompt. */
+  prompt_ms?: number;
+  completion_ms?: number;
+  /** Speculative decoding / MTP: tokens proposed by the draft, and accepted. */
+  draft_tokens?: number;
+  draft_accepted?: number;
+}
+
 export interface StreamChunk {
   content: string;
   reasoning_content?: string;
   tool_calls?: ToolCallDelta[];
   finish_reason?: string;
+  /** Present on the chunk(s) that carry usage; typically the last one. */
+  usage?: StreamUsage;
   done: boolean;
 }
 
@@ -41,6 +63,11 @@ export interface ChatOptions {
   max_tokens?: number;
   tools?: ToolDefinition[];
   tool_choice?: "auto" | "none" | "required";
+  /**
+   * Ask llama.cpp for `timings` on every streamed chunk instead of only the
+   * last one. Defaults to on; see perTokenTimingsWanted.
+   */
+  timingsPerToken?: boolean;
 }
 
 function parseDataUrl(url: string): { media_type: string; data: string } {
@@ -94,6 +121,13 @@ function buildChatCompletionsBody(model: string, messages: ChatMessage[], option
       return out;
     }),
     stream: true,
+    // Asks for a final chunk carrying token usage so the playground can show
+    // per-turn stats. Standard OpenAI; backends that predate it ignore it.
+    stream_options: { include_usage: true },
+    // llama.cpp extension: repeat the `timings` block on every chunk. Without
+    // it the exact numbers only arrive in the final chunk, which a cancelled
+    // stream never delivers.
+    ...(options?.timingsPerToken === false ? {} : { timings_per_token: true }),
     temperature: options?.temperature,
     ...(options?.max_tokens ? { max_tokens: options.max_tokens } : {}),
     ...(options?.tools?.length
@@ -193,6 +227,58 @@ export function buildRequest(
   }
 }
 
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * Reads a usage object in either the OpenAI (`prompt_tokens`) or Anthropic
+ * (`input_tokens`) spelling, with the cached-token count from whichever of
+ * the three places the endpoints put it. Returns undefined when neither
+ * token count is present.
+ */
+function parseUsageObject(usage: unknown): StreamUsage | undefined {
+  if (!usage || typeof usage !== "object") return undefined;
+  const u = usage as Record<string, unknown>;
+  const out: StreamUsage = {};
+  const prompt = asNumber(u.prompt_tokens) ?? asNumber(u.input_tokens);
+  const completion = asNumber(u.completion_tokens) ?? asNumber(u.output_tokens);
+  if (prompt !== undefined) out.prompt_tokens = prompt;
+  if (completion !== undefined) out.completion_tokens = completion;
+  if (prompt === undefined && completion === undefined) return undefined;
+  const cached =
+    asNumber((u.prompt_tokens_details as Record<string, unknown> | undefined)?.cached_tokens) ??
+    asNumber((u.input_tokens_details as Record<string, unknown> | undefined)?.cached_tokens) ??
+    asNumber(u.cache_read_input_tokens);
+  if (cached !== undefined) out.cached_tokens = cached;
+  return out;
+}
+
+/**
+ * Reads llama.cpp's `timings` object. Its `prompt_n` counts only the tokens
+ * actually processed, so the whole prompt is that plus `cache_n`.
+ */
+function parseTimingsObject(timings: unknown): StreamUsage | undefined {
+  if (!timings || typeof timings !== "object") return undefined;
+  const t = timings as Record<string, unknown>;
+  const out: StreamUsage = {};
+  const promptN = asNumber(t.prompt_n);
+  const cacheN = asNumber(t.cache_n);
+  const predictedN = asNumber(t.predicted_n);
+  const promptMs = asNumber(t.prompt_ms);
+  const predictedMs = asNumber(t.predicted_ms);
+  const draftN = asNumber(t.draft_n);
+  const draftAccepted = asNumber(t.draft_n_accepted);
+  if (promptN !== undefined) out.prompt_tokens = promptN + (cacheN ?? 0);
+  if (cacheN !== undefined) out.cached_tokens = cacheN;
+  if (predictedN !== undefined) out.completion_tokens = predictedN;
+  if (promptMs !== undefined) out.prompt_ms = promptMs;
+  if (predictedMs !== undefined) out.completion_ms = predictedMs;
+  if (draftN !== undefined) out.draft_tokens = draftN;
+  if (draftAccepted !== undefined) out.draft_accepted = draftAccepted;
+  return Object.keys(out).length ? out : undefined;
+}
+
 // Exported for tests.
 export function parseChatCompletionsLine(line: string): StreamChunk | null {
   const trimmed = line.trim();
@@ -213,9 +299,14 @@ export function parseChatCompletionsLine(line: string): StreamChunk | null {
     const reasoning_content = delta?.reasoning_content || delta?.reasoning || "";
     const tool_calls = Array.isArray(delta?.tool_calls) ? (delta.tool_calls as ToolCallDelta[]) : undefined;
     const finish_reason = choice?.finish_reason || undefined;
+    const usageFields = parseUsageObject(parsed.usage);
+    const timingFields = parseTimingsObject(parsed.timings);
+    // usage wins for the token counts (its prompt_tokens is always the whole
+    // prompt); timings supply everything else.
+    const usage = usageFields || timingFields ? { ...timingFields, ...usageFields } : undefined;
 
-    if (content || reasoning_content || tool_calls || finish_reason) {
-      return { content, reasoning_content, tool_calls, finish_reason, done: false };
+    if (content || reasoning_content || tool_calls || finish_reason || usage) {
+      return { content, reasoning_content, tool_calls, finish_reason, usage, done: false };
     }
     return null;
   } catch {
@@ -292,9 +383,16 @@ async function* parseMessagesStream(
         yield { content: "", done: true };
         return;
       }
-      if (parsed.event !== "content_block_delta" || !parsed.data) continue;
+      if (!parsed.data) continue;
       try {
         const json = JSON.parse(parsed.data);
+        // Input tokens arrive on message_start, output tokens on message_delta.
+        if (parsed.event === "message_start" || parsed.event === "message_delta") {
+          const usage = parseUsageObject(parsed.event === "message_start" ? json.message?.usage : json.usage);
+          if (usage) yield { content: "", usage, done: false };
+          continue;
+        }
+        if (parsed.event !== "content_block_delta") continue;
         const delta = json.delta;
         if (!delta) continue;
         if (delta.type === "text_delta" && delta.text) {
@@ -326,13 +424,15 @@ async function* parseResponsesStream(
     for (const block of blocks) {
       const parsed = parseSSEEventBlock(block);
       if (!parsed) continue;
-      if (parsed.event === "response.completed") {
-        yield { content: "", done: true };
-        return;
-      }
       if (!parsed.data) continue;
       try {
         const json = JSON.parse(parsed.data);
+        if (parsed.event === "response.completed") {
+          const usage = parseUsageObject(json.response?.usage);
+          if (usage) yield { content: "", usage, done: false };
+          yield { content: "", done: true };
+          return;
+        }
         if (parsed.event === "response.output_text.delta" && json.delta) {
           yield { content: json.delta, done: false };
         } else if (parsed.event === "response.reasoning_summary_text.delta" && json.delta) {
@@ -360,6 +460,14 @@ function parseStream(
   }
 }
 
+/**
+ * Whether to keep asking for per-chunk timings. The parameter is a llama.cpp
+ * extension, so a backend that validates its request body strictly answers
+ * 400. The first such rejection turns it off for the rest of the session and
+ * the request is retried without it.
+ */
+let perTokenTimingsWanted = true;
+
 export async function* streamChatCompletion(
   model: string,
   messages: ChatMessage[],
@@ -367,17 +475,28 @@ export async function* streamChatCompletion(
   options?: ChatOptions
 ): AsyncGenerator<StreamChunk> {
   const endpoint = options?.endpoint ?? "v1/chat/completions";
-  const { url, body } = buildRequest(endpoint, model, messages, options);
+  const send = (timingsPerToken: boolean) => {
+    const { url, body } = buildRequest(endpoint, model, messages, { ...options, timingsPerToken });
+    return fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...playgroundSessionHeaders,
+      },
+      body: JSON.stringify(body),
+      signal,
+    });
+  };
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      ...playgroundSessionHeaders,
-    },
-    body: JSON.stringify(body),
-    signal,
-  });
+  const askedForTimings = perTokenTimingsWanted && endpoint === "v1/chat/completions";
+  let response = await send(askedForTimings);
+
+  // A 400 on the one request that carried the extension is taken to be about
+  // the extension: drop it and try once more, plainly.
+  if (!response.ok && response.status === 400 && askedForTimings) {
+    perTokenTimingsWanted = false;
+    response = await send(false);
+  }
 
   if (!response.ok) {
     const errorText = await response.text();

--- a/ui/src/lib/chatApiStream.test.ts
+++ b/ui/src/lib/chatApiStream.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { streamChatCompletion } from "./chatApi";
+
+/** A streamed response body carrying the given SSE lines. */
+function sseResponse(lines: string[]): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      for (const line of lines) controller.enqueue(encoder.encode(line + "\n"));
+      controller.close();
+    },
+  });
+  return { ok: true, status: 200, body } as unknown as Response;
+}
+
+const rejection = { ok: false, status: 400, text: async () => "unknown field timings_per_token" } as Response;
+
+const bodyOf = (call: unknown[]) => JSON.parse((call[1] as RequestInit).body as string);
+
+async function collect(model = "m") {
+  const out = [];
+  for await (const chunk of streamChatCompletion(model, [{ role: "user", content: "hi" }])) out.push(chunk);
+  return out;
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("streamChatCompletion", () => {
+  it("asks for per-chunk timings and streams the reply", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(sseResponse([`data: {"choices":[{"delta":{"content":"hi"}}]}`, "data: [DONE]"]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const chunks = await collect();
+
+    expect(bodyOf(fetchMock.mock.calls[0]).timings_per_token).toBe(true);
+    expect(chunks[0]).toMatchObject({ content: "hi" });
+  });
+
+  // A backend that validates its request body rejects the llama.cpp
+  // extension; the turn must still go through, and later turns must not pay
+  // for the rejection again.
+  it("retries without the extension when the backend rejects it, then stops sending it", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(rejection)
+      .mockResolvedValue(sseResponse([`data: {"choices":[{"delta":{"content":"ok"}}]}`, "data: [DONE]"]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    expect((await collect()).some((c) => c.content === "ok")).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(bodyOf(fetchMock.mock.calls[0])).toHaveProperty("timings_per_token");
+    expect(bodyOf(fetchMock.mock.calls[1])).not.toHaveProperty("timings_per_token");
+
+    await collect();
+    expect(fetchMock).toHaveBeenCalledTimes(3); // one request, no retry
+    expect(bodyOf(fetchMock.mock.calls[2])).not.toHaveProperty("timings_per_token");
+  });
+
+  // Ordered after the test above on purpose: the session has given up on the
+  // extension, so a 400 now is a real error and must surface.
+  it("reports a 400 that is not about the extension", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 400, text: async () => "bad model" } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(collect()).rejects.toThrow(/400 - bad model/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/lib/chatApiStream.test.ts
+++ b/ui/src/lib/chatApiStream.test.ts
@@ -1,5 +1,14 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { streamChatCompletion } from "./chatApi";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChatOptions, StreamChunk } from "./chatApi";
+
+// chatApi remembers, per module instance, whether the backend rejected the
+// llama.cpp timings extension. Each test gets a fresh instance.
+let streamChatCompletion: typeof import("./chatApi").streamChatCompletion;
+beforeEach(async () => {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+  ({ streamChatCompletion } = await import("./chatApi"));
+});
 
 /** A streamed response body carrying the given SSE lines. */
 function sseResponse(lines: string[]): Response {
@@ -13,37 +22,37 @@ function sseResponse(lines: string[]): Response {
   return { ok: true, status: 200, body } as unknown as Response;
 }
 
-const rejection = { ok: false, status: 400, text: async () => "unknown field timings_per_token" } as Response;
-
+const badRequest = (text: string) => ({ ok: false, status: 400, text: async () => text }) as Response;
 const bodyOf = (call: unknown[]) => JSON.parse((call[1] as RequestInit).body as string);
+const okStream = () => sseResponse([`data: {"choices":[{"delta":{"content":"ok"}}]}`, "data: [DONE]"]);
 
-async function collect(model = "m") {
-  const out = [];
-  for await (const chunk of streamChatCompletion(model, [{ role: "user", content: "hi" }])) out.push(chunk);
+async function collect(options?: ChatOptions): Promise<StreamChunk[]> {
+  const out: StreamChunk[] = [];
+  for await (const chunk of streamChatCompletion("m", [{ role: "user", content: "hi" }], undefined, options)) {
+    out.push(chunk);
+  }
   return out;
 }
 
-afterEach(() => vi.unstubAllGlobals());
-
 describe("streamChatCompletion", () => {
   it("asks for per-chunk timings and streams the reply", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(sseResponse([`data: {"choices":[{"delta":{"content":"hi"}}]}`, "data: [DONE]"]));
+    const fetchMock = vi.fn().mockResolvedValue(okStream());
     vi.stubGlobal("fetch", fetchMock);
 
     const chunks = await collect();
 
     expect(bodyOf(fetchMock.mock.calls[0]).timings_per_token).toBe(true);
-    expect(chunks[0]).toMatchObject({ content: "hi" });
+    expect(chunks[0]).toMatchObject({ content: "ok" });
   });
 
   // A backend that validates its request body rejects the llama.cpp
-  // extension; the turn must still go through, and later turns must not pay
-  // for the rejection again.
-  it("retries without the extension when the backend rejects it, then stops sending it", async () => {
+  // extension by name; the turn must still go through, and later turns must
+  // not pay for the rejection again.
+  it("retries without the extension when the backend rejects it by name, then stops sending it", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(rejection)
-      .mockResolvedValue(sseResponse([`data: {"choices":[{"delta":{"content":"ok"}}]}`, "data: [DONE]"]));
+      .mockResolvedValueOnce(badRequest("Unrecognized request argument supplied: timings_per_token"))
+      .mockResolvedValue(okStream());
     vi.stubGlobal("fetch", fetchMock);
 
     expect((await collect()).some((c) => c.content === "ok")).toBe(true);
@@ -56,13 +65,94 @@ describe("streamChatCompletion", () => {
     expect(bodyOf(fetchMock.mock.calls[2])).not.toHaveProperty("timings_per_token");
   });
 
-  // Ordered after the test above on purpose: the session has given up on the
-  // extension, so a 400 now is a real error and must surface.
-  it("reports a 400 that is not about the extension", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 400, text: async () => "bad model" } as Response);
+  // An ordinary validation error says nothing about the extension: it is
+  // reported at once, costs no second request, and leaves the extension on.
+  it("reports a 400 that does not name the extension without retrying or giving up on it", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(badRequest("model not found")).mockResolvedValue(okStream());
     vi.stubGlobal("fetch", fetchMock);
 
-    await expect(collect()).rejects.toThrow(/400 - bad model/);
+    await expect(collect()).rejects.toThrow(/400 - model not found/);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await collect();
+    expect(bodyOf(fetchMock.mock.calls[1]).timings_per_token).toBe(true);
+  });
+
+  it("reports the second failure when the retry fails too", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(badRequest("unknown field timings_per_token"))
+      .mockResolvedValueOnce({ ok: false, status: 500, text: async () => "boom" } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(collect()).rejects.toThrow(/500 - boom/);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not send the extension to the other endpoints", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(sseResponse(["event: message_stop", "data: {}", ""]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await collect({ endpoint: "v1/messages" });
+    expect(bodyOf(fetchMock.mock.calls[0])).not.toHaveProperty("timings_per_token");
+  });
+});
+
+describe("stop reasons on the other endpoints", () => {
+  const event = (name: string, data: object) => [`event: ${name}`, `data: ${JSON.stringify(data)}`, ""];
+
+  it("reads usage and a normalized stop reason from an Anthropic stream", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        sseResponse([
+          ...event("message_start", { message: { usage: { input_tokens: 12 } } }),
+          ...event("content_block_delta", { delta: { type: "text_delta", text: "hi" } }),
+          ...event("message_delta", { delta: { stop_reason: "max_tokens" }, usage: { output_tokens: 7 } }),
+          ...event("message_stop", {}),
+        ])
+      )
+    );
+
+    const chunks = await collect({ endpoint: "v1/messages" });
+    expect(chunks.find((c) => c.usage?.prompt_tokens)?.usage).toEqual({ prompt_tokens: 12 });
+    expect(chunks.find((c) => c.finish_reason)).toMatchObject({ finish_reason: "length", usage: { completion_tokens: 7 } });
+    expect(chunks.at(-1)?.done).toBe(true);
+  });
+
+  it("reads a completed Responses stream as stop", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        sseResponse([
+          ...event("response.output_text.delta", { delta: "hi" }),
+          ...event("response.completed", { response: { status: "completed", usage: { input_tokens: 3, output_tokens: 1 } } }),
+        ])
+      )
+    );
+
+    const chunks = await collect({ endpoint: "v1/responses" });
+    expect(chunks.find((c) => c.finish_reason)).toMatchObject({
+      finish_reason: "stop",
+      usage: { prompt_tokens: 3, completion_tokens: 1 },
+    });
+  });
+
+  it("reads an incomplete Responses stream as length and still ends the turn", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        sseResponse([
+          ...event("response.output_text.delta", { delta: "hi" }),
+          ...event("response.incomplete", {
+            response: { status: "incomplete", incomplete_details: { reason: "max_output_tokens" } },
+          }),
+        ])
+      )
+    );
+
+    const chunks = await collect({ endpoint: "v1/responses" });
+    expect(chunks.find((c) => c.finish_reason)?.finish_reason).toBe("length");
+    expect(chunks.at(-1)?.done).toBe(true);
   });
 });

--- a/ui/src/lib/generationStats.test.ts
+++ b/ui/src/lib/generationStats.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import { currentStats, markCancelled, startTracking, tokensPerSecond, trackChunk } from "./generationStats";
+
+const text = (content: string) => ({ content, done: false });
+const think = (reasoning_content: string) => ({ content: "", reasoning_content, done: false });
+const approx = { approxTokens: true, approxTimings: true };
+
+describe("generationStats", () => {
+  it("estimates from chunks and wall clock while streaming", () => {
+    const t = startTracking(1000);
+    trackChunk(t, text("a"), 1500);
+    trackChunk(t, text("b"), 1600);
+    trackChunk(t, text("c"), 1700);
+
+    expect(currentStats(t, 2000, true)).toEqual({
+      prompt: { ms: 500, approxTokens: false, approxTimings: true },
+      generation: { tokens: 3, ms: 500, perSecond: 6, ...approx }, // runs to `now` while streaming
+      firstTokenMs: 500,
+      wallMs: 1000,
+    });
+    expect(currentStats(t, 2000, false).generation.ms).toBe(200); // stops at last token
+  });
+
+  it("counts tool-call chunks as answer tokens", () => {
+    const t = startTracking(0);
+    trackChunk(t, { content: "", tool_calls: [{ index: 0 }], done: false }, 20);
+    expect(currentStats(t, 30, false).generation.tokens).toBe(1);
+    expect(t.answerChunks).toBe(1);
+  });
+
+  it("ignores chunks that carry nothing but a finish_reason or usage", () => {
+    const t = startTracking(0);
+    trackChunk(t, { content: "", finish_reason: "stop", done: false }, 10);
+    trackChunk(t, { content: "", usage: { completion_tokens: 0 }, done: false }, 20);
+    expect(t.reasoningChunks + t.answerChunks).toBe(0);
+    expect(t.firstTokenAt).toBeUndefined();
+  });
+
+  it("runs only the prompt clock before the first token", () => {
+    const t = startTracking(0);
+    expect(currentStats(t, 100, true)).toEqual({
+      prompt: { ms: 100, approxTokens: false, approxTimings: true },
+      generation: approx,
+    });
+    // a turn that ended without a single token has nothing to report
+    expect(currentStats(t, 100, false)).toEqual({
+      prompt: { approxTokens: false, approxTimings: true },
+      generation: approx,
+    });
+  });
+
+  it("prefers backend usage counts over chunk counts", () => {
+    const t = startTracking(0);
+    trackChunk(t, text("a"), 100);
+    trackChunk(t, text("b"), 200);
+    trackChunk(t, { content: "", usage: { prompt_tokens: 40, completion_tokens: 7 }, done: false }, 300);
+
+    const { prompt, generation } = currentStats(t, 300, false);
+    expect(prompt).toEqual({ tokens: 40, ms: 100, perSecond: 400, approxTokens: false, approxTimings: true });
+    expect(generation).toEqual({ tokens: 7, ms: 100, perSecond: 70, approxTokens: false, approxTimings: true });
+  });
+
+  it("prefers backend timings over wall clock", () => {
+    const t = startTracking(0);
+    trackChunk(t, text("a"), 100);
+    trackChunk(
+      t,
+      { content: "", usage: { prompt_tokens: 10, prompt_ms: 50, completion_tokens: 1, completion_ms: 20 }, done: false },
+      300
+    );
+
+    expect(currentStats(t, 300, false)).toEqual({
+      prompt: { tokens: 10, ms: 50, perSecond: 200, approxTokens: false, approxTimings: false },
+      generation: { tokens: 1, ms: 20, perSecond: 50, approxTokens: false, approxTimings: false },
+      firstTokenMs: 100,
+      wallMs: 100,
+    });
+  });
+
+  it("measures prompt throughput over the non-cached tokens only", () => {
+    const t = startTracking(0);
+    trackChunk(t, text("a"), 100);
+    trackChunk(t, { content: "", usage: { prompt_tokens: 100, cached_tokens: 80, prompt_ms: 40 }, done: false }, 200);
+
+    const stats = currentStats(t, 200, false);
+    expect(stats.prompt.tokens).toBe(100);
+    expect(stats.cachedTokens).toBe(80);
+    expect(stats.prompt.perSecond).toBe(500); // 20 new tokens in 40ms
+  });
+
+  it("passes through draft counts and the finish reason", () => {
+    const t = startTracking(0);
+    trackChunk(t, text("a"), 100);
+    trackChunk(t, { content: "", finish_reason: "length", done: false }, 150);
+    trackChunk(t, { content: "", usage: { draft_tokens: 40, draft_accepted: 30 }, done: false }, 200);
+
+    const stats = currentStats(t, 200, false);
+    expect(stats.draftTokens).toBe(40);
+    expect(stats.draftAccepted).toBe(30);
+    expect(stats.finishReason).toBe("length");
+  });
+
+  it("merges usage that arrives in pieces", () => {
+    const t = startTracking(0);
+    trackChunk(t, { content: "", usage: { prompt_tokens: 12 }, done: false }, 1);
+    trackChunk(t, { content: "", usage: { completion_tokens: 3 }, done: false }, 2);
+    expect(t.usage).toEqual({ prompt_tokens: 12, completion_tokens: 3 });
+  });
+
+  describe("thinking", () => {
+    it("reports thinking as the whole generation while the model is still thinking", () => {
+      const t = startTracking(0);
+      trackChunk(t, think("hm"), 100);
+      trackChunk(t, think("hm"), 200);
+
+      const stats = currentStats(t, 300, true);
+      expect(stats.generation).toEqual({ tokens: 2, ms: 200, perSecond: 10, ...approx });
+      expect(stats.reasoning).toEqual(stats.generation);
+      expect(stats.answer).toBeUndefined();
+    });
+
+    it("splits thinking and answer at the first answer token", () => {
+      const t = startTracking(0);
+      trackChunk(t, think("a"), 100);
+      trackChunk(t, think("b"), 200);
+      trackChunk(t, think("c"), 300);
+      trackChunk(t, text("x"), 400);
+      trackChunk(t, text("y"), 500);
+
+      const stats = currentStats(t, 500, false);
+      expect(stats.generation).toEqual({ tokens: 5, ms: 400, perSecond: 12.5, ...approx });
+      expect(stats.reasoning).toEqual({ tokens: 3, ms: 300, perSecond: 10, ...approx });
+      expect(stats.answer).toEqual({ tokens: 2, ms: 100, perSecond: 20, ...approx });
+    });
+
+    it("splits a backend total by chunk ratio", () => {
+      const t = startTracking(0);
+      trackChunk(t, think("a"), 100);
+      trackChunk(t, think("b"), 200);
+      trackChunk(t, text("x"), 300);
+      trackChunk(t, text("y"), 400);
+      // 4 chunks, but the backend counted 6 tokens
+      trackChunk(t, { content: "", usage: { completion_tokens: 6, completion_ms: 290 }, done: false }, 400);
+
+      const stats = currentStats(t, 400, false);
+      expect(stats.generation).toEqual({
+        tokens: 6,
+        ms: 290,
+        perSecond: expect.closeTo(20.69, 2),
+        approxTokens: false,
+        approxTimings: false,
+      });
+      expect(stats.reasoning).toEqual({ tokens: 3, ms: 200, perSecond: 15, ...approx });
+      expect(stats.answer).toEqual({ tokens: 3, ms: 100, perSecond: 30, ...approx });
+    });
+
+    it("keeps thinking as the whole turn when no answer ever came", () => {
+      const t = startTracking(0);
+      trackChunk(t, think("a"), 100);
+      trackChunk(t, { content: "", usage: { completion_tokens: 1, completion_ms: 90 }, done: false }, 200);
+
+      const stats = currentStats(t, 200, false);
+      expect(stats.reasoning).toEqual({
+        tokens: 1,
+        ms: 90,
+        perSecond: expect.closeTo(11.11, 2),
+        approxTokens: false,
+        approxTimings: false,
+      });
+      expect(stats.answer).toBeUndefined();
+    });
+
+    it("has no thinking phases for a plain answer", () => {
+      const t = startTracking(0);
+      trackChunk(t, text("x"), 100);
+      const stats = currentStats(t, 100, false);
+      expect(stats.reasoning).toBeUndefined();
+      expect(stats.answer).toBeUndefined();
+    });
+  });
+
+  describe("cancelling", () => {
+    it("reports a cancelled turn as its own stop reason", () => {
+      const t = startTracking(0);
+      trackChunk(t, text("a"), 100);
+      markCancelled(t);
+      expect(currentStats(t, 200, false).finishReason).toBe("cancelled");
+    });
+
+    it("keeps the backend's reason when it already reported one", () => {
+      const t = startTracking(0);
+      trackChunk(t, { content: "", finish_reason: "stop", done: false }, 100);
+      markCancelled(t);
+      expect(currentStats(t, 200, false).finishReason).toBe("stop");
+    });
+
+    // Per-chunk timings mean an aborted turn still has exact backend numbers.
+    it("keeps the numbers the backend reported before the abort", () => {
+      const t = startTracking(0);
+      trackChunk(t, { content: "a", usage: { prompt_tokens: 17, cached_tokens: 13, prompt_ms: 20 }, done: false }, 100);
+      trackChunk(t, { content: "b", usage: { completion_tokens: 2, completion_ms: 60 }, done: false }, 160);
+      markCancelled(t);
+
+      const stats = currentStats(t, 200, false);
+      expect(stats.prompt).toEqual({ tokens: 17, ms: 20, perSecond: 200, approxTokens: false, approxTimings: false });
+      expect(stats.generation).toEqual({
+        tokens: 2,
+        ms: 60,
+        perSecond: expect.closeTo(33.33, 2),
+        approxTokens: false,
+        approxTimings: false,
+      });
+      expect(stats.cachedTokens).toBe(13);
+      expect(stats.finishReason).toBe("cancelled");
+    });
+  });
+
+  it("computes tokens per second only when it is meaningful", () => {
+    expect(tokensPerSecond(50, 2000)).toBe(25);
+    expect(tokensPerSecond(undefined, 2000)).toBeUndefined();
+    expect(tokensPerSecond(50, undefined)).toBeUndefined();
+    expect(tokensPerSecond(50, 0)).toBeUndefined();
+    expect(tokensPerSecond(0, 100)).toBeUndefined();
+  });
+});

--- a/ui/src/lib/generationStats.test.ts
+++ b/ui/src/lib/generationStats.test.ts
@@ -215,6 +215,14 @@ describe("generationStats", () => {
     });
   });
 
+  // The dropdown can change after a turn; the turn keeps the window it ran in.
+  it("carries the context window the turn was started with", () => {
+    const t = startTracking(0, 32768);
+    trackChunk(t, text("a"), 100);
+    expect(currentStats(t, 100, false).contextLength).toBe(32768);
+    expect(currentStats(startTracking(0), 100, false).contextLength).toBeUndefined();
+  });
+
   it("computes tokens per second only when it is meaningful", () => {
     expect(tokensPerSecond(50, 2000)).toBe(25);
     expect(tokensPerSecond(undefined, 2000)).toBeUndefined();

--- a/ui/src/lib/generationStats.ts
+++ b/ui/src/lib/generationStats.ts
@@ -22,10 +22,12 @@ export interface GenerationTracker {
   finishReason?: string;
   /** The user stopped the turn, so no backend finish_reason will arrive. */
   cancelled?: boolean;
+  /** Context window of the model the request went to, if known. */
+  contextLength?: number;
 }
 
-export function startTracking(now: number): GenerationTracker {
-  return { startedAt: now, reasoningChunks: 0, answerChunks: 0, usage: {} };
+export function startTracking(now: number, contextLength?: number): GenerationTracker {
+  return { startedAt: now, reasoningChunks: 0, answerChunks: 0, usage: {}, contextLength };
 }
 
 /** Folds one streamed chunk into the tracker. */
@@ -113,6 +115,7 @@ export function currentStats(tracker: GenerationTracker, now: number, streaming:
   } else if (tracker.cancelled) {
     stats.finishReason = "cancelled";
   }
+  if (tracker.contextLength) stats.contextLength = tracker.contextLength;
   if (reasoningChunks === 0 || firstTokenAt === undefined) return stats;
 
   // Still thinking, or the turn ended without an answer: thinking is all of it.

--- a/ui/src/lib/generationStats.ts
+++ b/ui/src/lib/generationStats.ts
@@ -1,0 +1,152 @@
+import type { StreamChunk, StreamUsage } from "./chatApi";
+import type { GenerationStats, PhaseStats } from "./types";
+
+/**
+ * Accumulates what a streamed turn reveals about its own cost: when the
+ * request started, when tokens started and stopped arriving, how many chunks
+ * came through in each phase, and whatever usage the backend reported.
+ *
+ * Chunks stand in for tokens until the backend says otherwise. llama.cpp
+ * streams one token per chunk (a multibyte character can span several), so
+ * the estimate is close and is replaced by the real count on the final chunk.
+ */
+export interface GenerationTracker {
+  startedAt: number;
+  firstTokenAt?: number;
+  lastTokenAt?: number;
+  /** When the first answer chunk arrived, which ends the thinking phase. */
+  answerStartedAt?: number;
+  reasoningChunks: number;
+  answerChunks: number;
+  usage: StreamUsage;
+  finishReason?: string;
+  /** The user stopped the turn, so no backend finish_reason will arrive. */
+  cancelled?: boolean;
+}
+
+export function startTracking(now: number): GenerationTracker {
+  return { startedAt: now, reasoningChunks: 0, answerChunks: 0, usage: {} };
+}
+
+/** Folds one streamed chunk into the tracker. */
+export function trackChunk(tracker: GenerationTracker, chunk: StreamChunk, now: number): void {
+  const isAnswer = Boolean(chunk.content) || Boolean(chunk.tool_calls?.length);
+  const isReasoning = !isAnswer && Boolean(chunk.reasoning_content);
+  if (isAnswer || isReasoning) {
+    tracker.firstTokenAt ??= now;
+    tracker.lastTokenAt = now;
+    if (isAnswer) {
+      tracker.answerChunks += 1;
+      tracker.answerStartedAt ??= now;
+    } else {
+      tracker.reasoningChunks += 1;
+    }
+  }
+  if (chunk.usage) {
+    // Later reports win field by field: /v1/messages sends input tokens on
+    // message_start and output tokens on message_delta.
+    tracker.usage = { ...tracker.usage, ...chunk.usage };
+  }
+  if (chunk.finish_reason) tracker.finishReason = chunk.finish_reason;
+}
+
+/** Records that the user stopped the turn. */
+export function markCancelled(tracker: GenerationTracker): void {
+  tracker.cancelled = true;
+}
+
+function perSecond(tokens: number | undefined, ms: number | undefined): number | undefined {
+  return tokensPerSecond(tokens, ms);
+}
+
+/**
+ * The stats to display at time `now`. While the turn is still streaming the
+ * clocks run to `now`: the prompt clock until the first token arrives, the
+ * generation clock after it. Once the turn is done they stop at the last token.
+ */
+export function currentStats(tracker: GenerationTracker, now: number, streaming: boolean): GenerationStats {
+  const { usage, startedAt, firstTokenAt, lastTokenAt, answerStartedAt, reasoningChunks, answerChunks } = tracker;
+  const chunks = reasoningChunks + answerChunks;
+  const end = streaming ? now : (lastTokenAt ?? now);
+
+  const prompt: PhaseStats = { approxTokens: false, approxTimings: usage.prompt_ms === undefined };
+  if (usage.prompt_tokens !== undefined) prompt.tokens = usage.prompt_tokens;
+  if (usage.prompt_ms !== undefined) {
+    prompt.ms = usage.prompt_ms;
+  } else if (firstTokenAt !== undefined) {
+    prompt.ms = firstTokenAt - startedAt;
+  } else if (streaming) {
+    prompt.ms = now - startedAt;
+  }
+  if (prompt.tokens !== undefined) {
+    prompt.perSecond = perSecond(prompt.tokens - (usage.cached_tokens ?? 0), prompt.ms);
+  }
+
+  const generation: PhaseStats = {
+    approxTokens: usage.completion_tokens === undefined,
+    approxTimings: usage.completion_ms === undefined,
+  };
+  if (usage.completion_tokens !== undefined) {
+    generation.tokens = usage.completion_tokens;
+  } else if (chunks > 0) {
+    generation.tokens = chunks;
+  }
+  if (usage.completion_ms !== undefined) {
+    generation.ms = usage.completion_ms;
+  } else if (firstTokenAt !== undefined) {
+    generation.ms = end - firstTokenAt;
+  }
+  generation.perSecond = perSecond(generation.tokens, generation.ms);
+
+  const stats: GenerationStats = { prompt, generation };
+  if (usage.cached_tokens !== undefined) stats.cachedTokens = usage.cached_tokens;
+  if (usage.draft_tokens !== undefined) stats.draftTokens = usage.draft_tokens;
+  if (usage.draft_accepted !== undefined) stats.draftAccepted = usage.draft_accepted;
+  if (firstTokenAt !== undefined) {
+    stats.firstTokenMs = firstTokenAt - startedAt;
+    stats.wallMs = end - startedAt;
+  }
+  // A cancelled turn gets no finish_reason of its own, so the client supplies
+  // one; a backend that already reported why it stopped still wins.
+  if (tracker.finishReason) {
+    stats.finishReason = tracker.finishReason;
+  } else if (tracker.cancelled) {
+    stats.finishReason = "cancelled";
+  }
+  if (reasoningChunks === 0 || firstTokenAt === undefined) return stats;
+
+  // Still thinking, or the turn ended without an answer: thinking is all of it.
+  if (answerChunks === 0 || answerStartedAt === undefined) {
+    stats.reasoning = { ...generation };
+    return stats;
+  }
+
+  // The backend reports one total, so it is split by chunk ratio; the phase
+  // boundary and both durations are wall clock.
+  const total = generation.tokens ?? chunks;
+  const reasoningTokens =
+    usage.completion_tokens === undefined ? reasoningChunks : Math.round((total * reasoningChunks) / chunks);
+  const reasoningMs = answerStartedAt - firstTokenAt;
+  const answerMs = end - answerStartedAt;
+  stats.reasoning = {
+    tokens: reasoningTokens,
+    ms: reasoningMs,
+    perSecond: perSecond(reasoningTokens, reasoningMs),
+    approxTokens: true,
+    approxTimings: true,
+  };
+  stats.answer = {
+    tokens: total - reasoningTokens,
+    ms: answerMs,
+    perSecond: perSecond(total - reasoningTokens, answerMs),
+    approxTokens: true,
+    approxTimings: true,
+  };
+  return stats;
+}
+
+/** Tokens per second, or undefined when either side is unknown or zero. */
+export function tokensPerSecond(tokens?: number, ms?: number): number | undefined {
+  if (tokens === undefined || ms === undefined || ms <= 0 || tokens <= 0) return undefined;
+  return (tokens / ms) * 1000;
+}

--- a/ui/src/lib/statsTooltips.test.ts
+++ b/ui/src/lib/statsTooltips.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { phaseValueTooltip, type PhaseKind, type PhaseMetric } from "./statsTooltips";
 
-const kinds: PhaseKind[] = ["prompt", "thinking", "answer", "generation"];
+const kinds: PhaseKind[] = ["prompt", "reasoning", "response", "generation"];
 const metrics: PhaseMetric[] = ["tokens", "time", "speed", "perToken"];
 
 describe("statsTooltips", () => {
@@ -17,9 +17,9 @@ describe("statsTooltips", () => {
 
   it("explains the ~ on estimated values", () => {
     const approx = { approxTokens: true, approxTimings: true };
-    expect(phaseValueTooltip("thinking", "tokens", approx)).toMatch(/~ Estimated.*split/);
+    expect(phaseValueTooltip("reasoning", "tokens", approx)).toMatch(/~ Estimated.*split/);
     expect(phaseValueTooltip("generation", "tokens", approx)).toMatch(/~ Estimated from streamed chunks/);
     expect(phaseValueTooltip("prompt", "time", approx)).toMatch(/first token.*browser/);
-    expect(phaseValueTooltip("answer", "speed", approx)).toMatch(/~ Derived/);
+    expect(phaseValueTooltip("response", "speed", approx)).toMatch(/~ Derived/);
   });
 });

--- a/ui/src/lib/statsTooltips.test.ts
+++ b/ui/src/lib/statsTooltips.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { phaseValueTooltip, type PhaseKind, type PhaseMetric } from "./statsTooltips";
+
+const kinds: PhaseKind[] = ["prompt", "thinking", "answer", "generation"];
+const metrics: PhaseMetric[] = ["tokens", "time", "speed", "perToken"];
+
+describe("statsTooltips", () => {
+  it("has a description for every value", () => {
+    for (const kind of kinds) {
+      for (const metric of metrics) {
+        const exact = phaseValueTooltip(kind, metric, { approxTokens: false, approxTimings: false });
+        expect(exact.length, `${kind}/${metric}`).toBeGreaterThan(20);
+        expect(exact, `${kind}/${metric}`).not.toContain("~");
+      }
+    }
+  });
+
+  it("explains the ~ on estimated values", () => {
+    const approx = { approxTokens: true, approxTimings: true };
+    expect(phaseValueTooltip("thinking", "tokens", approx)).toMatch(/~ Estimated.*split/);
+    expect(phaseValueTooltip("generation", "tokens", approx)).toMatch(/~ Estimated from streamed chunks/);
+    expect(phaseValueTooltip("prompt", "time", approx)).toMatch(/first token.*browser/);
+    expect(phaseValueTooltip("answer", "speed", approx)).toMatch(/~ Derived/);
+  });
+});

--- a/ui/src/lib/statsTooltips.ts
+++ b/ui/src/lib/statsTooltips.ts
@@ -1,0 +1,100 @@
+import type { PhaseStats } from "./types";
+
+/** The phases a stats line can describe. */
+export type PhaseKind = "prompt" | "thinking" | "answer" | "generation";
+
+export type PhaseMetric = "tokens" | "time" | "speed" | "perToken";
+
+export const PHASE_LABEL: Record<PhaseKind, string> = {
+  prompt: "Prompt",
+  thinking: "Thinking",
+  answer: "Answer",
+  generation: "Generation",
+};
+
+/** One-line description of a phase, for its row label. */
+export const PHASE_TOOLTIP: Record<PhaseKind, string> = {
+  prompt: "Prompt processing: reading everything sent to the model for this turn before it can generate.",
+  thinking: "Thinking: the reasoning the model produced before starting its answer.",
+  answer: "Answer: the visible reply, after any thinking.",
+  generation: "Generation: everything the model produced for this turn, thinking and answer together.",
+};
+
+const SPLIT_NOTE =
+  " ~ Estimated: the backend reports one total for the whole generation; it is split between thinking and answer by streamed chunks, and the boundary is the first answer token.";
+const CHUNK_NOTE = " ~ Estimated from streamed chunks until the backend reports the count.";
+const BROWSER_NOTE = " ~ Measured in the browser, not by the backend.";
+
+/** Tooltip for one value of a phase, explaining what it measures and how. */
+export function phaseValueTooltip(kind: PhaseKind, metric: PhaseMetric, phase: PhaseStats): string {
+  const approxSpeed = phase.approxTokens || phase.approxTimings;
+  switch (metric) {
+    case "tokens":
+      switch (kind) {
+        case "prompt":
+          return "Prompt tokens: everything sent to the model for this turn (system prompt, history and message), including tokens reused from the cache.";
+        case "thinking":
+          return "Thinking tokens: reasoning produced before the answer." + (phase.approxTokens ? SPLIT_NOTE : "");
+        case "answer":
+          return "Answer tokens: the visible reply." + (phase.approxTokens ? SPLIT_NOTE : "");
+        case "generation":
+          return "Generated tokens: thinking and answer together." + (phase.approxTokens ? CHUNK_NOTE : "");
+      }
+      break;
+    case "time":
+      switch (kind) {
+        case "prompt":
+          return phase.approxTimings
+            ? "Time to first token, measured in the browser: covers queueing, model loading and prompt processing."
+            : "Prefill time: how long the backend took to process the prompt tokens that were not already cached.";
+        case "thinking":
+          return "Thinking time: from the first thinking token to the first answer token." + (phase.approxTimings ? BROWSER_NOTE : "");
+        case "answer":
+          return "Answer time: from the first answer token to the last one." + (phase.approxTimings ? BROWSER_NOTE : "");
+        case "generation":
+          return phase.approxTimings
+            ? "Generation time: from the first to the last streamed token, measured in the browser."
+            : "Generation time: how long the backend spent producing tokens, thinking and answer together.";
+      }
+      break;
+    case "speed":
+      switch (kind) {
+        case "prompt":
+          return (
+            "Prefill speed: prompt tokens processed per second, counting only the tokens not served from the cache." +
+            (phase.approxTimings ? " ~ Based on the browser-measured time to first token." : "")
+          );
+        case "thinking":
+          return "Thinking speed: reasoning tokens generated per second." + (approxSpeed ? " ~ Derived from estimated values." : "");
+        case "answer":
+          return "Answer speed: reply tokens generated per second." + (approxSpeed ? " ~ Derived from estimated values." : "");
+        case "generation":
+          return "Generation speed: tokens generated per second over the whole turn." + (approxSpeed ? " ~ Derived from estimated values." : "");
+      }
+      break;
+    case "perToken":
+      return kind === "prompt"
+        ? "Average time to process one prompt token that was not served from the cache."
+        : "Average time to generate one token: the inverse of the speed.";
+  }
+  return "";
+}
+
+/** Tooltips for the details under the stats table. */
+export const DETAIL_TOOLTIP = {
+  cached:
+    "Prompt tokens served from the backend's KV cache, so they cost no prefill time. The share of the whole prompt is in brackets.",
+  draft:
+    "Speculative decoding / MTP: tokens proposed by the draft, how many the main model accepted, and the acceptance rate. Higher means the draft is paying off.",
+  firstToken:
+    "Time from sending the request to the first streamed token, measured in the browser. Includes queueing, model loading and prompt processing.",
+  wall: "Time from sending the request to the last streamed token, measured in the browser.",
+  context:
+    "How much of the model's context window this turn occupied: prompt plus generated tokens, against the model's context length.",
+  stop: "Why generation stopped: the model reached the end of its turn, hit the max_tokens limit, called a tool, or you cancelled it.",
+  waiting: "Waiting for the first token: the request has been sent and the model has not produced anything yet.",
+  columnTokens: "Token counts. A ~ marks an estimate; hover a value for how it was obtained.",
+  columnTime: "Time spent in each phase.",
+  columnSpeed: "Tokens per second in each phase.",
+  columnPerToken: "Average time per token in each phase.",
+} as const;

--- a/ui/src/lib/statsTooltips.ts
+++ b/ui/src/lib/statsTooltips.ts
@@ -1,27 +1,27 @@
 import type { PhaseStats } from "./types";
 
 /** The phases a stats line can describe. */
-export type PhaseKind = "prompt" | "thinking" | "answer" | "generation";
+export type PhaseKind = "prompt" | "reasoning" | "response" | "generation";
 
 export type PhaseMetric = "tokens" | "time" | "speed" | "perToken";
 
 export const PHASE_LABEL: Record<PhaseKind, string> = {
   prompt: "Prompt",
-  thinking: "Thinking",
-  answer: "Answer",
+  reasoning: "Reasoning",
+  response: "Response",
   generation: "Generation",
 };
 
 /** One-line description of a phase, for its row label. */
 export const PHASE_TOOLTIP: Record<PhaseKind, string> = {
   prompt: "Prompt processing: reading everything sent to the model for this turn before it can generate.",
-  thinking: "Thinking: the reasoning the model produced before starting its answer.",
-  answer: "Answer: the visible reply, after any thinking.",
-  generation: "Generation: everything the model produced for this turn, thinking and answer together.",
+  reasoning: "Reasoning: what the model produced before starting its response.",
+  response: "Response: the visible reply, after any reasoning.",
+  generation: "Generation: everything the model produced for this turn, reasoning and response together.",
 };
 
 const SPLIT_NOTE =
-  " ~ Estimated: the backend reports one total for the whole generation; it is split between thinking and answer by streamed chunks, and the boundary is the first answer token.";
+  " ~ Estimated: the backend reports one total for the whole generation; it is split between reasoning and response by streamed chunks, and the boundary is the first response token.";
 const CHUNK_NOTE = " ~ Estimated from streamed chunks until the backend reports the count.";
 const BROWSER_NOTE = " ~ Measured in the browser, not by the backend.";
 
@@ -33,12 +33,12 @@ export function phaseValueTooltip(kind: PhaseKind, metric: PhaseMetric, phase: P
       switch (kind) {
         case "prompt":
           return "Prompt tokens: everything sent to the model for this turn (system prompt, history and message), including tokens reused from the cache.";
-        case "thinking":
-          return "Thinking tokens: reasoning produced before the answer." + (phase.approxTokens ? SPLIT_NOTE : "");
-        case "answer":
-          return "Answer tokens: the visible reply." + (phase.approxTokens ? SPLIT_NOTE : "");
+        case "reasoning":
+          return "Reasoning tokens: produced before the response." + (phase.approxTokens ? SPLIT_NOTE : "");
+        case "response":
+          return "Response tokens: the visible reply." + (phase.approxTokens ? SPLIT_NOTE : "");
         case "generation":
-          return "Generated tokens: thinking and answer together." + (phase.approxTokens ? CHUNK_NOTE : "");
+          return "Generated tokens: reasoning and response together." + (phase.approxTokens ? CHUNK_NOTE : "");
       }
       break;
     case "time":
@@ -47,14 +47,14 @@ export function phaseValueTooltip(kind: PhaseKind, metric: PhaseMetric, phase: P
           return phase.approxTimings
             ? "Time to first token, measured in the browser: covers queueing, model loading and prompt processing."
             : "Prefill time: how long the backend took to process the prompt tokens that were not already cached.";
-        case "thinking":
-          return "Thinking time: from the first thinking token to the first answer token." + (phase.approxTimings ? BROWSER_NOTE : "");
-        case "answer":
-          return "Answer time: from the first answer token to the last one." + (phase.approxTimings ? BROWSER_NOTE : "");
+        case "reasoning":
+          return "Reasoning time: from the first reasoning token to the first response token." + (phase.approxTimings ? BROWSER_NOTE : "");
+        case "response":
+          return "Response time: from the first response token to the last one." + (phase.approxTimings ? BROWSER_NOTE : "");
         case "generation":
           return phase.approxTimings
             ? "Generation time: from the first to the last streamed token, measured in the browser."
-            : "Generation time: how long the backend spent producing tokens, thinking and answer together.";
+            : "Generation time: how long the backend spent producing tokens, reasoning and response together.";
       }
       break;
     case "speed":
@@ -64,10 +64,10 @@ export function phaseValueTooltip(kind: PhaseKind, metric: PhaseMetric, phase: P
             "Prefill speed: prompt tokens processed per second, counting only the tokens not served from the cache." +
             (phase.approxTimings ? " ~ Based on the browser-measured time to first token." : "")
           );
-        case "thinking":
-          return "Thinking speed: reasoning tokens generated per second." + (approxSpeed ? " ~ Derived from estimated values." : "");
-        case "answer":
-          return "Answer speed: reply tokens generated per second." + (approxSpeed ? " ~ Derived from estimated values." : "");
+        case "reasoning":
+          return "Reasoning speed: reasoning tokens generated per second." + (approxSpeed ? " ~ Derived from estimated values." : "");
+        case "response":
+          return "Response speed: reply tokens generated per second." + (approxSpeed ? " ~ Derived from estimated values." : "");
         case "generation":
           return "Generation speed: tokens generated per second over the whole turn." + (approxSpeed ? " ~ Derived from estimated values." : "");
       }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -330,6 +330,11 @@ export interface GenerationStats {
   wallMs?: number;
   /** The backend's finish_reason: "stop", "length", "tool_calls", ... */
   finishReason?: string;
+  /**
+   * Context window of the model that served the turn, captured when the turn
+   * started so the number stays put when a different model is selected later.
+   */
+  contextLength?: number;
 }
 
 export interface ChatMessage {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -280,11 +280,65 @@ export interface ToolCall {
   function: { name: string; arguments: string };
 }
 
+/** Token count and duration of one phase of a turn. */
+export interface PhaseStats {
+  /** Tokens in this phase. Absent when unknown. */
+  tokens?: number;
+  /** Time spent in this phase. */
+  ms?: number;
+  /**
+   * Throughput. Usually tokens / ms, but for the prompt only the non-cached
+   * tokens count: the cached ones took no time.
+   */
+  perSecond?: number;
+  /**
+   * True when `tokens` was not reported by the backend: it is a count of
+   * streamed chunks, or the backend total split between thinking and answer
+   * by chunk ratio.
+   */
+  approxTokens: boolean;
+  /** True when `ms` is wall-clock time measured in the browser. */
+  approxTimings: boolean;
+}
+
+/**
+ * Per-turn generation stats shown with a chat message. Counts and durations
+ * come from the backend when it reports usage/timings; until then they are
+ * client-side measurements, flagged so the UI can mark them approximate.
+ */
+export interface GenerationStats {
+  /** Prompt processing. Its token count is backend-reported only. */
+  prompt: PhaseStats;
+  /** Everything generated: thinking plus answer. */
+  generation: PhaseStats;
+  /**
+   * Only when the turn streamed reasoning. The backend reports one total, so
+   * the two are split by streamed chunks and the boundary is the first answer
+   * token; `answer` is absent while the model is still thinking.
+   */
+  reasoning?: PhaseStats;
+  answer?: PhaseStats;
+
+  /** Prompt tokens served from the KV cache; backend-reported only. */
+  cachedTokens?: number;
+  /** Speculative decoding / MTP draft counts; backend-reported only. */
+  draftTokens?: number;
+  draftAccepted?: number;
+  /** Request start to first streamed token, measured in the browser. */
+  firstTokenMs?: number;
+  /** Request start to last streamed token, measured in the browser. */
+  wallMs?: number;
+  /** The backend's finish_reason: "stop", "length", "tool_calls", ... */
+  finishReason?: string;
+}
+
 export interface ChatMessage {
   role: ChatRole;
   content: string | ContentPart[];
   reasoning_content?: string;
   reasoningTimeMs?: number;
+  /** UI-only. Stats for the request that produced this assistant turn. */
+  stats?: GenerationStats;
 
   /** Wire fields. tool_calls is assistant-only; the rest are tool-only. */
   tool_calls?: ToolCall[];

--- a/ui/src/stores/api.ts
+++ b/ui/src/stores/api.ts
@@ -263,6 +263,7 @@ interface ModelListRecord {
   name?: string;
   description?: string;
   capabilities?: Model["capabilities"];
+  context_length?: number;
   meta?: {
     llamaswap?: {
       type?: PlaygroundModelType | "alias";
@@ -314,6 +315,7 @@ async function loadPlaygroundModels(request: number): Promise<Model[]> {
           playgroundType,
           aliases: [...(aliasesByModel.get(record.id) ?? [])],
           capabilities: record.capabilities,
+          context_length: record.context_length,
           strategy: metadata?.strategy,
           targets: metadata?.targets ?? [],
           spillover: metadata?.spillover,


### PR DESCRIPTION
# What?
Per-turn stats in the Chat tab, updating live as tokens arrive:

- Prompt processing under the user message, thinking in the Reasoning header, and the turn total under the reply.
- A chevron on the total expands a table with a row per phase (prompt, thinking, answer, generation) giving tokens, time, speed and time per token, plus cache reuse, speculative decoding / MTP draft acceptance, time to first token, wall time, context use and stop reason.
- Expansion is per message and not persisted; a regenerated reply keeps whatever state it had.
- Every value has a tooltip explaining what it measures and, for values marked ~, how it was estimated.

# Why?
Playground Chat shows no information about a running generation. There is no way to see prompt processing time, token counts or generation speed, which llama.cpp's own web UI reports and which is the first thing you want when comparing quants or tuning flags.

# Where?
<img width="1387" height="774" alt="image" src="https://github.com/user-attachments/assets/59631c32-29e0-407e-b340-55b660dbd3e6" />

https://github.com/user-attachments/assets/bc3e0b8f-6091-4a43-8d39-4986860276a4


