### PR TITLE
Add TabbyAPI (ExLlamaV3) prefill/decode rates to activity metrics

### DIFF
--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -350,8 +350,10 @@ var usagePaths = []string{"usage", "response.usage", "message.usage"}
 
 // extractUsageTokens reads input/output/cached token counts from a usage
 // gjson.Result, handling the field-name differences across endpoints.
-func extractUsageTokens(usage gjson.Result) (input, output, cached int64, ok bool) {
+func extractUsageTokens(usage gjson.Result) (input, output, cached int64, promptPerSec, completionPerSec float64, ok bool) {
 	cached = -1
+	promptPerSec = -1
+	completionPerSec = -1
 	if !usage.Exists() {
 		return
 	}
@@ -382,16 +384,26 @@ func extractUsageTokens(usage gjson.Result) (input, output, cached int64, ok boo
 		cached = v.Int()
 		ok = true
 	}
+
+	// TabbyAPI (ExLlamaV3) reports prefill/decode rates inside usage, unlike
+	// llama.cpp (timings.*) and vLLM (metrics.*).
+	if v := usage.Get("prompt_tokens_per_sec"); v.Exists() {
+		promptPerSec = v.Float()
+	}
+	if v := usage.Get("completion_tokens_per_sec"); v.Exists() {
+		completionPerSec = v.Float()
+	}
 	return
 }
 
 func processStreamingResponse(modelID string, start time.Time, body []byte) (ActivityLogEntry, error) {
 	var (
-		inputTokens, outputTokens int64
-		cachedTokens              int64 = -1
-		hasAny                    bool
-		timings                   gjson.Result
-		responseMetrics           gjson.Result
+		inputTokens, outputTokens      int64
+		cachedTokens                   int64   = -1
+		promptPerSec, completionPerSec float64 = -1, -1
+		hasAny                         bool
+		timings                        gjson.Result
+		responseMetrics                gjson.Result
 	)
 
 	prefix := []byte("data:")
@@ -424,7 +436,7 @@ func processStreamingResponse(modelID string, start time.Time, body []byte) (Act
 			if !u.Exists() {
 				continue
 			}
-			i, o, c, ok := extractUsageTokens(u)
+			i, o, c, pps, cps, ok := extractUsageTokens(u)
 			if !ok {
 				continue
 			}
@@ -437,6 +449,12 @@ func processStreamingResponse(modelID string, start time.Time, body []byte) (Act
 			}
 			if c >= 0 {
 				cachedTokens = c
+			}
+			if pps > 0 {
+				promptPerSec = pps
+			}
+			if cps > 0 {
+				completionPerSec = cps
 			}
 		}
 		if t := parsed.Get("timings"); t.Exists() {
@@ -453,22 +471,30 @@ func processStreamingResponse(modelID string, start time.Time, body []byte) (Act
 		return ActivityLogEntry{}, fmt.Errorf("no valid JSON data found in stream")
 	}
 
-	return buildMetrics(modelID, start, inputTokens, outputTokens, cachedTokens, timings, responseMetrics), nil
+	return buildMetrics(modelID, start, inputTokens, outputTokens, cachedTokens, promptPerSec, completionPerSec, timings, responseMetrics), nil
 }
 
 func parseMetrics(modelID string, start time.Time, usage, timings, responseMetrics gjson.Result) (ActivityLogEntry, error) {
-	input, output, cached, _ := extractUsageTokens(usage)
-	return buildMetrics(modelID, start, input, output, cached, timings, responseMetrics), nil
+	input, output, cached, pps, cps, _ := extractUsageTokens(usage)
+	return buildMetrics(modelID, start, input, output, cached, pps, cps, timings, responseMetrics), nil
 }
 
 // buildMetrics composes an ActivityLogEntry from accumulated token counts and
 // optional llama-server timings (which override input/output and provide rates)
 // or vLLM response metrics (rates and speculative decoding counters).
-func buildMetrics(modelID string, start time.Time, inputTokens, outputTokens, cachedTokens int64, timings, responseMetrics gjson.Result) ActivityLogEntry {
+func buildMetrics(modelID string, start time.Time, inputTokens, outputTokens, cachedTokens int64, usagePromptPerSec, usageCompletionPerSec float64, timings, responseMetrics gjson.Result) ActivityLogEntry {
 	wallDurationMs := int(time.Since(start).Milliseconds())
 	durationMs := wallDurationMs
+	// TabbyAPI reports rates in usage.*_per_sec; seed them as a fallback so
+	// llama.cpp timings / vLLM metrics (below) can still override.
 	tokensPerSecond := -1.0
 	promptPerSecond := -1.0
+	if usageCompletionPerSec > 0 {
+		tokensPerSecond = usageCompletionPerSec
+	}
+	if usagePromptPerSec > 0 {
+		promptPerSecond = usagePromptPerSec
+	}
 	draftTokens := -1
 	draftAccTokens := -1
 

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -546,3 +546,51 @@ func TestServer_MetricsMiddleware_UpstreamAudioCaptureSkipsRespBody(t *testing.T
 		t.Error("RespHeaders not stored; want captureRespHeaders mask")
 	}
 }
+
+func TestServer_ProcessStreamingResponse_TabbyAPIUsageRates(t *testing.T) {
+	// Real TabbyAPI (ExLlamaV3) streaming usage chunk: rates live in
+	// usage.*_per_sec, not in timings (llama.cpp) or metrics (vLLM).
+	body := []byte(
+		"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n" +
+			"data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":64,\"prompt_time\":0.06,\"prompt_tokens_per_sec\":1066.67,\"completion_tokens\":76,\"completion_time\":0.39,\"completion_tokens_per_sec\":193.93,\"total_tokens\":140,\"total_time\":0.45}}\n\n" +
+			"data: [DONE]\n\n")
+	entry, err := processStreamingResponse("m", time.Now(), body)
+	if err != nil {
+		t.Fatalf("processStreamingResponse: %v", err)
+	}
+	if entry.Tokens.InputTokens != 64 || entry.Tokens.OutputTokens != 76 {
+		t.Fatalf("tokens = %+v", entry.Tokens)
+	}
+	if entry.Tokens.PromptPerSecond != 1066.67 {
+		t.Fatalf("PromptPerSecond = %v, want 1066.67", entry.Tokens.PromptPerSecond)
+	}
+	if entry.Tokens.TokensPerSecond != 193.93 {
+		t.Fatalf("TokensPerSecond = %v, want 193.93", entry.Tokens.TokensPerSecond)
+	}
+}
+
+func TestServer_ParseMetrics_TabbyAPIUsageRates(t *testing.T) {
+	body := `{"usage":{"prompt_tokens":64,"prompt_tokens_per_sec":1066.67,"completion_tokens":76,"completion_tokens_per_sec":193.93,"total_tokens":140}}`
+	parsed := gjson.Parse(body)
+	entry, err := parseMetrics("m", time.Now(), parsed.Get("usage"), parsed.Get("timings"), parsed.Get("metrics"))
+	if err != nil {
+		t.Fatalf("parseMetrics: %v", err)
+	}
+	if entry.Tokens.PromptPerSecond != 1066.67 || entry.Tokens.TokensPerSecond != 193.93 {
+		t.Fatalf("rates = %+v", entry.Tokens)
+	}
+}
+
+func TestServer_ProcessStreamingResponse_TabbyAPIRatesNotOverriddenByAbsence(t *testing.T) {
+	// No timings, no metrics -> TabbyAPI usage rates must survive (not reset to -1).
+	body := []byte(
+		"data: {\"usage\":{\"prompt_tokens\":10,\"prompt_tokens_per_sec\":500.0,\"completion_tokens\":20,\"completion_tokens_per_sec\":100.0}}\n\n" +
+			"data: [DONE]\n\n")
+	entry, err := processStreamingResponse("m", time.Now(), body)
+	if err != nil {
+		t.Fatalf("processStreamingResponse: %v", err)
+	}
+	if entry.Tokens.PromptPerSecond != 500.0 || entry.Tokens.TokensPerSecond != 100.0 {
+		t.Fatalf("rates = %+v", entry.Tokens)
+	}
+}


### PR DESCRIPTION
## Problem

When llama-swap proxies a **TabbyAPI (ExLlamaV3)** backend, the Activity page shows `-1` for the **Prefill** and **Decode** (token/s) columns, even though the data is available.

`buildMetrics` only reads rates from:
- llama.cpp: `timings.prompt_per_second` / `timings.predicted_per_second`
- vLLM: `metrics.time_to_first_token_ms` / `metrics.mean_itl_ms`

TabbyAPI reports its rates in a different place — inside the `usage` object:

```json
"usage": {
  "prompt_tokens": 64,
  "prompt_tokens_per_sec": 1066.67,
  "completion_tokens": 76,
  "completion_tokens_per_sec": 193.93
}
```

Neither existing path matches, so the rates fall through to `-1`.

## Fix

Extract `usage.prompt_tokens_per_sec` / `usage.completion_tokens_per_sec` in `extractUsageTokens` and seed them as a **fallback** in `buildMetrics`. llama.cpp `timings` and vLLM `metrics` still override when present, so existing backends are unaffected.

## Testing

- 3 new unit tests: streaming, non-streaming, and "rates survive when timings/metrics are absent"
- Full suite passes (21 packages, no regression)
- Verified in production against a live TabbyAPI (Qwen3.8-27B exl3): Prefill/Decode columns now populate (prefill ~1000–2900 tok/s, decode ~45–130 tok/s)
