### PR TITLE
internal/server: add tabbyapi usage data extraction

### DIFF
--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -390,6 +390,7 @@ func processStreamingResponse(modelID string, start time.Time, body []byte) (Act
 		inputTokens, outputTokens int64
 		cachedTokens              int64 = -1
 		hasAny                    bool
+		usage                     gjson.Result
 		timings                   gjson.Result
 		responseMetrics           gjson.Result
 	)
@@ -438,6 +439,9 @@ func processStreamingResponse(modelID string, start time.Time, body []byte) (Act
 			if c >= 0 {
 				cachedTokens = c
 			}
+			// Remember the last usage block so buildMetrics can read the
+			// TabbyAPI rates it embeds there.
+			usage = u
 		}
 		if t := parsed.Get("timings"); t.Exists() {
 			timings = t
@@ -453,24 +457,43 @@ func processStreamingResponse(modelID string, start time.Time, body []byte) (Act
 		return ActivityLogEntry{}, fmt.Errorf("no valid JSON data found in stream")
 	}
 
-	return buildMetrics(modelID, start, inputTokens, outputTokens, cachedTokens, timings, responseMetrics), nil
+	return buildMetrics(modelID, start, inputTokens, outputTokens, cachedTokens, usage, timings, responseMetrics), nil
 }
 
 func parseMetrics(modelID string, start time.Time, usage, timings, responseMetrics gjson.Result) (ActivityLogEntry, error) {
 	input, output, cached, _ := extractUsageTokens(usage)
-	return buildMetrics(modelID, start, input, output, cached, timings, responseMetrics), nil
+	return buildMetrics(modelID, start, input, output, cached, usage, timings, responseMetrics), nil
 }
 
 // buildMetrics composes an ActivityLogEntry from accumulated token counts and
 // optional llama-server timings (which override input/output and provide rates)
-// or vLLM response metrics (rates and speculative decoding counters).
-func buildMetrics(modelID string, start time.Time, inputTokens, outputTokens, cachedTokens int64, timings, responseMetrics gjson.Result) ActivityLogEntry {
+// or vLLM response metrics (rates and speculative decoding counters). TabbyAPI
+// embeds its rates and total time in the usage block, which supplies base rates
+// when timings and metrics are absent.
+func buildMetrics(modelID string, start time.Time, inputTokens, outputTokens, cachedTokens int64, usage, timings, responseMetrics gjson.Result) ActivityLogEntry {
 	wallDurationMs := int(time.Since(start).Milliseconds())
 	durationMs := wallDurationMs
 	tokensPerSecond := -1.0
 	promptPerSecond := -1.0
 	draftTokens := -1
 	draftAccTokens := -1
+
+	// TabbyAPI reports prompt/completion rates and total time inside its usage
+	// block. These are base values that llama-server timings and vLLM metrics
+	// override when present.
+	if usage.Exists() {
+		if v := usage.Get("prompt_tokens_per_sec"); v.Exists() {
+			promptPerSecond = v.Float()
+		}
+		if v := usage.Get("completion_tokens_per_sec"); v.Exists() {
+			tokensPerSecond = v.Float()
+		}
+		if v := usage.Get("total_time"); v.Exists() {
+			if totalTimeMs := int(v.Float() * 1000); totalTimeMs > durationMs {
+				durationMs = totalTimeMs
+			}
+		}
+	}
 
 	if timings.Exists() {
 		inputTokens = timings.Get("prompt_n").Int()

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -69,6 +69,60 @@ func TestServer_ParseMetrics_Timings(t *testing.T) {
 	}
 }
 
+func TestServer_ParseMetrics_TabbyAPI(t *testing.T) {
+	body := `{"id":"chatcmpl-131b9995cd0c40c99e2ce958083ee406","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":83,"prompt_time":2.36,"prompt_tokens_per_sec":35.17,"completion_tokens":192,"completion_time":11.22,"completion_tokens_per_sec":17.11,"total_tokens":275,"total_time":13.63},"model":"SC_6.00bpw_H6_V6"}`
+	parsed := gjson.Parse(body)
+	entry, err := parseMetrics("m", time.Now(), parsed.Get("usage"), parsed.Get("timings"), parsed.Get("metrics"))
+	if err != nil {
+		t.Fatalf("parseMetrics: %v", err)
+	}
+	if entry.Tokens.InputTokens != 83 || entry.Tokens.OutputTokens != 192 {
+		t.Fatalf("tokens = %+v", entry.Tokens)
+	}
+	if got, want := entry.Tokens.PromptPerSecond, 35.17; math.Abs(got-want) > 1e-9 {
+		t.Errorf("PromptPerSecond = %v, want %v", got, want)
+	}
+	if got, want := entry.Tokens.TokensPerSecond, 17.11; math.Abs(got-want) > 1e-9 {
+		t.Errorf("TokensPerSecond = %v, want %v", got, want)
+	}
+	if entry.DurationMs != 13630 {
+		t.Errorf("DurationMs = %d, want 13630", entry.DurationMs)
+	}
+}
+
+// llama-server timings and TabbyAPI usage rates never appear together, but a
+// response carrying both must keep the timings-sourced rates.
+func TestServer_ParseMetrics_TabbyAPINotOverwrittenByTimings(t *testing.T) {
+	body := `{"usage":{"prompt_tokens":83,"completion_tokens":192,"prompt_tokens_per_sec":35.17,"completion_tokens_per_sec":17.11},"timings":{"prompt_n":20,"predicted_n":50,"prompt_per_second":100.0,"predicted_per_second":40.0,"prompt_ms":200,"predicted_ms":1250}}`
+	parsed := gjson.Parse(body)
+	entry, err := parseMetrics("m", time.Now(), parsed.Get("usage"), parsed.Get("timings"), parsed.Get("metrics"))
+	if err != nil {
+		t.Fatalf("parseMetrics: %v", err)
+	}
+	if entry.Tokens.PromptPerSecond != 100.0 || entry.Tokens.TokensPerSecond != 40.0 {
+		t.Fatalf("rates = %+v, want timings rates", entry.Tokens)
+	}
+}
+
+func TestServer_ProcessStreamingResponse_TabbyAPI(t *testing.T) {
+	body := []byte("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n" +
+		"data: {\"id\":\"chatcmpl-131b9995cd0c40c99e2ce958083ee406\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":83,\"prompt_time\":2.36,\"prompt_tokens_per_sec\":35.17,\"completion_tokens\":192,\"completion_time\":11.22,\"completion_tokens_per_sec\":17.11,\"total_tokens\":275,\"total_time\":13.63},\"model\":\"SC_6.00bpw_H6_V6\"}\n\n" +
+		"data: [DONE]\n\n")
+	entry, err := processStreamingResponse("m", time.Now(), body)
+	if err != nil {
+		t.Fatalf("processStreamingResponse: %v", err)
+	}
+	if entry.Tokens.InputTokens != 83 || entry.Tokens.OutputTokens != 192 {
+		t.Fatalf("tokens = %+v", entry.Tokens)
+	}
+	if got, want := entry.Tokens.PromptPerSecond, 35.17; math.Abs(got-want) > 1e-9 {
+		t.Errorf("PromptPerSecond = %v, want %v", got, want)
+	}
+	if got, want := entry.Tokens.TokensPerSecond, 17.11; math.Abs(got-want) > 1e-9 {
+		t.Errorf("TokensPerSecond = %v, want %v", got, want)
+	}
+}
+
 func TestServer_ProcessStreamingResponse(t *testing.T) {
 	body := []byte("data: {\"choices\":[{}]}\n\n" +
 		"data: {\"usage\":{\"prompt_tokens\":15,\"completion_tokens\":33}}\n\n" +


### PR DESCRIPTION
use tabbyAPI's prompt_tokens_per_sec, completion_tokens_per_sec and total_time from the response's usage block in activity metrics.

supercedes: #1100

Note: this was an opportunity to set up TabbyAPI with Qwen3.8-27B-exl3/SC_6.00bpw_H6_V6 (xhigh) to write this PR. I also prompt GPT 5.6 Terra (high) with the same task and the implementation was nearly identical. Qwen's was a bit more complete with extraction of `total_time`.

Demo of functionality. This is running over dual 3090s with tensor parallel enabled.

<img width="1022" height="707" alt="image" src="https://github.com/user-attachments/assets/852e7100-9c5e-4b7c-a658-811403e91757" />

