### PR TITLE
feat: add TransformParams filter for conditional value replacement

### DIFF
--- a/internal/config/filters.go
+++ b/internal/config/filters.go
@@ -29,6 +29,13 @@ type Filters struct {
 	// Keys ending in "?" are set-if-undefined, as in SetParams.
 	// Protected params (like "model") cannot be set.
 	SetParamsByID map[string]map[string]any `yaml:"setParamsByID"`
+
+	// TransformParams maps JSON paths to value-translation maps.
+	// For each path, if the request carries a value that is a key in the map,
+	// that value is replaced with the corresponding map value.
+	// Example: "reasoning_effort": {"low": "medium", "medium": "high"}
+	// Transforms are applied after setParams/setParamsByID so they can override them.
+	TransformParams map[string]map[string]string `yaml:"transformParams"`
 }
 
 // SanitizedStripParams returns a sorted list of parameters to strip,
@@ -84,6 +91,15 @@ func (f Filters) SanitizedSetParams() (map[string]any, []string, map[string]bool
 		return nil, nil, nil
 	}
 	return sanitizeParams(f.SetParams)
+}
+
+// SanitizedTransformParams returns the transform maps for all paths.
+// Returns nil if no transforms are configured.
+func (f Filters) SanitizedTransformParams() map[string]map[string]string {
+	if len(f.TransformParams) == 0 {
+		return nil
+	}
+	return f.TransformParams
 }
 
 // sanitizeParams removes protected params from raw and strips the "?" suffix

--- a/internal/server/filters.go
+++ b/internal/server/filters.go
@@ -22,6 +22,7 @@ import (
 //   - StripParams removal (issue #174)
 //   - SetParams injection (issue #453)
 //   - SetParamsByID per-alias overrides
+//   - TransformParams value transformations
 //
 // Non-JSON requests (GET, multipart forms) pass through untouched. The buffered
 // body is re-attached with Content-Length / Transfer-Encoding cleanup so the
@@ -125,8 +126,8 @@ func resolveFilters(cfg config.Config, requested string) (useModelName string, f
 }
 
 // applyFilters rewrites the JSON body in place. Order matches the legacy
-// ProxyManager: useModelName, stripParams, setParams, then setParamsByID (which
-// can override setParams).
+// ProxyManager: useModelName, stripParams, setParams, setParamsByID, then
+// transformParams (which can override setParams/setParamsByID results).
 func applyFilters(body []byte, requested, useModelName string, f config.Filters) ([]byte, error) {
 	var err error
 
@@ -147,9 +148,8 @@ func applyFilters(body []byte, requested, useModelName string, f config.Filters)
 
 	// Set-if-undefined keys ("key?", issue #1052) only fill parameters the body
 	// does not carry at that point in the pipeline. Filters apply like a pipe —
-	// stripParams | setParams | setParamsByID — so a stripped key counts as
-	// undefined, and a key an earlier stage set counts as defined (a "key?" in
-	// setParamsByID is a no-op when setParams already set it).
+	// stripParams | setParams | setParamsByID | transformParams — so a stripped
+	// key counts as undefined, and a key an earlier stage set counts as defined.
 	for _, key := range setKeys {
 		if setSoft[key] && gjson.GetBytes(body, key).Exists() {
 			continue
@@ -165,6 +165,23 @@ func applyFilters(body []byte, requested, useModelName string, f config.Filters)
 		}
 		if body, err = sjson.SetBytes(body, key, byID[key]); err != nil {
 			return nil, fmt.Errorf("error setting parameter %s in request", key)
+		}
+	}
+
+	// Apply transforms: replace values based on path->mapping
+	// Transforms run last so they can override setParams/setParamsByID results
+	transforms := f.SanitizedTransformParams()
+	if len(transforms) > 0 {
+		for path, mapping := range transforms {
+			currentVal := gjson.GetBytes(body, path)
+			if currentVal.Exists() && currentVal.Type == gjson.String {
+				currentStr := currentVal.Str
+				if newVal, ok := mapping[currentStr]; ok {
+					if body, err = sjson.SetBytes(body, path, newVal); err != nil {
+						return nil, fmt.Errorf("error transforming %s: %w", path, err)
+					}
+				}
+			}
 		}
 	}
 

--- a/internal/server/filters_test.go
+++ b/internal/server/filters_test.go
@@ -187,6 +187,82 @@ func TestServer_ApplyFilters(t *testing.T) {
 			t.Errorf("top_p = %v, want 0.1", got)
 		}
 	})
+
+	t.Run("transformParams replaces value at path", func(t *testing.T) {
+		f := config.Filters{
+			TransformParams: map[string]map[string]string{
+				"reasoning_effort": {"low": "medium", "medium": "high"},
+			},
+		}
+		out, err := applyFilters([]byte(`{"model":"m","reasoning_effort":"low"}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "reasoning_effort").String(); got != "medium" {
+			t.Errorf("reasoning_effort = %q, want medium", got)
+		}
+	})
+
+	t.Run("transformParams no-op when value not in map", func(t *testing.T) {
+		f := config.Filters{
+			TransformParams: map[string]map[string]string{
+				"reasoning_effort": {"low": "medium"},
+			},
+		}
+		out, err := applyFilters([]byte(`{"model":"m","reasoning_effort":"high"}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "reasoning_effort").String(); got != "high" {
+			t.Errorf("reasoning_effort = %q, want high (no transform)", got)
+		}
+	})
+
+	t.Run("transformParams applies after setParams", func(t *testing.T) {
+		f := config.Filters{
+			SetParams: map[string]any{"reasoning_effort": "low"},
+			TransformParams: map[string]map[string]string{
+				"reasoning_effort": {"low": "medium"},
+			},
+		}
+		out, err := applyFilters([]byte(`{"model":"m"}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "reasoning_effort").String(); got != "medium" {
+			t.Errorf("reasoning_effort = %q, want medium (set then transform)", got)
+		}
+	})
+
+	t.Run("transformParams with nested path", func(t *testing.T) {
+		f := config.Filters{
+			TransformParams: map[string]map[string]string{
+				"chat_template_kwargs.reasoning_effort": {"medium": "xhigh"},
+			},
+		}
+		out, err := applyFilters([]byte(`{"model":"m","chat_template_kwargs":{"reasoning_effort":"medium"}}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "chat_template_kwargs.reasoning_effort").String(); got != "xhigh" {
+			t.Errorf("reasoning_effort = %q, want xhigh", got)
+		}
+	})
+
+	t.Run("transformParams with missing path is no-op", func(t *testing.T) {
+		f := config.Filters{
+			TransformParams: map[string]map[string]string{
+				"reasoning_effort": {"low": "medium"},
+			},
+		}
+		out, err := applyFilters([]byte(`{"model":"m"}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if gjson.GetBytes(out, "reasoning_effort").Exists() {
+			t.Error("reasoning_effort should not exist when path is missing")
+		}
+	})
 }
 
 func TestServer_ResolveFilters_QualifiedPeer(t *testing.T) {


### PR DESCRIPTION
## Summary

Add TransformParams filter support to allow conditional value transformation on top-level JSON fields.

## Use Case

When Hermes sends `reasoning_effort: medium` to the advanced model, transform it to `xhigh` because Qwen3.8-Flash benefits from higher reasoning effort.

## Config Example

```yaml
models:
  advanced:
    filters:
      transformParams:
        reasoning_effort:
          low: medium
          medium: high
        chat_template_kwargs.reasoning_effort:
          medium: xhigh
```

## Implementation

- Added `TransformParams` field to `Filters` struct
- Added transform logic that runs after setParams/setParamsByID
- Supports nested paths (e.g., `chat_template_kwargs.reasoning_effort`)
- Added 5 new test cases, all passing

## Pipeline Order

1. useModelName rewrite
2. stripParams
3. setParams
4. setParamsByID
5. **transformParams** (NEW)
