### PR TITLE
feat(filters): add TransformParams for conditional parameter translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Built in Go for performance and simplicity, llama-swap has zero dependencies and
   - Automatic unloading of models after timeout by setting a `ttl`
   - Docker and Podman support using `cmd` and `cmdStop` together
   - Preload models on startup with `hooks` ([#235](https://github.com/mostlygeek/llama-swap/pull/235))
-  - Apply filters to requests to control inference with `stripParams`, `setParams` and `setParamsByID`
+  - Apply filters to requests to control inference with `stripParams`, `setParams`, `setParamsByID`, and `transformParams`
 
 ### Web UI
 

--- a/config-schema.json
+++ b/config-schema.json
@@ -518,11 +518,22 @@
                                 },
                                 "default": {},
                                 "description": "Dictionary mapping requested model IDs (or aliases) to parameters to set/override in requests. Applied after setParams and can override those values. Useful with aliases to vary behaviour depending on which alias the client used (e.g. different reasoning_effort per alias). A parameter key ending in '?' (e.g. 'max_tokens?') is set-if-undefined: it is only applied when the request does not already contain that parameter. Keys support ${MODEL_ID} macro substitution. Protected params like 'model' cannot be overridden."
+                            },
+                            "transformParams": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                },
+                                "default": {},
+                                "description": "Dictionary mapping JSON paths to value-translation maps. For each path, if the request carries a value that is a key in the map, it is replaced with the corresponding map value. Transforms run after setParams/setParamsByID so they can override them. Supports nested paths using dot notation (e.g. 'chat_template_kwargs.reasoning_effort'). Protected paths like 'model' are filtered out."
                             }
                         },
                         "additionalProperties": false,
                         "default": {},
-                        "description": "Dictionary of filter settings. Supports stripParams, setParams, and setParamsByID."
+                        "description": "Dictionary of filter settings. Supports stripParams, setParams, setParamsByID, and transformParams."
                     },
                     "metadata": {
                         "type": "object",
@@ -750,11 +761,22 @@
                                 "additionalProperties": true,
                                 "default": {},
                                 "description": "Dictionary of parameters to set/override in requests to this peer. Useful for injecting provider-specific settings. A key ending in '?' (e.g. 'max_tokens?') is set-if-undefined: it is only applied when the request does not already contain that parameter. Protected params like 'model' cannot be overridden. Values can be strings, numbers, booleans, arrays, or objects."
+                            },
+                            "transformParams": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                },
+                                "default": {},
+                                "description": "Dictionary mapping JSON paths to value-translation maps. For each path, if the request carries a value that is a key in the map, it is replaced with the corresponding map value. Transforms run after setParams so they can override them. Supports nested paths using dot notation. Protected paths like 'model' are filtered out."
                             }
                         },
                         "additionalProperties": false,
                         "default": {},
-                        "description": "Dictionary of filter settings for peer requests. Supports stripParams and setParams."
+                        "description": "Dictionary of filter settings for peer requests. Supports stripParams, setParams, and transformParams."
                     },
                     "timeouts": {
                         "type": "object",

--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -340,7 +340,7 @@ models:
 
     # filters: a dictionary of filter settings
     # - optional, default: empty dictionary
-    # - same capabilities as peer filters (stripParams, setParams)
+    # - same capabilities as peer filters (stripParams, setParams, transformParams)
     filters:
       # stripParams: a comma separated list of parameters to remove from the request
       # - optional, default: ""
@@ -398,13 +398,6 @@ models:
         reasoning_effort:
           medium: high
           low: medium
-
-      # transformParams: conditional string replacement for request parameters
-      # - optional, default: empty dictionary
-      # - maps JSON paths to value-translation maps
-      # - for each path, if the request carries a value that is a key in the map,
-      #   it is replaced with the corresponding map value
-      # - trans
 
     # aliases: alternative model names that this model configuration is used for
     # - optional, default: empty array
@@ -777,7 +770,7 @@ peers:
 
     # filters: a dictionary of filter settings for peer requests
     # - optional, default: empty dictionary
-    # - same capabilities as model filters (stripParams, setParams)
+    # - same capabilities as model filters (stripParams, setParams, transformParams)
     filters:
       # stripParams: a comma separated list of parameters to remove from the request
       # - optional, default: ""
@@ -795,3 +788,16 @@ peers:
         provider:
           data_collection: "deny"
           zdr: true
+
+      # transformParams: conditional string replacement for request parameters
+      # - optional, default: empty dictionary
+      # - maps JSON paths to value-translation maps
+      # - for each path, if the request carries a value that is a key in the map,
+      #   it is replaced with the corresponding map value
+      # - transforms run after setParams so they can override them
+      # - supports nested paths using dot notation
+      # - protected paths like "model" are filtered out
+      transformParams:
+        # Example: translate reasoning effort for a peer that uses different levels
+        reasoning_effort:
+          medium: high

--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -384,6 +384,28 @@ models:
           chat_template_kwargs:
             reasoning_effort: low
 
+      # transformParams: conditional string replacement for request parameters
+      # - optional, default: empty dictionary
+      # - maps JSON paths to value-translation maps
+      # - for each path, if the request carries a value that is a key in the map,
+      #   it is replaced with the corresponding map value
+      # - transforms run after setParams/setParamsByID so they can override them
+      # - supports nested paths using dot notation (e.g. "chat_template_kwargs.reasoning_effort")
+      # - protected paths like "model" are filtered out
+      # - useful for translating reasoning effort levels between Hermes and models
+      #   that interpret levels differently (e.g., Hermes "medium" -> model "high")
+      transformParams:
+        reasoning_effort:
+          medium: high
+          low: medium
+
+      # transformParams: conditional string replacement for request parameters
+      # - optional, default: empty dictionary
+      # - maps JSON paths to value-translation maps
+      # - for each path, if the request carries a value that is a key in the map,
+      #   it is replaced with the corresponding map value
+      # - trans
+
     # aliases: alternative model names that this model configuration is used for
     # - optional, default: empty array
     # - aliases must be unique globally

--- a/docs/kb/guides/api-integration/filters-and-request-rewriting.md
+++ b/docs/kb/guides/api-integration/filters-and-request-rewriting.md
@@ -2,9 +2,9 @@
 title: Rewriting requests with filters
 summary: Use stripParams, setParams and setParamsByID while preserving the protected model parameter.
 category: guides
-tags: [filters, strip-params, set-params, set-if-undefined, aliases, sampling]
-config_keys: [models.*.filters, models.*.filters.stripParams, models.*.filters.setParams, models.*.filters.setParamsByID, peers.*.filters]
-updated: 2026-09-01
+tags: [filters, strip-params, set-params, set-if-undefined, aliases, sampling, transform-params]
+config_keys: [models.*.filters, models.*.filters.stripParams, models.*.filters.setParams, models.*.filters.setParamsByID, models.*.filters.transformParams, peers.*.filters]
+updated: 2026-09-09
 ---
 
 # Rewriting requests with filters
@@ -106,11 +106,67 @@ reload — with different parameters applied.
 3. `stripParams` removes keys
 4. `setParams` applies
 5. `setParamsByID` applies, overriding `setParams`
-6. The request is proxied
+6. `transformParams` applies, overriding previous settings
+7. The request is proxied
 
-Filters apply like a pipe: `stripParams | setParams | setParamsByID`. A
+Filters apply like a pipe: `stripParams | setParams | setParamsByID | transformParams`. A
 set-if-undefined key (`key?`) checks the body at its own stage, so a stripped
 key counts as undefined and a key an earlier stage set counts as defined.
+
+## `transformParams` — conditional value translation
+
+`transformParams` performs conditional string replacement on request parameters.
+It maps JSON paths to translation dictionaries, allowing you to rewrite values
+based on their current content.
+
+```yaml
+models:
+  kat-coder:
+    filters:
+      transformParams:
+        reasoning_effort:
+          medium: high
+          low: medium
+```
+
+This translates Hermes's `medium` reasoning effort to `high` for the
+KAT-Coder model, and `low` to `medium`. Useful when different models interpret
+reasoning effort levels differently.
+
+The transform runs after `setParams` and `setParamsByID`, so it can override
+those settings. Only string values are transformed — non-string values are left
+unchanged. Protected paths like `model` are filtered out and cannot be transformed.
+
+### Nested paths
+
+You can use dot notation for nested JSON paths:
+
+```yaml
+      transformParams:
+        chat_template_kwargs.reasoning_effort:
+          medium: high
+```
+
+### Use case: Hermes + llama-swap reasoning translation
+
+When using llama-swap as an inference engine for Hermes, different models may
+interpret reasoning effort levels differently. You can configure per-model
+translations:
+
+```yaml
+models:
+  advanced:
+    # Qwen3.8-Flash expects xhigh for best results
+    cmd: |
+      ${bin} --model path/to/model.gguf --reasoning-effort xhigh
+  intermediate:
+    filters:
+      transformParams:
+        # Hermes sends medium, but KAT-Coder works better with high
+        reasoning_effort:
+          medium: high
+          low: medium
+```
 
 ## When not to use filters
 

--- a/internal/config/filters.go
+++ b/internal/config/filters.go
@@ -29,6 +29,13 @@ type Filters struct {
 	// Keys ending in "?" are set-if-undefined, as in SetParams.
 	// Protected params (like "model") cannot be set.
 	SetParamsByID map[string]map[string]any `yaml:"setParamsByID"`
+
+	// TransformParams maps JSON paths to value-translation maps.
+	// For each path, if the request carries a value that is a key in the map,
+	// that value is replaced with the corresponding map value.
+	// Example: "reasoning_effort": {"low": "medium", "medium": "high"}
+	// Transforms are applied after setParams/setParamsByID so they can override them.
+	TransformParams map[string]map[string]string `yaml:"transformParams"`
 }
 
 // SanitizedStripParams returns a sorted list of parameters to strip,
@@ -84,6 +91,15 @@ func (f Filters) SanitizedSetParams() (map[string]any, []string, map[string]bool
 		return nil, nil, nil
 	}
 	return sanitizeParams(f.SetParams)
+}
+
+// SanitizedTransformParams returns the transform maps for all paths.
+// Returns nil if no transforms are configured.
+func (f Filters) SanitizedTransformParams() map[string]map[string]string {
+	if len(f.TransformParams) == 0 {
+		return nil
+	}
+	return f.TransformParams
 }
 
 // sanitizeParams removes protected params from raw and strips the "?" suffix

--- a/internal/config/filters.go
+++ b/internal/config/filters.go
@@ -93,13 +93,25 @@ func (f Filters) SanitizedSetParams() (map[string]any, []string, map[string]bool
 	return sanitizeParams(f.SetParams)
 }
 
-// SanitizedTransformParams returns the transform maps for all paths.
-// Returns nil if no transforms are configured.
+// SanitizedTransformParams returns the transform maps for all paths,
+// filtering out protected paths (like "model"). Returns nil if no transforms
+// are configured or all transforms are protected.
 func (f Filters) SanitizedTransformParams() map[string]map[string]string {
 	if len(f.TransformParams) == 0 {
 		return nil
 	}
-	return f.TransformParams
+	result := make(map[string]map[string]string, len(f.TransformParams))
+	for path, mapping := range f.TransformParams {
+		// Skip protected paths (e.g., "model")
+		if slices.Contains(ProtectedParams, path) {
+			continue
+		}
+		result[path] = mapping
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 // sanitizeParams removes protected params from raw and strips the "?" suffix

--- a/internal/server/filters.go
+++ b/internal/server/filters.go
@@ -171,19 +171,22 @@ func applyFilters(body []byte, requested, useModelName string, f config.Filters)
 	// Apply transforms: replace values based on path->mapping
 	// Transforms run last so they can override setParams/setParamsByID results
 	transforms := f.SanitizedTransformParams()
-	if len(transforms) > 0 {
-		for path, mapping := range transforms {
-			currentVal := gjson.GetBytes(body, path)
-			if currentVal.Exists() && currentVal.Type == gjson.String {
-				currentStr := currentVal.Str
-				if newVal, ok := mapping[currentStr]; ok {
-					if body, err = sjson.SetBytes(body, path, newVal); err != nil {
-						return nil, fmt.Errorf("error transforming %s: %w", path, err)
-					}
-				}
-			}
+	if len(transforms) == 0 {
+		return body, nil
+	}
+	for path, mapping := range transforms {
+		currentVal := gjson.GetBytes(body, path)
+		if !currentVal.Exists() || currentVal.Type != gjson.String {
+			continue
+		}
+		currentStr := currentVal.Str
+		newVal, ok := mapping[currentStr]
+		if !ok {
+			continue
+		}
+		if body, err = sjson.SetBytes(body, path, newVal); err != nil {
+			return nil, fmt.Errorf("error transforming %s: %w", path, err)
 		}
 	}
-
 	return body, nil
 }

--- a/internal/server/filters.go
+++ b/internal/server/filters.go
@@ -22,6 +22,7 @@ import (
 //   - StripParams removal (issue #174)
 //   - SetParams injection (issue #453)
 //   - SetParamsByID per-alias overrides
+//   - TransformParams value transformations
 //
 // Non-JSON requests (GET, multipart forms) pass through untouched. The buffered
 // body is re-attached with Content-Length / Transfer-Encoding cleanup so the
@@ -125,8 +126,8 @@ func resolveFilters(cfg config.Config, requested string) (useModelName string, f
 }
 
 // applyFilters rewrites the JSON body in place. Order matches the legacy
-// ProxyManager: useModelName, stripParams, setParams, then setParamsByID (which
-// can override setParams).
+// ProxyManager: useModelName, stripParams, setParams, setParamsByID, then
+// transformParams (which can override setParams/setParamsByID results).
 func applyFilters(body []byte, requested, useModelName string, f config.Filters) ([]byte, error) {
 	var err error
 
@@ -147,9 +148,8 @@ func applyFilters(body []byte, requested, useModelName string, f config.Filters)
 
 	// Set-if-undefined keys ("key?", issue #1052) only fill parameters the body
 	// does not carry at that point in the pipeline. Filters apply like a pipe —
-	// stripParams | setParams | setParamsByID — so a stripped key counts as
-	// undefined, and a key an earlier stage set counts as defined (a "key?" in
-	// setParamsByID is a no-op when setParams already set it).
+	// stripParams | setParams | setParamsByID | transformParams — so a stripped
+	// key counts as undefined, and a key an earlier stage set counts as defined.
 	for _, key := range setKeys {
 		if setSoft[key] && gjson.GetBytes(body, key).Exists() {
 			continue
@@ -165,6 +165,23 @@ func applyFilters(body []byte, requested, useModelName string, f config.Filters)
 		}
 		if body, err = sjson.SetBytes(body, key, byID[key]); err != nil {
 			return nil, fmt.Errorf("error setting parameter %s in request", key)
+		}
+	}
+
+	// Apply transforms: replace values based on path->mapping
+	// Transforms run last so they can override setParams/setParamsByID results
+	transforms := f.SanitizedTransformParams()
+	if len(transforms) > 0 {
+		for path, mapping := range transforms {
+			currentVal := gjson.GetBytes(body, path)
+			if currentVal.Exists() && currentVal.Type == gjson.String {
+				currentStr := currentVal.Str
+				if newVal, ok := mapping[currentStr]; ok {
+					if body, err = sjson.SetBytes(body, path, newVal); err != nil {
+						return nil, fmt.Errorf("error transforming %s: %w", path, err)
+					}
+				}
+			}
 		}
 	}
 

--- a/internal/server/filters_test.go
+++ b/internal/server/filters_test.go
@@ -187,6 +187,82 @@ func TestServer_ApplyFilters(t *testing.T) {
 			t.Errorf("top_p = %v, want 0.1", got)
 		}
 	})
+
+	t.Run("transformParams replaces value at path", func(t *testing.T) {
+		f := config.Filters{
+			TransformParams: map[string]map[string]string{
+				"reasoning_effort": {"low": "medium", "medium": "high"},
+			},
+		}
+		out, err := applyFilters([]byte(`{"model":"m","reasoning_effort":"low"}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "reasoning_effort").String(); got != "medium" {
+			t.Errorf("reasoning_effort = %q, want medium", got)
+		}
+	})
+
+	t.Run("transformParams no-op when value not in map", func(t *testing.T) {
+		f := config.Filters{
+			TransformParams: map[string]map[string]string{
+				"reasoning_effort": {"low": "medium"},
+			},
+		}
+		out, err := applyFilters([]byte(`{"model":"m","reasoning_effort":"high"}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "reasoning_effort").String(); got != "high" {
+			t.Errorf("reasoning_effort = %q, want high (no transform)", got)
+		}
+	})
+
+	t.Run("transformParams applies after setParams", func(t *testing.T) {
+		f := config.Filters{
+			SetParams: map[string]any{"reasoning_effort": "low"},
+			TransformParams: map[string]map[string]string{
+				"reasoning_effort": {"low": "medium"},
+			},
+		}
+		out, err := applyFilters([]byte(`{"model":"m"}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "reasoning_effort").String(); got != "medium" {
+			t.Errorf("reasoning_effort = %q, want medium (set then transform)", got)
+		}
+	})
+
+	t.Run("transformParams with nested path", func(t *testing.T) {
+		f := config.Filters{
+			TransformParams: map[string]map[string]string{
+				"chat_template_kwargs.reasoning_effort": {"medium": "xhigh"},
+			},
+		}
+		out, err := applyFilters([]byte(`{"model":"m","chat_template_kwargs":{"reasoning_effort":"medium"}}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "chat_template_kwargs.reasoning_effort").String(); got != "xhigh" {
+			t.Errorf("reasoning_effort = %q, want xhigh", got)
+		}
+	})
+
+	t.Run("transformParams with missing path is no-op", func(t *testing.T) {
+		f := config.Filters{
+			TransformParams: map[string]map[string]string{
+				"reasoning_effort": {"low": "medium"},
+			},
+		}
+		out, err := applyFilters([]byte(`{"model":"m"}`), "m", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if gjson.GetBytes(out, "reasoning_effort").Exists() {
+			t.Error("reasoning_effort should not exist when path is missing")
+		}
+	})
 }
 
 func TestServer_ResolveFilters_QualifiedPeer(t *testing.T) {

--- a/internal/server/filters_test.go
+++ b/internal/server/filters_test.go
@@ -263,6 +263,21 @@ func TestServer_ApplyFilters(t *testing.T) {
 			t.Error("reasoning_effort should not exist when path is missing")
 		}
 	})
+
+	t.Run("transformParams protects model path", func(t *testing.T) {
+		f := config.Filters{
+			TransformParams: map[string]map[string]string{
+				"model": {"advanced": "wrong-model"},
+			},
+		}
+		out, err := applyFilters([]byte(`{"model":"advanced"}`), "advanced", "", f)
+		if err != nil {
+			t.Fatalf("applyFilters: %v", err)
+		}
+		if got := gjson.GetBytes(out, "model").String(); got != "advanced" {
+			t.Errorf("model = %q, want advanced (protected)", got)
+		}
+	})
 }
 
 func TestServer_ResolveFilters_QualifiedPeer(t *testing.T) {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -749,9 +749,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -769,9 +766,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -789,9 +783,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -809,9 +800,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -829,9 +817,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -849,9 +834,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Summary

Adds `transformParams` to llama-swap filter configuration, enabling conditional string replacement for top-level request parameters. This feature allows per-model reasoning effort translations between Hermes and downstream inference backends.

## Use Case

When using llama-swap as an inference engine for Hermes, different models expect different reasoning effort levels.

With `transformParams`, you can configure per-model translations:

```yaml
models:
  intermediate:
    filters:
      transformParams:
        reasoning_effort:
          medium: high
```

## Implementation

- Added `TransformParams` config struct
- Added `SanitizedTransformParams()` accessor
- Added transform application logic
- Updated config schema
- Added 5 test cases

## Testing

All 16 filter tests pass.

## AI Disclosure

This PR description was drafted with assistance from Hermes AI agent using **Kwaipilot/KAT-Coder-V2.5-Dev**. Code changes were reviewed line-by-line and tested by me.
