### PR TITLE
internal/server: add global concurrency semaphore

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,19 @@ Only use these technologies:
 - Only when the user asks use `make eval-docs-agent` to score the
   Help page's Docs Agent against a local model after changing its system prompt, `docs/kb/` content, the MCP tool descriptions, or the docs search ranking. See `evals/docs-agent/README.md` for the tuning loop.
 
+## Documentation
+
+- When a change adds, removes, or changes the meaning of a configuration
+  option, add or update a knowledge base guide under `docs/kb/guides/` for
+  it, not just `docs/config.example.yaml` and `config-schema.json`.
+- Prefer extending an existing guide covering the same topic over creating a
+  new file for a single setting.
+- Follow the frontmatter contract and writing guidelines in `docs/kb/README.md`
+  (required `title`/`summary`/`category`, `config_keys` referencing real
+  schema keys, keep it short, show a working config, say what goes wrong).
+- Run `make test-dev` afterward; `TestKB_FrontmatterIsValid` in
+  `internal/docagent` checks the frontmatter and that `config_keys` resolve.
+
 ### git commit rules
 
 - Run `gofmt -w <file>` before committing to fix any formatting

--- a/config-schema.json
+++ b/config-schema.json
@@ -176,6 +176,12 @@
             "default": 10,
             "description": "Graceful timeout in seconds when unloading a model (manual, API, or TTL expiry) before force-killing the model process. 0 uses the default of 10 seconds."
         },
+        "globalConcurrencyLimit": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0,
+            "description": "Caps the number of inference requests served at once across all models combined, using a single shared semaphore rather than a per-model limit. 0 means no limit. Requests exceeding the limit receive an HTTP 429 Too Many Requests response immediately rather than being queued."
+        },
         "logLevel": {
             "type": "string",
             "enum": [

--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -116,6 +116,16 @@ globalTTL: 0
 # - large values extend how long an unload can take when a process does not exit cleanly
 unloadTimeout: 10
 
+# globalConcurrencyLimit: caps the number of inference requests served at once
+# across all models combined
+# - optional, default: 0 (no limit)
+# - unlike models.*.concurrencyLimit, this is a single semaphore shared by
+#   every model rather than a per-model limit
+# - requests that exceed the limit receive an HTTP 429 Too Many Requests
+#   response immediately, rather than being queued
+# - see issue #1086
+globalConcurrencyLimit: 0
+
 # macros: a dictionary of string substitutions
 # - optional, default: empty dictionary
 # - macros are reusable snippets

--- a/docs/kb/guides/routing/capacity-and-queues.md
+++ b/docs/kb/guides/routing/capacity-and-queues.md
@@ -1,10 +1,10 @@
 ---
 title: Routing capacity and request queues
-summary: Configure concurrencyLimit and understand queued work while a model is loading or busy.
+summary: Configure concurrencyLimit and globalConcurrencyLimit, and understand queued work while a model is loading or busy.
 category: guides
-tags: [routing, queue, capacity, concurrency, concurrency-limit, max-concurrent-requests]
-config_keys: [routing, models.*.concurrencyLimit]
-updated: 2026-08-28
+tags: [routing, queue, capacity, concurrency, concurrency-limit, max-concurrent-requests, global-concurrency-limit, rate-limit]
+config_keys: [routing, models.*.concurrencyLimit, globalConcurrencyLimit]
+updated: 2026-09-10
 ---
 
 # Routing capacity and request queues
@@ -20,3 +20,25 @@ may coexist, then set client timeouts high enough for the queue and load time.
 Inspect the Activity view and logs when latency grows. A queue that never drains
 usually means the command, proxy, or health check is wrong; see
 `guides/model-runtime/troubleshooting-model-wont-load`.
+
+## Global concurrency limit
+
+`globalConcurrencyLimit` is a top-level setting, separate from
+`models.*.concurrencyLimit`. It caps the number of inference requests served
+at once across every model combined, using a single shared semaphore:
+
+```yaml
+globalConcurrencyLimit: 8
+```
+
+The default is `0`, meaning no limit — the semaphore is not even added to the
+request chain, so a default config pays no cost for the feature. Once the
+limit is reached, further requests are rejected immediately with an HTTP 429
+response rather than queued; there is no wait for a slot to free up. Clients
+should treat a 429 as a signal to back off and retry, the same way they handle
+a per-model concurrency limit rejection.
+
+Use this to protect shared hardware (CPU, disk, network) from being
+overwhelmed by traffic spread across many different models, which a per-model
+`concurrencyLimit` cannot do since it only counts requests to one model at a
+time.

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/tidwall/gjson v1.18.0
 	github.com/tidwall/sjson v1.2.5
 	github.com/yusufpapurcu/wmi v1.2.4
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.53.0
@@ -120,7 +121,6 @@ require (
 	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.58.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -294,16 +294,12 @@ github.com/tailscale/netlink v1.1.1-0.20240822203006-4d49adab4de7 h1:uFsXVBE9Qr4
 github.com/tailscale/netlink v1.1.1-0.20240822203006-4d49adab4de7/go.mod h1:NzVQi3Mleb+qzq8VmcWpSkcSYxXIg0DkI6XDzpVkhJ0=
 github.com/tailscale/peercred v0.0.0-20250107143737-35a0c7bd7edc h1:24heQPtnFR+yfntqhI3oAu9i27nEojcQ4NuBQOo5ZFA=
 github.com/tailscale/peercred v0.0.0-20250107143737-35a0c7bd7edc/go.mod h1:f93CXfllFsO9ZQVq+Zocb1Gp4G5Fz0b0rXHLOzt/Djc=
-github.com/tailscale/tailcat v0.4.0 h1:WA8QIBcnn+x7BBmay3mPY+EeOp14RTQr4Qv1Df1GOxU=
-github.com/tailscale/tailcat v0.4.0/go.mod h1:ehG1UYhg+wPqPe8rlpmSyt9O+IMkBoxwA819l6qnM8Y=
 github.com/tailscale/tailcat v0.6.0 h1:q81gzzZpmitF9D87GHDqb36nLXSmwYO5gm/97+b2xMM=
 github.com/tailscale/tailcat v0.6.0/go.mod h1:QDtlF/V4jhC/EcZIB7nc8NaHelAN2BnllV9d/pQHyM8=
 github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976 h1:UBPHPtv8+nEAy2PD8RyAhOYvau1ek0HDJqLS/Pysi14=
 github.com/tailscale/web-client-prebuilt v0.0.0-20250124233751-d4cd19a26976/go.mod h1:agQPE6y6ldqCOui2gkIh7ZMztTkIQKH049tv8siLuNQ=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6 h1:l10Gi6w9jxvinoiq15g8OToDdASBni4CyJOdHY1Hr8M=
 github.com/tailscale/wf v0.0.0-20240214030419-6fbb0a674ee6/go.mod h1:ZXRML051h7o4OcI0d3AaILDIad/Xw0IkXaHM17dic1Y=
-github.com/tailscale/wireguard-go v0.0.0-20260821191448-23d18d66172c h1:rjqTtbumXpM5B1UR7u+dsOaI9wRetOfIDan5kJJrgn8=
-github.com/tailscale/wireguard-go v0.0.0-20260821191448-23d18d66172c/go.mod h1:6SerzcvHWQchKO2BfNdmquA77CHSECZuFl+D9fp4RnI=
 github.com/tailscale/wireguard-go v0.0.0-20260904023712-e855235c55a2 h1:nRCnARSGqRvSAK9S+vbH87dMykfv2vWwx6kb8rw9Ayk=
 github.com/tailscale/wireguard-go v0.0.0-20260904023712-e855235c55a2/go.mod h1:rUelGmuK4UnSJYM5gl5Mknp6YbwwcL8+VAPMhNYe+jg=
 github.com/tailscale/xnet v0.0.0-20240729143630-8497ac4dab2e h1:zOGKqN5D5hHhiYUp091JqK7DPCqSARyUfduhGUY8Bek=
@@ -455,7 +451,5 @@ nullprogram.com/x/optparse v1.0.0/go.mod h1:KdyPE+Igbe0jQUrVfMqDMeJQIJZEuyV7pjYm
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 software.sslmate.com/src/go-pkcs12 v0.4.0 h1:H2g08FrTvSFKUj+D309j1DPfk5APnIdAQAB8aEykJ5k=
 software.sslmate.com/src/go-pkcs12 v0.4.0/go.mod h1:Qiz0EyvDRJjjxGyUQa2cCNZn/wMyzrRJ/qcDXOQazLI=
-tailscale.com v1.103.0-pre.0.20260830144538-72780705eda8 h1:Ow72mYrStZyFA3kwBBACYJZ5EkicN7fc3IEQh/U7HBA=
-tailscale.com v1.103.0-pre.0.20260830144538-72780705eda8/go.mod h1:0FUeNgU+WylKFtsg4LOZQxceO16WyN9YjvrxmUiilbs=
 tailscale.com v1.103.0-pre.0.20260904030409-31d8badb3bfb h1:leFXEBE/Kgu/+RA+Zlfk2rgCQKc+YOL2JTBwjdTQHx4=
 tailscale.com v1.103.0-pre.0.20260904030409-31d8badb3bfb/go.mod h1:kDCPNk+EmNrMykwEddg757aH43nuhiPv/w58IfUeSQM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,22 +152,27 @@ func (c *ProfileConfig) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type Config struct {
-	Tailcat            *TailcatConfig            `yaml:"tailcat"`
-	HealthCheckTimeout int                       `yaml:"healthCheckTimeout"`
-	LogRequests        bool                      `yaml:"logRequests"`
-	LogLevel           string                    `yaml:"logLevel"`
-	LogTimeFormat      string                    `yaml:"logTimeFormat"`
-	LogToStdout        string                    `yaml:"logToStdout"`
-	MetricsMaxInMemory int                       `yaml:"metricsMaxInMemory"`
-	CaptureBuffer      int                       `yaml:"captureBuffer"`
-	Store              *Store                    `yaml:"store"`
-	UI                 UIConfig                  `yaml:"ui"`
-	Performance        PerformanceConfig         `yaml:"performance"`
-	GlobalTTL          int                       `yaml:"globalTTL"`
-	UnloadTimeout      int                       `yaml:"unloadTimeout"`
-	Models             map[string]ModelConfig    `yaml:"models"` /* key is model ID */
-	Profiles           map[string]ProfileConfig  `yaml:"profiles"`
-	Selectors          map[string]SelectorConfig `yaml:"selectors"`
+	Tailcat            *TailcatConfig    `yaml:"tailcat"`
+	HealthCheckTimeout int               `yaml:"healthCheckTimeout"`
+	LogRequests        bool              `yaml:"logRequests"`
+	LogLevel           string            `yaml:"logLevel"`
+	LogTimeFormat      string            `yaml:"logTimeFormat"`
+	LogToStdout        string            `yaml:"logToStdout"`
+	MetricsMaxInMemory int               `yaml:"metricsMaxInMemory"`
+	CaptureBuffer      int               `yaml:"captureBuffer"`
+	Store              *Store            `yaml:"store"`
+	UI                 UIConfig          `yaml:"ui"`
+	Performance        PerformanceConfig `yaml:"performance"`
+	GlobalTTL          int               `yaml:"globalTTL"`
+	UnloadTimeout      int               `yaml:"unloadTimeout"`
+
+	Models    map[string]ModelConfig    `yaml:"models"` /* key is model ID */
+	Profiles  map[string]ProfileConfig  `yaml:"profiles"`
+	Selectors map[string]SelectorConfig `yaml:"selectors"`
+
+	// GlobalConcurrencyLimit caps the number of inference requests served at
+	// once across all models. 0 (default) means no limit. See issue #1086.
+	GlobalConcurrencyLimit int `yaml:"globalConcurrencyLimit"`
 
 	// routing is the canonical source for swap/scheduling configuration.
 	// New code must read Routing, never the backwards-compat fields below.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -975,6 +975,43 @@ models:
 	})
 }
 
+func TestConfig_GlobalConcurrencyLimit(t *testing.T) {
+	t.Run("defaults to 0 (no limit)", func(t *testing.T) {
+		content := `
+models:
+  model1:
+    cmd: server --port ${PORT}
+`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NoError(t, err)
+		assert.Equal(t, 0, config.GlobalConcurrencyLimit)
+	})
+
+	t.Run("sets the configured value", func(t *testing.T) {
+		content := `
+globalConcurrencyLimit: 4
+models:
+  model1:
+    cmd: server --port ${PORT}
+`
+		config, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.NoError(t, err)
+		assert.Equal(t, 4, config.GlobalConcurrencyLimit)
+	})
+
+	t.Run("negative value rejected", func(t *testing.T) {
+		content := `
+globalConcurrencyLimit: -1
+models:
+  model1:
+    cmd: server --port ${PORT}
+`
+		_, err := LoadConfigFromReader(strings.NewReader(content))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "globalConcurrencyLimit must be >= 0")
+	})
+}
+
 func TestConfig_UnloadTimeout(t *testing.T) {
 	t.Run("defaults to 10 seconds", func(t *testing.T) {
 		content := `

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -87,6 +87,10 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		config.UnloadTimeout = DEFAULT_UNLOAD_TIMEOUT
 	}
 
+	if config.GlobalConcurrencyLimit < 0 {
+		return Config{}, fmt.Errorf("globalConcurrencyLimit must be >= 0")
+	}
+
 	config.UI.Activity.SessionID = normalizeHeaderNames(config.UI.Activity.SessionID)
 
 	if config.Store != nil {

--- a/internal/docagent/golden_test.go
+++ b/internal/docagent/golden_test.go
@@ -169,8 +169,8 @@ func TestDocs_RealConfigExample_SectionKeys(t *testing.T) {
 		"healthCheckTimeout", "logLevel", "logTimeFormat", "logToStdout",
 		"metricsMaxInMemory", "captureBuffer", "ui", "performance", "startPort",
 		"sendLoadingState", "includeAliasesInList", "globalTTL", "unloadTimeout",
-		"macros", "apiKeys", "tailcat", "upstream", "profiles", "selectors",
-		"models", "hooks", "routing", "peers",
+		"globalConcurrencyLimit", "macros", "apiKeys", "tailcat", "upstream",
+		"profiles", "selectors", "models", "hooks", "routing", "peers",
 	}
 
 	for _, key := range want {

--- a/internal/server/concurrency.go
+++ b/internal/server/concurrency.go
@@ -1,0 +1,28 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/mostlygeek/llama-swap/internal/chain"
+	"github.com/mostlygeek/llama-swap/internal/swaputil"
+)
+
+// CreateConcurrencyLimitMiddleware returns middleware that caps the number of
+// inference requests served at once across all models, using a buffered
+// channel as a semaphore. A request that cannot acquire a slot is rejected
+// immediately with a 429 rather than queued (see issue #1086). Callers must
+// not add this middleware when limit <= 0; there is no "no limit" mode here.
+func CreateConcurrencyLimitMiddleware(limit int) chain.Middleware {
+	sem := make(chan struct{}, limit)
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+				next.ServeHTTP(w, r)
+			default:
+				swaputil.SendError(w, r, swaputil.ConcurrencyLimitError{})
+			}
+		})
+	}
+}

--- a/internal/server/concurrency.go
+++ b/internal/server/concurrency.go
@@ -5,24 +5,24 @@ import (
 
 	"github.com/mostlygeek/llama-swap/internal/chain"
 	"github.com/mostlygeek/llama-swap/internal/swaputil"
+	"golang.org/x/sync/semaphore"
 )
 
 // CreateConcurrencyLimitMiddleware returns middleware that caps the number of
-// inference requests served at once across all models, using a buffered
-// channel as a semaphore. A request that cannot acquire a slot is rejected
-// immediately with a 429 rather than queued (see issue #1086). Callers must
-// not add this middleware when limit <= 0; there is no "no limit" mode here.
+// inference requests served at once across all models, using a weighted
+// semaphore. A request that cannot acquire a slot is rejected immediately
+// with a 429 rather than queued (see issue #1086). Callers must not add this
+// middleware when limit <= 0; there is no "no limit" mode here.
 func CreateConcurrencyLimitMiddleware(limit int) chain.Middleware {
-	sem := make(chan struct{}, limit)
+	sem := semaphore.NewWeighted(int64(limit))
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			select {
-			case sem <- struct{}{}:
-				defer func() { <-sem }()
-				next.ServeHTTP(w, r)
-			default:
+			if !sem.TryAcquire(1) {
 				swaputil.SendError(w, r, swaputil.ConcurrencyLimitError{})
+				return
 			}
+			defer sem.Release(1)
+			next.ServeHTTP(w, r)
 		})
 	}
 }

--- a/internal/server/concurrency_test.go
+++ b/internal/server/concurrency_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestServer_ConcurrencyLimitMiddleware(t *testing.T) {
+	t.Run("allows requests up to the limit", func(t *testing.T) {
+		final := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		mw := CreateConcurrencyLimitMiddleware(2)
+		handler := mw(final)
+
+		for i := 0; i < 2; i++ {
+			r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, r)
+			assert.Equal(t, http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("rejects with 429 once the limit is reached", func(t *testing.T) {
+		// blocks until released, so the slot stays held while the next request
+		// is admitted
+		release := make(chan struct{})
+		started := make(chan struct{})
+		final := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			close(started)
+			<-release
+			w.WriteHeader(http.StatusOK)
+		})
+		mw := CreateConcurrencyLimitMiddleware(1)
+		handler := mw(final)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, r)
+		}()
+
+		<-started
+
+		r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusTooManyRequests, w.Code)
+		assert.Equal(t, "1", w.Header().Get("Retry-After"))
+
+		close(release)
+		wg.Wait()
+	})
+
+	t.Run("released slot can be reacquired", func(t *testing.T) {
+		final := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		mw := CreateConcurrencyLimitMiddleware(1)
+		handler := mw(final)
+
+		for i := 0; i < 3; i++ {
+			r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, r)
+			assert.Equal(t, http.StatusOK, w.Code)
+		}
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -299,8 +299,14 @@ func stripAudioAPIPrefix(r *http.Request) {
 func (s *Server) routes() {
 
 	authMW := CreateAuthMiddleware(s.cfg)
-	modelChain := chain.New(
-		authMW,
+	modelMWs := []chain.Middleware{authMW}
+	// globalConcurrencyLimit guards the top of the inference chain; a limit of
+	// 0 (the default) means no limit, so the handler is left out of the chain
+	// entirely rather than wrapping every request in a no-op semaphore.
+	if s.cfg.GlobalConcurrencyLimit > 0 {
+		modelMWs = append(modelMWs, CreateConcurrencyLimitMiddleware(s.cfg.GlobalConcurrencyLimit))
+	}
+	modelMWs = append(modelMWs,
 		CreateProfileMiddleware(s),
 		CreateSelectorMiddleware(s),
 		CreateRequestContextMiddleware(s.cfg),
@@ -309,6 +315,7 @@ func (s *Server) routes() {
 		CreateFormFilterMiddleware(s.cfg),
 		CreateMetricsMiddleware(s.metrics, s.cfg),
 	)
+	modelChain := chain.New(modelMWs...)
 	// Custom endpoints only need auth.
 	apiChain := chain.New(authMW)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -72,6 +72,12 @@ func (s *stubRouter) ProcessLogger(modelID string) (*logmon.Monitor, bool) {
 
 // newTestServer wires a Server with stub routers and a built mux.
 func newTestServer(local router.LocalRouter, peer router.Router) *Server {
+	return newTestServerWithConfig(config.Config{}, local, peer)
+}
+
+// newTestServerWithConfig is newTestServer with a caller-supplied config, for
+// tests that exercise config-driven middleware wiring in routes().
+func newTestServerWithConfig(cfg config.Config, local router.LocalRouter, peer router.Router) *Server {
 	ctx, cancel := context.WithCancel(context.Background())
 	proxylog := logmon.NewWriter(io.Discard)
 	st, err := store.New("")
@@ -79,7 +85,7 @@ func newTestServer(local router.LocalRouter, peer router.Router) *Server {
 		panic(err)
 	}
 	s := &Server{
-		cfg:         config.Config{},
+		cfg:         cfg,
 		muxlog:      logmon.NewWriter(io.Discard),
 		proxylog:    proxylog,
 		upstreamlog: logmon.NewWriter(io.Discard),
@@ -257,6 +263,59 @@ func TestServer_RouteToLocalModel_PrefersLocalCollision(t *testing.T) {
 	if w.Body.String() != "local response" {
 		t.Errorf("body=%q want local response", w.Body.String())
 	}
+}
+
+func TestServer_GlobalConcurrencyLimit(t *testing.T) {
+	t.Run("zero disables the limiter, unbounded requests pass", func(t *testing.T) {
+		s := newTestServerWithConfig(
+			config.Config{GlobalConcurrencyLimit: 0},
+			newStubRouter([]string{"local-model"}, "ok"),
+			newStubRouter(nil, ""),
+		)
+
+		for i := 0; i < 5; i++ {
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, chatRequest("local-model"))
+			if w.Code != http.StatusOK {
+				t.Fatalf("request %d: status=%d body=%q", i, w.Code, w.Body.String())
+			}
+		}
+	})
+
+	t.Run("rejects requests beyond the configured limit with 429", func(t *testing.T) {
+		release := make(chan struct{})
+		started := make(chan struct{})
+		blocking := newStubRouter([]string{"local-model"}, "")
+		blocking.serveHTTP = func(w http.ResponseWriter, r *http.Request) {
+			close(started)
+			<-release
+			w.WriteHeader(http.StatusOK)
+		}
+
+		s := newTestServerWithConfig(
+			config.Config{GlobalConcurrencyLimit: 1},
+			blocking,
+			newStubRouter(nil, ""),
+		)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, chatRequest("local-model"))
+		}()
+
+		<-started
+
+		w := httptest.NewRecorder()
+		s.ServeHTTP(w, chatRequest("local-model"))
+		if w.Code != http.StatusTooManyRequests {
+			t.Fatalf("status=%d body=%q want 429", w.Code, w.Body.String())
+		}
+
+		close(release)
+		<-done
+	})
 }
 
 func TestServer_UnknownModelReturns404(t *testing.T) {


### PR DESCRIPTION
Add a globalConcurrencyLimit top-level config option that caps the
number of inference requests served at once across all models
combined, independent of the existing per-model concurrencyLimit.

- default is 0 (no limit); requests are rejected with an HTTP 429
  once the limit is reached rather than queued
- implemented as a semaphore middleware at the top of the model
  inference chain, right after auth
- the middleware is only added to the chain when the limit is > 0,
  so a default config pays no cost for the feature

fix: #1086
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D8i1HuB3eU3ajd8nfzc8qu