### PR TITLE
cmd/vllm-wrapper: add configurable response header timeout

### DIFF
--- a/cmd/vllm-wrapper/README.md
+++ b/cmd/vllm-wrapper/README.md
@@ -47,6 +47,7 @@ models:
       --vllm-url http://127.0.0.1:8000
       --listen :${PORT}
       --wait-timeout 600s
+      --response-header-timeout 20m
       --
       ${vllm}
       serve
@@ -56,6 +57,12 @@ models:
       --max-model-len ${context_size}
       --enable-sleep-mode
 ```
+
+`--response-header-timeout` (default `15m`) bounds how long the wrapper's
+reverse proxy waits for response headers from vLLM after a request is sent.
+Raise it for reasoning models or large-context requests that take a long
+time to produce their first token; set it to `0` to disable the timeout
+entirely and rely on the client's own timeout instead.
 
 Benefits of argv-based startup:
 - Enables native vLLM without Docker.

--- a/cmd/vllm-wrapper/README.md
+++ b/cmd/vllm-wrapper/README.md
@@ -47,7 +47,6 @@ models:
       --vllm-url http://127.0.0.1:8000
       --listen :${PORT}
       --wait-timeout 600s
-      --response-header-timeout 20m
       --
       ${vllm}
       serve
@@ -57,12 +56,6 @@ models:
       --max-model-len ${context_size}
       --enable-sleep-mode
 ```
-
-`--response-header-timeout` (default `15m`) bounds how long the wrapper's
-reverse proxy waits for response headers from vLLM after a request is sent.
-Raise it for reasoning models or large-context requests that take a long
-time to produce their first token; set it to `0` to disable the timeout
-entirely and rely on the client's own timeout instead.
 
 Benefits of argv-based startup:
 - Enables native vLLM without Docker.
@@ -225,6 +218,7 @@ sudo -u llama env \
 - For production use, ensure the vLLM daemon is properly managed (e.g., restarted if it crashes) outside of this wrapper.
 - The wrapper does not handle TLS certificates; if your vLLM server uses HTTPS, provide the appropriate URL and ensure the system's root CAs are configured.
 - On SIGTERM, the wrapper sends a sleep request to vLLM (using the configured sleep level) before shutting down, then exits cleanly without killing the vLLM daemon.
+- The reverse proxy uses Go's default HTTP transport (`http.DefaultTransport`), so there is no fixed limit on how long it waits for response headers from vLLM. Long-running generations are bounded only by the client's own timeout.
 
 ## Building
 

--- a/cmd/vllm-wrapper/main.go
+++ b/cmd/vllm-wrapper/main.go
@@ -49,12 +49,13 @@ func main() {
 // serveCmd implements the serve subcommand.
 func serveCmd(args []string) {
 	var (
-		vllmURL     string
-		listenAddr  string
-		sleepLevel  int
-		healthPath  string
-		waitTimeout time.Duration
-		journalUnit string
+		vllmURL               string
+		listenAddr            string
+		sleepLevel            int
+		healthPath            string
+		waitTimeout           time.Duration
+		journalUnit           string
+		responseHeaderTimeout time.Duration
 	)
 	fs := flag.NewFlagSet("serve", flag.ExitOnError)
 	fs.StringVar(&vllmURL, "vllm-url", "", "Base URL of vLLM server (e.g., http://127.0.0.1:8000)")
@@ -63,6 +64,8 @@ func serveCmd(args []string) {
 	fs.StringVar(&healthPath, "health-path", "/health", "Health check path (default /health)")
 	fs.DurationVar(&waitTimeout, "wait-timeout", 120*time.Second, "Timeout waiting for daemon to become healthy")
 	fs.StringVar(&journalUnit, "journal-unit", "", "User systemd unit whose logs should be forwarded to stdout")
+	fs.DurationVar(&responseHeaderTimeout, "response-header-timeout", 15*time.Minute,
+		"Max time to wait for response headers from vLLM after the request is written (e.g. 20m). 0 disables the timeout.")
 	fs.Parse(args)
 	startArgs := fs.Args()
 
@@ -125,22 +128,7 @@ func serveCmd(args []string) {
 		log.Fatalf("Invalid vLLM URL %q: %v", vllmURL, err)
 	}
 	proxy := httputil.NewSingleHostReverseProxy(proxyURL)
-
-	// Create a custom transport to set timeouts.
-	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: 300 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		MaxIdleConns:          100,
-		MaxIdleConnsPerHost:   10,
-		IdleConnTimeout:       90 * time.Second,
-	}
-	proxy.Transport = transport
+	proxy.Transport = newProxyTransport(responseHeaderTimeout)
 
 	// Modify response to disable buffering for streaming.
 	proxy.ModifyResponse = func(resp *http.Response) error {
@@ -188,6 +176,27 @@ func serveCmd(args []string) {
 		log.Fatalf("Server shutdown failed: %v", err)
 	}
 	log.Println("Server stopped")
+}
+
+// newProxyTransport builds the HTTP transport used to proxy requests to the
+// vLLM upstream. responseHeaderTimeout bounds how long to wait for response
+// headers after a request is written; 0 disables the timeout (net/http
+// semantics), letting long-running generations run as long as the client
+// allows.
+func newProxyTransport(responseHeaderTimeout time.Duration) *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: responseHeaderTimeout,
+		ExpectContinueTimeout: 1 * time.Second,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   10,
+		IdleConnTimeout:       90 * time.Second,
+	}
 }
 
 // sleepCmd implements the sleep subcommand.

--- a/cmd/vllm-wrapper/main.go
+++ b/cmd/vllm-wrapper/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -49,13 +48,12 @@ func main() {
 // serveCmd implements the serve subcommand.
 func serveCmd(args []string) {
 	var (
-		vllmURL               string
-		listenAddr            string
-		sleepLevel            int
-		healthPath            string
-		waitTimeout           time.Duration
-		journalUnit           string
-		responseHeaderTimeout time.Duration
+		vllmURL     string
+		listenAddr  string
+		sleepLevel  int
+		healthPath  string
+		waitTimeout time.Duration
+		journalUnit string
 	)
 	fs := flag.NewFlagSet("serve", flag.ExitOnError)
 	fs.StringVar(&vllmURL, "vllm-url", "", "Base URL of vLLM server (e.g., http://127.0.0.1:8000)")
@@ -64,8 +62,6 @@ func serveCmd(args []string) {
 	fs.StringVar(&healthPath, "health-path", "/health", "Health check path (default /health)")
 	fs.DurationVar(&waitTimeout, "wait-timeout", 120*time.Second, "Timeout waiting for daemon to become healthy")
 	fs.StringVar(&journalUnit, "journal-unit", "", "User systemd unit whose logs should be forwarded to stdout")
-	fs.DurationVar(&responseHeaderTimeout, "response-header-timeout", 15*time.Minute,
-		"Max time to wait for response headers from vLLM after the request is written (e.g. 20m). 0 disables the timeout.")
 	fs.Parse(args)
 	startArgs := fs.Args()
 
@@ -128,7 +124,6 @@ func serveCmd(args []string) {
 		log.Fatalf("Invalid vLLM URL %q: %v", vllmURL, err)
 	}
 	proxy := httputil.NewSingleHostReverseProxy(proxyURL)
-	proxy.Transport = newProxyTransport(responseHeaderTimeout)
 
 	// Modify response to disable buffering for streaming.
 	proxy.ModifyResponse = func(resp *http.Response) error {
@@ -176,27 +171,6 @@ func serveCmd(args []string) {
 		log.Fatalf("Server shutdown failed: %v", err)
 	}
 	log.Println("Server stopped")
-}
-
-// newProxyTransport builds the HTTP transport used to proxy requests to the
-// vLLM upstream. responseHeaderTimeout bounds how long to wait for response
-// headers after a request is written; 0 disables the timeout (net/http
-// semantics), letting long-running generations run as long as the client
-// allows.
-func newProxyTransport(responseHeaderTimeout time.Duration) *http.Transport {
-	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ResponseHeaderTimeout: responseHeaderTimeout,
-		ExpectContinueTimeout: 1 * time.Second,
-		MaxIdleConns:          100,
-		MaxIdleConnsPerHost:   10,
-		IdleConnTimeout:       90 * time.Second,
-	}
 }
 
 // sleepCmd implements the sleep subcommand.

--- a/cmd/vllm-wrapper/main_test.go
+++ b/cmd/vllm-wrapper/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -98,6 +99,45 @@ func TestStartDaemon(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "daemon did not become healthy") {
 		t.Errorf("error expected to contain 'daemon did not become healthy', got %v", err)
+	}
+}
+
+// TestNewProxyTransport_ResponseHeaderTimeout verifies that the configured
+// response header timeout is applied to the transport, and that 0 disables
+// it per net/http semantics.
+func TestNewProxyTransport_ResponseHeaderTimeout(t *testing.T) {
+	transport := newProxyTransport(15 * time.Minute)
+	if transport.ResponseHeaderTimeout != 15*time.Minute {
+		t.Errorf("ResponseHeaderTimeout: got %v, want %v", transport.ResponseHeaderTimeout, 15*time.Minute)
+	}
+
+	transport = newProxyTransport(0)
+	if transport.ResponseHeaderTimeout != 0 {
+		t.Errorf("ResponseHeaderTimeout: got %v, want 0 (disabled)", transport.ResponseHeaderTimeout)
+	}
+}
+
+// TestServeCmd_ResponseHeaderTimeoutFlag verifies the -response-header-timeout
+// flag defaults to at least 15 minutes and can be overridden.
+func TestServeCmd_ResponseHeaderTimeoutFlag(t *testing.T) {
+	var responseHeaderTimeout time.Duration
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	fs.DurationVar(&responseHeaderTimeout, "response-header-timeout", 15*time.Minute, "")
+
+	if err := fs.Parse(nil); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if responseHeaderTimeout < 15*time.Minute {
+		t.Errorf("default response-header-timeout: got %v, want >= 15m", responseHeaderTimeout)
+	}
+
+	fs2 := flag.NewFlagSet("serve", flag.ContinueOnError)
+	fs2.DurationVar(&responseHeaderTimeout, "response-header-timeout", 15*time.Minute, "")
+	if err := fs2.Parse([]string{"-response-header-timeout", "0"}); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if responseHeaderTimeout != 0 {
+		t.Errorf("override response-header-timeout: got %v, want 0", responseHeaderTimeout)
 	}
 }
 

--- a/cmd/vllm-wrapper/main_test.go
+++ b/cmd/vllm-wrapper/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -99,45 +98,6 @@ func TestStartDaemon(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "daemon did not become healthy") {
 		t.Errorf("error expected to contain 'daemon did not become healthy', got %v", err)
-	}
-}
-
-// TestNewProxyTransport_ResponseHeaderTimeout verifies that the configured
-// response header timeout is applied to the transport, and that 0 disables
-// it per net/http semantics.
-func TestNewProxyTransport_ResponseHeaderTimeout(t *testing.T) {
-	transport := newProxyTransport(15 * time.Minute)
-	if transport.ResponseHeaderTimeout != 15*time.Minute {
-		t.Errorf("ResponseHeaderTimeout: got %v, want %v", transport.ResponseHeaderTimeout, 15*time.Minute)
-	}
-
-	transport = newProxyTransport(0)
-	if transport.ResponseHeaderTimeout != 0 {
-		t.Errorf("ResponseHeaderTimeout: got %v, want 0 (disabled)", transport.ResponseHeaderTimeout)
-	}
-}
-
-// TestServeCmd_ResponseHeaderTimeoutFlag verifies the -response-header-timeout
-// flag defaults to at least 15 minutes and can be overridden.
-func TestServeCmd_ResponseHeaderTimeoutFlag(t *testing.T) {
-	var responseHeaderTimeout time.Duration
-	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
-	fs.DurationVar(&responseHeaderTimeout, "response-header-timeout", 15*time.Minute, "")
-
-	if err := fs.Parse(nil); err != nil {
-		t.Fatalf("Parse: %v", err)
-	}
-	if responseHeaderTimeout < 15*time.Minute {
-		t.Errorf("default response-header-timeout: got %v, want >= 15m", responseHeaderTimeout)
-	}
-
-	fs2 := flag.NewFlagSet("serve", flag.ContinueOnError)
-	fs2.DurationVar(&responseHeaderTimeout, "response-header-timeout", 15*time.Minute, "")
-	if err := fs2.Parse([]string{"-response-header-timeout", "0"}); err != nil {
-		t.Fatalf("Parse: %v", err)
-	}
-	if responseHeaderTimeout != 0 {
-		t.Errorf("override response-header-timeout: got %v, want 0", responseHeaderTimeout)
 	}
 }
 


### PR DESCRIPTION
Remove arbitrary timeout values. 

fix: #1090

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ui5LpyEX38gzXiRws1QyEx