### PR TITLE
internal/spl: add Swap Policy Language for request rewriting

### DIFF
--- a/ai-plans/spl.md
+++ b/ai-plans/spl.md
@@ -1,0 +1,312 @@
+# SPL (Swap Policy Language) implementation plan
+
+## Context
+
+Today a request body can only be rewritten with the predefined `filters` block
+(`useModelName`, `stripParams`, `setParams`, `setParamsByID`) implemented in
+`internal/server/filters.go`. Every new need (conditional defaults, client
+specific overrides, denying requests) means a new Go filter. SPL ("spell") is a
+small declarative language written inline in the YAML config. A program is a
+list of `ACTION [when CONDITION]` clauses evaluated top to bottom over the JSON
+request body. It is meant to be the long-term home for request rewriting,
+validation and denial.
+
+Decisions confirmed with the user:
+
+- Attach points: BOTH a global `hooks.on_request` program and a per-model /
+  per-peer `filters.policy` program, plus a top-level `policies:` map of named
+  reusable programs for `apply`. (The draft called the hook `preHook`; this plan
+  uses `hooks.on_request` to match the existing `hooks.on_startup` naming.)
+- Ordering: legacy filters first, then `hooks.on_request`, then the matched
+  model or peer `filters.policy`. A `deny` anywhere stops processing.
+- `deny "msg"` returns 403; `deny 400 "msg"` overrides the status (400-599).
+- Full operator set: `=`, `!=`, `<`, `<=`, `>`, `>=`, `matches /re/`,
+  `is present`, `is missing`, `in [...]`, `and`, `or`, `not`, parentheses.
+- Out of scope for v1: `auth.user` / `auth.claims` (no user or claims concept
+  exists in llama-swap). `auth.key` (the extracted API key) is exposed instead.
+
+## Package layout: new `internal/spl`
+
+Standalone package with no import of `internal/config` (config imports spl),
+mirroring how `internal/matrix` is wrapped by `internal/config/matrix.go`.
+Dependencies: stdlib, `github.com/tidwall/gjson`, `github.com/tidwall/sjson`
+(both already in go.mod).
+
+Files: `doc.go`, `token.go`, `lexer.go`, `ast.go`, `parser.go`, `path.go`,
+`value.go`, `eval.go`, `library.go`, `errors.go`, plus `*_test.go`.
+
+Exported API:
+
+```go
+type Error struct{ Line, Col int; Msg string }   // Error() => "line 3:12: msg"
+
+type Program struct{ /* clauses, applies */ }
+func Parse(src string) (*Program, error)         // syntax, regex compile, namespace checks
+func (p *Program) Applies() []string             // policy names referenced by apply
+func (p *Program) Len() int                      // 0 for blank/comment-only source
+func (p *Program) Validate(lib *Library, protected []string) error
+    // for standalone programs: protected write targets + apply references resolve
+
+type Library struct{ /* name -> *Program */ }
+func NewLibrary(policies map[string]string, protected []string) (*Library, error)
+    // parses all, checks apply references, DFS cycle detection, protected paths
+func (l *Library) Lookup(name string) (*Program, bool)
+
+type Request struct {
+    Body    []byte
+    Context map[string]string // context.* (read/write)
+    APIKey  string            // auth.key
+    Model   string            // request.model (ID the client asked for)
+    Path    string            // request.path
+    Method  string            // request.method
+    Header  http.Header       // request.header.<name>
+}
+type Denial struct{ Status int; Message string }
+func (p *Program) Run(lib *Library, req *Request) (*Denial, error)
+    // rewrites req.Body / req.Context in place; Denial non-nil on deny
+```
+
+`protected` is passed in from `config.ProtectedParams` (`internal/config/filters.go:11`)
+rather than duplicated. `Program` and `Library` are immutable after
+construction; `Run` allocates per call, so they are safe for concurrent use.
+`apply` resolves by map lookup in the `Library` at run time (validated at
+load); a missing name at run time is returned as an `error` (HTTP 500).
+
+## Grammar
+
+Tokens: `IDENT` `[A-Za-z_][A-Za-z0-9_-]*` (keywords are only keywords in
+keyword positions, so a body key named `set` or `in` still works as a path
+segment); `NUMBER` `-?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?`; `STRING` double
+quoted with JSON escapes; `REGEX` `/.../` with `\/` escape, Go regexp syntax,
+compiled at parse time; `OBJECT` `{...}` scanned as balanced braces (string
+aware) and required to satisfy `json.Valid`; punctuation `. [ ] ( ) , = == != <
+<= > >=`; `NEWLINE`; `EOF`. Comments: `#` to end of line.
+
+Keywords: `default set remove apply deny to when and or not is present missing
+in matches true false null`.
+
+Newline rules: `\r\n` normalised; blank and comment-only lines dropped;
+newlines inside `()`, `[]`, `{}` ignored; a newline followed by `when`, `and`
+or `or` is a continuation (no action begins with those words).
+
+```
+program    = [ clause { NEWLINE clause } ] ;
+clause     = action [ "when" condition ] ;
+action     = "default" wpath "to" value
+           | "set"     wpath "to" value
+           | "remove"  wpath
+           | "apply"   IDENT
+           | "deny"    [ NUMBER ] STRING ;           (* integer 400..599 *)
+value      = scalar | list | OBJECT ;
+scalar     = STRING | NUMBER | "true" | "false" | "null" ;
+list       = "[" [ value { "," value } ] "]" ;
+condition  = or_expr ;
+or_expr    = and_expr { "or" and_expr } ;
+and_expr   = not_expr { "and" not_expr } ;
+not_expr   = "not" not_expr | primary ;
+primary    = "(" condition ")" | predicate ;
+predicate  = rpath cmp scalar
+           | rpath "matches" REGEX
+           | rpath "is" "present" | rpath "is" "missing"
+           | rpath "in" "[" [ scalar { "," scalar } ] "]" ;
+cmp        = "=" | "!=" | "<" | "<=" | ">" | ">=" ;
+path       = IDENT { "." IDENT | "[" NUMBER "]" } ;  (* integer index, may be negative *)
+```
+
+Parse-time errors (all `*Error` with line:col): deny status outside 400-599,
+object/array literal used in a comparison, write to `auth.*` or `request.*`
+(read-only), `context` write path deeper than `context.<key>`, invalid regex,
+unexpected token / unexpected end of line with "expected ..." text.
+
+## Evaluation semantics
+
+Namespaces by first path segment:
+
+| segment | meaning | read | write |
+|---|---|---|---|
+| anything else | JSON request body via gjson/sjson | yes | yes |
+| `body.<path>` | explicit body prefix, escape hatch when a body's top-level key is literally `context`/`auth`/`request`/`body` (Ollama sends `context`) | yes | yes |
+| `context.<key>` | `Request.Context` string bag (becomes `ReqContextData.Metadata`, copied into the activity log) | yes | yes |
+| `auth.key` | API key extracted for the request; absent when empty | yes | no |
+| `request.model`, `request.path`, `request.method`, `request.header.<name>` | request facts; header via `Header.Get`, absent when empty | yes | no |
+
+gjson path translation: segments joined with `.`, integer indexes become numeric
+segments (`messages.0.content`). IDENT never contains characters that gjson
+treats specially, so no escaping. Negative index is resolved at eval time by
+reading the array at the prefix and substituting `len+idx`; if the prefix is
+not an array or `len+idx < 0` the path is unresolvable: reads are absent,
+writes/removes are no-ops.
+
+Value model: absent | null | bool | number (float64) | string | object | array,
+built from `gjson.Result`. JSON `null` counts as **present**. Literals are
+pre-encoded to raw JSON at parse time (numbers keep source text so large
+integers survive) and written with one `sjson.SetRawBytes` call.
+
+Operators:
+- `=`: same kind and equal; different kinds, absent, object/array → false.
+- `!=`: exact complement of `=` (absent `!= "x"` is true; document "use
+  `x is present and x != "y"`" when absence must not match).
+- `<` `<=` `>` `>=`: both numbers → numeric; both strings → byte order;
+  anything else → false.
+- `matches`: strings only; others → false.
+- `in [..]`: any element `=`.
+- `and` binds tighter than `or`; `not` tighter than both; parentheses override.
+
+Actions:
+- `default p to v`: set only when `p` is absent. `set p to v`: always write.
+- `remove p`: `sjson.DeleteBytes` when present, else no-op; context → delete key.
+- Context writes coerce to string: strings as-is, numbers by source text, bools
+  `"true"`/`"false"`, objects/arrays compact JSON, `null` deletes the key.
+- `apply name`: run the named program against the same state; depth guard
+  `maxApplyDepth = 32` returns an error (cycles are already rejected at load).
+  A `Denial` from the applied policy propagates immediately.
+- `deny [status] "msg"`: returns `Denial{Status (default 403), Message}` and
+  stops everything, including any later program in the chain.
+
+Errors from sjson/json → `error` from `Run` → HTTP 500, like legacy filters.
+
+## Config wiring (`internal/config`)
+
+Struct changes:
+- `config.go` `HooksConfig`: add `OnRequest string \`yaml:"on_request"\``.
+- `config.go` `Config`: add `Policies map[string]string \`yaml:"policies"\``
+  and an unexported `spl *SPLPrograms` with accessor `func (c Config) SPL() *SPLPrograms`.
+  **Leave `spl` nil when nothing SPL-related is configured** so the existing
+  whole-config equality test in `config_posix_test.go:304` keeps passing.
+- `filters.go` `Filters`: add `Policy string \`yaml:"policy"\``. `ModelFilters`
+  (inline embed, `model_config.go:171`) and `PeerConfig.Filters` (`peer.go:18`)
+  pick it up with no change.
+
+New file `internal/config/spl.go`:
+
+```go
+type SPLPrograms struct {
+    Library   *spl.Library
+    OnRequest *spl.Program            // nil when hooks.on_request is blank
+    Models    map[string]*spl.Program // model ID -> compiled filters.policy
+    Peers     map[string]*spl.Program // peer ID -> compiled filters.policy
+}
+var policyNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*$`)
+func validateSPL(config *Config) error
+```
+
+`validateSPL` (sorted iteration for deterministic errors): validate policy
+names against `policyNamePattern`; `spl.NewLibrary(config.Policies, ProtectedParams)`;
+parse+validate `hooks.on_request`; parse+validate each non-blank model and peer
+`filters.policy`; set `config.spl` only if any program exists. Error prefixes:
+`policies.<name>: line L:C: ...`, `policies: cycle detected: a -> b -> a`,
+`hooks.on_request: line L:C: ...`, `model <id>: filters.policy: line L:C: ...`,
+`peer <id>: filters.policy: line L:C: ...`, and
+`cannot set protected parameter "model"` for set/default/remove of `model`.
+
+Call site: `internal/config/load.go`, after `validateProfiles` and before
+`validateTailcatConfig` so models and peers are fully normalised first.
+
+Macros: no code needed. Global macros already expand into every top-level key
+and model-local macros (incl. `${MODEL_ID}`) into model fields, and leftover
+`${...}` already fails load via `validateConfigMacroUses` (`macros.go:307`).
+Document that `${...}` inside an SPL `#` comment is still substituted.
+
+Merge: add `"policies": true` to `identityMapPaths` in `internal/config/merge.go:17`
+so the same policy name in two `-config-dir` files is an error.
+
+## Server wiring (`internal/server/filters.go`)
+
+In `CreateFilterMiddleware`, after `applyFilters` (legacy filters) and before
+the body is re-attached:
+
+```go
+if programs := cfg.SPL(); programs != nil {
+    hook, policy := resolvePolicies(cfg, programs, data.Model) // same lookup order as resolveFilters
+    if hook != nil || policy != nil {
+        if data.Metadata == nil { // defensive; extractContext normally allocates it
+            data.Metadata = make(map[string]string)
+            *r = *r.WithContext(swaputil.SetContext(r.Context(), data))
+        }
+        req := &spl.Request{Body: body, Context: data.Metadata, APIKey: data.ApiKey,
+            Model: data.Model, Path: r.URL.Path, Method: r.Method, Header: r.Header}
+        denied, err := runPolicies(programs.Library, req, hook, policy)
+        if err != nil { swaputil.SendResponse(w, r, http.StatusInternalServerError, err.Error()); return }
+        if denied != nil { swaputil.SendResponse(w, r, denied.Status, denied.Message); return }
+        body = req.Body
+    }
+}
+```
+
+- `ReqContextData` is stored by value (`swaputil/http.go:494`) but `Metadata` is
+  a map, so `context.*` writes are visible to `CreateMetricsMiddleware`
+  (`metrics.go:148`), which copies them into `ActivityLogEntry.Metadata`.
+- Deny uses `swaputil.SendResponse` (`swaputil/http.go:193`) which emits the
+  OpenAI-style error envelope for JSON clients.
+- No logger added in v1 (keeps `CreateFilterMiddleware(cfg)` signature).
+- `CreateFormFilterMiddleware` (multipart) and the `/upstream/` chain are untouched.
+
+## Tests
+
+`internal/spl` (`TestSPL_*`, table-driven, testify): lexer tokens and newline
+rules and errors; parser actions, conditions, precedence, paths, errors with
+line:col; negative index resolution; comparison semantics across kinds; actions
+(default/set/remove, nested create, context coercion incl. `null` delete);
+request namespace reads; deny default/custom status/inside apply; apply order
+and depth guard; library unknown apply, cycle (direct and A→B→C→A), protected
+path (`model`, `body.model`, `model.x`), empty program; concurrent `Run`.
+
+`internal/config` (`spl_test.go`, via `LoadConfigFromReader`): `TestConfig_SPL_Valid`,
+`_ParseErrorLocation` (all four prefixes), `_UnknownPolicy`, `_Cycle`,
+`_ProtectedModel`, `_InvalidPolicyName`, `_MacroSubstitution`, `_NoSPLLeavesNil`;
+`merge_test.go`: duplicate policy across config-dir files.
+
+`internal/server` (`filters_test.go`, build cfg with `LoadConfigFromReader`,
+drive `CreateFilterMiddleware(cfg)(final)` with httptest like
+`TestServer_FormFilterMiddleware`): `TestServer_FilterMiddleware_SPL_DefaultSetRemove`,
+`_DenyEnvelope` (403 and `deny 429`), `_LegacyFiltersRunFirst` (stripped key
+counts as missing), `_GlobalHookBeforeModelPolicy` (override and hook deny
+short-circuit), `_ContextLandsInMetadata` (assert via `swaputil.ReadContext` in
+`final`), `_PeerPolicy`, `_UseModelNameVisible` (`request.model` is the alias,
+body `model` is rewritten), `_NonJSONUntouched`, `_NoSPLConfigured` (hand-built
+`config.Config{}` still works).
+
+`internal/docagent`: add `"policies"` to the `want` list in
+`TestDocs_RealConfigExample_SectionKeys` (`golden_test.go:168`) at its file
+position; KB frontmatter/cross-reference tests cover the new page automatically.
+
+## Docs
+
+- `config-schema.json`: top-level `policies` (object, `propertyNames` pattern
+  `^[A-Za-z_][A-Za-z0-9_-]*$`, string values); `hooks.properties.on_request`
+  (string) and fix the hooks description that says only `on_startup` exists;
+  `filters.properties.policy` (string) on both models and peers.
+- `docs/config.example.yaml`: new `policies:` section between `models:` and
+  `hooks:` with two or three short programs (default, set with object literal,
+  `deny 400`, `matches`, `messages[-1].content`); `hooks.on_request: |` example
+  using `apply` and `set context.<key>`; `filters.policy: |` on the model block
+  (with `${MODEL_ID}`) and on the openrouter peer block. Keep SPL comment lines
+  indented inside the block scalar so the section parser is not confused.
+- New KB page `docs/kb/guides/api-integration/swap-policy-language.md`
+  (frontmatter per `docs/kb/README.md`; `config_keys: [policies,
+  hooks.on_request, models.*.filters.policy, peers.*.filters.policy]`): what
+  SPL is, a working config, actions, conditions (absent vs null rules), paths
+  and namespaces and negative indexes, `apply` and cycles, `deny` and the error
+  envelope, `context.*` and the activity log, order of operations, macros,
+  what goes wrong, future work (`auth.user`/`auth.claims`).
+- Update "Order of operations" and Related links in
+  `docs/kb/guides/api-integration/filters-and-request-rewriting.md`.
+- Also save this plan as `ai-plans/spl.md` in the repo (user request).
+
+## Implementation order and verification
+
+1. `internal/spl`: errors → lexer (+tests) → parser (+tests) → path/value →
+   eval (+tests) → library (+tests). `go test -race ./internal/spl/...`
+2. Config: struct fields, `spl.go`, `load.go` call, `merge.go` entry, tests.
+   `go test ./internal/config/...`
+3. Server: `filters.go` changes + tests. `go test ./internal/server/...`
+4. Schema, `config.example.yaml`, docagent `want` list, KB pages.
+   `go test ./internal/config/ -run TestConfig_ExampleMatchesSchema` and
+   `go test ./internal/docagent/...`
+5. End-to-end: `make simple-responder`, write a config with a policy that
+   denies when `messages is missing` and defaults `temperature`, run
+   `./build/llama-swap`, curl `/v1/chat/completions` and check the 403 envelope
+   and the rewritten body reaching the responder.
+6. `gofmt -w` on every touched file, `make test-dev`, then `make test-all`.
+   Commit per AGENTS.md format (`internal/spl: add Swap Policy Language`,
+   hard-wrapped at 80) and push to `claude/spl-implementation-699fvi`.

--- a/config-schema.json
+++ b/config-schema.json
@@ -518,11 +518,16 @@
                                 },
                                 "default": {},
                                 "description": "Dictionary mapping requested model IDs (or aliases) to parameters to set/override in requests. Applied after setParams and can override those values. Useful with aliases to vary behaviour depending on which alias the client used (e.g. different reasoning_effort per alias). A parameter key ending in '?' (e.g. 'max_tokens?') is set-if-undefined: it is only applied when the request does not already contain that parameter. Keys support ${MODEL_ID} macro substitution. Protected params like 'model' cannot be overridden."
+                            },
+                            "policy": {
+                                "type": "string",
+                                "default": "",
+                                "description": "Swap Policy Language (SPL) program applied to requests for this model. Runs after stripParams, setParams, setParamsByID and hooks.on_request. The model parameter cannot be set or removed. See docs/kb/guides/api-integration/swap-policy-language.md."
                             }
                         },
                         "additionalProperties": false,
                         "default": {},
-                        "description": "Dictionary of filter settings. Supports stripParams, setParams, and setParamsByID."
+                        "description": "Dictionary of filter settings. Supports stripParams, setParams, setParamsByID and policy (SPL)."
                     },
                     "metadata": {
                         "type": "object",
@@ -619,6 +624,17 @@
                 }
             }
         },
+        "policies": {
+            "type": "object",
+            "default": {},
+            "propertyNames": {
+                "pattern": "^[A-Za-z_][A-Za-z0-9_-]*$"
+            },
+            "additionalProperties": {
+                "type": "string"
+            },
+            "description": "Named Swap Policy Language (SPL) programs. Other programs run them with `apply <name>`. Policies may apply other policies; unknown names and cycles are rejected when the configuration loads."
+        },
         "groups": {
             "$ref": "#/definitions/groupsConfig"
         },
@@ -647,10 +663,15 @@
                     },
                     "additionalProperties": false,
                     "description": "Actions to perform on startup."
+                },
+                "on_request": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Swap Policy Language (SPL) program run for every JSON request to a model or peer. Runs after the legacy filters (stripParams, setParams, setParamsByID) and before the model's or peer's filters.policy. A deny stops the request with an error response."
                 }
             },
             "additionalProperties": false,
-            "description": "A dictionary of event triggers and actions. Only supported hook is on_startup."
+            "description": "A dictionary of event triggers and actions. Supported hooks are on_startup and on_request."
         },
         "logToStdout": {
             "type": "string",
@@ -750,11 +771,16 @@
                                 "additionalProperties": true,
                                 "default": {},
                                 "description": "Dictionary of parameters to set/override in requests to this peer. Useful for injecting provider-specific settings. A key ending in '?' (e.g. 'max_tokens?') is set-if-undefined: it is only applied when the request does not already contain that parameter. Protected params like 'model' cannot be overridden. Values can be strings, numbers, booleans, arrays, or objects."
+                            },
+                            "policy": {
+                                "type": "string",
+                                "default": "",
+                                "description": "Swap Policy Language (SPL) program applied to requests for this peer. Runs after stripParams, setParams and hooks.on_request. The model parameter cannot be set or removed."
                             }
                         },
                         "additionalProperties": false,
                         "default": {},
-                        "description": "Dictionary of filter settings for peer requests. Supports stripParams and setParams."
+                        "description": "Dictionary of filter settings for peer requests. Supports stripParams, setParams and policy (SPL)."
                     },
                     "timeouts": {
                         "type": "object",

--- a/docs/config.example.yaml
+++ b/docs/config.example.yaml
@@ -340,7 +340,7 @@ models:
 
     # filters: a dictionary of filter settings
     # - optional, default: empty dictionary
-    # - same capabilities as peer filters (stripParams, setParams)
+    # - same capabilities as peer filters (stripParams, setParams, policy)
     filters:
       # stripParams: a comma separated list of parameters to remove from the request
       # - optional, default: ""
@@ -383,6 +383,20 @@ models:
         "${MODEL_ID}:low":
           chat_template_kwargs:
             reasoning_effort: low
+
+      # policy: a Swap Policy Language (SPL) program for this model's requests
+      # - optional, default: ""
+      # - runs after stripParams, setParams, setParamsByID and hooks.on_request
+      # - one clause per line: ACTION, optionally followed by `when CONDITION`
+      # - actions: default, set, remove, apply, deny
+      # - the `model` parameter cannot be set or removed
+      # - macros such as ${MODEL_ID} are expanded before the program is parsed
+      # - see the policies section below for the full syntax
+      policy: |
+        default top_k to 40
+        remove reasoning_effort
+          when request.model = "${MODEL_ID}:low"
+        set context.workload to "coding"
 
     # aliases: alternative model names that this model configuration is used for
     # - optional, default: empty array
@@ -507,10 +521,83 @@ models:
     # - processes have 5 seconds to shutdown until forceful termination is attempted
     cmdStop: docker stop ${MODEL_ID}
 
+# policies: named request policies written in the Swap Policy Language (SPL)
+# - optional, default: empty dictionary
+# - keys are policy names, values are SPL programs
+# - policies are run with `apply <name>` from hooks.on_request, from a
+#   model's or peer's filters.policy, or from another policy
+# - a policy that applies itself, directly or indirectly, fails to load
+# - programs modify the JSON request body before it is sent upstream
+#
+# SPL syntax, one clause per line:
+#
+#   default <path> to <value>   set the value only when the path is missing
+#   set <path> to <value>       always set the value
+#   remove <path>               delete the value
+#   apply <policy>              run a named policy, then continue
+#   deny "<message>"            reject the request with a 403
+#   deny <status> "<message>"   reject the request with a 4xx or 5xx status
+#
+# A clause can end with `when <condition>`, on the same line or the next:
+#
+#   <path> = <value>            also: !=, <, <=, >, >=
+#   <path> matches /<regex>/    Go regular expression, string values only
+#   <path> is present           the path exists (a JSON null is present)
+#   <path> is missing           the path does not exist
+#   <path> in [<value>, ...]    equal to any listed value
+#   combine with `and`, `or`, `not` and parentheses
+#
+# Values are "strings", numbers, true, false, null, [lists] or {"json": "objects"}.
+#
+# Paths address the request body (temperature, messages[-1].content) and
+# these read-only request facts: auth.key, request.model, request.path,
+# request.method, request.header.<name>. Writing context.<key> stores a
+# string that appears in the activity log. Use body.<path> when a request
+# field is literally named context, auth, request or body.
+policies:
+  coding-defaults: |
+    default temperature to 0.2
+    default top_p to 0.95
+    set context.workload to "coding"
+
+  # deny stops processing: nothing after it runs, including the caller
+  authenticated: |
+    deny 401 "API key required"
+      when auth.key is missing
+
+  # policies can apply other policies
+  private-model: |
+    apply authenticated
+    deny "Model is disabled"
+      when request.model = "private-old"
+
+  no-tools: |
+    remove tools
+    remove tool_choice
+    deny 400 "the last message must come from the user"
+      when messages[-1].role != "user"
+
 # hooks: a dictionary of event triggers and actions
 # - optional, default: empty dictionary
-# - the only supported hook is on_startup
+# - supported hooks are on_startup and on_request
 hooks:
+  # on_request: an SPL program run for every JSON request to a model or peer
+  # - optional, default: ""
+  # - runs after the model's legacy filters (stripParams, setParams,
+  #   setParamsByID) and before the model's or peer's filters.policy
+  # - see the policies section for the syntax
+  on_request: |
+    deny 400 "messages is required"
+      when messages is missing
+
+    apply private-model
+      when request.model matches /^private-/
+
+    apply coding-defaults
+      when request.model matches /coder/
+
+    default context.workload to "default"
+
   # on_startup: a dictionary of actions to perform on startup
   # - optional, default: empty dictionary
   on_startup:
@@ -773,3 +860,11 @@ peers:
         provider:
           data_collection: "deny"
           zdr: true
+
+      # policy: a Swap Policy Language (SPL) program for requests to this peer
+      # - optional, default: ""
+      # - runs after stripParams, setParams and hooks.on_request
+      # - see the policies section for the syntax
+      policy: |
+        remove reasoning_effort
+        default max_tokens to 4096

--- a/docs/kb/guides/api-integration/filters-and-request-rewriting.md
+++ b/docs/kb/guides/api-integration/filters-and-request-rewriting.md
@@ -106,11 +106,18 @@ reload — with different parameters applied.
 3. `stripParams` removes keys
 4. `setParams` applies
 5. `setParamsByID` applies, overriding `setParams`
-6. The request is proxied
+6. The global `hooks.on_request` SPL program runs
+7. The model's or peer's `filters.policy` SPL program runs
+8. The request is proxied
 
 Filters apply like a pipe: `stripParams | setParams | setParamsByID`. A
 set-if-undefined key (`key?`) checks the body at its own stage, so a stripped
 key counts as undefined and a key an earlier stage set counts as defined.
+
+SPL programs see the body after the filters above ran, so a `default` in a
+policy fills a key that `stripParams` removed. When a rule needs a condition,
+such as "only for requests without an API key", use a policy instead of a
+filter; see `guides/api-integration/swap-policy-language`.
 
 ## When not to use filters
 
@@ -120,6 +127,7 @@ only rewrite the request body; they cannot change how the server was started.
 
 ## Related
 
+- `guides/api-integration/swap-policy-language` — conditional rewriting and denying with SPL
 - `guides/api-integration/set-if-undefined` — set a parameter only if the request didn't
 - `reference/config/models` — the annotated `filters` block
 - `reference/config/peers` — peer filters

--- a/docs/kb/guides/api-integration/swap-policy-language.md
+++ b/docs/kb/guides/api-integration/swap-policy-language.md
@@ -1,0 +1,160 @@
+---
+title: Rewriting and rejecting requests with SPL
+summary: Write conditional rules in the Swap Policy Language to set defaults, remove parameters, tag requests and deny them before they reach the upstream server.
+category: guides
+tags: [spl, policy, filters, deny, hooks, request-rewriting]
+config_keys: [policies, hooks.on_request, models.*.filters.policy, peers.*.filters.policy]
+updated: 2026-09-10
+---
+
+# Rewriting and rejecting requests with SPL
+
+The Swap Policy Language ("spell") describes what should happen to a request
+when a condition matches. Filters (`stripParams`, `setParams`) always apply;
+SPL adds conditions, reusable policies and the ability to reject a request.
+
+A program is a list of clauses, one per line, evaluated top to bottom:
+
+```text
+ACTION
+  when CONDITION
+```
+
+## A working config
+
+```yaml
+policies:
+  coding-defaults: |
+    default temperature to 0.2
+    set context.workload to "coding"
+
+  authenticated: |
+    deny 401 "API key required"
+      when auth.key is missing
+
+hooks:
+  on_request: |
+    deny 400 "messages is required"
+      when messages is missing
+    apply authenticated
+      when request.model matches /^private-/
+    apply coding-defaults
+      when request.model matches /coder/
+
+models:
+  qwen-coder:
+    cmd: llama-server --port ${PORT} -m qwen-coder.gguf
+    filters:
+      policy: |
+        remove reasoning_effort
+        default max_tokens to 4096
+```
+
+`policies` holds named programs. `hooks.on_request` runs for every JSON
+request. A model's or peer's `filters.policy` runs only for that model.
+
+## Actions
+
+| action | effect |
+| --- | --- |
+| `default <path> to <value>` | set only when the path is missing |
+| `set <path> to <value>` | always set, overwriting |
+| `remove <path>` | delete the value; a missing path is a no-op |
+| `apply <name>` | run a policy from `policies`, then continue |
+| `deny "<message>"` | reject with HTTP 403 |
+| `deny <status> "<message>"` | reject with a status from 400 to 599 |
+
+Values are `"strings"`, numbers, `true`, `false`, `null`, lists like
+`["</s>", "\n"]` and JSON objects like `{"reasoning_effort": "high"}`.
+
+`deny` stops everything: later clauses, the policy that applied it, and any
+program that would run after it. The client gets the same error envelope as
+other llama-swap errors, with the message in `error.message`.
+
+The request's `model` parameter is protected. A program that sets or removes
+it fails to load.
+
+## Conditions
+
+| condition | true when |
+| --- | --- |
+| `<path> = <value>` | same type and equal; also `!=`, `<`, `<=`, `>`, `>=` |
+| `<path> matches /<regex>/` | the value is a string matching a Go regular expression |
+| `<path> is present` | the path exists; a JSON `null` counts as present |
+| `<path> is missing` | the path does not exist |
+| `<path> in [<value>, ...]` | equal to any listed value |
+
+Combine conditions with `and`, `or`, `not` and parentheses. `and` binds
+tighter than `or`. A `when` may sit on the action's line or on the next
+lines; a line starting with `and` or `or` continues the condition.
+
+A missing path is neither equal to nor ordered against anything, so
+`temperature > 1` is false when `temperature` is absent. `!=` is the exact
+opposite of `=`, which means `messages[-1].role != "user"` is also true when
+there are no messages. Write `x is present and x != "y"` when absence must
+not match. Ordering works for numbers and, byte by byte, for strings; mixed
+types are never ordered.
+
+## Paths
+
+Body fields are addressed as in JSON, with array indexes in brackets:
+`messages[0].role`, `messages[-1].content`, `tools[0].function.name`. A
+negative index counts from the end. If the array is shorter than the index,
+reads are absent and writes do nothing.
+
+A few prefixes read outside the body:
+
+| path | value |
+| --- | --- |
+| `auth.key` | the API key sent with the request, missing when there is none |
+| `request.model` | the model ID the client asked for, before `useModelName` rewrote the body |
+| `request.path`, `request.method` | the HTTP path and method |
+| `request.header.<name>` | a request header, missing when empty |
+| `context.<key>` | a string bag that `set` can write; it appears in the activity log's metadata |
+
+These are read-only apart from `context`. If a request body has a top-level
+field named `context`, `auth`, `request` or `body`, address it as
+`body.context` and so on.
+
+## Order of operations
+
+1. `useModelName`, `stripParams`, `setParams` and `setParamsByID` run first
+2. `hooks.on_request` runs
+3. The model's or peer's `filters.policy` runs
+4. The request is proxied
+
+Each stage sees the previous stage's output. A key `stripParams` removed is
+missing for a later `default`. Only `application/json` bodies are processed;
+multipart uploads and `/upstream/` passthrough requests skip SPL.
+
+Macros expand before a program is parsed, so `${MODEL_ID}` and model-level
+macros work inside `filters.policy`. Note that `${...}` inside an SPL `#`
+comment is also expanded and must name a real macro.
+
+## What goes wrong
+
+- **`policies.coding-defaults: line 2:7: unexpected "1", expected 'to'`**:
+  a syntax error. Line and column count from the start of that program, not
+  the YAML file. The same format is used for `hooks.on_request` and
+  `model <id>: filters.policy`.
+- **`apply references unknown policy "x"`**: `apply` names a key that is not
+  under `policies`.
+- **`policies: cycle detected: a -> b -> a`**: a policy applies itself
+  through a chain. Break the loop; policies cannot recurse.
+- **`cannot set protected parameter "model"`**: use `useModelName` or aliases
+  to change what the upstream sees as the model.
+- **A rule never fires**: check the type. `"0.7"` is a string and `0.7` is a
+  number; they are not equal. Use `is present` to test existence rather than
+  comparing against `null`.
+- **`deny` returns 403 for a validation error**: pass the status you want,
+  such as `deny 400 "..."`.
+
+There is no user or claims concept yet; `auth.key` is the only
+authentication fact a policy can see.
+
+## Related
+
+- `guides/api-integration/filters-and-request-rewriting` — the always-on filters SPL runs after
+- `guides/api-integration/api-keys-and-auth` — where `auth.key` comes from
+- `reference/config/policies` — the annotated `policies` block with the full syntax
+- `reference/config/hooks` — `hooks.on_request`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,6 +109,9 @@ func (c *GroupConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 type HooksConfig struct {
 	OnStartup HookOnStartup `yaml:"on_startup"`
+	// OnRequest is an SPL program run for every JSON request after the
+	// model's legacy filters and before its filters.policy.
+	OnRequest string `yaml:"on_request"`
 }
 
 type HookOnStartup struct {
@@ -191,6 +194,10 @@ type Config struct {
 	// hooks, see: #209
 	Hooks HooksConfig `yaml:"hooks"`
 
+	// Policies are named SPL programs that other programs run with
+	// `apply <name>`. See internal/spl.
+	Policies map[string]string `yaml:"policies"`
+
 	// send loading state in reasoning
 	SendLoadingState bool `yaml:"sendLoadingState"`
 
@@ -210,6 +217,16 @@ type Config struct {
 	// It is runtime state, not user configuration, so it must never appear in
 	// rendered configuration output.
 	tailcatEnabled bool
+
+	// spl holds the compiled SPL programs. It is nil when the configuration
+	// declares no policies, on_request hook or filters.policy.
+	spl *SPLPrograms
+}
+
+// SPL returns the compiled SPL programs, or nil when none are configured or
+// the Config was not built by LoadConfigFromReader.
+func (c Config) SPL() *SPLPrograms {
+	return c.spl
 }
 
 // SetTailcatEnabled records whether this process has a Tailcat listener.

--- a/internal/config/filters.go
+++ b/internal/config/filters.go
@@ -29,6 +29,11 @@ type Filters struct {
 	// Keys ending in "?" are set-if-undefined, as in SetParams.
 	// Protected params (like "model") cannot be set.
 	SetParamsByID map[string]map[string]any `yaml:"setParamsByID"`
+
+	// Policy is an SPL program applied to requests for this model or peer.
+	// It runs after stripParams, setParams and setParamsByID, and after the
+	// global hooks.on_request program. See internal/spl.
+	Policy string `yaml:"policy"`
 }
 
 // SanitizedStripParams returns a sorted list of parameters to strip,

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -305,6 +305,10 @@ func LoadConfigFromReader(r io.Reader) (Config, error) {
 		return Config{}, err
 	}
 
+	if err := validateSPL(&config); err != nil {
+		return Config{}, err
+	}
+
 	if err := validateTailcatConfig(&config); err != nil {
 		return Config{}, err
 	}

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -20,6 +20,7 @@ var identityMapPaths = map[string]bool{
 	"profiles":                       true,
 	"selectors":                      true,
 	"peers":                          true,
+	"policies":                       true,
 	"matrix":                         true,
 	"routing.router.settings.groups": true,
 	"routing.router.settings.matrix": true,

--- a/internal/config/spl.go
+++ b/internal/config/spl.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/mostlygeek/llama-swap/internal/spl"
+)
+
+// SPLPrograms holds the compiled Swap Policy Language programs from a
+// configuration. Programs are compiled once at load time and are safe for
+// concurrent use.
+type SPLPrograms struct {
+	// Library holds the named policies from the top-level policies key.
+	Library *spl.Library
+	// OnRequest is hooks.on_request, or nil when blank.
+	OnRequest *spl.Program
+	// Models maps a model ID to its compiled filters.policy. Models with a
+	// blank policy have no entry.
+	Models map[string]*spl.Program
+	// Peers maps a peer ID to its compiled filters.policy. Peers with a
+	// blank policy have no entry.
+	Peers map[string]*spl.Program
+}
+
+// policyNamePattern restricts policy names to what `apply <name>` can parse.
+var policyNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_-]*$`)
+
+// validateSPL compiles every SPL program in the configuration and stores the
+// result in config.spl. It is left nil when no program is configured so a
+// Config without SPL is indistinguishable from one loaded before SPL existed.
+func validateSPL(config *Config) error {
+	for name := range config.Policies {
+		if !policyNamePattern.MatchString(name) {
+			return fmt.Errorf("policies: invalid policy name %q, must match %s", name, policyNamePattern.String())
+		}
+	}
+
+	lib, err := spl.NewLibrary(config.Policies, ProtectedParams)
+	if err != nil {
+		return err
+	}
+
+	programs := &SPLPrograms{
+		Library: lib,
+		Models:  make(map[string]*spl.Program),
+		Peers:   make(map[string]*spl.Program),
+	}
+	found := len(config.Policies) > 0
+
+	compile := func(src string) (*spl.Program, error) {
+		if strings.TrimSpace(src) == "" {
+			return nil, nil
+		}
+		prog, err := spl.Parse(src)
+		if err != nil {
+			return nil, err
+		}
+		if err := prog.Validate(lib, ProtectedParams); err != nil {
+			return nil, err
+		}
+		return prog, nil
+	}
+
+	if prog, err := compile(config.Hooks.OnRequest); err != nil {
+		return fmt.Errorf("hooks.on_request: %w", err)
+	} else if prog != nil {
+		programs.OnRequest = prog
+		found = true
+	}
+
+	modelIDs := make([]string, 0, len(config.Models))
+	for id := range config.Models {
+		modelIDs = append(modelIDs, id)
+	}
+	sort.Strings(modelIDs)
+	for _, id := range modelIDs {
+		prog, err := compile(config.Models[id].Filters.Policy)
+		if err != nil {
+			return fmt.Errorf("model %s: filters.policy: %w", id, err)
+		}
+		if prog != nil {
+			programs.Models[id] = prog
+			found = true
+		}
+	}
+
+	peerIDs := make([]string, 0, len(config.Peers))
+	for id := range config.Peers {
+		peerIDs = append(peerIDs, id)
+	}
+	sort.Strings(peerIDs)
+	for _, id := range peerIDs {
+		prog, err := compile(config.Peers[id].Filters.Policy)
+		if err != nil {
+			return fmt.Errorf("peer %s: filters.policy: %w", id, err)
+		}
+		if prog != nil {
+			programs.Peers[id] = prog
+			found = true
+		}
+	}
+
+	if found {
+		config.spl = programs
+	}
+	return nil
+}

--- a/internal/config/spl_test.go
+++ b/internal/config/spl_test.go
@@ -1,0 +1,320 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/mostlygeek/llama-swap/internal/spl"
+)
+
+func TestConfig_SPL_Valid(t *testing.T) {
+	content := `
+policies:
+  coding-defaults: |
+    default temperature to 0.2
+    set context.workload to "coding"
+  private-model: |
+    deny "Login required"
+      when auth.key is missing
+    apply coding-defaults
+
+hooks:
+  on_request: |
+    deny 400 "messages is required"
+      when messages is missing
+    apply private-model
+      when request.model matches /^private-/
+
+models:
+  qwen-coder:
+    cmd: echo hi
+    proxy: "http://localhost:9999"
+    filters:
+      policy: |
+        remove reasoning_effort
+        set context.model_id to "${MODEL_ID}"
+  plain:
+    cmd: echo hi
+    proxy: "http://localhost:9999"
+    filters:
+      policy: "   "
+
+peers:
+  remote:
+    proxy: http://remote
+    models: [m1]
+    filters:
+      policy: |
+        set provider to {"zdr": true}
+`
+	cfg, err := LoadConfigFromReader(strings.NewReader(content))
+	require.NoError(t, err)
+
+	programs := cfg.SPL()
+	require.NotNil(t, programs)
+	assert.Equal(t, []string{"coding-defaults", "private-model"}, programs.Library.Names())
+	require.NotNil(t, programs.OnRequest)
+	assert.Equal(t, 2, programs.OnRequest.Len())
+
+	require.Contains(t, programs.Models, "qwen-coder")
+	assert.NotContains(t, programs.Models, "plain", "blank policies are not compiled")
+	require.Contains(t, programs.Peers, "remote")
+
+	// ${MODEL_ID} was expanded inside the model policy.
+	req := &spl.Request{Body: []byte(`{"reasoning_effort":"high"}`)}
+	denied, err := programs.Models["qwen-coder"].Run(programs.Library, req)
+	require.NoError(t, err)
+	assert.Nil(t, denied)
+	assert.Equal(t, `{}`, string(req.Body))
+	assert.Equal(t, "qwen-coder", req.Context["model_id"])
+
+	// The hook applies policies from the library.
+	req = &spl.Request{Body: []byte(`{"messages":[]}`), Model: "private-x"}
+	denied, err = programs.OnRequest.Run(programs.Library, req)
+	require.NoError(t, err)
+	require.NotNil(t, denied)
+	assert.Equal(t, 403, denied.Status)
+	assert.Equal(t, "Login required", denied.Message)
+
+	req = &spl.Request{Body: []byte(`{"messages":[]}`), Model: "private-x", APIKey: "k"}
+	denied, err = programs.OnRequest.Run(programs.Library, req)
+	require.NoError(t, err)
+	assert.Nil(t, denied)
+	assert.Equal(t, 0.2, gjson.GetBytes(req.Body, "temperature").Float())
+	assert.Equal(t, "coding", req.Context["workload"])
+}
+
+func TestConfig_SPL_NoSPLLeavesNil(t *testing.T) {
+	content := `
+models:
+  m:
+    cmd: echo hi
+    proxy: "http://localhost:9999"
+    filters:
+      policy: ""
+hooks:
+  on_request: ""
+`
+	cfg, err := LoadConfigFromReader(strings.NewReader(content))
+	require.NoError(t, err)
+	assert.Nil(t, cfg.SPL())
+	assert.Nil(t, Config{}.SPL())
+}
+
+func TestConfig_SPL_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name: "policy parse error location",
+			content: `
+policies:
+  bad: |
+    remove a
+    set b 1
+`,
+			want: `policies.bad: line 2:7: unexpected "1", expected 'to'`,
+		},
+		{
+			name: "hook parse error",
+			content: `
+hooks:
+  on_request: |
+    deny "x" when a matches /(/
+`,
+			want: "hooks.on_request: line 1:25: invalid regex:",
+		},
+		{
+			name: "model policy parse error",
+			content: `
+models:
+  qwen:
+    cmd: echo hi
+    proxy: "http://localhost:9999"
+    filters:
+      policy: |
+        sett a to 1
+`,
+			want: `model qwen: filters.policy: line 1:1: unexpected "sett", expected an action`,
+		},
+		{
+			name: "peer policy parse error",
+			content: `
+peers:
+  remote:
+    proxy: http://remote
+    models: [m1]
+    filters:
+      policy: |
+        remove a
+        deny 200 "x"
+`,
+			want: "peer remote: filters.policy: line 2:6: deny status must be an integer between 400 and 599",
+		},
+		{
+			name: "unknown policy in library",
+			content: `
+policies:
+  a: |
+    apply zzz
+`,
+			want: `policies.a: line 1:7: apply references unknown policy "zzz"`,
+		},
+		{
+			name: "unknown policy in hook",
+			content: `
+hooks:
+  on_request: apply nope
+`,
+			want: `hooks.on_request: line 1:7: apply references unknown policy "nope"`,
+		},
+		{
+			name: "unknown policy in model without any policies",
+			content: `
+models:
+  qwen:
+    cmd: echo hi
+    proxy: "http://localhost:9999"
+    filters:
+      policy: apply nope
+`,
+			want: `model qwen: filters.policy: line 1:7: apply references unknown policy "nope"`,
+		},
+		{
+			name: "cycle",
+			content: `
+policies:
+  a: apply b
+  b: apply c
+  c: apply a
+`,
+			want: "policies: cycle detected: a -> b -> c -> a",
+		},
+		{
+			name: "protected model in policy",
+			content: `
+policies:
+  p: |
+    set model to "other"
+`,
+			want: `policies.p: line 1:5: cannot set protected parameter "model"`,
+		},
+		{
+			name: "protected model in model policy",
+			content: `
+models:
+  qwen:
+    cmd: echo hi
+    proxy: "http://localhost:9999"
+    filters:
+      policy: remove model
+`,
+			want: `model qwen: filters.policy: line 1:8: cannot remove protected parameter "model"`,
+		},
+		{
+			name: "invalid policy name",
+			content: `
+policies:
+  "bad name": remove a
+`,
+			want: `policies: invalid policy name "bad name"`,
+		},
+		{
+			name: "unknown macro in policy",
+			content: `
+policies:
+  p: |
+    set a to "${nope}"
+`,
+			want: "unknown macro '${nope}'",
+		},
+		{
+			name: "unknown macro in model policy",
+			content: `
+models:
+  qwen:
+    cmd: echo hi
+    proxy: "http://localhost:9999"
+    filters:
+      policy: |
+        set a to "${nope}"
+`,
+			want: "unknown macro '${nope}'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadConfigFromReader(strings.NewReader(tt.content))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestConfig_SPL_MacroSubstitution(t *testing.T) {
+	content := `
+macros:
+  default_temp: 0.3
+  tag: "global"
+
+policies:
+  defaults: |
+    default temperature to ${default_temp}
+    set context.tag to "${tag}"
+
+hooks:
+  on_request: |
+    apply defaults
+
+models:
+  qwen:
+    cmd: echo hi
+    proxy: "http://localhost:9999"
+    macros:
+      tag: "model-local"
+    filters:
+      policy: |
+        set context.model to "${MODEL_ID}"
+        set context.local_tag to "${tag}"
+`
+	cfg, err := LoadConfigFromReader(strings.NewReader(content))
+	require.NoError(t, err)
+	programs := cfg.SPL()
+	require.NotNil(t, programs)
+
+	req := &spl.Request{Body: []byte(`{}`)}
+	_, err = programs.OnRequest.Run(programs.Library, req)
+	require.NoError(t, err)
+	assert.Equal(t, 0.3, gjson.GetBytes(req.Body, "temperature").Float())
+	assert.Equal(t, "global", req.Context["tag"])
+
+	req = &spl.Request{Body: []byte(`{}`)}
+	_, err = programs.Models["qwen"].Run(programs.Library, req)
+	require.NoError(t, err)
+	assert.Equal(t, "qwen", req.Context["model"])
+	assert.Equal(t, "model-local", req.Context["local_tag"])
+}
+
+func TestLoadConfigSources_DuplicatePolicy(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, "a.yaml", "policies:\n  shared: remove a\nmodels:\n"+modelCfg("alpha", "echo a"))
+	writeYAML(t, dir, "b.yaml", "policies:\n  shared: remove b\n")
+
+	_, err := LoadConfigSources("", dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate policies "shared"`)
+
+	// Distinct names across files merge.
+	dir = t.TempDir()
+	writeYAML(t, dir, "a.yaml", "policies:\n  one: remove a\nmodels:\n"+modelCfg("alpha", "echo a"))
+	writeYAML(t, dir, "b.yaml", "policies:\n  two: apply one\n")
+	cfg, err := LoadConfigSources("", dir)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"one", "two"}, cfg.SPL().Library.Names())
+}

--- a/internal/docagent/golden_test.go
+++ b/internal/docagent/golden_test.go
@@ -170,7 +170,7 @@ func TestDocs_RealConfigExample_SectionKeys(t *testing.T) {
 		"metricsMaxInMemory", "captureBuffer", "ui", "performance", "startPort",
 		"sendLoadingState", "includeAliasesInList", "globalTTL", "unloadTimeout",
 		"macros", "apiKeys", "tailcat", "upstream", "profiles", "selectors",
-		"models", "hooks", "routing", "peers",
+		"models", "policies", "hooks", "routing", "peers",
 	}
 
 	for _, key := range want {

--- a/internal/server/filters.go
+++ b/internal/server/filters.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mostlygeek/llama-swap/internal/chain"
 	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/spl"
 	"github.com/mostlygeek/llama-swap/internal/swaputil"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
@@ -22,6 +23,7 @@ import (
 //   - StripParams removal (issue #174)
 //   - SetParams injection (issue #453)
 //   - SetParamsByID per-alias overrides
+//   - SPL programs: hooks.on_request, then the model or peer filters.policy
 //
 // Non-JSON requests (GET, multipart forms) pass through untouched. The buffered
 // body is re-attached with Content-Length / Transfer-Encoding cleanup so the
@@ -56,6 +58,38 @@ func CreateFilterMiddleware(cfg config.Config) chain.Middleware {
 			if err != nil {
 				swaputil.SendResponse(w, r, http.StatusInternalServerError, err.Error())
 				return
+			}
+
+			if programs := cfg.SPL(); programs != nil {
+				hook, policy := resolvePolicies(cfg, programs, data.Model)
+				if hook != nil || policy != nil {
+					if data.Metadata == nil {
+						// extractContext allocates the map on the normal path;
+						// this covers hand-built contexts so context.* writes
+						// still reach the metrics middleware.
+						data.Metadata = make(map[string]string)
+						*r = *r.WithContext(swaputil.SetContext(r.Context(), data))
+					}
+					req := &spl.Request{
+						Body:    body,
+						Context: data.Metadata,
+						APIKey:  data.ApiKey,
+						Model:   data.Model,
+						Path:    r.URL.Path,
+						Method:  r.Method,
+						Header:  r.Header,
+					}
+					denied, err := runPolicies(programs.Library, req, hook, policy)
+					if err != nil {
+						swaputil.SendResponse(w, r, http.StatusInternalServerError, err.Error())
+						return
+					}
+					if denied != nil {
+						swaputil.SendResponse(w, r, denied.Status, denied.Message)
+						return
+					}
+					body = req.Body
+				}
 			}
 
 			r.Body = io.NopCloser(bytes.NewReader(body))
@@ -122,6 +156,38 @@ func resolveFilters(cfg config.Config, requested string) (useModelName string, f
 		return "", cfg.Peers[peerID].Filters, true
 	}
 	return "", config.Filters{}, false
+}
+
+// resolvePolicies returns the global hooks.on_request program and the
+// filters.policy of the requested model or peer. The lookup order matches
+// resolveFilters: local models first, then peers.
+func resolvePolicies(cfg config.Config, programs *config.SPLPrograms, requested string) (hook, policy *spl.Program) {
+	hook = programs.OnRequest
+	if realName, found := cfg.RealModelName(requested); found {
+		return hook, programs.Models[realName]
+	}
+	if peerID, _, found := cfg.ResolvePeerModel(requested); found {
+		return hook, programs.Peers[peerID]
+	}
+	return hook, nil
+}
+
+// runPolicies runs each non-nil program in order over req. The body and
+// context carry from one program to the next. The first deny stops the chain.
+func runPolicies(lib *spl.Library, req *spl.Request, programs ...*spl.Program) (*spl.Denial, error) {
+	for _, prog := range programs {
+		if prog == nil {
+			continue
+		}
+		denied, err := prog.Run(lib, req)
+		if err != nil {
+			return nil, fmt.Errorf("policy error: %w", err)
+		}
+		if denied != nil {
+			return denied, nil
+		}
+	}
+	return nil, nil
 }
 
 // applyFilters rewrites the JSON body in place. Order matches the legacy

--- a/internal/server/filters_spl_test.go
+++ b/internal/server/filters_spl_test.go
@@ -1,0 +1,242 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+
+	"github.com/mostlygeek/llama-swap/internal/config"
+	"github.com/mostlygeek/llama-swap/internal/swaputil"
+)
+
+// splConfig loads a config that has one local model, one alias and one peer.
+func splConfig(t *testing.T, extra string) config.Config {
+	t.Helper()
+	cfg, err := config.LoadConfigFromReader(strings.NewReader(`
+models:
+  qwen-coder:
+    cmd: echo hi
+    proxy: "http://localhost:9999"
+    aliases: ["coder"]
+    useModelName: "upstream-coder"
+    filters:
+      stripParams: "temperature"
+      setParams:
+        top_p: 0.9
+      policy: |
+        default temperature to 0.1
+        set context.model_policy to "ran"
+        set from_model to true
+
+peers:
+  remote:
+    proxy: http://remote
+    models: [m1]
+    filters:
+      policy: |
+        set provider to {"zdr": true}
+        deny 402 "payment required" when tier = "free"
+` + extra))
+	require.NoError(t, err)
+	return cfg
+}
+
+// runJSON sends a JSON body through the filter middleware and returns the
+// recorder plus what the downstream handler saw (nil body when not reached).
+func runJSON(t *testing.T, cfg config.Config, body string, mutate func(*http.Request)) (*httptest.ResponseRecorder, []byte, swaputil.ReqContextData) {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	if mutate != nil {
+		mutate(r)
+	}
+
+	var got []byte
+	var ctx swaputil.ReqContextData
+	final := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		got = data
+		ctx, _ = swaputil.ReadContext(r.Context())
+		assert.Equal(t, int64(len(data)), r.ContentLength)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	CreateFilterMiddleware(cfg)(final).ServeHTTP(rec, r)
+	return rec, got, ctx
+}
+
+func TestServer_FilterMiddleware_SPL_LegacyFiltersRunFirst(t *testing.T) {
+	cfg := splConfig(t, "")
+	rec, got, _ := runJSON(t, cfg, `{"model":"qwen-coder","temperature":0.7}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	// stripParams removed temperature, so the policy's default filled it.
+	assert.Equal(t, 0.1, gjson.GetBytes(got, "temperature").Float())
+	assert.Equal(t, 0.9, gjson.GetBytes(got, "top_p").Float())
+	assert.True(t, gjson.GetBytes(got, "from_model").Bool())
+	assert.Equal(t, "upstream-coder", gjson.GetBytes(got, "model").String())
+}
+
+func TestServer_FilterMiddleware_SPL_GlobalHookBeforeModelPolicy(t *testing.T) {
+	cfg := splConfig(t, `
+hooks:
+  on_request: |
+    set from_hook to true
+    set order to "hook"
+    set temperature to 0.5
+`)
+	rec, got, _ := runJSON(t, cfg, `{"model":"qwen-coder"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, gjson.GetBytes(got, "from_hook").Bool())
+	assert.True(t, gjson.GetBytes(got, "from_model").Bool())
+	// The hook set temperature, so the model policy's default did not apply.
+	assert.Equal(t, 0.5, gjson.GetBytes(got, "temperature").Float())
+}
+
+func TestServer_FilterMiddleware_SPL_HookDenyStopsModelPolicy(t *testing.T) {
+	cfg := splConfig(t, `
+hooks:
+  on_request: |
+    deny 400 "messages is required" when messages is missing
+`)
+	rec, got, _ := runJSON(t, cfg, `{"model":"qwen-coder"}`, nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Nil(t, got, "downstream handler must not run after deny")
+
+	rec, got, _ = runJSON(t, cfg, `{"model":"qwen-coder","messages":[]}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, gjson.GetBytes(got, "from_model").Bool())
+}
+
+func TestServer_FilterMiddleware_SPL_DenyEnvelope(t *testing.T) {
+	cfg := splConfig(t, `
+hooks:
+  on_request: |
+    deny "Model is disabled" when request.model = "coder"
+    deny 429 "slow down" when request.model = "qwen-coder"
+`)
+
+	rec, got, _ := runJSON(t, cfg, `{"model":"coder"}`, nil)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Nil(t, got)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	var envelope struct {
+		Src   string `json:"src"`
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &envelope))
+	assert.Equal(t, "llama-swap", envelope.Src)
+	assert.Equal(t, "Model is disabled", envelope.Error.Message)
+	assert.NotEmpty(t, envelope.Error.Type)
+
+	rec, _, _ = runJSON(t, cfg, `{"model":"qwen-coder"}`, nil)
+	assert.Equal(t, http.StatusTooManyRequests, rec.Code)
+	assert.Contains(t, rec.Body.String(), "slow down")
+
+	// Text clients get a plain message.
+	rec, _, _ = runJSON(t, cfg, `{"model":"coder"}`, func(r *http.Request) {
+		r.Header.Set("Accept", "text/plain")
+	})
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Equal(t, "llama-swap: Model is disabled", rec.Body.String())
+}
+
+func TestServer_FilterMiddleware_SPL_ContextLandsInMetadata(t *testing.T) {
+	cfg := splConfig(t, `
+hooks:
+  on_request: |
+    set context.tier to "gold" when auth.key = "secret"
+    set context.session to "x" when request.header.x-session-id is present
+`)
+	rec, _, ctx := runJSON(t, cfg, `{"model":"qwen-coder"}`, func(r *http.Request) {
+		r.Header.Set("Authorization", "Bearer secret")
+		r.Header.Set("X-Session-ID", "abc")
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "gold", ctx.Metadata["tier"])
+	assert.Equal(t, "x", ctx.Metadata["session"])
+	assert.Equal(t, "ran", ctx.Metadata["model_policy"])
+
+	// Without the key the tier is never set.
+	rec, _, ctx = runJSON(t, cfg, `{"model":"qwen-coder"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	_, hasTier := ctx.Metadata["tier"]
+	assert.False(t, hasTier)
+}
+
+func TestServer_FilterMiddleware_SPL_UseModelNameVisible(t *testing.T) {
+	cfg := splConfig(t, `
+hooks:
+  on_request: |
+    set requested to "alias" when request.model = "coder"
+    set body_model to "rewritten" when model = "upstream-coder"
+`)
+	rec, got, _ := runJSON(t, cfg, `{"model":"coder"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "alias", gjson.GetBytes(got, "requested").String())
+	assert.Equal(t, "rewritten", gjson.GetBytes(got, "body_model").String())
+	assert.Equal(t, "upstream-coder", gjson.GetBytes(got, "model").String())
+}
+
+func TestServer_FilterMiddleware_SPL_PeerPolicy(t *testing.T) {
+	cfg := splConfig(t, "")
+
+	rec, got, _ := runJSON(t, cfg, `{"model":"remote/m1"}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.True(t, gjson.GetBytes(got, "provider.zdr").Bool())
+	assert.False(t, gjson.GetBytes(got, "from_model").Exists(), "model policy must not run for a peer")
+
+	rec, got, _ = runJSON(t, cfg, `{"model":"m1","tier":"free"}`, nil)
+	assert.Equal(t, http.StatusPaymentRequired, rec.Code)
+	assert.Nil(t, got)
+}
+
+func TestServer_FilterMiddleware_SPL_NonJSONUntouched(t *testing.T) {
+	cfg := splConfig(t, `
+hooks:
+  on_request: deny "always"
+`)
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("model=qwen-coder"))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	reached := false
+	final := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { reached = true })
+	rec := httptest.NewRecorder()
+	CreateFilterMiddleware(cfg)(final).ServeHTTP(rec, r)
+	assert.True(t, reached)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestServer_FilterMiddleware_NoSPLConfigured(t *testing.T) {
+	// A hand-built config has no compiled programs; legacy filters still run.
+	cfg := config.Config{Models: map[string]config.ModelConfig{
+		"m": {Filters: config.ModelFilters{Filters: config.Filters{StripParams: "temperature"}}},
+	}}
+	rec, got, _ := runJSON(t, cfg, `{"model":"m","temperature":1}`, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.False(t, gjson.GetBytes(got, "temperature").Exists())
+	assert.Nil(t, cfg.SPL())
+}
+
+func TestServer_FilterMiddleware_SPL_UnknownModelPassesThrough(t *testing.T) {
+	cfg := splConfig(t, `
+hooks:
+  on_request: deny "always"
+`)
+	// resolveFilters fails for an unknown model, so nothing runs and the
+	// dispatcher downstream reports the 404.
+	rec, got, _ := runJSON(t, cfg, `{"model":"nope"}`, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, `{"model":"nope"}`, string(got))
+}

--- a/internal/spl/ast.go
+++ b/internal/spl/ast.go
@@ -1,0 +1,165 @@
+package spl
+
+import "regexp"
+
+type actionKind int
+
+const (
+	actDefault actionKind = iota
+	actSet
+	actRemove
+	actApply
+	actDeny
+)
+
+func (a actionKind) String() string {
+	switch a {
+	case actDefault:
+		return kwDefault
+	case actSet:
+		return kwSet
+	case actRemove:
+		return kwRemove
+	case actApply:
+		return kwApply
+	case actDeny:
+		return kwDeny
+	}
+	return "?"
+}
+
+// namespace identifies where a path reads from and writes to.
+type namespace int
+
+const (
+	nsBody    namespace = iota // JSON request body (default, or explicit body. prefix)
+	nsContext                  // context.<key>: request metadata string bag
+	nsAuth                     // auth.key: read-only
+	nsRequest                  // request.model|path|method|header.<name>: read-only
+)
+
+type segment struct {
+	key     string
+	index   int
+	isIndex bool
+}
+
+// path is a parsed field path. For nsBody, segs are the body path segments.
+// For the other namespaces, segs holds the segments after the namespace word.
+type path struct {
+	ns   namespace
+	segs []segment
+	text string // original spelling, for error messages
+	line int
+	col  int
+}
+
+type valueKind int
+
+const (
+	kindAbsent valueKind = iota
+	kindNull
+	kindBool
+	kindNumber
+	kindString
+	kindObject
+	kindArray
+)
+
+func (k valueKind) String() string {
+	switch k {
+	case kindAbsent:
+		return "absent"
+	case kindNull:
+		return "null"
+	case kindBool:
+		return "bool"
+	case kindNumber:
+		return "number"
+	case kindString:
+		return "string"
+	case kindObject:
+		return "object"
+	case kindArray:
+		return "array"
+	}
+	return "?"
+}
+
+// literal is a constant value from the program source. raw is its JSON
+// encoding, used verbatim for body writes.
+type literal struct {
+	kind valueKind
+	raw  string
+	str  string
+	num  float64
+	b    bool
+}
+
+type clause struct {
+	action  actionKind
+	path    *path    // default, set, remove
+	value   *literal // default, set
+	policy  string   // apply
+	status  int      // deny
+	message string   // deny
+	cond    condNode // nil when the clause has no when
+	line    int
+	col     int
+}
+
+type condNode interface {
+	isCond()
+}
+
+type condAnd struct{ left, right condNode }
+type condOr struct{ left, right condNode }
+type condNot struct{ inner condNode }
+
+// condCmp is path OP scalar.
+type condCmp struct {
+	path  *path
+	op    tokenKind
+	value literal
+}
+
+type condMatches struct {
+	path *path
+	re   *regexp.Regexp
+}
+
+type condPresent struct {
+	path    *path
+	present bool
+}
+
+type condIn struct {
+	path   *path
+	values []literal
+}
+
+func (condAnd) isCond()     {}
+func (condOr) isCond()      {}
+func (condNot) isCond()     {}
+func (condCmp) isCond()     {}
+func (condMatches) isCond() {}
+func (condPresent) isCond() {}
+func (condIn) isCond()      {}
+
+// Program is a parsed, immutable SPL program. It is safe for concurrent use.
+type Program struct {
+	clauses []clause
+	applies []string // policy names referenced by apply, deduplicated in order
+}
+
+// Applies returns the policy names this program references with apply.
+func (p *Program) Applies() []string {
+	out := make([]string, len(p.applies))
+	copy(out, p.applies)
+	return out
+}
+
+// Len returns the number of clauses in the program.
+func (p *Program) Len() int {
+	return len(p.clauses)
+}

--- a/internal/spl/doc.go
+++ b/internal/spl/doc.go
@@ -1,0 +1,32 @@
+// Package spl implements the Swap Policy Language ("spell"), a small
+// declarative language for rewriting, validating and denying JSON requests
+// before llama-swap forwards them upstream.
+//
+// A program is a list of clauses evaluated top to bottom:
+//
+//	ACTION [when CONDITION]
+//
+// Actions:
+//
+//	default <path> to <value>   set only when the path is missing
+//	set <path> to <value>       always set
+//	remove <path>               delete
+//	apply <policy>              run a named policy from the Library
+//	deny [status] "<message>"   reject the request (status defaults to 403)
+//
+// Conditions combine predicates with and, or, not and parentheses:
+//
+//	<path> = | != | < | <= | > | >= <scalar>
+//	<path> matches /regex/
+//	<path> is present | is missing
+//	<path> in [<scalar>, ...]
+//
+// Paths address the JSON body (temperature, messages[-1].content), the
+// request metadata bag (context.<key>), the API key (auth.key) and request
+// facts (request.model, request.path, request.method, request.header.<name>).
+// A negative index counts from the end of an array. Missing paths are absent:
+// comparisons against them are false and "is missing" is true. A JSON null
+// counts as present.
+//
+// Programs and Libraries are immutable once built and safe for concurrent use.
+package spl

--- a/internal/spl/errors.go
+++ b/internal/spl/errors.go
@@ -1,0 +1,18 @@
+package spl
+
+import "fmt"
+
+// Error is a parse or validation error located in the program source.
+type Error struct {
+	Line int
+	Col  int
+	Msg  string
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("line %d:%d: %s", e.Line, e.Col, e.Msg)
+}
+
+func errorAt(line, col int, format string, args ...any) *Error {
+	return &Error{Line: line, Col: col, Msg: fmt.Sprintf(format, args...)}
+}

--- a/internal/spl/eval.go
+++ b/internal/spl/eval.go
@@ -1,0 +1,223 @@
+package spl
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// maxApplyDepth bounds nested apply calls. Cycles are rejected when a Library
+// is built, so this only guards against hand-built libraries.
+const maxApplyDepth = 32
+
+// Request is the state a program reads and rewrites. Body and Context are
+// modified in place by Run.
+type Request struct {
+	Body    []byte
+	Context map[string]string // context.<key>; allocated by Run when nil
+	APIKey  string            // auth.key; absent when empty
+	Model   string            // request.model: the model ID the client asked for
+	Path    string            // request.path
+	Method  string            // request.method
+	Header  http.Header       // request.header.<name>
+}
+
+// Denial is the outcome of a deny action.
+type Denial struct {
+	Status  int
+	Message string
+}
+
+// Run evaluates the program against req. Body and Context are updated in
+// place. A non-nil Denial means a deny clause fired and processing stopped;
+// the request should be rejected with its status and message. An error means
+// the body could not be rewritten and the request should fail.
+func (p *Program) Run(lib *Library, req *Request) (*Denial, error) {
+	if req.Context == nil {
+		req.Context = make(map[string]string)
+	}
+	e := &evaluator{lib: lib, req: req}
+	return e.run(p)
+}
+
+type evaluator struct {
+	lib   *Library
+	req   *Request
+	depth int
+}
+
+func (e *evaluator) run(p *Program) (*Denial, error) {
+	for i := range p.clauses {
+		c := &p.clauses[i]
+		if c.cond != nil && !e.eval(c.cond) {
+			continue
+		}
+		switch c.action {
+		case actDefault:
+			if e.exists(c.path) {
+				continue
+			}
+			if err := e.set(c.path, c.value); err != nil {
+				return nil, err
+			}
+		case actSet:
+			if err := e.set(c.path, c.value); err != nil {
+				return nil, err
+			}
+		case actRemove:
+			if err := e.remove(c.path); err != nil {
+				return nil, err
+			}
+		case actApply:
+			denied, err := e.apply(c.policy)
+			if err != nil {
+				return nil, err
+			}
+			if denied != nil {
+				return denied, nil
+			}
+		case actDeny:
+			return &Denial{Status: c.status, Message: c.message}, nil
+		}
+	}
+	return nil, nil
+}
+
+func (e *evaluator) apply(name string) (*Denial, error) {
+	if e.lib == nil {
+		return nil, fmt.Errorf("apply %s: no policy library", name)
+	}
+	prog, ok := e.lib.Lookup(name)
+	if !ok {
+		return nil, fmt.Errorf("apply %s: unknown policy", name)
+	}
+	if e.depth >= maxApplyDepth {
+		return nil, fmt.Errorf("apply %s: policy nesting deeper than %d", name, maxApplyDepth)
+	}
+	e.depth++
+	defer func() { e.depth-- }()
+	return e.run(prog)
+}
+
+// read resolves a path to its current value.
+func (e *evaluator) read(p *path) value {
+	switch p.ns {
+	case nsBody:
+		gp, ok := p.gjsonPath(e.req.Body)
+		if !ok {
+			return absent
+		}
+		return fromResult(gjson.GetBytes(e.req.Body, gp))
+	case nsContext:
+		if v, ok := e.req.Context[p.key()]; ok {
+			return stringValue(v)
+		}
+		return absent
+	case nsAuth:
+		if e.req.APIKey == "" {
+			return absent
+		}
+		return stringValue(e.req.APIKey)
+	case nsRequest:
+		var s string
+		switch p.segs[0].key {
+		case "model":
+			s = e.req.Model
+		case "path":
+			s = e.req.Path
+		case "method":
+			s = e.req.Method
+		case "header":
+			if e.req.Header != nil {
+				s = e.req.Header.Get(p.segs[1].key)
+			}
+		}
+		if s == "" {
+			return absent
+		}
+		return stringValue(s)
+	}
+	return absent
+}
+
+func (e *evaluator) exists(p *path) bool {
+	return e.read(p).kind != kindAbsent
+}
+
+func (e *evaluator) set(p *path, lit *literal) error {
+	switch p.ns {
+	case nsBody:
+		gp, ok := p.gjsonPath(e.req.Body)
+		if !ok {
+			return nil
+		}
+		body, err := sjson.SetRawBytes(e.req.Body, gp, []byte(lit.raw))
+		if err != nil {
+			return fmt.Errorf("set %s: %w", p.text, err)
+		}
+		e.req.Body = body
+	case nsContext:
+		s, ok := lit.contextString()
+		if !ok {
+			delete(e.req.Context, p.key())
+			return nil
+		}
+		e.req.Context[p.key()] = s
+	}
+	return nil
+}
+
+func (e *evaluator) remove(p *path) error {
+	switch p.ns {
+	case nsBody:
+		gp, ok := p.gjsonPath(e.req.Body)
+		if !ok || !gjson.GetBytes(e.req.Body, gp).Exists() {
+			return nil
+		}
+		body, err := sjson.DeleteBytes(e.req.Body, gp)
+		if err != nil {
+			return fmt.Errorf("remove %s: %w", p.text, err)
+		}
+		e.req.Body = body
+	case nsContext:
+		delete(e.req.Context, p.key())
+	}
+	return nil
+}
+
+func (e *evaluator) eval(c condNode) bool {
+	switch n := c.(type) {
+	case condAnd:
+		return e.eval(n.left) && e.eval(n.right)
+	case condOr:
+		return e.eval(n.left) || e.eval(n.right)
+	case condNot:
+		return !e.eval(n.inner)
+	case condCmp:
+		v := e.read(n.path)
+		switch n.op {
+		case tokEq:
+			return v.equals(n.value)
+		case tokNeq:
+			return !v.equals(n.value)
+		default:
+			return v.compare(n.op, n.value)
+		}
+	case condMatches:
+		v := e.read(n.path)
+		return v.kind == kindString && n.re.MatchString(v.str)
+	case condPresent:
+		return e.exists(n.path) == n.present
+	case condIn:
+		v := e.read(n.path)
+		for _, lit := range n.values {
+			if v.equals(lit) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}

--- a/internal/spl/eval_test.go
+++ b/internal/spl/eval_test.go
@@ -1,0 +1,373 @@
+package spl
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// run parses src and evaluates it against body, returning the new body.
+func run(t *testing.T, src, body string, lib *Library) (string, *Denial) {
+	t.Helper()
+	prog, err := Parse(src)
+	require.NoError(t, err)
+	req := &Request{Body: []byte(body)}
+	denied, err := prog.Run(lib, req)
+	require.NoError(t, err)
+	return string(req.Body), denied
+}
+
+// matches reports whether the condition in src holds for body.
+func matches(t *testing.T, cond, body string) bool {
+	t.Helper()
+	out, _ := run(t, "set hit to true when "+cond, body, nil)
+	return gjson.Get(out, "hit").Bool()
+}
+
+func TestSPL_Path_NegativeIndex(t *testing.T) {
+	body := `{"messages":[{"role":"system"},{"role":"user","content":"hi"},{"role":"assistant"}],"tools":[{"function":{"name":"f1"}}],"s":"str"}`
+
+	tests := []struct {
+		path string
+		want string
+		ok   bool
+	}{
+		{"messages[-1].role", "messages.2.role", true},
+		{"messages[-3].role", "messages.0.role", true},
+		{"messages[-4].role", "", false},
+		{"messages[0].role", "messages.0.role", true},
+		{"tools[-1].function.name", "tools.0.function.name", true},
+		{"s[-1]", "", false},
+		{"missing[-1]", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			prog, err := Parse("remove " + tt.path)
+			require.NoError(t, err)
+			got, ok := prog.clauses[0].path.gjsonPath([]byte(body))
+			assert.Equal(t, tt.ok, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	// Root-level array with a negative index.
+	prog, err := Parse("remove a[-1]")
+	require.NoError(t, err)
+	got, ok := prog.clauses[0].path.gjsonPath([]byte(`{"a":[1,2,3]}`))
+	assert.True(t, ok)
+	assert.Equal(t, "a.2", got)
+
+	assert.True(t, matches(t, `messages[-1].role = "assistant"`, body))
+	assert.True(t, matches(t, `messages[-1].content is missing`, body))
+	assert.True(t, matches(t, `messages[-9].role is missing`, body))
+	assert.False(t, matches(t, `messages[-9].role is present`, body))
+}
+
+func TestSPL_Eval_Compare(t *testing.T) {
+	body := `{"s":"abc","n":2,"b":true,"z":null,"o":{"k":1},"a":[1],"big":12345678901234567890}`
+	tests := []struct {
+		cond string
+		want bool
+	}{
+		{`s = "abc"`, true},
+		{`s == "abc"`, true},
+		{`s = "abd"`, false},
+		{`s != "abd"`, true},
+		{`s = 2`, false},
+		{`s != 2`, true},
+		{`n = 2`, true},
+		{`n = 2.0`, true},
+		{`n = "2"`, false},
+		{`b = true`, true},
+		{`b = false`, false},
+		{`b != false`, true},
+		{`z = null`, true},
+		{`z != null`, false},
+		{`missing = null`, false},
+		{`missing != null`, true},
+		{`missing != "x"`, true},
+		{`missing = "x"`, false},
+		{`o = "x"`, false},
+		{`o != "x"`, true},
+		{`a = 1`, false},
+		{`n < 3`, true},
+		{`n <= 2`, true},
+		{`n > 2`, false},
+		{`n >= 2`, true},
+		{`n < "3"`, false},
+		{`s < "abd"`, true},
+		{`s > "abb"`, true},
+		{`s >= "abc"`, true},
+		{`s <= "abb"`, false},
+		{`b < true`, false},
+		{`z < 1`, false},
+		{`missing < 1`, false},
+		{`missing > 1`, false},
+		{`s matches /^a.c$/`, true},
+		{`s matches /^b/`, false},
+		{`n matches /2/`, false},
+		{`missing matches /.*/`, false},
+		{`s is present`, true},
+		{`z is present`, true},
+		{`z is missing`, false},
+		{`missing is missing`, true},
+		{`o.k is present`, true},
+		{`s in ["x", "abc"]`, true},
+		{`s in ["x"]`, false},
+		{`n in [1, 2]`, true},
+		{`z in [null]`, true},
+		{`missing in [null]`, false},
+		{`s in []`, false},
+		{`s = "abc" and n = 2`, true},
+		{`s = "abc" and n = 3`, false},
+		{`s = "x" or n = 2`, true},
+		{`not s = "x"`, true},
+		{`not (s = "abc" or n = 3)`, false},
+		{`s = "x" or n = 2 and b = false`, false},
+		{`(s = "x" or n = 2) and b = true`, true},
+		{`big = 12345678901234567890`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.cond, func(t *testing.T) {
+			assert.Equal(t, tt.want, matches(t, tt.cond, body))
+		})
+	}
+}
+
+func TestSPL_Eval_Actions(t *testing.T) {
+	t.Run("default only fills missing", func(t *testing.T) {
+		out, _ := run(t, "default temperature to 0.2\ndefault top_p to 0.9\ndefault stop to \"x\"", `{"temperature":0.7,"stop":null}`, nil)
+		assert.Equal(t, 0.7, gjson.Get(out, "temperature").Float())
+		assert.Equal(t, 0.9, gjson.Get(out, "top_p").Float())
+		assert.Equal(t, gjson.Null, gjson.Get(out, "stop").Type, "null counts as present")
+	})
+
+	t.Run("set overwrites and creates nested", func(t *testing.T) {
+		out, _ := run(t, `set temperature to 0.1
+set chat_template_kwargs.enable_thinking to false
+set meta to {"a": [1, 2], "b": "s"}
+set stop to ["</s>", "\n"]
+set n to null
+set big to 12345678901234567890`, `{"temperature":0.7}`, nil)
+		assert.Equal(t, `{"temperature":0.1,"chat_template_kwargs":{"enable_thinking":false},"meta":{"a":[1,2],"b":"s"},"stop":["</s>","\n"],"n":null,"big":12345678901234567890}`, out)
+	})
+
+	t.Run("remove present and missing", func(t *testing.T) {
+		out, _ := run(t, "remove a\nremove missing\nremove o.k\nremove arr[-1]\nremove arr[-9]", `{"a":1,"o":{"k":1,"j":2},"arr":[1,2,3]}`, nil)
+		assert.Equal(t, `{"o":{"j":2},"arr":[1,2]}`, out)
+	})
+
+	t.Run("set through negative index", func(t *testing.T) {
+		out, _ := run(t, `set messages[-1].content to "replaced"`, `{"messages":[{"content":"a"},{"content":"b"}]}`, nil)
+		assert.Equal(t, "replaced", gjson.Get(out, "messages.1.content").String())
+		assert.Equal(t, "a", gjson.Get(out, "messages.0.content").String())
+	})
+
+	t.Run("unresolvable negative index is a no-op", func(t *testing.T) {
+		out, _ := run(t, `set messages[-1].content to "x"`, `{"messages":[]}`, nil)
+		assert.Equal(t, `{"messages":[]}`, out)
+	})
+
+	t.Run("body prefix escapes namespace words", func(t *testing.T) {
+		out, _ := run(t, `set body.context to [1]
+remove body.auth
+set body.request.x to 1`, `{"auth":"k"}`, nil)
+		assert.Equal(t, `{"context":[1],"request":{"x":1}}`, out)
+	})
+
+	t.Run("clauses run in order and conditions gate them", func(t *testing.T) {
+		out, _ := run(t, `set a to 1
+set a to 2 when a = 1
+set a to 3 when a = 1
+remove b when a = 2`, `{"b":true}`, nil)
+		assert.Equal(t, `{"a":2}`, out)
+	})
+}
+
+func TestSPL_Eval_Context(t *testing.T) {
+	prog, err := Parse(`set context.s to "str"
+set context.n to 1.5
+set context.b to true
+set context.o to {"k": "v"}
+set context.l to [1, "a"]
+default context.s to "ignored"
+default context.d to "filled"
+set context.gone to "x"
+set context.gone to null
+set context.removed to "x"
+remove context.removed
+set hit to true when context.s = "str" and context.n = "1.5" and context.missing is missing`)
+	require.NoError(t, err)
+
+	req := &Request{Body: []byte(`{}`)}
+	denied, err := prog.Run(nil, req)
+	require.NoError(t, err)
+	assert.Nil(t, denied)
+	assert.Equal(t, map[string]string{
+		"s": "str",
+		"n": "1.5",
+		"b": "true",
+		"o": `{"k":"v"}`,
+		"l": `[1,"a"]`,
+		"d": "filled",
+	}, req.Context)
+	assert.True(t, gjson.GetBytes(req.Body, "hit").Bool())
+
+	// An existing map is written in place.
+	existing := map[string]string{"pre": "set"}
+	req = &Request{Body: []byte(`{}`), Context: existing}
+	_, err = prog.Run(nil, req)
+	require.NoError(t, err)
+	assert.Equal(t, "set", existing["pre"])
+	assert.Equal(t, "str", existing["s"])
+}
+
+func TestSPL_Eval_RequestNamespace(t *testing.T) {
+	prog, err := Parse(`set key to true when auth.key is present
+set key_val to true when auth.key = "secret"
+set model to true when request.model = "alias"
+set path to true when request.path matches /^\/v1\/chat/
+set method to true when request.method = "POST"
+set hdr to true when request.header.x-session-id = "abc"
+set hdr_ci to true when request.header.X-Session-Id = "abc"
+set hdr_missing to true when request.header.nope is missing`)
+	require.NoError(t, err)
+
+	req := &Request{
+		Body:   []byte(`{}`),
+		APIKey: "secret",
+		Model:  "alias",
+		Path:   "/v1/chat/completions",
+		Method: "POST",
+		Header: http.Header{"X-Session-Id": []string{"abc"}},
+	}
+	_, err = prog.Run(nil, req)
+	require.NoError(t, err)
+	assert.Equal(t, `{"key":true,"key_val":true,"model":true,"path":true,"method":true,"hdr":true,"hdr_ci":true,"hdr_missing":true}`, string(req.Body))
+
+	// Everything absent.
+	prog, err = Parse(`set a to true when auth.key is missing
+set b to true when request.model is missing
+set c to true when request.header.x is missing
+set d to true when request.path is missing`)
+	require.NoError(t, err)
+	req = &Request{Body: []byte(`{}`)}
+	_, err = prog.Run(nil, req)
+	require.NoError(t, err)
+	assert.Equal(t, `{"a":true,"b":true,"c":true,"d":true}`, string(req.Body))
+}
+
+func TestSPL_Eval_Deny(t *testing.T) {
+	t.Run("default status", func(t *testing.T) {
+		out, denied := run(t, `deny "no"
+set after to true`, `{}`, nil)
+		require.NotNil(t, denied)
+		assert.Equal(t, 403, denied.Status)
+		assert.Equal(t, "no", denied.Message)
+		assert.Equal(t, `{}`, out, "nothing after deny runs")
+	})
+
+	t.Run("custom status", func(t *testing.T) {
+		_, denied := run(t, `deny 400 "messages is required" when messages is missing`, `{}`, nil)
+		require.NotNil(t, denied)
+		assert.Equal(t, 400, denied.Status)
+	})
+
+	t.Run("condition false", func(t *testing.T) {
+		out, denied := run(t, `deny "no" when a = 1
+set after to true`, `{"a":2}`, nil)
+		assert.Nil(t, denied)
+		assert.True(t, gjson.Get(out, "after").Bool())
+	})
+
+	t.Run("deny inside apply stops caller", func(t *testing.T) {
+		lib, err := NewLibrary(map[string]string{
+			"authed": `deny 401 "login required" when auth.key is missing`,
+		}, nil)
+		require.NoError(t, err)
+		out, denied := run(t, "apply authed\nset after to true", `{}`, lib)
+		require.NotNil(t, denied)
+		assert.Equal(t, 401, denied.Status)
+		assert.Equal(t, `{}`, out)
+	})
+}
+
+func TestSPL_Eval_ApplyOrderAndDepth(t *testing.T) {
+	lib, err := NewLibrary(map[string]string{
+		"inner": "set inner to true\nset shared to \"inner\"",
+		"outer": "apply inner\nset outer to true",
+	}, nil)
+	require.NoError(t, err)
+
+	out, denied := run(t, `set shared to "before"
+apply outer
+set after to true`, `{}`, lib)
+	assert.Nil(t, denied)
+	assert.Equal(t, `{"shared":"inner","inner":true,"outer":true,"after":true}`, out)
+
+	// Applied policies see the caller's context map.
+	lib, err = NewLibrary(map[string]string{"tag": `set context.tag to "x"`}, nil)
+	require.NoError(t, err)
+	prog, err := Parse("apply tag")
+	require.NoError(t, err)
+	req := &Request{Body: []byte(`{}`)}
+	_, err = prog.Run(lib, req)
+	require.NoError(t, err)
+	assert.Equal(t, "x", req.Context["tag"])
+
+	// A hand-built cyclic library trips the depth guard instead of looping.
+	cyclic := &Library{policies: map[string]*Program{}}
+	a, err := Parse("apply b")
+	require.NoError(t, err)
+	b, err := Parse("apply a")
+	require.NoError(t, err)
+	cyclic.policies["a"] = a
+	cyclic.policies["b"] = b
+	_, err = a.Run(cyclic, &Request{Body: []byte(`{}`)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "policy nesting deeper than 32")
+
+	// Unknown policy at run time is an error, not a panic.
+	_, err = a.Run(&Library{policies: map[string]*Program{}}, &Request{Body: []byte(`{}`)})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown policy")
+	_, err = a.Run(nil, &Request{Body: []byte(`{}`)})
+	require.Error(t, err)
+}
+
+func TestSPL_Eval_InvalidBody(t *testing.T) {
+	// gjson tolerates junk: reads are absent, writes still produce JSON.
+	prog, err := Parse(`deny "bad" when messages is missing`)
+	require.NoError(t, err)
+	denied, err := prog.Run(nil, &Request{Body: []byte(`not json`)})
+	require.NoError(t, err)
+	require.NotNil(t, denied)
+}
+
+func TestSPL_Run_Concurrent(t *testing.T) {
+	lib, err := NewLibrary(map[string]string{"p": `default temperature to 0.2`}, nil)
+	require.NoError(t, err)
+	prog, err := Parse(`apply p
+set context.w to "coding" when model matches /coder/
+deny "x" when messages is missing`)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := &Request{Body: []byte(`{"model":"qwen-coder","messages":[]}`)}
+			denied, err := prog.Run(lib, req)
+			assert.NoError(t, err)
+			assert.Nil(t, denied)
+			assert.Equal(t, 0.2, gjson.GetBytes(req.Body, "temperature").Float())
+			assert.Equal(t, "coding", req.Context["w"])
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/spl/lexer.go
+++ b/internal/spl/lexer.go
@@ -1,0 +1,312 @@
+package spl
+
+import (
+	"bytes"
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+type lexer struct {
+	src    []rune
+	pos    int
+	line   int
+	col    int
+	depth  int // nesting inside ( ) and [ ]; newlines are insignificant when > 0
+	tokens []token
+}
+
+// lex splits src into tokens. Newlines are significant clause separators
+// except inside brackets, after a comment-only or blank line, or before a
+// continuation keyword (when, and, or).
+func lex(src string) ([]token, error) {
+	src = strings.ReplaceAll(src, "\r\n", "\n")
+	l := &lexer{src: []rune(src), line: 1, col: 1}
+	if err := l.run(); err != nil {
+		return nil, err
+	}
+	return l.finish(), nil
+}
+
+func (l *lexer) peekRune(offset int) rune {
+	if l.pos+offset < len(l.src) {
+		return l.src[l.pos+offset]
+	}
+	return 0
+}
+
+func (l *lexer) advance() rune {
+	ch := l.src[l.pos]
+	l.pos++
+	if ch == '\n' {
+		l.line++
+		l.col = 1
+	} else {
+		l.col++
+	}
+	return ch
+}
+
+func (l *lexer) emit(kind tokenKind, text string, line, col int) {
+	l.tokens = append(l.tokens, token{kind: kind, text: text, line: line, col: col})
+}
+
+func (l *lexer) run() error {
+	for l.pos < len(l.src) {
+		ch := l.peekRune(0)
+		line, col := l.line, l.col
+
+		switch {
+		case ch == '\n':
+			l.advance()
+			if l.depth == 0 {
+				l.emit(tokNewline, "\n", line, col)
+			}
+		case ch == ' ' || ch == '\t':
+			l.advance()
+		case ch == '#':
+			for l.pos < len(l.src) && l.peekRune(0) != '\n' {
+				l.advance()
+			}
+		case ch == '"':
+			if err := l.lexString(); err != nil {
+				return err
+			}
+		case ch == '/':
+			if err := l.lexRegex(); err != nil {
+				return err
+			}
+		case ch == '{':
+			if err := l.lexObject(); err != nil {
+				return err
+			}
+		case isDigit(ch) || (ch == '-' && isDigit(l.peekRune(1))):
+			if err := l.lexNumber(); err != nil {
+				return err
+			}
+		case isIdentStart(ch):
+			start := l.pos
+			for l.pos < len(l.src) && isIdentChar(l.peekRune(0)) {
+				l.advance()
+			}
+			l.emit(tokIdent, string(l.src[start:l.pos]), line, col)
+		default:
+			l.advance()
+			switch ch {
+			case '.':
+				l.emit(tokDot, ".", line, col)
+			case '[':
+				l.depth++
+				l.emit(tokLBracket, "[", line, col)
+			case ']':
+				if l.depth > 0 {
+					l.depth--
+				}
+				l.emit(tokRBracket, "]", line, col)
+			case '(':
+				l.depth++
+				l.emit(tokLParen, "(", line, col)
+			case ')':
+				if l.depth > 0 {
+					l.depth--
+				}
+				l.emit(tokRParen, ")", line, col)
+			case ',':
+				l.emit(tokComma, ",", line, col)
+			case '=':
+				if l.peekRune(0) == '=' {
+					l.advance()
+					l.emit(tokEq, "==", line, col)
+				} else {
+					l.emit(tokEq, "=", line, col)
+				}
+			case '!':
+				if l.peekRune(0) != '=' {
+					return errorAt(line, col, `unexpected character "!"`)
+				}
+				l.advance()
+				l.emit(tokNeq, "!=", line, col)
+			case '<':
+				if l.peekRune(0) == '=' {
+					l.advance()
+					l.emit(tokLte, "<=", line, col)
+				} else {
+					l.emit(tokLt, "<", line, col)
+				}
+			case '>':
+				if l.peekRune(0) == '=' {
+					l.advance()
+					l.emit(tokGte, ">=", line, col)
+				} else {
+					l.emit(tokGt, ">", line, col)
+				}
+			default:
+				return errorAt(line, col, "unexpected character %q", ch)
+			}
+		}
+	}
+	return nil
+}
+
+// lexString scans a double-quoted string with JSON escapes.
+func (l *lexer) lexString() error {
+	line, col := l.line, l.col
+	start := l.pos
+	l.advance() // opening quote
+	for {
+		if l.pos >= len(l.src) || l.peekRune(0) == '\n' {
+			return errorAt(line, col, "unterminated string")
+		}
+		ch := l.advance()
+		if ch == '\\' {
+			if l.pos >= len(l.src) || l.peekRune(0) == '\n' {
+				return errorAt(line, col, "unterminated string")
+			}
+			l.advance()
+			continue
+		}
+		if ch == '"' {
+			break
+		}
+	}
+	raw := string(l.src[start:l.pos])
+	var decoded string
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return errorAt(line, col, "invalid string literal: %v", err)
+	}
+	l.emit(tokString, decoded, line, col)
+	return nil
+}
+
+// lexRegex scans /pattern/ where \/ escapes the delimiter. Any other escape
+// is passed through unchanged to the Go regexp compiler.
+func (l *lexer) lexRegex() error {
+	line, col := l.line, l.col
+	l.advance() // opening slash
+	var pattern strings.Builder
+	for {
+		if l.pos >= len(l.src) || l.peekRune(0) == '\n' {
+			return errorAt(line, col, "unterminated regex")
+		}
+		ch := l.advance()
+		if ch == '\\' {
+			if l.pos >= len(l.src) || l.peekRune(0) == '\n' {
+				return errorAt(line, col, "unterminated regex")
+			}
+			next := l.advance()
+			if next == '/' {
+				pattern.WriteRune('/')
+			} else {
+				pattern.WriteRune('\\')
+				pattern.WriteRune(next)
+			}
+			continue
+		}
+		if ch == '/' {
+			break
+		}
+		pattern.WriteRune(ch)
+	}
+	l.emit(tokRegex, pattern.String(), line, col)
+	return nil
+}
+
+// lexObject scans a balanced, string-aware {...} JSON object literal.
+func (l *lexer) lexObject() error {
+	line, col := l.line, l.col
+	start := l.pos
+	depth := 0
+	inString := false
+	for l.pos < len(l.src) {
+		ch := l.advance()
+		if inString {
+			if ch == '\\' && l.pos < len(l.src) {
+				l.advance()
+			} else if ch == '"' {
+				inString = false
+			}
+			continue
+		}
+		switch ch {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				raw := []byte(string(l.src[start:l.pos]))
+				var compact bytes.Buffer
+				if err := json.Compact(&compact, raw); err != nil || !json.Valid(raw) {
+					return errorAt(line, col, "invalid JSON object literal")
+				}
+				l.emit(tokObject, compact.String(), line, col)
+				return nil
+			}
+		}
+	}
+	return errorAt(line, col, "unterminated object literal")
+}
+
+func (l *lexer) lexNumber() error {
+	line, col := l.line, l.col
+	start := l.pos
+	if l.peekRune(0) == '-' {
+		l.advance()
+	}
+	for l.pos < len(l.src) {
+		ch := l.peekRune(0)
+		if isDigit(ch) || ch == '.' || ch == 'e' || ch == 'E' {
+			l.advance()
+			continue
+		}
+		if (ch == '+' || ch == '-') && (l.src[l.pos-1] == 'e' || l.src[l.pos-1] == 'E') {
+			l.advance()
+			continue
+		}
+		break
+	}
+	text := string(l.src[start:l.pos])
+	if _, err := strconv.ParseFloat(text, 64); err != nil {
+		return errorAt(line, col, "invalid number %q", text)
+	}
+	l.emit(tokNumber, text, line, col)
+	return nil
+}
+
+// finish drops redundant newline tokens: leading, trailing, consecutive, and
+// those preceding a continuation keyword. It appends the EOF token.
+func (l *lexer) finish() []token {
+	out := make([]token, 0, len(l.tokens)+1)
+	for i, t := range l.tokens {
+		if t.kind == tokNewline {
+			if len(out) == 0 || out[len(out)-1].kind == tokNewline {
+				continue
+			}
+			if i+1 < len(l.tokens) {
+				next := l.tokens[i+1]
+				if next.isKeyword(kwWhen) || next.isKeyword(kwAnd) || next.isKeyword(kwOr) {
+					continue
+				}
+			}
+		}
+		out = append(out, t)
+	}
+	if len(out) > 0 && out[len(out)-1].kind == tokNewline {
+		out = out[:len(out)-1]
+	}
+	eofLine, eofCol := l.line, l.col
+	return append(out, token{kind: tokEOF, line: eofLine, col: eofCol})
+}
+
+func isDigit(ch rune) bool {
+	return ch >= '0' && ch <= '9'
+}
+
+func isIdentStart(ch rune) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || ch == '_'
+}
+
+func isIdentChar(ch rune) bool {
+	return isIdentStart(ch) || isDigit(ch) || ch == '-'
+}

--- a/internal/spl/library.go
+++ b/internal/spl/library.go
@@ -1,0 +1,134 @@
+package spl
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// Library holds named policies that programs reference with apply. It is
+// immutable after construction and safe for concurrent use.
+type Library struct {
+	policies map[string]*Program
+}
+
+// NewLibrary parses every policy, checks that apply references resolve, that
+// no program writes a protected body parameter, and that the apply graph has
+// no cycles. Errors name the policy: "policies.<name>: line L:C: ...".
+func NewLibrary(policies map[string]string, protected []string) (*Library, error) {
+	lib := &Library{policies: make(map[string]*Program, len(policies))}
+
+	names := make([]string, 0, len(policies))
+	for name := range policies {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		prog, err := Parse(policies[name])
+		if err != nil {
+			return nil, fmt.Errorf("policies.%s: %w", name, err)
+		}
+		lib.policies[name] = prog
+	}
+
+	for _, name := range names {
+		if err := lib.policies[name].Validate(lib, protected); err != nil {
+			return nil, fmt.Errorf("policies.%s: %w", name, err)
+		}
+	}
+
+	if cycle := lib.findCycle(names); cycle != nil {
+		return nil, fmt.Errorf("policies: cycle detected: %s", strings.Join(cycle, " -> "))
+	}
+	return lib, nil
+}
+
+// Lookup returns the named policy.
+func (l *Library) Lookup(name string) (*Program, bool) {
+	if l == nil {
+		return nil, false
+	}
+	prog, ok := l.policies[name]
+	return prog, ok
+}
+
+// Names returns the policy names in sorted order.
+func (l *Library) Names() []string {
+	if l == nil {
+		return nil
+	}
+	names := make([]string, 0, len(l.policies))
+	for name := range l.policies {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// findCycle walks the apply graph depth-first and returns the first cycle
+// found as a path (a -> b -> a), or nil.
+func (l *Library) findCycle(names []string) []string {
+	const (
+		unvisited = iota
+		visiting
+		done
+	)
+	state := make(map[string]int, len(names))
+	var stack []string
+
+	var visit func(name string) []string
+	visit = func(name string) []string {
+		state[name] = visiting
+		stack = append(stack, name)
+		for _, dep := range l.policies[name].applies {
+			switch state[dep] {
+			case visiting:
+				start := slices.Index(stack, dep)
+				cycle := append([]string{}, stack[start:]...)
+				return append(cycle, dep)
+			case unvisited:
+				if cycle := visit(dep); cycle != nil {
+					return cycle
+				}
+			}
+		}
+		stack = stack[:len(stack)-1]
+		state[name] = done
+		return nil
+	}
+
+	for _, name := range names {
+		if state[name] == unvisited {
+			if cycle := visit(name); cycle != nil {
+				return cycle
+			}
+		}
+	}
+	return nil
+}
+
+// Validate checks a program against a library: every apply must name a policy
+// in lib (a nil lib means no apply is allowed) and no default, set or remove
+// may target a protected body parameter.
+func (p *Program) Validate(lib *Library, protected []string) error {
+	for i := range p.clauses {
+		c := &p.clauses[i]
+		switch c.action {
+		case actApply:
+			if _, ok := lib.Lookup(c.policy); !ok {
+				return errorAt(c.line, c.col, "apply references unknown policy %q", c.policy)
+			}
+		case actDefault, actSet, actRemove:
+			if key := c.path.firstKey(); key != "" && slices.Contains(protected, key) {
+				verb := "set"
+				if c.action == actRemove {
+					verb = "remove"
+				}
+				return errorAt(c.path.line, c.path.col, "cannot %s protected parameter %q", verb, key)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/spl/library_test.go
+++ b/internal/spl/library_test.go
@@ -1,0 +1,118 @@
+package spl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSPL_Library_Valid(t *testing.T) {
+	lib, err := NewLibrary(map[string]string{
+		"b":     "apply a",
+		"a":     "set x to 1",
+		"empty": "",
+	}, []string{"model"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b", "empty"}, lib.Names())
+	prog, ok := lib.Lookup("a")
+	require.True(t, ok)
+	assert.Equal(t, 1, prog.Len())
+	_, ok = lib.Lookup("nope")
+	assert.False(t, ok)
+
+	var nilLib *Library
+	_, ok = nilLib.Lookup("a")
+	assert.False(t, ok)
+	assert.Nil(t, nilLib.Names())
+}
+
+func TestSPL_Library_ParseError(t *testing.T) {
+	_, err := NewLibrary(map[string]string{"ok": "remove a", "bad": "set a"}, nil)
+	require.Error(t, err)
+	assert.Equal(t, "policies.bad: line 1:6: unexpected end of program, expected 'to'", err.Error())
+}
+
+func TestSPL_Library_UnknownApply(t *testing.T) {
+	_, err := NewLibrary(map[string]string{"a": "remove x\napply zzz"}, nil)
+	require.Error(t, err)
+	assert.Equal(t, `policies.a: line 2:7: apply references unknown policy "zzz"`, err.Error())
+}
+
+func TestSPL_Library_Cycle(t *testing.T) {
+	_, err := NewLibrary(map[string]string{"a": "apply a"}, nil)
+	require.Error(t, err)
+	assert.Equal(t, "policies: cycle detected: a -> a", err.Error())
+
+	_, err = NewLibrary(map[string]string{"a": "apply b", "b": "apply a"}, nil)
+	require.Error(t, err)
+	assert.Equal(t, "policies: cycle detected: a -> b -> a", err.Error())
+
+	_, err = NewLibrary(map[string]string{
+		"a": "apply b",
+		"b": "apply c",
+		"c": "apply a",
+		"d": "apply a",
+	}, nil)
+	require.Error(t, err)
+	assert.Equal(t, "policies: cycle detected: a -> b -> c -> a", err.Error())
+
+	// A diamond is not a cycle.
+	_, err = NewLibrary(map[string]string{
+		"a": "apply b\napply c",
+		"b": "apply d",
+		"c": "apply d",
+		"d": "remove x",
+	}, nil)
+	require.NoError(t, err)
+}
+
+func TestSPL_Library_ProtectedPath(t *testing.T) {
+	protected := []string{"model"}
+	tests := []struct {
+		src  string
+		want string
+	}{
+		{`set model to "x"`, `line 1:5: cannot set protected parameter "model"`},
+		{`default model to "x"`, `line 1:9: cannot set protected parameter "model"`},
+		{`remove model`, `line 1:8: cannot remove protected parameter "model"`},
+		{`set body.model to "x"`, `line 1:5: cannot set protected parameter "model"`},
+		{`set model.x to "x"`, `line 1:5: cannot set protected parameter "model"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.src, func(t *testing.T) {
+			_, err := NewLibrary(map[string]string{"p": tt.src}, protected)
+			require.Error(t, err)
+			assert.Equal(t, "policies.p: "+tt.want, err.Error())
+
+			prog, err := Parse(tt.src)
+			require.NoError(t, err)
+			err = prog.Validate(nil, protected)
+			require.Error(t, err)
+			assert.Equal(t, tt.want, err.Error())
+		})
+	}
+
+	// Reading model and writing context.model are fine.
+	prog, err := Parse(`set context.model to "x" when model = "y"
+set request_model to "z" when request.model = "y"`)
+	require.NoError(t, err)
+	assert.NoError(t, prog.Validate(nil, protected))
+
+	// Without a protected list anything goes.
+	prog, err = Parse(`set model to "x"`)
+	require.NoError(t, err)
+	assert.NoError(t, prog.Validate(nil, nil))
+}
+
+func TestSPL_Program_Validate_NilLibrary(t *testing.T) {
+	prog, err := Parse("apply anything")
+	require.NoError(t, err)
+	err = prog.Validate(nil, nil)
+	require.Error(t, err)
+	assert.Equal(t, `line 1:7: apply references unknown policy "anything"`, err.Error())
+
+	lib, err := NewLibrary(map[string]string{"anything": ""}, nil)
+	require.NoError(t, err)
+	assert.NoError(t, prog.Validate(lib, nil))
+}

--- a/internal/spl/parser.go
+++ b/internal/spl/parser.go
@@ -1,0 +1,442 @@
+package spl
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Parse compiles SPL source into a Program. It checks syntax, compiles regular
+// expressions, and validates namespaces (read-only paths, context path shape).
+// Semantic checks that need outside knowledge (protected parameters, apply
+// references) are done by Program.Validate and NewLibrary.
+func Parse(src string) (*Program, error) {
+	tokens, err := lex(src)
+	if err != nil {
+		return nil, err
+	}
+	p := &parser{tokens: tokens}
+	prog := &Program{}
+	seen := map[string]bool{}
+
+	for p.peek().kind != tokEOF {
+		c, err := p.parseClause()
+		if err != nil {
+			return nil, err
+		}
+		if c.action == actApply && !seen[c.policy] {
+			seen[c.policy] = true
+			prog.applies = append(prog.applies, c.policy)
+		}
+		prog.clauses = append(prog.clauses, c)
+
+		switch p.peek().kind {
+		case tokNewline:
+			p.next()
+		case tokEOF:
+		default:
+			t := p.peek()
+			return nil, errorAt(t.line, t.col, "unexpected %s, expected end of line", t.describe())
+		}
+	}
+	return prog, nil
+}
+
+type parser struct {
+	tokens []token
+	pos    int
+}
+
+func (p *parser) peek() token {
+	if p.pos < len(p.tokens) {
+		return p.tokens[p.pos]
+	}
+	return p.tokens[len(p.tokens)-1]
+}
+
+func (p *parser) next() token {
+	t := p.peek()
+	if t.kind != tokEOF {
+		p.pos++
+	}
+	return t
+}
+
+func (p *parser) expectKeyword(kw string) error {
+	t := p.peek()
+	if !t.isKeyword(kw) {
+		return errorAt(t.line, t.col, "unexpected %s, expected '%s'", t.describe(), kw)
+	}
+	p.next()
+	return nil
+}
+
+func (p *parser) expect(kind tokenKind, what string) (token, error) {
+	t := p.peek()
+	if t.kind != kind {
+		return t, errorAt(t.line, t.col, "unexpected %s, expected %s", t.describe(), what)
+	}
+	return p.next(), nil
+}
+
+func (p *parser) parseClause() (clause, error) {
+	t := p.peek()
+	c := clause{line: t.line, col: t.col}
+	if t.kind != tokIdent {
+		return c, errorAt(t.line, t.col, "unexpected %s, expected an action (default, set, remove, apply, deny)", t.describe())
+	}
+
+	switch t.text {
+	case kwDefault, kwSet:
+		p.next()
+		c.action = actDefault
+		if t.text == kwSet {
+			c.action = actSet
+		}
+		path, err := p.parsePath(true)
+		if err != nil {
+			return c, err
+		}
+		if err := p.expectKeyword(kwTo); err != nil {
+			return c, err
+		}
+		val, err := p.parseValue()
+		if err != nil {
+			return c, err
+		}
+		c.path = path
+		c.value = &val
+
+	case kwRemove:
+		p.next()
+		c.action = actRemove
+		path, err := p.parsePath(true)
+		if err != nil {
+			return c, err
+		}
+		c.path = path
+
+	case kwApply:
+		p.next()
+		c.action = actApply
+		name, err := p.expect(tokIdent, "a policy name")
+		if err != nil {
+			return c, err
+		}
+		c.policy = name.text
+		c.line, c.col = name.line, name.col
+
+	case kwDeny:
+		p.next()
+		c.action = actDeny
+		c.status = 403
+		if p.peek().kind == tokNumber {
+			num := p.next()
+			status, err := strconv.Atoi(num.text)
+			if err != nil || status < 400 || status > 599 {
+				return c, errorAt(num.line, num.col, "deny status must be an integer between 400 and 599")
+			}
+			c.status = status
+		}
+		msg, err := p.expect(tokString, "a quoted message")
+		if err != nil {
+			return c, err
+		}
+		c.message = msg.text
+
+	default:
+		return c, errorAt(t.line, t.col, "unexpected %s, expected an action (default, set, remove, apply, deny)", t.describe())
+	}
+
+	if p.peek().isKeyword(kwWhen) {
+		p.next()
+		cond, err := p.parseOr()
+		if err != nil {
+			return c, err
+		}
+		c.cond = cond
+	}
+	return c, nil
+}
+
+// parsePath parses IDENT { "." IDENT | "[" NUMBER "]" } and classifies its
+// namespace. write restricts the path to body and context.<key>.
+func (p *parser) parsePath(write bool) (*path, error) {
+	first, err := p.expect(tokIdent, "a field path")
+	if err != nil {
+		return nil, err
+	}
+	segs := []segment{{key: first.text}}
+	var text strings.Builder
+	text.WriteString(first.text)
+
+	for {
+		switch p.peek().kind {
+		case tokDot:
+			p.next()
+			id, err := p.expect(tokIdent, "a field name after '.'")
+			if err != nil {
+				return nil, err
+			}
+			segs = append(segs, segment{key: id.text})
+			text.WriteString("." + id.text)
+		case tokLBracket:
+			p.next()
+			num, err := p.expect(tokNumber, "an array index")
+			if err != nil {
+				return nil, err
+			}
+			idx, err := strconv.Atoi(num.text)
+			if err != nil {
+				return nil, errorAt(num.line, num.col, "array index must be an integer")
+			}
+			if _, err := p.expect(tokRBracket, "']'"); err != nil {
+				return nil, err
+			}
+			segs = append(segs, segment{index: idx, isIndex: true})
+			text.WriteString("[" + num.text + "]")
+		default:
+			return classifyPath(segs, text.String(), first.line, first.col, write)
+		}
+	}
+}
+
+// classifyPath assigns a namespace. A bare namespace word with no further
+// segments refers to a body key of that name.
+func classifyPath(segs []segment, text string, line, col int, write bool) (*path, error) {
+	pth := &path{ns: nsBody, segs: segs, text: text, line: line, col: col}
+	if len(segs) < 2 || segs[0].isIndex {
+		return pth, nil
+	}
+	rest := segs[1:]
+	switch segs[0].key {
+	case "body":
+		pth.segs = rest
+	case "context":
+		pth.ns = nsContext
+		pth.segs = rest
+		if len(rest) != 1 || rest[0].isIndex {
+			return nil, errorAt(line, col, "context paths must be context.<key>")
+		}
+	case "auth":
+		pth.ns = nsAuth
+		pth.segs = rest
+		if write {
+			return nil, errorAt(line, col, "auth.* is read-only")
+		}
+		if len(rest) != 1 || rest[0].isIndex || rest[0].key != "key" {
+			return nil, errorAt(line, col, "unknown auth field %q, only auth.key is available", text)
+		}
+	case "request":
+		pth.ns = nsRequest
+		pth.segs = rest
+		if write {
+			return nil, errorAt(line, col, "request.* is read-only")
+		}
+		valid := false
+		switch {
+		case len(rest) == 1 && !rest[0].isIndex:
+			valid = rest[0].key == "model" || rest[0].key == "path" || rest[0].key == "method"
+		case len(rest) == 2 && !rest[0].isIndex && !rest[1].isIndex:
+			valid = rest[0].key == "header"
+		}
+		if !valid {
+			return nil, errorAt(line, col, "unknown request field %q, available: request.model, request.path, request.method, request.header.<name>", text)
+		}
+	}
+	return pth, nil
+}
+
+// parseValue parses a set/default value: scalar, list or object literal.
+func (p *parser) parseValue() (literal, error) {
+	t := p.peek()
+	switch t.kind {
+	case tokObject:
+		p.next()
+		return literal{kind: kindObject, raw: t.text}, nil
+	case tokLBracket:
+		p.next()
+		var raws []string
+		for p.peek().kind != tokRBracket {
+			if len(raws) > 0 {
+				if _, err := p.expect(tokComma, "',' or ']'"); err != nil {
+					return literal{}, err
+				}
+			}
+			elem, err := p.parseValue()
+			if err != nil {
+				return literal{}, err
+			}
+			raws = append(raws, elem.raw)
+		}
+		p.next()
+		return literal{kind: kindArray, raw: "[" + strings.Join(raws, ",") + "]"}, nil
+	default:
+		return p.parseScalar()
+	}
+}
+
+// parseScalar parses STRING | NUMBER | true | false | null.
+func (p *parser) parseScalar() (literal, error) {
+	t := p.peek()
+	switch t.kind {
+	case tokString:
+		p.next()
+		return literal{kind: kindString, raw: jsonString(t.text), str: t.text}, nil
+	case tokNumber:
+		p.next()
+		num, _ := strconv.ParseFloat(t.text, 64)
+		return literal{kind: kindNumber, raw: t.text, num: num}, nil
+	case tokIdent:
+		switch t.text {
+		case kwTrue:
+			p.next()
+			return literal{kind: kindBool, raw: "true", b: true}, nil
+		case kwFalse:
+			p.next()
+			return literal{kind: kindBool, raw: "false", b: false}, nil
+		case kwNull:
+			p.next()
+			return literal{kind: kindNull, raw: "null"}, nil
+		}
+	case tokObject, tokLBracket:
+		return literal{}, errorAt(t.line, t.col, "object and array literals are only allowed in set and default values")
+	}
+	return literal{}, errorAt(t.line, t.col, "unexpected %s, expected a value (string, number, true, false, null)", t.describe())
+}
+
+func (p *parser) parseOr() (condNode, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for p.peek().isKeyword(kwOr) {
+		p.next()
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = condOr{left: left, right: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseAnd() (condNode, error) {
+	left, err := p.parseNot()
+	if err != nil {
+		return nil, err
+	}
+	for p.peek().isKeyword(kwAnd) {
+		p.next()
+		right, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		left = condAnd{left: left, right: right}
+	}
+	return left, nil
+}
+
+func (p *parser) parseNot() (condNode, error) {
+	if p.peek().isKeyword(kwNot) {
+		p.next()
+		inner, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		return condNot{inner: inner}, nil
+	}
+	return p.parsePrimary()
+}
+
+func (p *parser) parsePrimary() (condNode, error) {
+	if p.peek().kind == tokLParen {
+		p.next()
+		inner, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+		if _, err := p.expect(tokRParen, "')'"); err != nil {
+			return nil, err
+		}
+		return inner, nil
+	}
+	return p.parsePredicate()
+}
+
+func (p *parser) parsePredicate() (condNode, error) {
+	pth, err := p.parsePath(false)
+	if err != nil {
+		return nil, err
+	}
+
+	t := p.peek()
+	switch t.kind {
+	case tokEq, tokNeq, tokLt, tokLte, tokGt, tokGte:
+		p.next()
+		val, err := p.parseScalar()
+		if err != nil {
+			return nil, err
+		}
+		return condCmp{path: pth, op: t.kind, value: val}, nil
+	case tokIdent:
+		switch t.text {
+		case kwIs:
+			p.next()
+			w := p.peek()
+			switch {
+			case w.isKeyword(kwPresent):
+				p.next()
+				return condPresent{path: pth, present: true}, nil
+			case w.isKeyword(kwMissing):
+				p.next()
+				return condPresent{path: pth, present: false}, nil
+			}
+			return nil, errorAt(w.line, w.col, "unexpected %s, expected 'present' or 'missing'", w.describe())
+		case kwMatches:
+			p.next()
+			re, err := p.expect(tokRegex, "a /regex/")
+			if err != nil {
+				return nil, err
+			}
+			compiled, err := regexp.Compile(re.text)
+			if err != nil {
+				return nil, errorAt(re.line, re.col, "invalid regex: %v", err)
+			}
+			return condMatches{path: pth, re: compiled}, nil
+		case kwIn:
+			p.next()
+			if _, err := p.expect(tokLBracket, "'['"); err != nil {
+				return nil, err
+			}
+			var values []literal
+			for p.peek().kind != tokRBracket {
+				if len(values) > 0 {
+					if _, err := p.expect(tokComma, "',' or ']'"); err != nil {
+						return nil, err
+					}
+				}
+				val, err := p.parseScalar()
+				if err != nil {
+					return nil, err
+				}
+				values = append(values, val)
+			}
+			p.next()
+			return condIn{path: pth, values: values}, nil
+		}
+	}
+	return nil, errorAt(t.line, t.col, "unexpected %s, expected a comparison operator, 'is', 'matches' or 'in'", t.describe())
+}
+
+// jsonString encodes s as a JSON string without HTML escaping, so "</s>"
+// stays readable in the forwarded body.
+func jsonString(s string) string {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	_ = enc.Encode(s)
+	return strings.TrimSuffix(buf.String(), "\n")
+}

--- a/internal/spl/parser_test.go
+++ b/internal/spl/parser_test.go
@@ -1,0 +1,251 @@
+package spl
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSPL_Lexer_Tokens(t *testing.T) {
+	tokens, err := lex(`set a-b.c[0] to "x\"y" # comment
+  when d == 1 and e != -2.5e3 or f matches /a\/b\d/ and g in [true, null]
+deny 400 "no"
+default h to {"k": [1, {"n": "}"}]}`)
+	require.NoError(t, err)
+
+	kinds := make([]tokenKind, 0, len(tokens))
+	texts := make([]string, 0, len(tokens))
+	for _, tok := range tokens {
+		kinds = append(kinds, tok.kind)
+		texts = append(texts, tok.text)
+	}
+	assert.Equal(t, []tokenKind{
+		tokIdent, tokIdent, tokDot, tokIdent, tokLBracket, tokNumber, tokRBracket, tokIdent, tokString,
+		tokIdent, tokIdent, tokEq, tokNumber, tokIdent, tokIdent, tokNeq, tokNumber, tokIdent,
+		tokIdent, tokIdent, tokRegex, tokIdent, tokIdent, tokIdent, tokLBracket, tokIdent, tokComma, tokIdent, tokRBracket,
+		tokNewline,
+		tokIdent, tokNumber, tokString,
+		tokNewline,
+		tokIdent, tokIdent, tokIdent, tokObject,
+		tokEOF,
+	}, kinds)
+	assert.Equal(t, `x"y`, texts[8])
+	assert.Equal(t, "-2.5e3", texts[16])
+	assert.Equal(t, `a/b\d`, texts[20])
+	assert.Equal(t, `{"k":[1,{"n":"}"}]}`, texts[37])
+	// The continuation "when" on the next line swallowed the newline before it.
+	assert.Equal(t, 2, tokens[9].line)
+	assert.Equal(t, 3, tokens[9].col)
+}
+
+func TestSPL_Lexer_NewlineRules(t *testing.T) {
+	tokens, err := lex("\n\n# leading comment\nremove a\n\n\nremove b\n  and\n  or\nremove c (\n)\n[\n1\n]\r\n")
+	require.NoError(t, err)
+	var newlines int
+	for _, tok := range tokens {
+		if tok.kind == tokNewline {
+			newlines++
+		}
+	}
+	// remove a | remove b and or | remove c ( ) | [ 1 ]
+	assert.Equal(t, 3, newlines)
+	assert.Equal(t, tokEOF, tokens[len(tokens)-1].kind)
+}
+
+func TestSPL_Lexer_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"unterminated string", "deny \"oops\n", "line 1:6: unterminated string"},
+		{"unterminated regex", "remove a when b matches /abc\n", "line 1:25: unterminated regex"},
+		{"unterminated object", "set a to {\"k\": 1", "line 1:10: unterminated object literal"},
+		{"invalid object", "set a to {k: 1}", "line 1:10: invalid JSON object literal"},
+		{"bad char", "set a to $", "line 1:10: unexpected character '$'"},
+		{"lone bang", "remove a when b ! 1", `line 1:17: unexpected character "!"`},
+		{"bad number", "set a to 1.2.3", `line 1:10: invalid number "1.2.3"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := lex(tt.src)
+			require.Error(t, err)
+			assert.Equal(t, tt.want, err.Error())
+		})
+	}
+}
+
+func TestSPL_Parse_Actions(t *testing.T) {
+	prog, err := Parse(`
+default temperature to 0.2
+set chat_template_kwargs to {"reasoning_effort": "high"}
+set stop to ["a", ["b", 1], {"c": null}]
+remove reasoning_effort
+apply coding-defaults
+apply coding-defaults
+deny "nope"
+deny 429 "slow down"
+set set.in to "keywords as keys"
+set context.workload to "coding"
+`)
+	require.NoError(t, err)
+	require.Equal(t, 10, prog.Len())
+	assert.Equal(t, []string{"coding-defaults"}, prog.Applies())
+
+	c := prog.clauses
+	assert.Equal(t, actDefault, c[0].action)
+	assert.Equal(t, "0.2", c[0].value.raw)
+	assert.Equal(t, actSet, c[1].action)
+	assert.Equal(t, `{"reasoning_effort":"high"}`, c[1].value.raw)
+	assert.Equal(t, `["a",["b",1],{"c":null}]`, c[2].value.raw)
+	assert.Equal(t, kindArray, c[2].value.kind)
+	assert.Equal(t, actRemove, c[3].action)
+	assert.Equal(t, actApply, c[4].action)
+	assert.Equal(t, "coding-defaults", c[4].policy)
+	assert.Equal(t, actDeny, c[6].action)
+	assert.Equal(t, 403, c[6].status)
+	assert.Equal(t, "nope", c[6].message)
+	assert.Equal(t, 429, c[7].status)
+	assert.Equal(t, "slow down", c[7].message)
+	assert.Equal(t, nsBody, c[8].path.ns)
+	assert.Equal(t, "set.in", c[8].path.text)
+	assert.Equal(t, nsContext, c[9].path.ns)
+	assert.Equal(t, "workload", c[9].path.key())
+}
+
+func TestSPL_Parse_Conditions(t *testing.T) {
+	prog, err := Parse(`
+remove a when b = "x"
+remove a when b == 1
+remove a when b != true
+remove a when b < 1 or b <= 2 or b > 3 or b >= 4
+remove a when b matches /^co+der$/
+remove a when b is present and c is missing
+remove a when b in ["x", 2, null]
+remove a when a = 1 or b = 2 and c = 3
+remove a when not a = 1 and b = 2
+remove a when (a = 1 or b = 2) and not (c = 3)
+remove a
+  when b = 1
+  and c = 2
+  or d = 3
+`)
+	require.NoError(t, err)
+	require.Equal(t, 11, prog.Len())
+
+	assert.Equal(t, tokEq, prog.clauses[0].cond.(condCmp).op)
+	assert.Equal(t, tokEq, prog.clauses[1].cond.(condCmp).op)
+	assert.Equal(t, tokNeq, prog.clauses[2].cond.(condCmp).op)
+	assert.IsType(t, condOr{}, prog.clauses[3].cond)
+	assert.IsType(t, condMatches{}, prog.clauses[4].cond)
+	assert.IsType(t, condAnd{}, prog.clauses[5].cond)
+	assert.Len(t, prog.clauses[6].cond.(condIn).values, 3)
+
+	// a = 1 or (b = 2 and c = 3)
+	or7 := prog.clauses[7].cond.(condOr)
+	assert.IsType(t, condCmp{}, or7.left)
+	assert.IsType(t, condAnd{}, or7.right)
+
+	// (not a = 1) and b = 2
+	and8 := prog.clauses[8].cond.(condAnd)
+	assert.IsType(t, condNot{}, and8.left)
+
+	and9 := prog.clauses[9].cond.(condAnd)
+	assert.IsType(t, condOr{}, and9.left)
+	assert.IsType(t, condNot{}, and9.right)
+
+	// (b = 1 and c = 2) or d = 3, spread over continuation lines
+	or10 := prog.clauses[10].cond.(condOr)
+	assert.IsType(t, condAnd{}, or10.left)
+}
+
+func TestSPL_Parse_Paths(t *testing.T) {
+	tests := []struct {
+		src     string
+		ns      namespace
+		segs    []segment
+		wantErr string
+	}{
+		{src: "remove a", ns: nsBody, segs: []segment{{key: "a"}}},
+		{src: "remove metadata.client.name", ns: nsBody, segs: []segment{{key: "metadata"}, {key: "client"}, {key: "name"}}},
+		{src: "remove messages[0].role", ns: nsBody, segs: []segment{{key: "messages"}, {index: 0, isIndex: true}, {key: "role"}}},
+		{src: "remove messages[-1]", ns: nsBody, segs: []segment{{key: "messages"}, {index: -1, isIndex: true}}},
+		{src: "remove body.context", ns: nsBody, segs: []segment{{key: "context"}}},
+		{src: "remove context", ns: nsBody, segs: []segment{{key: "context"}}},
+		{src: "remove context.x", ns: nsContext, segs: []segment{{key: "x"}}},
+		{src: "remove a when auth.key is present", ns: nsBody},
+		{src: "remove a when request.header.x-session-id is present", ns: nsBody},
+		{src: "remove a when request.model = \"m\"", ns: nsBody},
+		{src: "remove context.a.b", wantErr: "line 1:8: context paths must be context.<key>"},
+		{src: "remove context[0]", wantErr: "line 1:8: context paths must be context.<key>"},
+		{src: "set auth.key to \"x\"", wantErr: "line 1:5: auth.* is read-only"},
+		{src: "remove request.path", wantErr: "line 1:8: request.* is read-only"},
+		{src: "remove a when auth.user is present", wantErr: `line 1:15: unknown auth field "auth.user", only auth.key is available`},
+		{src: "remove a when request.body is present", wantErr: `line 1:15: unknown request field "request.body"`},
+		{src: "remove a[1.5]", wantErr: "line 1:10: array index must be an integer"},
+		{src: "remove a.", wantErr: "line 1:10: unexpected end of program, expected a field name after '.'"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.src, func(t *testing.T) {
+			prog, err := Parse(tt.src)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			pth := prog.clauses[0].path
+			assert.Equal(t, tt.ns, pth.ns)
+			if tt.segs != nil {
+				assert.Equal(t, tt.segs, pth.segs)
+			}
+		})
+	}
+}
+
+func TestSPL_Parse_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{"missing to", "set a 1", `line 1:7: unexpected "1", expected 'to'`},
+		{"missing value", "set a to", "line 1:9: unexpected end of program, expected a value"},
+		{"unknown action", "sett a to 1", `line 1:1: unexpected "sett", expected an action (default, set, remove, apply, deny)`},
+		{"number action", "1", `line 1:1: unexpected "1", expected an action`},
+		{"deny low status", `deny 200 "x"`, "line 1:6: deny status must be an integer between 400 and 599"},
+		{"deny high status", `deny 600 "x"`, "line 1:6: deny status must be an integer between 400 and 599"},
+		{"deny float status", `deny 403.5 "x"`, "line 1:6: deny status must be an integer between 400 and 599"},
+		{"deny missing message", "deny", "line 1:5: unexpected end of program, expected a quoted message"},
+		{"object in comparison", `remove a when b = {"x": 1}`, "line 1:19: object and array literals are only allowed in set and default values"},
+		{"list in comparison", `remove a when b = [1]`, "line 1:19: object and array literals are only allowed in set and default values"},
+		{"invalid regex", "remove a when b matches /(/", "line 1:25: invalid regex:"},
+		{"bad predicate", "remove a when b", "line 1:16: unexpected end of program, expected a comparison operator, 'is', 'matches' or 'in'"},
+		{"bad is", "remove a when b is absent", `line 1:20: unexpected "absent", expected 'present' or 'missing'`},
+		{"trailing garbage", "remove a b", `line 1:10: unexpected "b", expected end of line`},
+		{"trailing garbage after when", "remove a when b = 1 c", `line 1:21: unexpected "c", expected end of line`},
+		{"unclosed paren", "remove a when (b = 1", "line 1:21: unexpected end of program, expected ')'"},
+		{"apply number", "apply 1", `line 1:7: unexpected "1", expected a policy name`},
+		{"second line", "remove a\nset b 1", `line 2:7: unexpected "1", expected 'to'`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse(tt.src)
+			require.Error(t, err)
+			var perr *Error
+			require.True(t, errors.As(err, &perr), "error should be *spl.Error")
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestSPL_Parse_Empty(t *testing.T) {
+	for _, src := range []string{"", "\n\n", "# just a comment\n", "  \n # c \n\n"} {
+		prog, err := Parse(src)
+		require.NoError(t, err)
+		assert.Equal(t, 0, prog.Len())
+		assert.Empty(t, prog.Applies())
+	}
+}

--- a/internal/spl/path.go
+++ b/internal/spl/path.go
@@ -1,0 +1,59 @@
+package spl
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// gjsonPath renders a body path for gjson/sjson. Negative indexes are resolved
+// against the current body: the array at the prefix is read and len+index is
+// substituted. ok is false when a negative index cannot be resolved (the
+// prefix is not an array, or the index is out of range), in which case reads
+// are absent and writes are no-ops.
+func (p *path) gjsonPath(body []byte) (string, bool) {
+	var sb strings.Builder
+	for i, seg := range p.segs {
+		prefix := sb.String()
+		if i > 0 {
+			sb.WriteByte('.')
+		}
+		if !seg.isIndex {
+			sb.WriteString(seg.key)
+			continue
+		}
+		idx := seg.index
+		if idx < 0 {
+			var arr gjson.Result
+			if i == 0 {
+				arr = gjson.ParseBytes(body)
+			} else {
+				arr = gjson.GetBytes(body, prefix)
+			}
+			if !arr.IsArray() {
+				return "", false
+			}
+			idx += len(arr.Array())
+			if idx < 0 {
+				return "", false
+			}
+		}
+		sb.WriteString(strconv.Itoa(idx))
+	}
+	return sb.String(), true
+}
+
+// key returns the single context key for a context path.
+func (p *path) key() string {
+	return p.segs[0].key
+}
+
+// firstKey returns the first body key of a body path, or "" when the path
+// starts with an index.
+func (p *path) firstKey() string {
+	if p.ns != nsBody || len(p.segs) == 0 || p.segs[0].isIndex {
+		return ""
+	}
+	return p.segs[0].key
+}

--- a/internal/spl/program_bench_test.go
+++ b/internal/spl/program_bench_test.go
@@ -1,0 +1,377 @@
+package spl
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// benchDenial keeps Run's result observable so the compiler cannot elide the
+// call being measured.
+var benchDenial *Denial
+
+// benchProgram keeps Parse's result observable for the same reason.
+var benchProgram *Program
+
+// benchmarkPrograms are the program shapes measured against one body. Baseline
+// is an empty program: its numbers are the loop, the body reset and the call
+// overhead, so subtract it to read the other rows.
+var benchmarkPrograms = []struct {
+	name string
+	src  string
+}{
+	{"Baseline", ""},
+	{
+		"NoMatch",
+		`set a to 1 when model = "no-such-model"
+set b to 2 when temperature > 100
+set c to 3 when messages[0].role = "system"`,
+	},
+	{
+		"Defaults",
+		`default temperature to 0.2
+default top_p to 0.95
+set chat_template_kwargs to {"reasoning_effort": "high"}`,
+	},
+	{
+		"Regex",
+		`set a to 1 when request.model matches /coder/
+set b to 2 when messages[0].content matches /message 0/
+set c to 3 when request.path matches /^\/v1\/chat/`,
+	},
+	{
+		"NegativeIndex",
+		`set a to 1 when messages[-1].role = "user"
+set messages[-1].name to "last"`,
+	},
+	{
+		"ContextWrites",
+		`set context.workload to "coding"
+set context.tier to "gold" when auth.key is present
+default context.session to "none"`,
+	},
+	{
+		// The deny fires on the first clause, so the two writes below it never
+		// run: this is the cost of rejecting a request.
+		"Deny",
+		`deny 403 "Model is disabled" when request.model = "qwen-coder"
+default temperature to 0.2
+default top_p to 0.95`,
+	},
+	{
+		// The hooks.on_request example from docs/config.example.yaml, followed
+		// by the kind of clauses a model's filters.policy carries.
+		"Realistic",
+		`deny 400 "messages is required"
+  when messages is missing
+
+apply authenticated
+  when request.model matches /^private-/
+
+apply coding-defaults
+  when request.model matches /coder/
+
+default context.workload to "default"
+remove reasoning_effort
+default max_tokens to 4096`,
+	},
+}
+
+// BenchmarkProgram_Run measures Run for each program shape against a short
+// conversation. Both time and allocations are reported.
+func BenchmarkProgram_Run(b *testing.B) {
+	lib := benchLibrary(b)
+	body := benchBody(8, 200)
+
+	for _, tt := range benchmarkPrograms {
+		prog := benchParse(b, tt.src)
+		b.Run(tt.name, func(b *testing.B) {
+			req := benchRequest()
+			scratch := make([]byte, 0, len(body)*2)
+			b.ReportAllocs()
+			for b.Loop() {
+				// Run rewrites Body in place, so every iteration starts from
+				// the original bytes. The scratch buffer has room for the
+				// whole body, so the reset itself never allocates.
+				req.Body = append(scratch[:0], body...)
+				denial, err := prog.Run(lib, req)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchDenial = denial
+			}
+		})
+	}
+}
+
+// BenchmarkProgram_RunBodySize measures how Run scales with the size of the
+// request body. gjson and sjson scan the body, and a negative index also
+// materializes the array it indexes into, so the two shapes are expected to
+// degrade differently as a conversation grows.
+func BenchmarkProgram_RunBodySize(b *testing.B) {
+	shapes := []struct {
+		name string
+		src  string
+	}{
+		{"Defaults", "default temperature to 0.2\nset top_p to 0.95"},
+		{"NegativeIndex", `set a to 1 when messages[-1].role = "user"`},
+	}
+
+	for _, shape := range shapes {
+		prog := benchParse(b, shape.src)
+		for _, messages := range []int{4, 32, 256} {
+			body := benchBody(messages, 200)
+			name := fmt.Sprintf("%s/Messages_%d", shape.name, messages)
+			b.Run(name, func(b *testing.B) {
+				req := benchRequest()
+				scratch := make([]byte, 0, len(body)*2)
+				b.SetBytes(int64(len(body)))
+				b.ReportAllocs()
+				for b.Loop() {
+					req.Body = append(scratch[:0], body...)
+					denial, err := prog.Run(nil, req)
+					if err != nil {
+						b.Fatal(err)
+					}
+					benchDenial = denial
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkProgram_RunParallel checks that a Program really is usable from
+// many goroutines at once, as the package documents, and that doing so does
+// not serialize on shared state.
+func BenchmarkProgram_RunParallel(b *testing.B) {
+	lib := benchLibrary(b)
+	body := benchBody(8, 200)
+	var src string
+	for _, tt := range benchmarkPrograms {
+		if tt.name == "Realistic" {
+			src = tt.src
+		}
+	}
+	prog := benchParse(b, src)
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		req := benchRequest()
+		scratch := make([]byte, 0, len(body)*2)
+		for pb.Next() {
+			req.Body = append(scratch[:0], body...)
+			if _, err := prog.Run(lib, req); err != nil {
+				b.Error(err)
+				return
+			}
+		}
+	})
+}
+
+// BenchmarkProgram_Parse measures the compile cost paid once per program when
+// a configuration loads.
+func BenchmarkProgram_Parse(b *testing.B) {
+	var realistic string
+	for _, tt := range benchmarkPrograms {
+		if tt.name == "Realistic" {
+			realistic = tt.src
+		}
+	}
+
+	sources := []struct {
+		name string
+		src  string
+	}{
+		{"Realistic", realistic},
+		{"Clauses_200", benchGeneratedProgram(200)},
+	}
+
+	for _, tt := range sources {
+		b.Run(tt.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				prog, err := Parse(tt.src)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchProgram = prog
+			}
+		})
+	}
+}
+
+// TestSPL_BenchmarkFixtures keeps the benchmark honest. Each row above is only
+// meaningful if it exercises what its name claims, and the Run loop only
+// measures steady-state work if resetting the body really restores it. A row
+// whose condition quietly stops matching would still report a number, so the
+// intent is asserted here rather than left to inspection.
+func TestSPL_BenchmarkFixtures(t *testing.T) {
+	body := benchBody(8, 200)
+	require.True(t, gjson.ValidBytes(body), "generated body must be valid JSON")
+	require.Len(t, gjson.GetBytes(body, "messages").Array(), 8)
+	assert.Equal(t, "user", gjson.GetBytes(body, "messages.7.role").String(),
+		"a chat request ends with the user's turn")
+	assert.Equal(t, "assistant", gjson.GetBytes(body, "messages.6.role").String())
+	assert.Len(t, gjson.GetBytes(body, "messages.0.content").String(), 200)
+
+	lib := benchLibrary(t)
+	run := func(t *testing.T, src string) ([]byte, map[string]string, *Denial) {
+		t.Helper()
+		req := benchRequest()
+		req.Body = append([]byte(nil), body...)
+		denial, err := benchParse(t, src).Run(lib, req)
+		require.NoError(t, err)
+		return req.Body, req.Context, denial
+	}
+
+	checks := map[string]func(t *testing.T, out []byte, ctx map[string]string, denial *Denial){
+		"Baseline": func(t *testing.T, out []byte, _ map[string]string, denial *Denial) {
+			assert.Nil(t, denial)
+			assert.Equal(t, string(body), string(out), "an empty program changes nothing")
+		},
+		"NoMatch": func(t *testing.T, out []byte, _ map[string]string, denial *Denial) {
+			assert.Nil(t, denial)
+			assert.Equal(t, string(body), string(out), "no condition should match")
+		},
+		"Defaults": func(t *testing.T, out []byte, _ map[string]string, _ *Denial) {
+			assert.Equal(t, 0.7, gjson.GetBytes(out, "temperature").Float(), "request value wins")
+			assert.Equal(t, 0.95, gjson.GetBytes(out, "top_p").Float())
+			assert.Equal(t, "high", gjson.GetBytes(out, "chat_template_kwargs.reasoning_effort").String())
+		},
+		"Regex": func(t *testing.T, out []byte, _ map[string]string, _ *Denial) {
+			for _, key := range []string{"a", "b", "c"} {
+				assert.True(t, gjson.GetBytes(out, key).Exists(), "regex %q should match", key)
+			}
+		},
+		"NegativeIndex": func(t *testing.T, out []byte, _ map[string]string, _ *Denial) {
+			assert.True(t, gjson.GetBytes(out, "a").Exists(), "the last message is a user turn")
+			assert.Equal(t, "last", gjson.GetBytes(out, "messages.7.name").String())
+		},
+		"ContextWrites": func(t *testing.T, out []byte, ctx map[string]string, _ *Denial) {
+			assert.Equal(t, map[string]string{
+				"workload": "coding",
+				"tier":     "gold",
+				"session":  "none",
+			}, ctx)
+			assert.Equal(t, string(body), string(out), "context writes leave the body alone")
+		},
+		"Deny": func(t *testing.T, out []byte, _ map[string]string, denial *Denial) {
+			require.NotNil(t, denial, "the deny must fire, or this row measures the writes below it")
+			assert.Equal(t, 403, denial.Status)
+			assert.Equal(t, string(body), string(out), "nothing after the deny runs")
+		},
+		"Realistic": func(t *testing.T, out []byte, ctx map[string]string, denial *Denial) {
+			require.Nil(t, denial)
+			assert.Equal(t, 0.95, gjson.GetBytes(out, "top_p").Float(), "coding-defaults applied")
+			assert.Equal(t, int64(4096), gjson.GetBytes(out, "max_tokens").Int())
+			assert.Equal(t, "coding", ctx["workload"])
+		},
+	}
+
+	for _, tt := range benchmarkPrograms {
+		t.Run(tt.name, func(t *testing.T) {
+			check, ok := checks[tt.name]
+			require.True(t, ok, "every benchmark program needs a fixture check")
+			out, ctx, denial := run(t, tt.src)
+			check(t, out, ctx, denial)
+
+			// The Run loop resets the body between iterations, so the same
+			// program over a restored body must produce the same result every
+			// time. Without this, later iterations would measure a body that
+			// earlier ones already rewrote.
+			again, _, _ := run(t, tt.src)
+			assert.Equal(t, string(out), string(again), "runs over a reset body must match")
+		})
+	}
+
+	assert.Equal(t, 200, benchParse(t, benchGeneratedProgram(200)).Len())
+}
+
+// benchParse compiles src or fails the benchmark.
+func benchParse(tb testing.TB, src string) *Program {
+	tb.Helper()
+	prog, err := Parse(src)
+	if err != nil {
+		tb.Fatalf("parsing benchmark program: %v", err)
+	}
+	return prog
+}
+
+// benchLibrary builds the policies the Realistic program applies.
+func benchLibrary(tb testing.TB) *Library {
+	tb.Helper()
+	lib, err := NewLibrary(map[string]string{
+		"coding-defaults": `default temperature to 0.2
+default top_p to 0.95
+set context.workload to "coding"`,
+		"authenticated": `deny 401 "API key required"
+  when auth.key is missing`,
+	}, []string{"model"})
+	if err != nil {
+		tb.Fatalf("building benchmark library: %v", err)
+	}
+	return lib
+}
+
+// benchRequest mirrors what CreateFilterMiddleware builds per request: a
+// resolved model name, the request line, an API key and an allocated metadata
+// map.
+func benchRequest() *Request {
+	return &Request{
+		Context: make(map[string]string),
+		APIKey:  "benchmark-key",
+		Model:   "qwen-coder",
+		Path:    "/v1/chat/completions",
+		Method:  http.MethodPost,
+		Header:  http.Header{"X-Session-Id": []string{"bench"}},
+	}
+}
+
+// benchBody builds a chat completions request with the given number of
+// messages, each carrying contentLen characters of deterministic text.
+func benchBody(messages, contentLen int) []byte {
+	var sb strings.Builder
+	sb.WriteString(`{"model":"qwen-coder","temperature":0.7,"stream":false,"messages":[`)
+	for i := range messages {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		// Count roles backwards so the conversation always ends with a user
+		// turn, the way a real chat completion request arrives.
+		role := "user"
+		if (messages-1-i)%2 == 1 {
+			role = "assistant"
+		}
+		content := fmt.Sprintf("%s message %d: ", role, i)
+		if pad := contentLen - len(content); pad > 0 {
+			content += strings.Repeat("x", pad)
+		}
+		fmt.Fprintf(&sb, `{"role":%q,"content":%q}`, role, content)
+	}
+	sb.WriteString(`]}`)
+	return []byte(sb.String())
+}
+
+// benchGeneratedProgram builds a program with the given number of clauses,
+// cycling through the action and condition forms.
+func benchGeneratedProgram(clauses int) string {
+	var sb strings.Builder
+	for i := range clauses {
+		switch i % 4 {
+		case 0:
+			fmt.Fprintf(&sb, "default field_%d to %d\n", i, i)
+		case 1:
+			fmt.Fprintf(&sb, "set field_%d to \"value %d\"\n  when model matches /coder/\n", i, i)
+		case 2:
+			fmt.Fprintf(&sb, "remove field_%d\n  when field_%d is present and temperature < 1\n", i, i)
+		case 3:
+			fmt.Fprintf(&sb, "set context.key_%d to true\n  when field_%d in [1, 2, \"three\"]\n", i, i)
+		}
+	}
+	return sb.String()
+}

--- a/internal/spl/token.go
+++ b/internal/spl/token.go
@@ -1,0 +1,78 @@
+package spl
+
+type tokenKind int
+
+const (
+	tokEOF tokenKind = iota
+	tokNewline
+	tokIdent
+	tokNumber // text holds the source spelling
+	tokString // text holds the decoded value
+	tokRegex  // text holds the pattern
+	tokObject // text holds compact JSON
+	tokDot
+	tokLBracket
+	tokRBracket
+	tokLParen
+	tokRParen
+	tokComma
+	tokEq
+	tokNeq
+	tokLt
+	tokLte
+	tokGt
+	tokGte
+)
+
+type token struct {
+	kind tokenKind
+	text string
+	line int
+	col  int
+}
+
+// describe renders a token for error messages.
+func (t token) describe() string {
+	switch t.kind {
+	case tokEOF:
+		return "end of program"
+	case tokNewline:
+		return "end of line"
+	case tokString:
+		return `"` + t.text + `"`
+	case tokRegex:
+		return "/" + t.text + "/"
+	case tokObject:
+		return "object literal"
+	default:
+		return `"` + t.text + `"`
+	}
+}
+
+// isKeyword reports whether the token is the identifier kw. Keywords are only
+// meaningful in keyword positions, so a body key named "set" still works as a
+// path segment.
+func (t token) isKeyword(kw string) bool {
+	return t.kind == tokIdent && t.text == kw
+}
+
+const (
+	kwDefault = "default"
+	kwSet     = "set"
+	kwRemove  = "remove"
+	kwApply   = "apply"
+	kwDeny    = "deny"
+	kwTo      = "to"
+	kwWhen    = "when"
+	kwAnd     = "and"
+	kwOr      = "or"
+	kwNot     = "not"
+	kwIs      = "is"
+	kwPresent = "present"
+	kwMissing = "missing"
+	kwIn      = "in"
+	kwMatches = "matches"
+	kwTrue    = "true"
+	kwFalse   = "false"
+	kwNull    = "null"
+)

--- a/internal/spl/value.go
+++ b/internal/spl/value.go
@@ -1,0 +1,109 @@
+package spl
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// value is a runtime value read from a request namespace.
+type value struct {
+	kind valueKind
+	num  float64
+	str  string
+	b    bool
+}
+
+var absent = value{kind: kindAbsent}
+
+func stringValue(s string) value {
+	return value{kind: kindString, str: s}
+}
+
+// fromResult converts a gjson lookup into a value. A missing path is absent;
+// an explicit JSON null is present with kind null.
+func fromResult(r gjson.Result) value {
+	if !r.Exists() {
+		return absent
+	}
+	switch r.Type {
+	case gjson.Null:
+		return value{kind: kindNull}
+	case gjson.True:
+		return value{kind: kindBool, b: true}
+	case gjson.False:
+		return value{kind: kindBool, b: false}
+	case gjson.Number:
+		return value{kind: kindNumber, num: r.Num}
+	case gjson.String:
+		return value{kind: kindString, str: r.Str}
+	default:
+		if r.IsArray() {
+			return value{kind: kindArray}
+		}
+		return value{kind: kindObject}
+	}
+}
+
+// equals implements =. Values are equal only when they share a kind and
+// compare equal; objects, arrays and absent values never compare equal.
+func (v value) equals(lit literal) bool {
+	if v.kind != lit.kind {
+		return false
+	}
+	switch v.kind {
+	case kindNull:
+		return true
+	case kindBool:
+		return v.b == lit.b
+	case kindNumber:
+		return v.num == lit.num
+	case kindString:
+		return v.str == lit.str
+	}
+	return false
+}
+
+// compare implements the ordering operators. Only number-to-number and
+// string-to-string comparisons are ordered; anything else is false.
+func (v value) compare(op tokenKind, lit literal) bool {
+	var c int
+	switch {
+	case v.kind == kindNumber && lit.kind == kindNumber:
+		switch {
+		case v.num < lit.num:
+			c = -1
+		case v.num > lit.num:
+			c = 1
+		}
+	case v.kind == kindString && lit.kind == kindString:
+		c = strings.Compare(v.str, lit.str)
+	default:
+		return false
+	}
+	switch op {
+	case tokLt:
+		return c < 0
+	case tokLte:
+		return c <= 0
+	case tokGt:
+		return c > 0
+	case tokGte:
+		return c >= 0
+	}
+	return false
+}
+
+// contextString coerces a literal for a context.<key> write. Strings are
+// stored as-is, everything else as its JSON text. Returns ok=false for null,
+// which callers treat as a delete.
+func (lit literal) contextString() (string, bool) {
+	switch lit.kind {
+	case kindNull:
+		return "", false
+	case kindString:
+		return lit.str, true
+	default:
+		return lit.raw, true
+	}
+}


### PR DESCRIPTION
Add SPL ("spell"), a small declarative language for rewriting, validating
and denying JSON requests before they are proxied upstream. A program is
a list of `ACTION when CONDITION` clauses. Programs attach in three
places: a top-level `policies` map of named, reusable programs; a global
`hooks.on_request` program; and a per-model or per-peer `filters.policy`.
Legacy filters run first, then the hook, then the model or peer policy.

- internal/spl: lexer, parser, evaluator and policy library built on
  gjson/sjson; actions default, set, remove, apply and deny; conditions
  =, !=, <, <=, >, >=, matches, is present, is missing, in, with and,
  or, not and parentheses; negative array indexes; read-only auth.key
  and request.* namespaces; writable context.* metadata
- internal/config: `policies`, `hooks.on_request` and `filters.policy`
  fields, compiled and validated at load time with line:col errors,
  unknown-policy and cycle detection, and protection of `model`;
  `policies` is an identity-keyed map for -config-dir merging
- internal/server: run SPL programs in the JSON filter middleware after
  the legacy filters; deny returns the standard error envelope with a
  configurable status (default 403)
- docs: schema, config.example.yaml reference, a new KB guide and an
  updated filters guide; ai-plans/spl.md records the design

Fixes #970

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0119va269CqAR3PYhnoexFL1